### PR TITLE
fix: importing an optional peer dep should throw an runtime error

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -282,15 +282,11 @@ module.exports = Object.create(new Proxy({}, {
       build.onLoad(
         { filter: /.*/, namespace: 'optional-peer-dep' },
         ({ path }) => {
-          if (isProduction) {
-            return {
-              contents: 'module.exports = {}',
-            }
-          } else {
-            const [, peerDep, parentDep] = path.split(':')
-            return {
-              contents: `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?\`)`,
-            }
+          const [, peerDep, parentDep] = path.split(':')
+          return {
+            contents:
+              'module.exports = {};' +
+              `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}".${isProduction ? '' : ' Is it installed?'}\`)`,
           }
         },
       )

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -488,12 +488,18 @@ export function resolvePlugin(
           }
         }
         if (id.startsWith(optionalPeerDepId)) {
-          if (isProduction) {
-            return `export default {}`
-          } else {
-            const [, peerDep, parentDep] = id.split(':')
-            return `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?\`)`
+          const [, peerDep, parentDep, isRequire] = id.split(':')
+          // rollup + @rollup/plugin-commonjs hoists dynamic `require`s by default
+          // If we add a `throw` statement, it will be injected to the top-level and break the whole bundle
+          // Instead, we mock the module for now
+          // This can be fixed when we migrate to rolldown
+          if (isRequire === 'true' && isProduction) {
+            return 'export default {}'
           }
+          return (
+            'export default {};' +
+            `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}".${isProduction ? '' : ' Is it installed?'}\`)`
+          )
         }
       },
     },
@@ -758,7 +764,7 @@ export function tryNodeResolve(
           mainPkg.peerDependenciesMeta?.[pkgName]?.optional
         ) {
           return {
-            id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,
+            id: `${optionalPeerDepId}:${id}:${mainPkg.name}:${!!options.isRequire}`,
           }
         }
       }

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -142,26 +142,28 @@ test('dep with optional peer dep', async () => {
   await expectWithRetry(() =>
     page.textContent('.dep-with-optional-peer-dep'),
   ).toMatch(`[success]`)
-  if (isServe) {
-    expect(browserErrors.map((error) => error.message)).toEqual(
-      expect.arrayContaining([
-        'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?',
-      ]),
-    )
-  }
+  await expectWithRetry(() =>
+    page.textContent('.dep-with-optional-peer-dep-error'),
+  ).toMatch(`[success]`)
 })
 
 test('dep with optional peer dep submodule', async () => {
   await expectWithRetry(() =>
     page.textContent('.dep-with-optional-peer-dep-submodule'),
   ).toMatch(`[success]`)
-  if (isServe) {
-    expect(browserErrors.map((error) => error.message)).toEqual(
-      expect.arrayContaining([
-        'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
-      ]),
-    )
-  }
+  await expectWithRetry(() =>
+    page.textContent('.dep-with-optional-peer-dep-submodule-error'),
+  ).toMatch(`[success]`)
+})
+
+test('dep with optional peer dep (cjs)', async () => {
+  await expectWithRetry(() =>
+    page.textContent('.dep-with-optional-peer-dep-cjs'),
+  ).toMatch(`[success]`)
+  // FIXME
+  // await expectWithRetry(() =>
+  //   page.textContent('.dep-with-optional-peer-dep-cjs-error'),
+  // ).toMatch(`[success]`)
 })
 
 test('dep with css import', async () => {

--- a/playground/optimize-deps/dep-with-optional-peer-dep-cjs/index.js
+++ b/playground/optimize-deps/dep-with-optional-peer-dep-cjs/index.js
@@ -1,0 +1,11 @@
+exports.callItself = function () {
+  return '[success]'
+}
+
+exports.callPeerDep = function () {
+  try {
+    return require('foobar')
+  } catch {
+    return 'fallback'
+  }
+}

--- a/playground/optimize-deps/dep-with-optional-peer-dep-cjs/package.json
+++ b/playground/optimize-deps/dep-with-optional-peer-dep-cjs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vitejs/test-dep-with-optional-peer-dep-cjs",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "peerDependencies": {
+    "foobar": "0.0.0"
+  },
+  "peerDependenciesMeta": {
+    "foobar": {
+      "optional": true
+    }
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -68,9 +68,15 @@
 
 <h2>Import from dependency with optional peer dep</h2>
 <div class="dep-with-optional-peer-dep"></div>
+<div class="dep-with-optional-peer-dep-error"></div>
 
 <h2>Import from dependency with optional peer dep submodule</h2>
 <div class="dep-with-optional-peer-dep-submodule"></div>
+<div class="dep-with-optional-peer-dep-submodule-error"></div>
+
+<h2>Import from dependency with optional peer dep (cjs)</h2>
+<div class="dep-with-optional-peer-dep-cjs"></div>
+<div class="dep-with-optional-peer-dep-cjs-error"></div>
 
 <h2>Externalize known non-js files in optimize included dep</h2>
 <div class="externalize-known-non-js"></div>
@@ -232,8 +238,20 @@
     callPeerDep,
   } from '@vitejs/test-dep-with-optional-peer-dep'
   text('.dep-with-optional-peer-dep', callItself())
+
   // expect error as optional peer dep not installed
-  callPeerDep()
+  callPeerDep().catch((e) => {
+    text(
+      '.dep-with-optional-peer-dep-error',
+      e &&
+        typeof e.message === 'string' &&
+        e.message.includes(
+          'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep".',
+        )
+        ? '[success]'
+        : `[failed]: ${e.message}`,
+    )
+  })
 </script>
 
 <script type="module">
@@ -242,8 +260,34 @@
     callPeerDepSubmodule,
   } from '@vitejs/test-dep-with-optional-peer-dep-submodule'
   text('.dep-with-optional-peer-dep-submodule', callItself())
+
   // expect error as optional peer dep not installed
-  callPeerDepSubmodule()
+  callPeerDepSubmodule().catch((e) => {
+    text(
+      '.dep-with-optional-peer-dep-submodule-error',
+      e &&
+        typeof e.message === 'string' &&
+        e.message.includes(
+          'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule".',
+        )
+        ? '[success]'
+        : `[failed]: ${e.message}`,
+    )
+  })
+</script>
+
+<script type="module">
+  import {
+    callItself,
+    callPeerDep,
+  } from '@vitejs/test-dep-with-optional-peer-dep-cjs'
+  text('.dep-with-optional-peer-dep-cjs', callItself())
+
+  // expect fallback as optional peer dep not installed
+  text(
+    '.dep-with-optional-peer-dep-cjs-error',
+    callPeerDep() === 'fallback' ? '[success]' : `[failed]: did not fallback`,
+  )
 </script>
 
 <script type="module">

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -37,6 +37,7 @@
     "@vitejs/test-dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "@vitejs/test-dep-with-dynamic-import": "file:./dep-with-dynamic-import",
     "@vitejs/test-dep-with-optional-peer-dep": "file:./dep-with-optional-peer-dep",
+    "@vitejs/test-dep-with-optional-peer-dep-cjs": "file:./dep-with-optional-peer-dep-cjs",
     "@vitejs/test-dep-with-optional-peer-dep-submodule": "file:./dep-with-optional-peer-dep-submodule",
     "@vitejs/test-dep-non-optimized": "file:./dep-non-optimized",
     "@vitejs/test-added-in-entries": "file:./added-in-entries",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1022,6 +1022,9 @@ importers:
       '@vitejs/test-dep-with-optional-peer-dep':
         specifier: file:./dep-with-optional-peer-dep
         version: file:playground/optimize-deps/dep-with-optional-peer-dep
+      '@vitejs/test-dep-with-optional-peer-dep-cjs':
+        specifier: file:./dep-with-optional-peer-dep-cjs
+        version: file:playground/optimize-deps/dep-with-optional-peer-dep-cjs
       '@vitejs/test-dep-with-optional-peer-dep-submodule':
         specifier: file:./dep-with-optional-peer-dep-submodule
         version: file:playground/optimize-deps/dep-with-optional-peer-dep-submodule
@@ -1154,6 +1157,8 @@ importers:
   playground/optimize-deps/dep-with-dynamic-import: {}
 
   playground/optimize-deps/dep-with-optional-peer-dep: {}
+
+  playground/optimize-deps/dep-with-optional-peer-dep-cjs: {}
 
   playground/optimize-deps/dep-with-optional-peer-dep-submodule: {}
 
@@ -3737,6 +3742,14 @@ packages:
 
   '@vitejs/test-dep-with-dynamic-import@file:playground/optimize-deps/dep-with-dynamic-import':
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
+
+  '@vitejs/test-dep-with-optional-peer-dep-cjs@file:playground/optimize-deps/dep-with-optional-peer-dep-cjs':
+    resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-cjs, type: directory}
+    peerDependencies:
+      foobar: 0.0.0
+    peerDependenciesMeta:
+      foobar:
+        optional: true
 
   '@vitejs/test-dep-with-optional-peer-dep-submodule@file:playground/optimize-deps/dep-with-optional-peer-dep-submodule':
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-submodule, type: directory}
@@ -9629,6 +9642,8 @@ snapshots:
   '@vitejs/test-dep-with-builtin-module-esm@file:playground/optimize-deps/dep-with-builtin-module-esm': {}
 
   '@vitejs/test-dep-with-dynamic-import@file:playground/optimize-deps/dep-with-dynamic-import': {}
+
+  '@vitejs/test-dep-with-optional-peer-dep-cjs@file:playground/optimize-deps/dep-with-optional-peer-dep-cjs': {}
 
   '@vitejs/test-dep-with-optional-peer-dep-submodule@file:playground/optimize-deps/dep-with-optional-peer-dep-submodule': {}
 


### PR DESCRIPTION
### Description

Currently `await import('optional-peer-dep')` and `require('optional-peer-dep')` does not throw an runtime error after bundling with Vite. This is caused by mocking the optional peer dep module (introduced by #9321).

Note: This current mocking behavior can be skipped by adding the module to `external` option.

While we still need to keep the module mocked for `require` (see comment in the code for details), we can make `await import('optional-peer-dep')` to throw an runtime error to align with the input behavior (although, `import 'optional-peer-dep'` should be an early error, not a runtime error).

refs #6007 #9321 https://github.com/vitejs/rolldown-vite/issues/165 https://github.com/rolldown/rolldown/issues/4051#issuecomment-2786052934

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
