### PR TITLE
refactor!: remove `experimental.skipSsrTransform` option

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -501,14 +501,6 @@ export interface ExperimentalOptions {
    * @default false
    */
   hmrPartialAccept?: boolean
-  /**
-   * Skips SSR transform to make it easier to use Vite with Node ESM loaders.
-   * @warning Enabling this will break normal operation of Vite's SSR in development mode.
-   *
-   * @experimental
-   * @default false
-   */
-  skipSsrTransform?: boolean
 }
 
 export interface LegacyOptions {
@@ -695,7 +687,6 @@ export const configDefaults = Object.freeze({
     importGlobRestoreExtension: false,
     renderBuiltUrl: undefined,
     hmrPartialAccept: false,
-    skipSsrTransform: false,
   },
   future: {
     removePluginHookHandleHotUpdate: undefined,
@@ -744,8 +735,6 @@ export function resolveDevEnvironmentOptions(
   dev: DevEnvironmentOptions | undefined,
   environmentName: string | undefined,
   consumer: 'client' | 'server' | undefined,
-  // Backward compatibility
-  skipSsrTransform?: boolean,
   preTransformRequest?: boolean,
 ): ResolvedDevEnvironmentOptions {
   const resolved = mergeWithDefaults(
@@ -758,10 +747,7 @@ export function resolveDevEnvironmentOptions(
           ? defaultCreateClientDevEnvironment
           : defaultCreateDevEnvironment,
       recoverable: consumer === 'client',
-      moduleRunnerTransform:
-        skipSsrTransform !== undefined && consumer === 'server'
-          ? skipSsrTransform
-          : consumer === 'server',
+      moduleRunnerTransform: consumer === 'server',
     },
     dev ?? {},
   )
@@ -781,8 +767,6 @@ function resolveEnvironmentOptions(
   forceOptimizeDeps: boolean | undefined,
   logger: Logger,
   environmentName: string,
-  // Backward compatibility
-  skipSsrTransform?: boolean,
   isSsrTargetWebworkerSet?: boolean,
   preTransformRequests?: boolean,
 ): ResolvedEnvironmentOptions {
@@ -837,7 +821,6 @@ function resolveEnvironmentOptions(
       options.dev,
       environmentName,
       consumer,
-      skipSsrTransform,
       preTransformRequests,
     ),
     build: resolveBuildEnvironmentOptions(
@@ -1244,7 +1227,6 @@ export async function resolveConfig(
       inlineConfig.forceOptimizeDeps,
       logger,
       environmentName,
-      config.experimental?.skipSsrTransform,
       config.ssr?.target === 'webworker',
       config.server?.preTransformRequests,
     )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -735,6 +735,7 @@ export function resolveDevEnvironmentOptions(
   dev: DevEnvironmentOptions | undefined,
   environmentName: string | undefined,
   consumer: 'client' | 'server' | undefined,
+  // Backward compatibility
   preTransformRequest?: boolean,
 ): ResolvedDevEnvironmentOptions {
   const resolved = mergeWithDefaults(
@@ -767,6 +768,7 @@ function resolveEnvironmentOptions(
   forceOptimizeDeps: boolean | undefined,
   logger: Logger,
   environmentName: string,
+  // Backward compatibility
   isSsrTargetWebworkerSet?: boolean,
   preTransformRequests?: boolean,
 ): ResolvedEnvironmentOptions {


### PR DESCRIPTION
### Description

This PR removes `experimental.skipSsrTransform` option.
It is only used by `@vavite/node-loader` ([code search](https://github.com/search?q=skipSsrTransform+NOT+is%3Afork&type=code&p=1)) and that also doesn't work with Node 20+ (https://github.com/cyco130/vavite/issues/39).
We still have a way to experiment this by setting `environments.ssr.dev.moduleRunnerTransform: false`, so I think we can remove this option.

refs https://github.com/vitejs/vite/discussions/13812

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
