### PR TITLE
refactor: remove no-op `legacy.proxySsrExternalModules`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -513,17 +513,6 @@ export interface ExperimentalOptions {
 
 export interface LegacyOptions {
   /**
-   * In Vite 4, SSR-externalized modules (modules not bundled and loaded by Node.js at runtime)
-   * are implicitly proxied in dev to automatically handle `default` and `__esModule` access.
-   * However, this does not correctly reflect how it works in the Node.js runtime, causing
-   * inconsistencies between dev and prod.
-   *
-   * In Vite 5, the proxy is removed so dev and prod are consistent, but if you still require
-   * the old behaviour, you can enable this option. If so, please leave your feedback at
-   * https://github.com/vitejs/vite/discussions/14697.
-   */
-  proxySsrExternalModules?: boolean
-  /**
    * In Vite 6.0.8 and below, WebSocket server was able to connect from any web pages. However,
    * that could be exploited by a malicious web page.
    *
@@ -706,7 +695,6 @@ export const configDefaults = Object.freeze({
     removeSsrLoadModule: undefined,
   },
   legacy: {
-    proxySsrExternalModules: false,
     skipWebSocketTokenCheck: false,
   },
   logLevel: 'info',


### PR DESCRIPTION
### Description

It seems #16471 made `legacy.proxySsrExternalModules` option a no-op, but it wasn't removed.

refs #14521

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
