### PR TITLE
fix(client): render the last part of the stacktrace

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -280,6 +280,9 @@ export class ErrorOverlay extends HTMLElement {
         el.appendChild(link)
         curIndex += frag.length + file.length
       }
+      if (curIndex < text.length) {
+        el.appendChild(document.createTextNode(text.slice(curIndex)))
+      }
     }
   }
   close(): void {


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/e88fda8c-043b-4a44-9fb0-a8e6b8c62366)

This last `)` was not rendered on the overlay. This PR fixes that.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
