### PR TITLE
feat: resolve environments plugins at config time

### DIFF
--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -116,7 +116,7 @@ export class PartialEnvironment {
 }
 
 export class BaseEnvironment extends PartialEnvironment {
-  get plugins(): Plugin[] {
+  get plugins(): readonly Plugin[] {
     return this.config.plugins
   }
 

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -20,6 +20,7 @@ export function getDefaultResolvedEnvironmentOptions(
     optimizeDeps: config.optimizeDeps,
     dev: config.dev,
     build: config.build,
+    plugins: config.plugins,
   }
 }
 

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -10,20 +10,6 @@ const environmentColors = [
   colors.gray,
 ]
 
-export function getDefaultResolvedEnvironmentOptions(
-  config: ResolvedConfig,
-): ResolvedEnvironmentOptions {
-  return {
-    define: config.define,
-    resolve: config.resolve,
-    consumer: 'server',
-    optimizeDeps: config.optimizeDeps,
-    dev: config.dev,
-    build: config.build,
-    plugins: config.plugins,
-  }
-}
-
 export class PartialEnvironment {
   name: string
   getTopLevelConfig(): ResolvedConfig {

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -116,17 +116,9 @@ export class PartialEnvironment {
 
 export class BaseEnvironment extends PartialEnvironment {
   get plugins(): Plugin[] {
-    if (!this._plugins)
-      throw new Error(
-        `${this.name} environment.plugins called before initialized`,
-      )
-    return this._plugins
+    return this.config.plugins
   }
 
-  /**
-   * @internal
-   */
-  _plugins: Plugin[] | undefined
   /**
    * @internal
    */

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -56,7 +56,7 @@ import {
   normalizePath,
   partialEncodeURIPath,
 } from './utils'
-import { perEnvironmentPlugin, resolveEnvironmentPlugins } from './plugin'
+import { perEnvironmentPlugin } from './plugin'
 import { manifestPlugin } from './plugins/manifest'
 import type { Logger } from './logger'
 import { dataURIPlugin } from './plugins/dataUri'
@@ -1499,7 +1499,6 @@ export class BuildEnvironment extends BaseEnvironment {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
   }
 }
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -73,10 +73,7 @@ import {
 import { completeSystemWrapPlugin } from './plugins/completeSystemWrap'
 import { webWorkerPostPlugin } from './plugins/worker'
 import { getHookHandler } from './plugins'
-import {
-  BaseEnvironment,
-  getDefaultResolvedEnvironmentOptions,
-} from './baseEnvironment'
+import { BaseEnvironment } from './baseEnvironment'
 import type { MinimalPluginContextWithoutEnvironment, Plugin } from './plugin'
 import type { RollupPluginHooks } from './typeUtils'
 import {
@@ -1483,8 +1480,10 @@ export class BuildEnvironment extends BaseEnvironment {
       options?: EnvironmentOptions
     },
   ) {
-    let options =
-      config.environments[name] ?? getDefaultResolvedEnvironmentOptions(config)
+    let options = config.environments[name]
+    if (!options) {
+      throw new Error(`Environment "${name}" is not defined in the config.`)
+    }
     if (setup?.options) {
       options = mergeConfig(
         options,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -295,7 +295,7 @@ export type ResolvedEnvironmentOptions = {
   optimizeDeps: DepOptimizationOptions
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
-  plugins: Plugin[]
+  plugins: readonly Plugin[]
 }
 
 export type DefaultEnvironmentOptions = Omit<

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -852,7 +852,7 @@ function resolveEnvironmentOptions(
       logger,
       consumer,
     ),
-    plugins: undefined as any, // to be resolved later
+    plugins: undefined!, // to be resolved later
   }
 }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1449,7 +1449,7 @@ export async function resolveConfig(
       workerPostPlugins,
     )
 
-    // During Build the client environment is used to bundler the worker
+    // During Build the client environment is used to bundle the worker
     // Avoid overriding the mainConfig (resolved.environments.client)
     ;(workerResolved.environments as Record<
       string,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -25,6 +25,7 @@ import {
   ENV_ENTRY,
   FS_PREFIX,
 } from './constants'
+import { resolveEnvironmentPlugins } from './plugin'
 import type {
   FalsyPlugin,
   HookHandler,
@@ -294,6 +295,7 @@ export type ResolvedEnvironmentOptions = {
   optimizeDeps: DepOptimizationOptions
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
+  plugins: Plugin[]
 }
 
 export type DefaultEnvironmentOptions = Omit<
@@ -850,6 +852,7 @@ function resolveEnvironmentOptions(
       logger,
       consumer,
     ),
+    plugins: undefined as any, // to be resolved later
   }
 }
 
@@ -1603,6 +1606,12 @@ export async function resolveConfig(
 
   // TODO: Deprecate config.getSortedPlugins and config.getSortedPluginHooks
   Object.assign(resolved, createPluginHookUtils(resolved.plugins))
+
+  for (const name of Object.keys(resolved.environments)) {
+    resolved.environments[name].plugins = await resolveEnvironmentPlugins(
+      new PartialEnvironment(name, resolved),
+    )
+  }
 
   // call configResolved hooks
   await Promise.all(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1453,10 +1453,20 @@ export async function resolveConfig(
         .getSortedPluginHooks('configResolved')
         .map((hook) => hook.call(resolvedConfigContext, workerResolved)),
     )
+    ;(workerResolved.plugins as Plugin[]) = resolvedWorkerPlugins
 
     return {
       ...workerResolved,
-      plugins: resolvedWorkerPlugins,
+      environments: {
+        ...workerResolved.environments,
+        // During Build the client environment is used to bundler the worker
+        client: {
+          ...workerResolved.environments.client,
+          plugins: await resolveEnvironmentPlugins(
+            new PartialEnvironment('client', workerResolved),
+          ),
+        },
+      },
     }
   }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -34,7 +34,6 @@ import {
   virtualModulePrefix,
   virtualModuleRE,
 } from '../utils'
-import { resolveEnvironmentPlugins } from '../plugin'
 import type { EnvironmentPluginContainer } from '../server/pluginContainer'
 import { createEnvironmentPluginContainer } from '../server/pluginContainer'
 import { BaseEnvironment } from '../baseEnvironment'
@@ -63,7 +62,6 @@ export class ScanEnvironment extends BaseEnvironment {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this.plugins,

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -1,10 +1,7 @@
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
 import type { FSWatcher } from 'dep-types/chokidar'
 import colors from 'picocolors'
-import {
-  BaseEnvironment,
-  getDefaultResolvedEnvironmentOptions,
-} from '../baseEnvironment'
+import { BaseEnvironment } from '../baseEnvironment'
 import type {
   EnvironmentOptions,
   ResolvedConfig,
@@ -101,8 +98,10 @@ export class DevEnvironment extends BaseEnvironment {
     config: ResolvedConfig,
     context: DevEnvironmentContext,
   ) {
-    let options =
-      config.environments[name] ?? getDefaultResolvedEnvironmentOptions(config)
+    let options = config.environments[name]
+    if (!options) {
+      throw new Error(`Environment "${name}" is not defined in the config.`)
+    }
     if (context.options) {
       options = mergeConfig(
         options,

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -18,7 +18,6 @@ import {
   createDepsOptimizer,
   createExplicitDepsOptimizer,
 } from '../optimizer/optimizer'
-import { resolveEnvironmentPlugins } from '../plugin'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
 import { promiseWithResolvers } from '../../shared/utils'
 import type { ViteDevServer } from '../server'
@@ -172,10 +171,9 @@ export class DevEnvironment extends BaseEnvironment {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
-      this._plugins,
+      this.config.plugins,
       options?.watcher,
     )
   }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -141,7 +141,7 @@ export async function createEnvironmentPluginContainer<
   Env extends Environment = Environment,
 >(
   environment: Env,
-  plugins: Plugin[],
+  plugins: readonly Plugin[],
   watcher?: FSWatcher,
   autoStart = true,
 ): Promise<EnvironmentPluginContainer<Env>> {
@@ -190,7 +190,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
    */
   constructor(
     public environment: Env,
-    public plugins: Plugin[],
+    public plugins: readonly Plugin[],
     public watcher?: FSWatcher,
     autoStart = true,
   ) {


### PR DESCRIPTION
### Description

We recently discussed with @dominikg about environment plugins resolutions and he asked how to access the resolved plugins for a given environment. These are currently present at `environment.plugins` once the instance are inited. So during dev, there is the need to wait after server listen.

We decided to pass a `PartialEnvironment` to `applyToEnvironment` to avoid committing to resolving the plugins after the Environment instance are created, and leave the door open to move the resolution to config time. This PR explores this change.

The benefits are:
- The plugins for each environments are available at `resolvedConfig.environments[name].plugins`.
- `configResolved` can be used to read this values.
- vite-plugin-inspect et al would be easier to implement.
- Align with the way `config.plugins` always worked (they are fixed at config time, not after the server is created)
- Easier to explain

The main difference with creating the plugins in the Environment instance is that if two Environments are created with the same config, they will share the environment plugins after this PR. We only allow a single server per ResolvedConfig, and we should do the same for Environments so this doesn't seems like an issue to me.