### PR TITLE
feat(create-vite): update target to es2023 in `tsconfig.node.json`

### DIFF
--- a/packages/create-vite/template-preact-ts/tsconfig.node.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/create-vite/template-qwik-ts/tsconfig.node.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/create-vite/template-react-ts/tsconfig.node.json
+++ b/packages/create-vite/template-react-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/create-vite/template-solid-ts/tsconfig.node.json
+++ b/packages/create-vite/template-solid-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/create-vite/template-svelte-ts/tsconfig.node.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,

--- a/packages/create-vite/template-vue-ts/tsconfig.node.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.node.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
+    "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,


### PR DESCRIPTION
### Description

Set `"target": "es2023"` in `tsconfig.node.json`.

Node 20+ supports ES2023.
https://node.green/#ES2023

`"target": "es2023"` behaves the same with `"target": "es2022"` (https://github.com/microsoft/TypeScript/issues/57683#issuecomment-1984715362) so this does not matter much, but this should be less confusing (#20056).

close #20056

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
