### PR TITLE
feat: add `this.meta.viteVersion`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -55,7 +55,6 @@ import {
   mergeWithDefaults,
   normalizePath,
   partialEncodeURIPath,
-  rollupVersion,
 } from './utils'
 import { perEnvironmentPlugin, resolveEnvironmentPlugins } from './plugin'
 import { manifestPlugin } from './plugins/manifest'
@@ -80,7 +79,10 @@ import {
 } from './baseEnvironment'
 import type { MinimalPluginContextWithoutEnvironment, Plugin } from './plugin'
 import type { RollupPluginHooks } from './typeUtils'
-import { BasicMinimalPluginContext } from './server/pluginContainer'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from './server/pluginContainer'
 
 export interface BuildEnvironmentOptions {
   /**
@@ -1269,6 +1271,7 @@ function injectEnvironmentInContext<Context extends MinimalPluginContext>(
   context: Context,
   environment: BuildEnvironment,
 ) {
+  context.meta.viteVersion ??= VERSION
   context.environment ??= environment
   return context
 }
@@ -1576,10 +1579,7 @@ export async function createBuilder(
     config,
     async buildApp() {
       const pluginContext = new BasicMinimalPluginContext(
-        {
-          rollupVersion,
-          watchMode: false,
-        },
+        { ...basePluginContextMeta, watchMode: false },
         config.logger,
       )
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -76,7 +76,6 @@ import {
   nodeLikeBuiltins,
   normalizeAlias,
   normalizePath,
-  rollupVersion,
 } from './utils'
 import {
   createPluginHookUtils,
@@ -104,7 +103,10 @@ import { PartialEnvironment } from './baseEnvironment'
 import { createIdResolver } from './idResolver'
 import { runnerImport } from './ssr/runnerImport'
 import { getAdditionalAllowedHosts } from './server/middlewares/hostCheck'
-import { BasicMinimalPluginContext } from './server/pluginContainer'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from './server/pluginContainer'
 
 const debug = createDebugger('vite:config', { depth: 10 })
 const promisifiedRealpath = promisify(fs.realpath)
@@ -1378,7 +1380,7 @@ export async function resolveConfig(
 
   const resolvedConfigContext = new BasicMinimalPluginContext(
     {
-      rollupVersion,
+      ...basePluginContextMeta,
       watchMode:
         (command === 'serve' && !isPreview) ||
         (command === 'build' && !!resolvedBuildOptions.watch),
@@ -2110,7 +2112,7 @@ async function runConfigHook(
   })
   const context = new BasicMinimalPluginContext<
     Omit<PluginContextMeta, 'watchMode'>
-  >({ rollupVersion }, tempLogger)
+  >(basePluginContextMeta, tempLogger)
 
   for (const p of getSortedPluginsByHook('config', plugins)) {
     const hook = p.config
@@ -2133,7 +2135,7 @@ async function runConfigEnvironmentHook(
 ): Promise<void> {
   const context = new BasicMinimalPluginContext<
     Omit<PluginContextMeta, 'watchMode'>
-  >({ rollupVersion }, logger)
+  >(basePluginContextMeta, logger)
 
   const environmentNames = Object.keys(environments)
   for (const p of getSortedPluginsByHook('configEnvironment', plugins)) {

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -63,6 +63,10 @@ export interface PluginContextExtension {
   environment: Environment
 }
 
+export interface PluginContextMetaExtension {
+  viteVersion: string
+}
+
 export interface ConfigPluginContext
   extends Omit<MinimalPluginContext, 'meta' | 'environment'> {
   meta: Omit<PluginContextMeta, 'watchMode'>
@@ -74,6 +78,7 @@ export interface MinimalPluginContextWithoutEnvironment
 // Augment Rollup types to have the PluginContextExtension
 declare module 'rollup' {
   export interface MinimalPluginContext extends PluginContextExtension {}
+  export interface PluginContextMeta extends PluginContextMetaExtension {}
 }
 
 /**

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -28,7 +28,6 @@ import {
   getServerUrlByHost,
   resolveHostname,
   resolveServerUrls,
-  rollupVersion,
   setupSIGTERMListener,
   shouldServeFile,
   teardownSIGTERMListener,
@@ -41,7 +40,10 @@ import type { InlineConfig, ResolvedConfig } from './config'
 import { DEFAULT_PREVIEW_PORT } from './constants'
 import type { RequiredExceptFor } from './typeUtils'
 import { hostValidationMiddleware } from './server/middlewares/hostCheck'
-import { BasicMinimalPluginContext } from './server/pluginContainer'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from './server/pluginContainer'
 import type { MinimalPluginContextWithoutEnvironment } from './plugin'
 
 export interface PreviewOptions extends CommonServerOptions {}
@@ -195,10 +197,7 @@ export async function preview(
 
   // apply server hooks from plugins
   const configurePreviewServerContext = new BasicMinimalPluginContext(
-    {
-      rollupVersion,
-      watchMode: false,
-    },
+    { ...basePluginContextMeta, watchMode: false },
     config.logger,
   )
   const postHooks: ((() => void) | void)[] = []

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -10,12 +10,7 @@ import type {
   InvokeSendData,
 } from '../../shared/invokeMethods'
 import { CLIENT_DIR } from '../constants'
-import {
-  createDebugger,
-  isCSSRequest,
-  normalizePath,
-  rollupVersion,
-} from '../utils'
+import { createDebugger, isCSSRequest, normalizePath } from '../utils'
 import type { InferCustomEventPayload, ViteDevServer } from '..'
 import { getHookHandler } from '../plugins'
 import { isExplicitImportRequired } from '../plugins/importAnalysis'
@@ -31,7 +26,10 @@ import type { EnvironmentModuleNode } from './moduleGraph'
 import type { ModuleNode } from './mixedModuleGraph'
 import type { DevEnvironment } from './environment'
 import { prepareError } from './middlewares/error'
-import { BasicMinimalPluginContext } from './pluginContainer'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from './pluginContainer'
 import type { HttpServer } from '.'
 import { restartServerWithUrls } from '.'
 
@@ -455,10 +453,7 @@ export async function handleHMRUpdate(
   }
 
   const contextForHandleHotUpdate = new BasicMinimalPluginContext(
-    {
-      rollupVersion,
-      watchMode: true,
-    },
+    { ...basePluginContextMeta, watchMode: true },
     config.logger,
   )
   const clientEnvironment = server.environments.client

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -35,7 +35,6 @@ import {
   normalizePath,
   resolveHostname,
   resolveServerUrls,
-  rollupVersion,
   setupSIGTERMListener,
   teardownSIGTERMListener,
 } from '../utils'
@@ -68,6 +67,7 @@ import type { PluginContainer } from './pluginContainer'
 import {
   BasicMinimalPluginContext,
   ERR_CLOSED_SERVER,
+  basePluginContextMeta,
   createPluginContainer,
 } from './pluginContainer'
 import type { WebSocketServer } from './ws'
@@ -861,10 +861,7 @@ export async function _createServer(
 
   // apply server configuration hooks from plugins
   const configureServerContext = new BasicMinimalPluginContext(
-    {
-      rollupVersion,
-      watchMode: true,
-    },
+    { ...basePluginContextMeta, watchMode: true },
     config.logger,
   )
   const postHooks: ((() => void) | void)[] = []

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -38,14 +38,16 @@ import {
   joinUrlSegments,
   normalizePath,
   processSrcSetSync,
-  rollupVersion,
   stripBase,
 } from '../../utils'
 import { checkPublicFile } from '../../publicDir'
 import { getCodeWithSourcemap, injectSourcesContent } from '../sourcemap'
 import { cleanUrl, unwrapId, wrapId } from '../../../shared/utils'
 import { getNodeAssetAttributes } from '../../assetSource'
-import { BasicMinimalPluginContext } from '../pluginContainer'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from '../pluginContainer'
 
 interface AssetNode {
   start: number
@@ -82,7 +84,7 @@ export function createDevHtmlTransformFn(
     postImportMapHook(),
   ]
   const pluginContext = new BasicMinimalPluginContext(
-    { rollupVersion, watchMode: true },
+    { ...basePluginContextMeta, watchMode: true },
     config.logger,
   )
   return (

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -77,7 +77,7 @@ import {
   rollupVersion,
   timeFrom,
 } from '../utils'
-import { FS_PREFIX } from '../constants'
+import { FS_PREFIX, VERSION as viteVersion } from '../constants'
 import {
   createPluginHookUtils,
   getCachedFilterForPlugin,
@@ -196,7 +196,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   ) {
     this._started = !autoStart
     this.minimalContext = new MinimalPluginContext(
-      { rollupVersion, watchMode: true },
+      { ...basePluginContextMeta, watchMode: true },
       environment,
     )
     const utils = createPluginHookUtils(plugins)
@@ -558,6 +558,11 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
       () => [],
     )
   }
+}
+
+export const basePluginContextMeta = {
+  viteVersion,
+  rollupVersion,
 }
 
 export class BasicMinimalPluginContext<Meta = PluginContextMeta> {


### PR DESCRIPTION
### Description

~~_Built on top of #19936_~~

This PR adds `this.meta.viteVersion`. This would allow plugins to get the version of Vite the dev server / build is running. It is slightly different from `import { VERSION } from 'vite'` as that would resolve to the dependency of that plugin.

Rollup has `this.meta.rollupVersion` and Rolldown has `this.meta.rolldownVersion`.

close #19355

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
