### PR TITLE
docs: image svg element use href attribute

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -176,7 +176,7 @@ Assets referenced by HTML elements such as `<script type="module" src>` and `<li
 - `<audio src>`
 - `<embed src>`
 - `<img src>` and `<img srcset>`
-- `<image src>`
+- `<image href>` and `<image xlink:href>`
 - `<input src>`
 - `<link href>` and `<link imagesrcset>`
 - `<object data>`


### PR DESCRIPTION
### Description

`<image>` uses `href` attribute, not `src`

vite supports `<image href>` and image `<image xlink:href>` and doesn't support not `<image src>` https://stackblitz.com/edit/vitejs-vite-xjxwtx9y?file=index.html