### PR TITLE
fix(legacy): use unbuild 3.4 for now

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "acorn": "^8.14.1",
     "picocolors": "^1.1.1",
-    "unbuild": "^3.5.0",
+    "unbuild": "3.4.2",
     "vite": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       unbuild:
-        specifier: ^3.5.0
-        version: 3.5.0(sass@1.86.3)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
+        specifier: 3.4.2
+        version: 3.4.2(sass@1.86.3)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
       vite:
         specifier: workspace:*
         version: link:../vite
@@ -7305,6 +7305,15 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  unbuild@3.4.2:
+    resolution: {integrity: sha512-bp+xhJ+MvxTDp/gcmzWf/e9IUQ12zFKz42VIMEtJo9GTrbkcAfq+rTcN1GSIr9ZyOEfdlsYdK85wguPHZ97YOQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.7.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   unbuild@3.5.0:
     resolution: {integrity: sha512-DPFttsiADnHRb/K+yJ9r9jdn6JyXlsmdT0S12VFC14DFSJD+cxBnHq+v0INmqqPVPxOoUjvJFYUVIb02rWnVeA==}
     hasBin: true
@@ -13427,6 +13436,38 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  unbuild@3.4.2(sass@1.86.3)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)):
+    dependencies:
+      '@rollup/plugin-alias': 5.1.1(rollup@4.34.9)
+      '@rollup/plugin-commonjs': 28.0.3(rollup@4.34.9)
+      '@rollup/plugin-json': 6.1.0(rollup@4.34.9)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.34.9)
+      '@rollup/plugin-replace': 6.0.2(rollup@4.34.9)
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
+      citty: 0.1.6
+      consola: 3.4.0
+      defu: 6.1.4
+      esbuild: 0.25.0
+      hookable: 5.5.3
+      jiti: 2.4.2
+      magic-string: 0.30.17
+      mkdist: 2.2.0(sass@1.86.3)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
+      mlly: 1.7.4
+      pathe: 2.0.3
+      pkg-types: 2.0.1
+      pretty-bytes: 6.1.1
+      rollup: 4.34.9
+      rollup-plugin-dts: 6.2.1(rollup@4.34.9)(typescript@5.7.3)
+      scule: 1.3.0
+      tinyglobby: 0.2.13
+      untyped: 2.0.0
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - sass
+      - vue
+      - vue-tsc
 
   unbuild@3.5.0(sass@1.86.3)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
### Description

The types output seems to be incorrect (https://github.com/unjs/unbuild/issues/531).
(Even if that's fixed, we might need to update `patchCJS.ts` to patch the types as well)

fixes #19924

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
