### PR TITLE
chore: group rolldown related deps for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,10 @@
       "excludePackagePrefixes": ["actions/", "github/"],
       "pinDigests": true,
     },
+    {
+      "groupName": "rolldown-related dependencies",
+      "matchDepNames": ["rolldown", "rolldown-plugin-dts", "tsdown"],
+    },
   ],
   "ignoreDeps": [
     // manually bumping
@@ -22,6 +26,8 @@
     "node",
     "typescript",
     "@rollup/plugin-dynamic-import-vars", // prefer version using tinyglobby
+    "@oxc-project/runtime", // align version with rolldown
+    "@oxc-project/types", // align version with rolldown
 
     // pinned
     "slash3",


### PR DESCRIPTION
### Description

Grouped rolldown related deps for renovate as these may have some peer dep requirements.
Also ignored `@oxc-project/*` deps as these should be synced with rolldown's peer dep and renovate does not handle them.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
