### PR TITLE
docs: update `options.ssr` migration guide

### DIFF
--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -18,7 +18,7 @@ Affect scope: `Vite Plugin Authors`
 
 ## Migration Guide
 
-For the existing plugin to do a quick migration, replace the `options.ssr` argument with `this.environment.name !== 'client'` in the `resolveId`, `load` and `transform` hooks:
+For the existing plugin to do a quick migration, replace the `options.ssr` argument with `this.environment.config.consumer === 'server'` in the `resolveId`, `load` and `transform` hooks:
 
 ```ts
 import { Plugin } from 'vite'
@@ -28,7 +28,7 @@ export function myPlugin(): Plugin {
     name: 'my-plugin',
     resolveId(id, importer, options) {
       const isSSR = options.ssr // [!code --]
-      const isSSR = this.environment.name !== 'client' // [!code ++]
+      const isSSR = this.environment.config.consumer === 'server' // [!code ++]
 
       if (isSSR) {
         // SSR specific logic


### PR DESCRIPTION
### Description

Again while talking with @schiller-manuel, I noticed the migration guide is suggesting to replace `options.ssr` with `this.environment.name`, but we should recommend checkking `this.environment.config.consumer` instead as that's current back compat.

https://github.com/vitejs/vite/blob/f014b0fb5cc555941a7951e43437f1135e0f6520/packages/vite/src/node/server/pluginContainer.ts#L365

https://github.com/vitejs/vite/blob/f014b0fb5cc555941a7951e43437f1135e0f6520/packages/vite/src/node/build.ts#L1298-L1306