### PR TITLE
feat: expose import analysis url normalization util

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -19,6 +19,7 @@ export { createIdResolver } from './idResolver'
 
 export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
 export { transformWithEsbuild } from './plugins/esbuild'
+export { normalizeResolvedIdToUrl } from './plugins/importAnalysis'
 export { buildErrorMessage } from './server/middlewares/error'
 
 export {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -100,7 +100,7 @@ export function isExplicitImportRequired(url: string): boolean {
   return !isJSRequest(url) && !isCSSRequest(url)
 }
 
-function normalizeResolvedIdToUrl(
+export function normalizeResolvedIdToUrl(
   environment: DevEnvironment,
   url: string,
   resolved: PartialResolvedId,


### PR DESCRIPTION
### Description

To have consistence browser module identity for RSC client reference, it's necessary to apply the same normalization as Vite's import analysis in one of our routines. Exposing `normalizeResolvedIdToUrl` isn't probably the right way, but just starting a draft PR here for me to point as a reference.