### PR TITLE
refactor: use the built-in `isBuiltin` to replace the `isNodeBuiltin`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -4,7 +4,7 @@ import fsp from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import { performance } from 'node:perf_hooks'
-import { createRequire } from 'node:module'
+import { createRequire, isBuiltin } from 'node:module'
 import crypto from 'node:crypto'
 import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'dep-types/alias'
@@ -66,7 +66,6 @@ import {
   isExternalUrl,
   isFilePathESM,
   isInNodeModules,
-  isNodeBuiltin,
   isNodeLikeBuiltin,
   isObject,
   isParentDirectory,
@@ -1927,12 +1926,12 @@ async function bundleConfigFile(
               if (
                 kind === 'entry-point' ||
                 path.isAbsolute(id) ||
-                isNodeBuiltin(id)
+                isBuiltin(id)
               ) {
                 return
               }
 
-              // With the `isNodeBuiltin` check above, this check captures if the builtin is a
+              // With the `isBuiltin` check above, this check captures if the builtin is a
               // non-node built-in, which esbuild doesn't know how to handle. In that case, we
               // externalize it so the non-node runtime handles it instead.
               if (isNodeLikeBuiltin(id)) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -144,11 +144,6 @@ export function isNodeLikeBuiltin(id: string): boolean {
   return isBuiltin(nodeLikeBuiltins, id)
 }
 
-export function isNodeBuiltin(id: string): boolean {
-  if (id.startsWith(NODE_BUILTIN_NAMESPACE)) return true
-  return nodeBuiltins.includes(id)
-}
-
 export function isInNodeModules(id: string): boolean {
   return id.includes('node_modules')
 }


### PR DESCRIPTION

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
Nodejs has supported `module.isBuiltin(moduleName)` since version 18.6.0. https://nodejs.org/docs/latest-v20.x/api/module.html#moduleisbuiltinmodulename