### PR TITLE
docs: clarify `build.minify` in `'es'` mode

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -234,7 +234,7 @@ During the SSR build, static assets aren't emitted as it is assumed they would b
 
 Set to `false` to disable minification, or specify the minifier to use. The default is [esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
 
-Note the `build.minify` option does not minify whitespaces when using the `'es'` format in lib mode, as it removes pure annotations and breaks tree-shaking.
+Note the `build.minify` option does not minify output when using the `'es'` format in lib mode. Minifying would remove pure annotations and break tree-shaking.
 
 Terser must be installed when it is set to `'terser'`.
 


### PR DESCRIPTION
`build.minify` doesn't minify at all in `'es'` mode.

See also #6555 and #6585.