### PR TITLE
fix(types): expose additional PluginContext types

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -97,7 +97,13 @@ export type {
   DevEnvironmentOptions,
   ResolvedDevEnvironmentOptions,
 } from './config'
-export type { Plugin, PluginOption, HookHandler } from './plugin'
+export type {
+  Plugin,
+  PluginOption,
+  HookHandler,
+  ConfigPluginContext,
+  MinimalPluginContextWithoutEnvironment,
+} from './plugin'
 export type { Environment } from './environment'
 export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'


### PR DESCRIPTION
### Description

This PR exposes `ConfigPluginContext` type and `MinimalPluginContextWithoutEnvironment` type.
This PR will fix this ecosystem-ci failure by allowing the emitted type definition to use these types.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15291891294/job/43012757738#step:8:759

refs #19936

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
