### PR TITLE
fix(config): workaround failure creating temporary file (take 2)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2107,7 +2107,16 @@ async function loadConfigFromBundledFile(
           `.vite-temp/${path.basename(fileName)}.${hash}.mjs`,
         )
       : `${fileName}.${hash}.mjs`
-    await fsp.writeFile(tempFileName, bundledCode)
+    try {
+      await fsp.writeFile(tempFileName, bundledCode)
+    } catch (e) {
+      if (e.code === 'EACCES') {
+        const url = `data:text/javascript;base64,${Buffer.from(bundledCode).toString('base64')}`
+        return (await import(url)).default
+      } else {
+        throw e
+      }
+    }
     try {
       return (await import(pathToFileURL(tempFileName).href)).default
     } finally {


### PR DESCRIPTION
If node_modules is not writable, loadConfigFromBundledFile fails to write its temp file and vite aborts with an exception.

This was previously fixed in #13269, but was reverted after several reports of failure to load config with relative imports (see #13631 and #13730).

Instead of replacing the current code, try to load from string only as a workaround, when the directory doesn't exist.

This should solve the case of unwritable node_modules when relative imports are not used without breaking anything that works.
