### PR TITLE
refactor!: remove `HotBroadcaster`

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1143,6 +1143,7 @@ export function createServerHotChannel(): ServerHotChannel {
 
 /** @deprecated use `environment.hot` instead */
 export interface HotBroadcaster extends NormalizedHotChannel {
+  /** @deprecated this always returns `[server.ws]` */
   readonly channels: NormalizedHotChannel[]
 }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1149,34 +1149,18 @@ export interface HotBroadcaster extends NormalizedHotChannel {
    * @deprecated
    */
   addChannel(channel: HotChannel): HotBroadcaster
-  close(): Promise<unknown[]>
 }
 
 export function createDeprecatedHotBroadcaster(
   ws: NormalizedHotChannel,
 ): HotBroadcaster {
-  const broadcaster: HotBroadcaster = {
-    on: ws.on,
-    off: ws.off,
-    listen: ws.listen,
-    send: ws.send,
-    setInvokeHandler: ws.setInvokeHandler,
-    handleInvoke: async () => ({
-      error: {
-        name: 'TransportError',
-        message: 'handleInvoke not implemented',
-        stack: new Error().stack,
-      },
-    }),
+  return {
+    ...ws,
     get channels() {
       return [ws]
     },
     addChannel() {
       return broadcaster
     },
-    close() {
-      return Promise.all(broadcaster.channels.map((channel) => channel.close()))
-    },
   }
-  return broadcaster
 }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1140,20 +1140,3 @@ export function createServerHotChannel(): ServerHotChannel {
     },
   }
 }
-
-/** @deprecated use `environment.hot` instead */
-export interface HotBroadcaster extends NormalizedHotChannel {
-  /** @deprecated this always returns `[server.ws]` */
-  readonly channels: NormalizedHotChannel[]
-}
-
-export function createDeprecatedHotBroadcaster(
-  ws: NormalizedHotChannel,
-): HotBroadcaster {
-  return {
-    ...ws,
-    get channels() {
-      return [ws]
-    },
-  }
-}

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1144,11 +1144,6 @@ export function createServerHotChannel(): ServerHotChannel {
 /** @deprecated use `environment.hot` instead */
 export interface HotBroadcaster extends NormalizedHotChannel {
   readonly channels: NormalizedHotChannel[]
-  /**
-   * A noop.
-   * @deprecated
-   */
-  addChannel(channel: HotChannel): HotBroadcaster
 }
 
 export function createDeprecatedHotBroadcaster(
@@ -1158,9 +1153,6 @@ export function createDeprecatedHotBroadcaster(
     ...ws,
     get channels() {
       return [ws]
-    },
-    addChannel() {
-      return broadcaster
     },
   }
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -278,10 +278,8 @@ export interface ViteDevServer {
    */
   ws: WebSocketServer
   /**
-   * HMR broadcaster that can be used to send custom HMR messages to the client
-   *
-   * Always sends a message to at least a WebSocket client. Any third party can
-   * add a channel to the broadcaster to process messages
+   * An alias to `server.environments.client.hot`.
+   * If you want to interact with all environments, loop over `server.environments`.
    */
   hot: HotBroadcaster
   /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -87,12 +87,8 @@ import { ModuleGraph } from './mixedModuleGraph'
 import type { ModuleNode } from './mixedModuleGraph'
 import { notFoundMiddleware } from './middlewares/notFound'
 import { buildErrorMessage, errorMiddleware } from './middlewares/error'
-import type { HmrOptions, HotBroadcaster } from './hmr'
-import {
-  createDeprecatedHotBroadcaster,
-  handleHMRUpdate,
-  updateModules,
-} from './hmr'
+import type { HmrOptions, NormalizedHotChannel } from './hmr'
+import { handleHMRUpdate, updateModules } from './hmr'
 import { openBrowser as _openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
@@ -281,7 +277,7 @@ export interface ViteDevServer {
    * An alias to `server.environments.client.hot`.
    * If you want to interact with all environments, loop over `server.environments`.
    */
-  hot: HotBroadcaster
+  hot: NormalizedHotChannel
   /**
    * Rollup plugin container that can run plugin hooks on a given file
    */
@@ -565,7 +561,7 @@ export async function _createServer(
     httpServer,
     watcher,
     ws,
-    hot: createDeprecatedHotBroadcaster(ws),
+    hot: ws,
 
     environments,
     pluginContainer,


### PR DESCRIPTION
### Description

~~built on top of #19987~~

This PR removes `HotBroadcaster` type and changes the type of `server.hot` to `NormalizedHotChannel`.

- 17db814298d8a1b49f45ab4844003b3d76cf3b61: simply reduces the code by using the fact that the number of channel is 1
- 9e7b2cf35c1f583c89b2f3853890b629683cf965: correct the comment. `server.hot` is more like an alias to `server.environments.client.hot` instead of a separate concept
- ad9baa37579f6a066d9136c4553efd584466585e: remove deprecated no-op `HotBroadcaster.addChannel` method
- ec6eb8edda3da0c6fe52f051e73b66ad0068da94: deprecate `HotBroadcaster.channels` property. `HotBroadcaster` is deprecated but `server.hot` is not deprecated, maybe users won't expect this property to be removed.
- 53b8bc1688ac4888f31eafc019afc426532631bd: remove `HotBroadcaster.channels` property. If removing this property directly without a deprecation phase, this commit can be included. I guess it's fine to remove it directly. It's always `[server.ws]` and easy to replace. While I found [`server.hot` used in many places](https://github.com/search?q=%2Fserver%5C.hot%5Cb%2F+NOT+is%3Afork&type=code), I only found [`hot.channels` used in a single place](https://github.com/search?q=%2F%5Cbhot%5C.channels%2F+NOT+is%3Afork&type=code).

I didn't deprecate `server.hot` as it's used in many places and keeping that won't be much burden.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
