### PR TITLE
refactor: remove duplicate plugin context type

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -50,7 +50,6 @@ const identifierReplacements: Record<string, Record<string, string>> = {
     Plugin$1: 'rollup.Plugin',
     PluginContext$1: 'rollup.PluginContext',
     MinimalPluginContext$1: 'rollup.MinimalPluginContext',
-    TransformPluginContext$1: 'rollup.TransformPluginContext',
     TransformResult$1: 'rollup.TransformResult',
   },
   esbuild: {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -7,8 +7,10 @@ import type {
   InternalModuleFormat,
   LogLevel,
   LogOrStringHandler,
+  MinimalPluginContext,
   ModuleFormat,
   OutputOptions,
+  PluginContext,
   RollupBuild,
   RollupError,
   RollupLog,
@@ -75,7 +77,7 @@ import {
   BaseEnvironment,
   getDefaultResolvedEnvironmentOptions,
 } from './baseEnvironment'
-import type { MinimalPluginContext, Plugin, PluginContext } from './plugin'
+import type { Plugin } from './plugin'
 import type { RollupPluginHooks } from './typeUtils'
 import {
   createFilterForTransform,

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -1,8 +1,8 @@
+import type { PluginContext } from 'rollup'
 import type { DevEnvironment } from './server/environment'
 import type { BuildEnvironment } from './build'
 import type { ScanEnvironment } from './optimizer/scan'
 import type { UnknownEnvironment } from './baseEnvironment'
-import type { PluginContext } from './plugin'
 
 export type Environment =
   | DevEnvironment

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -2,11 +2,10 @@ import type {
   CustomPluginOptions,
   LoadResult,
   ObjectHook,
+  PluginContext,
   ResolveIdResult,
-  MinimalPluginContext as RollupMinimalPluginContext,
   Plugin as RollupPlugin,
-  PluginContext as RollupPluginContext,
-  TransformPluginContext as RollupTransformPluginContext,
+  TransformPluginContext,
   TransformResult,
 } from 'rollup'
 import type {
@@ -65,23 +64,7 @@ export interface HotUpdatePluginContext {
   environment: DevEnvironment
 }
 
-export interface MinimalPluginContext
-  extends RollupMinimalPluginContext,
-    PluginContextExtension {}
-
-export interface PluginContext
-  extends RollupPluginContext,
-    PluginContextExtension {}
-
-export interface ResolveIdPluginContext
-  extends RollupPluginContext,
-    PluginContextExtension {}
-
-export interface TransformPluginContext
-  extends RollupTransformPluginContext,
-    PluginContextExtension {}
-
-// Argument Rollup types to have the PluginContextExtension
+// Augment Rollup types to have the PluginContextExtension
 declare module 'rollup' {
   export interface MinimalPluginContext extends PluginContextExtension {}
 }
@@ -127,7 +110,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
    */
   resolveId?: ObjectHook<
     (
-      this: ResolveIdPluginContext,
+      this: PluginContext,
       source: string,
       importer: string | undefined,
       options: {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -2,14 +2,18 @@ import path from 'node:path'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
-import type { NormalizedOutputOptions, RenderedChunk } from 'rollup'
+import type {
+  NormalizedOutputOptions,
+  PluginContext,
+  RenderedChunk,
+} from 'rollup'
 import MagicString from 'magic-string'
 import colors from 'picocolors'
 import {
   createToImportMetaURLBasedRelativeRuntime,
   toOutputFilePathInJS,
 } from '../build'
-import type { Plugin, PluginContext } from '../plugin'
+import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { checkPublicFile } from '../publicDir'
 import {


### PR DESCRIPTION
### Description

We augment Rollup types to have the `environment` property. But we also had types that extends `RollupMinimalPluginContext` and `PluginContextExtension` (the type that has the `environment` property). This type is not needed since `RollupMinimalPluginContext` already have the property by the augmentation.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
