### PR TITLE
refactor!: remove deprecated no-op type only properties

### DIFF
--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -84,11 +84,6 @@ export interface ModuleRunnerHmr {
 
 export interface ModuleRunnerOptions {
   /**
-   * Root of the project
-   * @deprecated not used and to be removed
-   */
-  root?: string
-  /**
    * A set of methods to communicate with the server.
    */
   transport: ModuleRunnerTransport

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -35,7 +35,6 @@ import {
 } from '../utils'
 import { optimizedDepInfoFromFile, optimizedDepInfoFromId } from '../optimizer'
 import type { DepsOptimizer } from '../optimizer'
-import type { SSROptions } from '..'
 import type { PackageCache, PackageData } from '../packages'
 import { canExternalizeFile, shouldExternalize } from '../external'
 import {
@@ -124,8 +123,6 @@ interface ResolvePluginOptions {
   tryPrefix?: string
   preferRelative?: boolean
   isRequire?: boolean
-  /** @deprecated */
-  isFromTsImporter?: boolean
   // True when resolving during the scan phase to discover dependencies
   scan?: boolean
 
@@ -143,30 +140,11 @@ interface ResolvePluginOptions {
   externalize?: boolean
 
   /**
-   * Previous deps optimizer logic
-   * @internal
-   * @deprecated
-   */
-  getDepsOptimizer?: (ssr: boolean) => DepsOptimizer | undefined
-
-  /**
-   * Externalize logic for SSR builds
-   * @internal
-   * @deprecated
-   */
-  shouldExternalize?: (id: string, importer?: string) => boolean | undefined
-
-  /**
    * Set by createResolver, we only care about the resolved id. moduleSideEffects
    * and other fields are discarded so we can avoid computing them.
    * @internal
    */
   idOnly?: boolean
-
-  /**
-   * @deprecated environment.config are used instead
-   */
-  ssrConfig?: SSROptions
 }
 
 export interface InternalResolveOptions

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -389,13 +389,6 @@ export interface ViteDevServer {
    */
   _setInternalServer(server: ViteDevServer): void
   /**
-   * Left for backward compatibility with VitePress, HMR may not work in some cases
-   * but the there will not be a hard error.
-   * @internal
-   * @deprecated this map is not used anymore
-   */
-  _importGlobMap: Map<string, { affirmed: string[]; negated: string[] }[]>
-  /**
    * @internal
    */
   _restartPromise: Promise<void> | null
@@ -746,7 +739,6 @@ export async function _createServer(
       // server instance after a restart
       server = _server
     },
-    _importGlobMap: new Map(),
     _restartPromise: null,
     _forceOptimizeOnRestart: false,
     _shortcutsOptions: undefined,

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -126,7 +126,6 @@ export function createServerModuleRunner(
   return new ModuleRunner(
     {
       ...options,
-      root: environment.config.root,
       transport: createServerModuleRunnerTransport({
         channel: environment.hot as NormalizedServerHotChannel,
       }),

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -66,7 +66,6 @@ class SSRCompatModuleRunner extends ModuleRunner {
   constructor(private environment: DevEnvironment) {
     super(
       {
-        root: environment.config.root,
         transport: createServerModuleRunnerTransport({
           channel: environment.hot as NormalizedServerHotChannel,
         }),


### PR DESCRIPTION
### Description

This PR removes the following deprecated no-op properties:

- `ModuleRunnerOptions.root`
  - changed to no-op in https://github.com/vitejs/vite/pull/18361 (v6.0.6)
- `ViteDevServer._importGlobMap`
  - changed to no-op in https://github.com/vitejs/vite/pull/16249 as part of Env API change (v6.0.0)
  - vitepress doesn't use it anymore
  - not many usage other than old forks of vite or vitepress in [code search](https://github.com/search?q=_importGlobMap+NOT+is%3Afork&type=code&p=1)
- `ResolvePluginOptions.isFromTsImporter`
  - changed to no-op in #18889 (v6.1.0)
  - no usage other than old forks of vite in [code search](https://github.com/search?q=isFromTsImporter+NOT+is%3Afork&type=code)
- `ResolvePluginOptions.getDepsOptimizer`
  - changed to no-op as part of Env API change (v6.0.0)
- `ResolvePluginOptions.shouldExternalize`
  - changed to no-op as part of Env API change (v6.0.0)
- `ResolvePluginOptions.ssrConfig`
  - changed to no-op as part of Env API change (v6.0.0)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
