### PR TITLE
refactor!: remove deprecated `optimizeDeps.disabled`

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -86,21 +86,6 @@ Set to `true` to force dependency pre-bundling, ignoring previously cached optim
 
 When enabled, it will hold the first optimized deps results until all static imports are crawled on cold start. This avoids the need for full-page reloads when new dependencies are discovered and they trigger the generation of new common chunks. If all dependencies are found by the scanner plus the explicitly defined ones in `include`, it is better to disable this option to let the browser process more requests in parallel.
 
-## optimizeDeps.disabled
-
-- **Deprecated**
-- **Experimental:** [Give Feedback](https://github.com/vitejs/vite/discussions/13839)
-- **Type:** `boolean | 'build' | 'dev'`
-- **Default:** `'build'`
-
-This option is deprecated. As of Vite 5.1, pre-bundling of dependencies during build have been removed. Setting `optimizeDeps.disabled` to `true` or `'dev'` disables the optimizer, and configured to `false` or `'build'` leaves the optimizer during dev enabled.
-
-To disable the optimizer completely, use `optimizeDeps.noDiscovery: true` to disallow automatic discovery of dependencies and leave `optimizeDeps.include` undefined or empty.
-
-:::warning
-Optimizing dependencies during build time was an **experimental** feature. Projects trying out this strategy also removed `@rollup/plugin-commonjs` using `build.commonjsOptions: { include: [] }`. If you did so, a warning will guide you to re-enable it to support CJS only packages while bundling.
-:::
-
 ## optimizeDeps.needsInterop
 
 - **Experimental**

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -114,16 +114,6 @@ export interface DepOptimizationConfig {
    */
   extensions?: string[]
   /**
-   * Deps optimization during build was removed in Vite 5.1. This option is
-   * now redundant and will be removed in a future version. Switch to using
-   * `optimizeDeps.noDiscovery` and an empty or undefined `optimizeDeps.include`.
-   * true or 'dev' disables the optimizer, false or 'build' leaves it enabled.
-   * @default 'build'
-   * @deprecated
-   * @experimental
-   */
-  disabled?: boolean | 'build' | 'dev'
-  /**
    * Automatic dependency discovery. When `noDiscovery` is true, only dependencies
    * listed in `include` will be optimized. The scanner isn't run for cold start
    * in this case. CJS-only dependencies must be present in `include` during dev.
@@ -166,11 +156,7 @@ export type DepOptimizationOptions = DepOptimizationConfig & {
 export function isDepOptimizationDisabled(
   optimizeDeps: DepOptimizationOptions,
 ): boolean {
-  return (
-    optimizeDeps.disabled === true ||
-    optimizeDeps.disabled === 'dev' ||
-    (!!optimizeDeps.noDiscovery && !optimizeDeps.include?.length)
-  )
+  return !!optimizeDeps.noDiscovery && !optimizeDeps.include?.length
 }
 
 export interface DepOptimizationResult {

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -47,7 +47,6 @@ export async function createModuleRunnerTester(
         external: ['@vitejs/cjs-external', '@vitejs/esm-external'],
       },
       optimizeDeps: {
-        disabled: true,
         noDiscovery: true,
         include: [],
       },

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -1110,7 +1110,6 @@ async function setupModuleRunner(
       },
     },
     optimizeDeps: {
-      disabled: true,
       noDiscovery: true,
       include: [],
     },


### PR DESCRIPTION
### Description

Removes `optimizeDeps.disabled` option.
`optimizeDeps.disabled` was deprecated in 5.1.

refs #15184

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
