### PR TITLE
perf(ssr): optimize `isCircularImport` algorithm for large codebases

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -150,47 +150,44 @@ export class ModuleRunner {
     return false
   }
 
-  private isCircularImport(
-    importers: Set<string>,
-    moduleUrl: string,
-  ) {
+  private isCircularImport(importers: Set<string>, moduleUrl: string) {
     // 0 = unvisited, 1 = visiting (on-stack), 2 = done (no cycle below)
-    const color = new Map<string, 0|1|2>();
-    color.set(moduleUrl, 1);
+    const color = new Map<string, 0 | 1 | 2>()
+    color.set(moduleUrl, 1)
 
     const dfs = (id: string): boolean => {
-      const mod = this.evaluatedModules.getModuleById(id);
+      const mod = this.evaluatedModules.getModuleById(id)
       if (!mod) {
-        color.set(id, 2);
-        return false;
+        color.set(id, 2)
+        return false
       }
 
       for (const imp of mod.importers) {
-        const c = color.get(imp) ?? 0;
-        if (c === 1) return true;
+        const c = color.get(imp) ?? 0
+        if (c === 1) return true
 
         if (c === 0) {
-          color.set(imp, 1);
-          if (dfs(imp)) return true;
+          color.set(imp, 1)
+          if (dfs(imp)) return true
         }
       }
 
-      color.set(id, 2);
-      return false;
-    };
+      color.set(id, 2)
+      return false
+    }
 
     for (const imp of importers) {
       if ((color.get(imp) ?? 0) === 0) {
-        color.set(imp, 1);
+        color.set(imp, 1)
 
         if (dfs(imp)) {
-          return true;
+          return true
         }
       }
     }
 
-    return false;
-  };
+    return false
+  }
 
   private async cachedRequest(
     url: string,

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -180,19 +180,9 @@ export class ModuleRunner {
         if (dfs(imp)) return true
       }
     }
+
     return false;
-    };
-    
-    for (const imp of importers) {
-      // if it hasn’t been visited, dive in
-      if ((color.get(imp) ?? 0) === 0) {
-        color.set(imp, 1);
-        if (dfs(imp)) return true;
-      }
-    }
-    
-    return false;
-  }
+  };
 
   private async cachedRequest(
     url: string,

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -160,16 +160,21 @@ export class ModuleRunner {
 
     const dfs = (id: string): boolean => {
       const mod = this.evaluatedModules.getModuleById(id);
-      if (!mod) { color.set(id, 2); return false; }
+      if (!mod) {
+        color.set(id, 2);
+        return false;
+      }
 
       for (const imp of mod.importers) {
         const c = color.get(imp) ?? 0;
-        if (c === 1) return true
+        if (c === 1) return true;
+
         if (c === 0) {
           color.set(imp, 1);
-          if (dfs(imp)) return true
+          if (dfs(imp)) return true;
         }
       }
+
       color.set(id, 2);
       return false;
     };
@@ -177,7 +182,10 @@ export class ModuleRunner {
     for (const imp of importers) {
       if ((color.get(imp) ?? 0) === 0) {
         color.set(imp, 1);
-        if (dfs(imp)) return true
+
+        if (dfs(imp)) {
+          return true;
+        }
       }
     }
 

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -154,15 +154,12 @@ export class ModuleRunner {
     importers: Set<string>,
     moduleUrl: string,
   ) {
-    // Union-Find data structure
     const parent = new Map<string, string>();
     const rank = new Map<string, number>();
-    
-    // Initialize with the target module
+
     parent.set(moduleUrl, moduleUrl);
     rank.set(moduleUrl, 0);
     
-    // Find with path compression
     const find = (x: string): string => {
       if (parent.get(x) !== x) {
         parent.set(x, find(parent.get(x)!));
@@ -170,15 +167,13 @@ export class ModuleRunner {
       return parent.get(x)!;
     };
     
-    // Union by rank
-    const union = (x: string, y: string): boolean => {
+    const unionByRank = (x: string, y: string): boolean => {
       const rootX = find(x);
       const rootY = find(y);
       
       if (rootX === rootY) {
-        console.log('Cycle detected!', x, y);
         return true;
-      } // Cycle detected!
+      }
       
       if (rank.get(rootX)! < rank.get(rootY)!) {
         parent.set(rootX, rootY);
@@ -198,8 +193,8 @@ export class ModuleRunner {
         rank.set(importer, 0);
       }
       
-      // If union returns true, we found a cycle
-      if (union(importer, moduleUrl)) {
+      // If unionByRank returns true, we found a circle
+      if (unionByRank(importer, moduleUrl)) {
         return true;
       }
       
@@ -211,7 +206,7 @@ export class ModuleRunner {
             parent.set(subImporter, subImporter);
             rank.set(subImporter, 0);
           }
-          if (union(subImporter, moduleUrl)) {
+          if (unionByRank(subImporter, moduleUrl)) {
             return true;
           }
         }


### PR DESCRIPTION
### Description

I swapped out the old recursive “visited” set for a simple 3-state map (unvisited, visiting, done) that walks each module only once. As soon as we hit a module marked “visiting,” we know there’s a cycle and bail out.

#### Why It Matters

1. Old code would re-scan big dependency trees many times
2. The single integer map tracks both “on the stack” and “already safe” status
3. Early exit on cycle means less wasted time/work
4. Startup time dropped noticeably in our big repo

fixes #20084