### PR TITLE
feat: stabilize `optimizeDeps.noDiscovery`

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -78,6 +78,13 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 Set to `true` to force dependency pre-bundling, ignoring previously cached optimized dependencies.
 
+## optimizeDeps.noDiscovery
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+When set to `true`, automatic dependency discovery will be disabled and only dependencies listed in `optimizeDeps.include` will be optimized. CJS-only dependencies must be present in `optimizeDeps.include` during dev.
+
 ## optimizeDeps.holdUntilCrawlEnd
 
 - **Experimental:** [Give Feedback](https://github.com/vitejs/vite/discussions/15834)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -128,7 +128,6 @@ export interface DepOptimizationConfig {
    * listed in `include` will be optimized. The scanner isn't run for cold start
    * in this case. CJS-only dependencies must be present in `include` during dev.
    * @default false
-   * @experimental
    */
   noDiscovery?: boolean
   /**


### PR DESCRIPTION
### Description

Stabilize `optimizeDeps.noDiscovery`.

`optimizeDeps.noDiscovery` was introduced in Vite 4.3.
It's used in Vitest for a while.

refs https://github.com/vitejs/vite/discussions/13814


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
