### PR TITLE
fix(optimizer): return plain object when using `require` to import externals in optimized dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -339,7 +339,7 @@ export function esbuildCjsExternalPlugin(
           contents:
             `import * as m from ${JSON.stringify(
               nonFacadePrefix + args.path,
-            )};` + `module.exports = m;`,
+            )};` + `module.exports = { ...m };`,
         }),
       )
     },

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -352,3 +352,9 @@ test('external package name with asset extension', async () => {
     page.textContent('.dep-with-asset-ext-prebundled'),
   ).toBe(String(isServe))
 })
+
+test('dependency with external sub-dependency', async () => {
+  await expectWithRetry(() =>
+    page.textContent('.dep-cjs-with-external-dep'),
+  ).toBe('ok')
+})

--- a/playground/optimize-deps/dep-cjs-with-external-dep/index.js
+++ b/playground/optimize-deps/dep-cjs-with-external-dep/index.js
@@ -1,0 +1,4 @@
+const external = require('@vitejs/test-dep-esm-external')
+// eslint-disable-next-line no-prototype-builtins
+const result = external.hasOwnProperty('foo') ? 'ok' : 'error'
+module.exports = { result }

--- a/playground/optimize-deps/dep-cjs-with-external-dep/package.json
+++ b/playground/optimize-deps/dep-cjs-with-external-dep/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-dep-cjs-with-external-dep",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@vitejs/test-dep-esm-external": "file:../dep-esm-external"
+  }
+}

--- a/playground/optimize-deps/dep-esm-external/index.js
+++ b/playground/optimize-deps/dep-esm-external/index.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo'
+}

--- a/playground/optimize-deps/dep-esm-external/package.json
+++ b/playground/optimize-deps/dep-esm-external/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-dep-esm-external",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "module"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -305,3 +305,13 @@
   import * as sub from '@vitejs/test-dep-source-map-no-sources/sub.js'
   import * as all from '@vitejs/test-dep-source-map-no-sources/all.js'
 </script>
+
+<h2>Pre-bundle dependency with external sub-dependency</h2>
+<div>
+  require('some-external-sub-dependency') returns a plain object:
+  <span class="dep-cjs-with-external-dep">???</span>
+</div>
+<script type="module">
+  import * as optimized from '@vitejs/test-dep-cjs-with-external-dep'
+  text('.dep-cjs-with-external-dep', optimized.result)
+</script>

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -18,6 +18,7 @@
     "@vitejs/test-dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "@vitejs/test-dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "@vitejs/test-dep-cjs-with-assets": "file:./dep-cjs-with-assets",
+    "@vitejs/test-dep-cjs-with-external-dep": "file:./dep-cjs-with-external-dep",
     "@vitejs/test-dep-css-require": "file:./dep-css-require",
     "@vitejs/test-dep-esbuild-plugin-transform": "file:./dep-esbuild-plugin-transform",
     "@vitejs/test-dep-incompatible": "file:./dep-incompatible",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -23,8 +23,13 @@ export default defineConfig({
       '@vitejs/test-dep-optimize-exports-with-glob/**/*',
       '@vitejs/test-dep-optimize-exports-with-root-glob/**/*.js',
       '@vitejs/test-dep-optimize-with-glob/**/*.js',
+      '@vitejs/test-dep-cjs-with-external-dep',
     ],
-    exclude: ['@vitejs/test-nested-exclude', '@vitejs/test-dep-non-optimized'],
+    exclude: [
+      '@vitejs/test-nested-exclude',
+      '@vitejs/test-dep-non-optimized',
+      '@vitejs/test-dep-esm-external',
+    ],
     esbuildOptions: {
       plugins: [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,9 @@ importers:
       '@vitejs/test-dep-cjs-with-assets':
         specifier: file:./dep-cjs-with-assets
         version: file:playground/optimize-deps/dep-cjs-with-assets
+      '@vitejs/test-dep-cjs-with-external-dep':
+        specifier: file:./dep-cjs-with-external-dep
+        version: file:playground/optimize-deps/dep-cjs-with-external-dep
       '@vitejs/test-dep-css-require':
         specifier: file:./dep-css-require
         version: file:playground/optimize-deps/dep-css-require
@@ -1101,9 +1104,17 @@ importers:
 
   playground/optimize-deps/dep-cjs-with-assets: {}
 
+  playground/optimize-deps/dep-cjs-with-external-dep:
+    dependencies:
+      '@vitejs/test-dep-esm-external':
+        specifier: file:../dep-esm-external
+        version: file:playground/optimize-deps/dep-esm-external
+
   playground/optimize-deps/dep-css-require: {}
 
   playground/optimize-deps/dep-esbuild-plugin-transform: {}
+
+  playground/optimize-deps/dep-esm-external: {}
 
   playground/optimize-deps/dep-incompatible: {}
 
@@ -3671,6 +3682,9 @@ packages:
   '@vitejs/test-dep-cjs-with-assets@file:playground/optimize-deps/dep-cjs-with-assets':
     resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
 
+  '@vitejs/test-dep-cjs-with-external-dep@file:playground/optimize-deps/dep-cjs-with-external-dep':
+    resolution: {directory: playground/optimize-deps/dep-cjs-with-external-dep, type: directory}
+
   '@vitejs/test-dep-conditions@file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions':
     resolution: {directory: packages/vite/src/node/__tests__/fixtures/test-dep-conditions, type: directory}
 
@@ -3679,6 +3693,9 @@ packages:
 
   '@vitejs/test-dep-esbuild-plugin-transform@file:playground/optimize-deps/dep-esbuild-plugin-transform':
     resolution: {directory: playground/optimize-deps/dep-esbuild-plugin-transform, type: directory}
+
+  '@vitejs/test-dep-esm-external@file:playground/optimize-deps/dep-esm-external':
+    resolution: {directory: playground/optimize-deps/dep-esm-external, type: directory}
 
   '@vitejs/test-dep-including-a@file:playground/preload/dep-including-a':
     resolution: {directory: playground/preload/dep-including-a, type: directory}
@@ -9570,11 +9587,17 @@ snapshots:
 
   '@vitejs/test-dep-cjs-with-assets@file:playground/optimize-deps/dep-cjs-with-assets': {}
 
+  '@vitejs/test-dep-cjs-with-external-dep@file:playground/optimize-deps/dep-cjs-with-external-dep':
+    dependencies:
+      '@vitejs/test-dep-esm-external': file:playground/optimize-deps/dep-esm-external
+
   '@vitejs/test-dep-conditions@file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions': {}
 
   '@vitejs/test-dep-css-require@file:playground/optimize-deps/dep-css-require': {}
 
   '@vitejs/test-dep-esbuild-plugin-transform@file:playground/optimize-deps/dep-esbuild-plugin-transform': {}
+
+  '@vitejs/test-dep-esm-external@file:playground/optimize-deps/dep-esm-external': {}
 
   '@vitejs/test-dep-including-a@file:playground/preload/dep-including-a':
     dependencies:


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite/issues/19931

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
