### PR TITLE
feat(create-vite): set types compiler option in tsconfigs

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -62,10 +62,14 @@ if (import.meta.hot) {
 
 ## IntelliSense for TypeScript
 
-Vite provides type definitions for `import.meta.hot` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). You can create an `vite-env.d.ts` in the `src` directory so TypeScript picks up the type definitions:
+Vite provides type definitions for `import.meta.hot` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). You can add "vite/client" in the `tsconfig` so TypeScript picks up the type definitions:
 
-```ts [vite-env.d.ts]
-/// <reference types="vite/client" />
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "types": ["vite/client"]
+  }
+}
 ```
 
 ## `hot.accept(cb)`

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -62,7 +62,7 @@ if (import.meta.hot) {
 
 ## IntelliSense for TypeScript
 
-Vite provides type definitions for `import.meta.hot` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). You can add "vite/client" in the `tsconfig` so TypeScript picks up the type definitions:
+Vite provides type definitions for `import.meta.hot` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). You can add "vite/client" in the `tsconfig.json` so TypeScript picks up the type definitions:
 
 ```json [tsconfig.json]
 {

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -106,8 +106,6 @@ By default, Vite provides type definitions for `import.meta.env` in [`vite/clien
 To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augment `ImportMetaEnv` like this:
 
 ```typescript [vite-env.d.ts]
-/// <reference types="vite/client" />
-
 interface ViteTypeOptions {
   // By adding this line, you can make the type of ImportMetaEnv strict
   // to disallow unknown keys.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -153,12 +153,10 @@ For example, to make the default import of `*.svg` a React component:
     export default content
   }
   ```
-- If you are using `compilerOptions.types`, update `tsconfig.json` to include your override file:
+- If you are using `compilerOptions.types`, ensure the file is included in `tsconfig.json`:
   ```json [tsconfig.json]
   {
-    "compilerOptions": {
-      "types": ["./vite-env-override.d.ts", "vite/client"]
-    }
+    "include": ["src", "./vite-env-override.d.ts"]
   }
   ```
 - If you are using triple-slash directives, update the file containing the reference to `vite/client` (normally `vite-env.d.ts`):

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -125,9 +125,9 @@ Vite's default types are for its Node.js API. To shim the environment of client-
 
 Note that if [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig#types) is specified, only these packages will be included in the global scope (instead of all visible ”@types” packages). This is recommended since TS 5.9.
 
-Alternatively, you can add a `d.ts` declaration file:
-
 ::: details Using triple-slash directive
+
+Alternatively, you can add a `d.ts` declaration file:
 
 ```typescript [vite-env.d.ts]
 /// <reference types="vite/client" />

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -113,15 +113,7 @@ Vite starter templates have `"skipLibCheck": "true"` by default to avoid typeche
 
 ### Client Types
 
-Vite's default types are for its Node.js API. To shim the environment of client-side code in a Vite application, add a `d.ts` declaration file:
-
-```typescript
-/// <reference types="vite/client" />
-```
-
-::: details Using `compilerOptions.types`
-
-Alternatively, you can add `vite/client` to `compilerOptions.types` inside `tsconfig.json`:
+Vite's default types are for its Node.js API. To shim the environment of client-side code in a Vite application, you can add `vite/client` to `compilerOptions.types` inside `tsconfig.json`:
 
 ```json [tsconfig.json]
 {
@@ -131,7 +123,15 @@ Alternatively, you can add `vite/client` to `compilerOptions.types` inside `tsco
 }
 ```
 
-Note that if [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig#types) is specified, only these packages will be included in the global scope (instead of all visible ”@types” packages).
+Note that if [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig#types) is specified, only these packages will be included in the global scope (instead of all visible ”@types” packages). This is recommended since TS 5.9.
+
+Alternatively, you can add a `d.ts` declaration file:
+
+::: details Using triple-slash directive
+
+```typescript [vite-env.d.ts]
+/// <reference types="vite/client" />
+```
 
 :::
 
@@ -153,7 +153,15 @@ For example, to make the default import of `*.svg` a React component:
     export default content
   }
   ```
-- The file containing the reference to `vite/client` (normally `vite-env.d.ts`):
+- If you are using `compilerOptions.types`, update `tsconfig.json` to include your override file:
+  ```json [tsconfig.json]
+  {
+    "compilerOptions": {
+      "types": ["./vite-env-override.d.ts", "vite/client"]
+    }
+  }
+  ```
+- If you are using triple-slash directives, update the file containing the reference to `vite/client` (normally `vite-env.d.ts`):
   ```ts
   /// <reference types="./vite-env-override.d.ts" />
   /// <reference types="vite/client" />

--- a/packages/create-vite/template-lit-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-lit-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-lit-ts/tsconfig.json
+++ b/packages/create-vite/template-lit-ts/tsconfig.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": false,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-preact-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-preact-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-preact-ts/tsconfig.app.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.app.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],

--- a/packages/create-vite/template-preact-ts/tsconfig.node.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-qwik-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-qwik-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-qwik-ts/tsconfig.app.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.app.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-qwik-ts/tsconfig.node.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-qwik/src/vite-env.d.ts
+++ b/packages/create-vite/template-qwik/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-react-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-react-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-react-ts/tsconfig.app.json
+++ b/packages/create-vite/template-react-ts/tsconfig.app.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-react-ts/tsconfig.node.json
+++ b/packages/create-vite/template-react-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-solid-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-solid-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-solid-ts/tsconfig.app.json
+++ b/packages/create-vite/template-solid-ts/tsconfig.app.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-solid-ts/tsconfig.node.json
+++ b/packages/create-vite/template-solid-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-svelte-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-svelte-ts/src/vite-env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="svelte" />
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-svelte-ts/tsconfig.app.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.app.json
@@ -5,7 +5,7 @@
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["svelte", "vite/client"],
     "noEmit": true,
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/create-vite/template-svelte-ts/tsconfig.app.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",

--- a/packages/create-vite/template-svelte-ts/tsconfig.app.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.app.json
@@ -1,10 +1,12 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "resolveJsonModule": true,
+    "types": ["vite/client"],
+    "noEmit": true,
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.
      * Disable checkJs if you'd like to use dynamic types in JS.
@@ -13,7 +15,6 @@
      */
     "allowJs": true,
     "checkJs": true,
-    "isolatedModules": true,
     "moduleDetection": "force"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]

--- a/packages/create-vite/template-svelte-ts/tsconfig.node.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-svelte/README.md
+++ b/packages/create-vite/template-svelte/README.md
@@ -21,10 +21,6 @@ This template contains as little as possible to get started with Vite + Svelte, 
 
 Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
 
-**Why `global.d.ts` instead of `compilerOptions.types` inside `jsconfig.json` or `tsconfig.json`?**
-
-Setting `compilerOptions.types` shuts out all other types not explicitly listed in the configuration. Using triple-slash references keeps the default TypeScript setting of accepting type information from the entire workspace, while also adding `svelte` and `vite/client` type information.
-
 **Why include `.vscode/extensions.json`?**
 
 Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.

--- a/packages/create-vite/template-svelte/jsconfig.json
+++ b/packages/create-vite/template-svelte/jsconfig.json
@@ -17,6 +17,7 @@
      */
     "sourceMap": true,
     "esModuleInterop": true,
+    "types": ["vite/client"],
     "skipLibCheck": true,
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/create-vite/template-svelte/src/vite-env.d.ts
+++ b/packages/create-vite/template-svelte/src/vite-env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="svelte" />
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-vanilla-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-vanilla-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-vanilla-ts/tsconfig.json
+++ b/packages/create-vite/template-vanilla-ts/tsconfig.json
@@ -4,6 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/packages/create-vite/template-vue-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-vue-ts/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/packages/create-vite/template-vue-ts/tsconfig.app.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "types": ["vite/client"],
 
     /* Linting */
     "strict": true,

--- a/packages/create-vite/template-vue-ts/tsconfig.node.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.node.json
@@ -4,6 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "types": [],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
It will be the default in the next [`tsc --init`](https://github.com/microsoft/TypeScript/issues/58420#issuecomment-2919996436), and I think we should do too. See https://github.com/vitejs/vite/pull/20131 for impact once the codebase grows.

The shared config in the vue template already sets it.

I updated the svelte one to include previous changes (isolatedModules is implied by the bundler mode in the shared config)