### PR TITLE
docs(rolldown): fix regex pattern in withFilter example for SVG imports

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -126,7 +126,7 @@ export default defineConfig({
       svgr({
         /*...*/
       }),
-      { load: { id: /\.svg?react$/ } },
+      { load: { id: /\.svg\?react$/ } },
     ),
   ],
 })


### PR DESCRIPTION
### Description

This PR fixes an incorrect regex pattern in the `docs/guide/rolldown.md` documentation example for `withFilter` with SVG imports.

**Problem**: The current example uses `/\.svg?react$/` where the `?` is treated as a regex quantifier (0 or 1 `v` characters) instead of matching the literal `?react` query parameter. This causes the filter to match unintended patterns like `logo.sgreact` or `logo.svgreact` but fails to match the actual `logo.svg?react` imports.

**Solution**: Escape the question mark to `/\.svg\?react$/` to correctly match the literal `?react` query parameter.

**Impact**: 
- Developers following the documentation will now have working code
- Prevents confusion about why SVG imports with `?react` aren't being processed correctly
- Ensures the withFilter example functions as intended

**Alternatives explored**: 
- Could use `include: '**/*.svg?react'` in svgr options instead of withFilter, but the documentation example should still be correct
- Could mention both approaches in the docs

**Areas for review attention**:
- Verify the regex pattern is correct
- Check if there are other similar patterns in the codebase that need fixing