### PR TITLE
chore: declare version range for peer dependencies

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -157,12 +157,12 @@
   "peerDependencies": {
     "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
     "jiti": ">=1.21.0",
-    "less": "*",
+    "less": "^4.0.0",
     "lightningcss": "^1.21.0",
-    "sass": "*",
-    "sass-embedded": "*",
-    "stylus": "*",
-    "sugarss": "*",
+    "sass": "^1.70.0",
+    "sass-embedded": "^1.70.0",
+    "stylus": ">=0.54.8",
+    "sugarss": "^5.0.0",
     "terser": "^5.16.0",
     "tsx": "^4.8.1",
     "yaml": "^2.4.2"


### PR DESCRIPTION
### Description

Specified the peer dependencies version range.
Previously, we used `*`, which didn't clearly communicate which versions were actually supported. For example, #19977 requires sass 1.45.0+ and #19978 requires sass 1.70.0+, but this isn't obvious from the current `package.json` and it wasn't clear whether relying on which feature would require a major version.

Here's the reasoning behind the chosen ranges for each peer dependency:

- less: selected range `^4.0.0`
  - actually, less 2.1.0 worked
  - it would be better to have it at least `^3.8.0 || ^4.0.0` because [`rewriteUrls` feature](https://lesscss.org/usage/#less-options-rewrite-urls) was [introduced in 3.8.0](https://github.com/less/less.js/blob/master/CHANGELOG.md#v380-2018-07-23) which we might use in the future
  - but since 4.0.0 was released 5 years ago (`2020-12-18`), I guess it's fine to require that
- sass: selected range `^1.70.0`
  - modern API was [introduced in 1.45.0](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/) so this is the lowest version for #19977
  - compiler API was [introduced in 1.70.0](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1700) so this is the lowest version for #19978
  - while there're some breaking changes between 1.45.0 - 1.70.0, but I think the benefits of #19978 justifies it
- stylus: selected range `>=0.54.8`
  - deps list support was [introduced in 0.43.0](https://github.com/stylus/stylus/commit/daea761415d636895cf9749d1f2fbc6e68e1de85) (we use it for watching the imported files)
  - source map support was [introduced in 0.48.0](https://github.com/stylus/stylus/commit/068f88feaa061d7a113a6eda54db705d4e542713)
  - but I think we go with 0.54.8+ because when using a version before that, many warnings are shown (https://github.com/stylus/stylus/pull/2538)
  - stylus uses 0.x versions. I used `>=` so that we don't need to keep adding `|| ^0.x` to the range
- sugarss: selected range `>=5.0.0`
  - 2.0.0 uses postcss v7 and 3.0.0+ uses postscss v8 (Vite uses postcss v8)
  - we can support `^3.0.0 || ^4.0.0 || ^5.0.0` without much burden. But the breaking changes between them are only dropping Node versions older than 16, so probably ok to simply go with `^5.0.0`

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
