### PR TITLE
chore(gitattributes): mark `openChrome.applescript` as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
+# See https://git-scm.com/docs/gitattributes#_pattern_format for more about `.gitattributes`.
+
+# Normalize EOL for all files that Git considers text files
 * text=auto eol=lf
+
+packages/vite/bin/openChrome.applescript linguist-vendored


### PR DESCRIPTION
### Description

As far as I understand, this file was copied from somewhere else and pasted into this repository, so it's better to exclude it so that it doesn't appear in the list of languages ​​used in the project
