### PR TITLE
feat(client): support opening fileURL in editor

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -200,7 +200,7 @@ const createTemplate = () =>
     h('style', {}, templateStyle),
   )
 
-const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
+const fileRE = /(?:file:\/\/)?(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
 const codeframeRE = /^(?:>?\s*\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where


### PR DESCRIPTION
### Description

Before
![image](https://github.com/user-attachments/assets/431df271-994c-40ba-a1f4-c57bc13458a5)
After
![image](https://github.com/user-attachments/assets/b583c248-085a-4506-96ba-de1d4aa2368a)
The underline is set for the `file:` part.

This PR fixes the link, but the clicking the link does not open the file correctly right now. It requires https://github.com/yyx990803/launch-editor/pull/95 to be merged / released. But I think we can have this PR merged separately.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
