### PR TITLE
fix(cli): make `cleanGlobalCLIOptions()` clean `--force`

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -95,6 +95,7 @@ function cleanGlobalCLIOptions<Options extends GlobalCLIOptions>(
   delete ret.filter
   delete ret.m
   delete ret.mode
+  delete ret.force
   delete ret.w
 
   // convert the sourcemap option to a boolean if necessary


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Currently `cleanGlobalCLIOptions()` does not clean the `force` option, causing `server.options.server.force` to be set to true when using the `--force` flag, despite how `server.force` isn't supposed to be part of the API. [I've created a repo to easily demonstrate the issue here.](https://github.com/MoperMop/vite-force-bug)

It seems like at one point `server.force` was a part of the API, so not cleaning it was intentional. However, as the code evolved this was overlooked.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
