### PR TITLE
fix(optimizer): show error when `computeEntries` failed

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -200,11 +200,23 @@ export function createDepsOptimizer(
             try {
               debug?.(colors.green(`scanning for dependencies...`))
 
-              discover = discoverProjectDependencies(
-                devToScanEnvironment(environment),
-              )
-              const deps = await discover.result
-              discover = undefined
+              let deps: Record<string, string>
+              try {
+                discover = discoverProjectDependencies(
+                  devToScanEnvironment(environment),
+                )
+                deps = await discover.result
+                discover = undefined
+              } catch (e) {
+                environment.logger.error(
+                  colors.red(
+                    '(!) Failed to run dependency scan. ' +
+                      'Skipping dependency pre-bundling. ' +
+                      e.stack,
+                  ),
+                )
+                return
+              }
 
               const manuallyIncluded = Object.keys(manuallyIncludedDepsInfo)
               discoveredDepsWhileScanning.push(

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -178,7 +178,7 @@ export function scanImports(environment: ScanEnvironment): {
         if (e.errors && e.message.includes('The build was canceled')) {
           // esbuild logs an error when cancelling, but this is expected so
           // return an empty result instead
-          return { deps: {}, missing: {} }
+          return
         }
 
         const prependMessage = colors.red(`\

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -123,17 +123,17 @@ export function scanImports(environment: ScanEnvironment): {
   }>
 } {
   const start = performance.now()
-  const deps: Record<string, string> = {}
-  const missing: Record<string, string> = {}
-  let entries: string[]
-
   const { config } = environment
-  const scanContext = { cancelled: false }
-  const esbuildContext: Promise<BuildContext | undefined> = computeEntries(
-    environment,
-  ).then((computedEntries) => {
-    entries = computedEntries
 
+  const scanContext = { cancelled: false }
+  let esbuildContext: Promise<BuildContext | undefined> | undefined
+  async function cancel() {
+    scanContext.cancelled = true
+    return esbuildContext?.then((context) => context?.cancel())
+  }
+
+  async function scan() {
+    const entries = await computeEntries(environment)
     if (!entries.length) {
       if (!config.optimizeDeps.entries && !config.optimizeDeps.include) {
         environment.logger.warn(
@@ -153,82 +153,73 @@ export function scanImports(environment: ScanEnvironment): {
         .map((entry) => `\n  ${colors.dim(entry)}`)
         .join('')}`,
     )
-    return prepareEsbuildScanner(
-      environment,
-      entries,
-      deps,
-      missing,
-      scanContext,
-    )
-  })
+    const deps: Record<string, string> = {}
+    const missing: Record<string, string> = {}
 
-  const result = esbuildContext
-    .then((context) => {
-      function disposeContext() {
-        return context?.dispose().catch((e) => {
-          environment.logger.error('Failed to dispose esbuild context', {
-            error: e,
-          })
-        })
-      }
-      if (!context || scanContext.cancelled) {
-        disposeContext()
-        return { deps: {}, missing: {} }
-      }
-      return context
-        .rebuild()
-        .then(() => {
-          return {
-            // Ensure a fixed order so hashes are stable and improve logs
-            deps: orderedDependencies(deps),
-            missing,
-          }
-        })
-        .finally(() => {
-          return disposeContext()
-        })
-    })
-    .catch(async (e) => {
-      if (e.errors && e.message.includes('The build was canceled')) {
-        // esbuild logs an error when cancelling, but this is expected so
-        // return an empty result instead
-        return { deps: {}, missing: {} }
-      }
+    let context: BuildContext | undefined
+    try {
+      esbuildContext = prepareEsbuildScanner(
+        environment,
+        entries,
+        deps,
+        missing,
+      )
+      context = await esbuildContext
+      if (scanContext.cancelled) return
 
-      const prependMessage = colors.red(`\
+      try {
+        await context!.rebuild()
+        return {
+          // Ensure a fixed order so hashes are stable and improve logs
+          deps: orderedDependencies(deps),
+          missing,
+        }
+      } catch (e) {
+        if (e.errors && e.message.includes('The build was canceled')) {
+          // esbuild logs an error when cancelling, but this is expected so
+          // return an empty result instead
+          return { deps: {}, missing: {} }
+        }
+
+        const prependMessage = colors.red(`\
   Failed to scan for dependencies from entries:
   ${entries.join('\n')}
 
   `)
-      if (e.errors) {
-        const msgs = await formatMessages(e.errors, {
-          kind: 'error',
-          color: true,
+        if (e.errors) {
+          const msgs = await formatMessages(e.errors, {
+            kind: 'error',
+            color: true,
+          })
+          e.message = prependMessage + msgs.join('\n')
+        } else {
+          e.message = prependMessage + e.message
+        }
+        throw e
+      } finally {
+        if (debug) {
+          const duration = (performance.now() - start).toFixed(2)
+          const depsStr =
+            Object.keys(orderedDependencies(deps))
+              .sort()
+              .map((id) => `\n  ${colors.cyan(id)} -> ${colors.dim(deps[id])}`)
+              .join('') || colors.dim('no dependencies found')
+          debug(`Scan completed in ${duration}ms: ${depsStr}`)
+        }
+      }
+    } finally {
+      context?.dispose().catch((e) => {
+        environment.logger.error('Failed to dispose esbuild context', {
+          error: e,
         })
-        e.message = prependMessage + msgs.join('\n')
-      } else {
-        e.message = prependMessage + e.message
-      }
-      throw e
-    })
-    .finally(() => {
-      if (debug) {
-        const duration = (performance.now() - start).toFixed(2)
-        const depsStr =
-          Object.keys(orderedDependencies(deps))
-            .sort()
-            .map((id) => `\n  ${colors.cyan(id)} -> ${colors.dim(deps[id])}`)
-            .join('') || colors.dim('no dependencies found')
-        debug(`Scan completed in ${duration}ms: ${depsStr}`)
-      }
-    })
+      })
+    }
+  }
+  const result = scan()
 
   return {
-    cancel: async () => {
-      scanContext.cancelled = true
-      return esbuildContext.then((context) => context?.cancel())
-    },
-    result,
+    cancel,
+    result: result.then((res) => res ?? { deps: {}, missing: {} }),
   }
 }
 
@@ -283,10 +274,7 @@ async function prepareEsbuildScanner(
   entries: string[],
   deps: Record<string, string>,
   missing: Record<string, string>,
-  scanContext: { cancelled: boolean },
-): Promise<BuildContext | undefined> {
-  if (scanContext.cancelled) return
-
+): Promise<BuildContext> {
   const plugin = esbuildScanPlugin(environment, deps, missing, entries)
 
   const { plugins = [], ...esbuildOptions } =


### PR DESCRIPTION
### Description

When this `computeEntries` call errored, an error was happening during the error handling and was hiding the actual error.
https://github.com/vitejs/vite/blob/61b6b96b191c6071b9c574ad4c795f97f2646f18/packages/vite/src/node/optimizer/scan.ts#L132-L134
```
TypeError: Cannot read properties of undefined (reading 'join')
    at file:///D:/documents/GitHub/vite/packages/vite/dist/node/chunks/dep-BXs3190j.js:10726:13
    at file:///D:/documents/GitHub/vite/packages/vite/dist/node/chunks/dep-BXs3190j.js:34673:20
```

reproduction: https://stackblitz.com/edit/vitejs-vite-nte18shp?file=package.json,vite.config.js&terminal=dev

This PR fixes the error handling logic so that it doesn't hide the actual error. This PR **does not** fix the actual error (I'll do it in a separate PR).

reported at https://github.com/vitejs/vite/discussions/15834#discussioncomment-13207937

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
