### PR TITLE
fix: treat all `optimizeDeps.entries` values as globs

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -10,7 +10,7 @@ Unless noted, the options in this section are only applied to the dependency opt
 
 By default, Vite will crawl all your `.html` files to detect dependencies that need to be pre-bundled (ignoring `node_modules`, `build.outDir`, `__tests__` and `coverage`). If `build.rollupOptions.input` is specified, Vite will crawl those entry points instead.
 
-If neither of these fit your needs, you can specify custom entries using this option - the value should be a [`tinyglobby` pattern](https://github.com/SuperchupuDev/tinyglobby) or array of patterns that are relative from Vite project root. This will overwrite default entries inference. Only `node_modules` and `build.outDir` folders will be ignored by default when `optimizeDeps.entries` is explicitly defined. If other folders need to be ignored, you can use an ignore pattern as part of the entries list, marked with an initial `!`. If you don't want to ignore `node_modules` and `build.outDir`, you can specify using literal string paths (without `tinyglobby` patterns) instead.
+If neither of these fit your needs, you can specify custom entries using this option - the value should be a [`tinyglobby` pattern](https://github.com/SuperchupuDev/tinyglobby) or array of patterns that are relative from Vite project root. This will overwrite default entries inference. Only `node_modules` and `build.outDir` folders will be ignored by default when `optimizeDeps.entries` is explicitly defined. If other folders need to be ignored, you can use an ignore pattern as part of the entries list, marked with an initial `!`. `node_modules` will not be ignored for patterns that explicitly include the string `node_modules`.
 
 ## optimizeDeps.exclude
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -343,11 +343,11 @@ async function globEntries(
   const nodeModulesPatterns: string[] = []
   const regularPatterns: string[] = []
 
-  for (const entry of arraify(patterns)) {
-    if (entry.includes('node_modules')) {
-      nodeModulesPatterns.push(entry)
+  for (const pattern of arraify(patterns)) {
+    if (pattern.includes('node_modules')) {
+      nodeModulesPatterns.push(pattern)
     } else {
-      regularPatterns.push(entry)
+      regularPatterns.push(pattern)
     }
   }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -12,7 +12,7 @@ import type {
 import esbuild, { formatMessages, transform } from 'esbuild'
 import type { PartialResolvedId } from 'rollup'
 import colors from 'picocolors'
-import { glob, isDynamicPattern } from 'tinyglobby'
+import { glob } from 'tinyglobby'
 import {
   CSS_LANGS_RE,
   JS_TYPES_RE,
@@ -336,25 +336,42 @@ function orderedDependencies(deps: Record<string, string>) {
   return Object.fromEntries(depsList)
 }
 
-function globEntries(pattern: string | string[], environment: ScanEnvironment) {
-  const resolvedPatterns = arraify(pattern)
-  if (resolvedPatterns.every((str) => !isDynamicPattern(str))) {
-    return resolvedPatterns.map((p) =>
-      normalizePath(path.resolve(environment.config.root, p)),
-    )
+async function globEntries(
+  pattern: string | string[],
+  environment: ScanEnvironment,
+) {
+  const nodeModulesPatterns: string[] = []
+  const regularPatterns: string[] = []
+
+  for (const entry of arraify(pattern)) {
+    if (entry.includes('node_modules')) {
+      nodeModulesPatterns.push(entry)
+    } else {
+      regularPatterns.push(entry)
+    }
   }
-  return glob(pattern, {
+
+  const sharedOptions = {
     absolute: true,
     cwd: environment.config.root,
     ignore: [
-      '**/node_modules/**',
       `**/${environment.config.build.outDir}/**`,
       // if there aren't explicit entries, also ignore other common folders
       ...(environment.config.optimizeDeps.entries
         ? []
         : [`**/__tests__/**`, `**/coverage/**`]),
     ],
-  })
+  }
+
+  const results = await Promise.all([
+    glob(nodeModulesPatterns, sharedOptions),
+    glob(regularPatterns, {
+      ...sharedOptions,
+      ignore: [...sharedOptions.ignore, '**/node_modules/**'],
+    }),
+  ])
+
+  return results.flat()
 }
 
 export const scriptRE =

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -337,13 +337,13 @@ function orderedDependencies(deps: Record<string, string>) {
 }
 
 async function globEntries(
-  pattern: string | string[],
+  patterns: string | string[],
   environment: ScanEnvironment,
 ) {
   const nodeModulesPatterns: string[] = []
   const regularPatterns: string[] = []
 
-  for (const entry of arraify(pattern)) {
+  for (const entry of arraify(patterns)) {
     if (entry.includes('node_modules')) {
       nodeModulesPatterns.push(entry)
     } else {


### PR DESCRIPTION
### Description

This fixes an issue introduced in https://github.com/vitejs/vite/pull/15853 that meant globs containing `\\` could be treated as literals rather than globs. This would then lead the filesystem check here - https://github.com/vitejs/vite/blob/8679a43de710052c5c84bb6c253829ab999b040a/packages/vite/src/node/optimizer/scan.ts#L281 - to fail because the path would include `\`. It also improves upon the previous approach because entries explicitly including `node_modules` can now be used alongside other glob entries.

These changes mean that explicitly passing entries containing the environment's build output directory no longer work. It's not clear why this feature was introduced but if it would be considered breaking to remove it then I can add in the extra handling.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
