### PR TITLE
feat: stabilize `css.preprocessorMaxWorkers` and default to `true`

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -280,11 +280,12 @@ export default defineConfig({
 
 ## css.preprocessorMaxWorkers
 
-- **Experimental:** [Give Feedback](https://github.com/vitejs/vite/discussions/15835)
 - **Type:** `number | true`
-- **Default:** `0` (does not create any workers and run in the main thread)
+- **Default:** `true`
 
-If this option is set, CSS preprocessors will run in workers when possible. `true` means the number of CPUs minus 1.
+Specifies how many threads CSS preprocessors will run on. `true` means the number of CPUs minus 1. When set to `0`, Vite will not create any workers and run the preprocessors in the main thread.
+
+Depending on the preprocessor options, Vite may run the preprocessors on the main thread even if this option is not set to `0`.
 
 ## css.devSourcemap
 

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -283,7 +283,7 @@ export default defineConfig({
 - **Type:** `number | true`
 - **Default:** `true`
 
-Specifies how many threads CSS preprocessors will run on. `true` means the number of CPUs minus 1. When set to `0`, Vite will not create any workers and run the preprocessors in the main thread.
+Specifies the maximum number of threads CSS preprocessors can use. `true` means up to the number of CPUs minus 1. When set to `0`, Vite will not create any workers and will run the preprocessors in the main thread.
 
 Depending on the preprocessor options, Vite may run the preprocessors on the main thread even if this option is not set to `0`.
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -144,8 +144,7 @@ export interface CSSOptions {
    * If this option is set, preprocessors will run in workers when possible.
    * `true` means the number of CPUs minus 1.
    *
-   * @default 0
-   * @experimental
+   * @default true
    */
   preprocessorMaxWorkers?: number | true
   postcss?:
@@ -199,8 +198,7 @@ export const cssConfigDefaults = Object.freeze({
   transformer: 'postcss',
   // modules
   // preprocessorOptions
-  /** @experimental */
-  preprocessorMaxWorkers: 0,
+  preprocessorMaxWorkers: true,
   // postcss
   /** @experimental */
   devSourcemap: false,


### PR DESCRIPTION
### Description

`css.preprocessorMaxWorkers` was introduced in Vite 5.1 by #13584.
I think we have collected enough issues and can stabilize it.

This PR also sets `css.preprocessorMaxWorkers` to be `true` by default (was `0`, disabled).

refs https://github.com/vitejs/vite/discussions/15835

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
