### PR TITLE
docs: provide `https` instead of `http`

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -15,7 +15,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
      server: {
        cors: {
          // the origin you will be accessing via browser
-         origin: 'http://my-backend.example.com',
+         origin: 'https://my-backend.example.com',
        },
      },
      build: {


### PR DESCRIPTION
Actually the url is given here is not `localhost`. This is like real domain. That's why I think we can provide here `https` instead of `http`... may be.