### PR TITLE
fix: watch build mode infinite build

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -782,6 +782,12 @@ async function buildEnvironment(
 
     // watch file changes with rollup
     if (options.watch) {
+      if (!options.outDir) {
+        throw new Error(
+          `build.outDir must not be the same directory of root at watch model, this will cause Vite to build in an infinite loop.`,
+        )
+      }
+
       logger.info(colors.cyan(`\nwatching for file changes...`))
 
       const resolvedChokidarOptions = resolveChokidarOptions(


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
When executing `vite build -w`, if `build.outDir` is an empty string, it will cause an infinite packaging loop.