### PR TITLE
feat: buildApp hook

### DIFF
--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -329,6 +329,8 @@ export default {
 }
 ```
 
+Plugins can also define a `buildApp` hook. Order `'pre'` and `null'` are executed before the configured `builder.buildApp`, and order `'post'` hooks are executed after it. `environment.isBuilt` can be used to check if an environment has already being build.
+
 ## Environment Agnostic Code
 
 Most of the time, the current `environment` instance will be available as part of the context of the code being run so the need to access them through `server.environments` should be rare. For example, inside plugin hooks the environment is exposed as part of the `PluginContext`, so it can be accessed using `this.environment`. See [Environment API for Plugins](./api-environment-plugins.md) to learn about how to build environment aware plugins.

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1625,10 +1625,8 @@ export async function createBuilder(
     async build(
       environment: BuildEnvironment,
     ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
-      const output = buildEnvironment(environment)
-      output.then(() => {
-        environment.isBuilt = true
-      })
+      const output = await buildEnvironment(environment)
+      environment.isBuilt = true
       return output
     },
   }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1618,6 +1618,9 @@ export async function createBuilder(
         const handler = getHookHandler(hook)
         await handler(builder)
       }
+      if (!configBuilderBuildAppCalled) {
+        await configBuilder.buildApp(builder)
+      }
     },
     async build(
       environment: BuildEnvironment,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1625,8 +1625,11 @@ export async function createBuilder(
     async build(
       environment: BuildEnvironment,
     ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
-      environment.isBuilt = true
-      return buildEnvironment(environment)
+      const output = buildEnvironment(environment)
+      output.then(() => {
+        environment.isBuilt = true
+      })
+      return output
     },
   }
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -87,6 +87,7 @@ export type {
 } from './server'
 export type {
   ViteBuilder,
+  BuildAppHook,
   BuilderOptions,
   BuildOptions,
   BuildEnvironmentOptions,

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -294,6 +294,8 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
   transformIndexHtml?: IndexHtmlTransform
   /**
    * Build Environments
+   *
+   * @experimental
    */
   buildApp?: ObjectHook<BuildAppHook>
   /**

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -15,6 +15,7 @@ import type {
   UserConfig,
 } from './config'
 import type { ServerHook } from './server'
+import type { BuildAppHook } from './build'
 import type { IndexHtmlTransform } from './plugins/html'
 import type { EnvironmentModuleNode } from './server/moduleGraph'
 import type { ModuleNode } from './server/mixedModuleGraph'
@@ -291,7 +292,10 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
    * `{ order: 'pre', handler: hook }`
    */
   transformIndexHtml?: IndexHtmlTransform
-
+  /**
+   * Build Environments
+   */
+  buildApp?: ObjectHook<BuildAppHook>
   /**
    * Perform custom handling of HMR updates.
    * The handler receives a context containing changed filename, timestamp, a

--- a/playground/environment-react-ssr/vite.config.ts
+++ b/playground/environment-react-ssr/vite.config.ts
@@ -20,6 +20,12 @@ export default defineConfig((env) => ({
         Object.assign(globalThis, { __globalServer: server })
       },
     },
+    {
+      name: 'build-client',
+      async buildApp(builder) {
+        await builder.build(builder.environments.client)
+      },
+    },
   ],
   resolve: {
     noExternal: true,
@@ -54,7 +60,9 @@ export default defineConfig((env) => ({
 
   builder: {
     async buildApp(builder) {
-      await builder.build(builder.environments.client)
+      if (!builder.environments.client.isBuilt) {
+        throw new Error('Client environment should be built first')
+      }
       await builder.build(builder.environments.ssr)
     },
   },


### PR DESCRIPTION
### Description

Implement a `buildApp` hook, with a similar API to @dario-piotrowicz' proposal:
- https://github.com/vitejs/vite/discussions/19714

I didn't end up going forward with [the builder.build(environment) returning a promise proposal](https://github.com/vitejs/vite/discussions/19714#discussioncomment-12614396) because we have a current use case for building environments multiple times with RSC right now (that hopefully won't be needed in the future).

Instead of a `builtEnvironments` array, this PR implements the same idea with a `environment.isBuilt` flag. We may end up adding more state later and I think we shouldn't create arrays for each of them. It feels a bit strange to have this state in the `BuildEnvironment` at first, but we have a lot of state in dev environments already.

Note: I ended up not removing `config.builder.buildApp` because it is easy to keep working and I think it would help with the current explorations to avoid the breaking change. We can still decide to do a clean move to a hook only world in Vite 7 or delay that to Vite 8 (if the hook proves to be the final shape of the API, what I'm leaning towards). We can deprecate `config.builder.buildApp` at one point during Vite 7 then.