### PR TITLE
test: correct esbuild `useDefineForClassFields` test

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -1,9 +1,11 @@
+import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import type { ResolvedConfig, UserConfig } from '../../config'
 import {
   resolveEsbuildTranspileOptions,
   transformWithEsbuild,
 } from '../../plugins/esbuild'
+import { normalizePath } from '../../utils'
 
 describe('resolveEsbuildTranspileOptions', () => {
   test('resolve default', () => {
@@ -326,7 +328,7 @@ describe('transformWithEsbuild', () => {
             bar = 'bar'
           }
         `,
-        'bar.ts',
+        normalizePath(path.resolve(import.meta.dirname, 'bar.ts')),
         {
           target,
           tsconfigRaw: { compilerOptions: tsconfigCompilerOptions },
@@ -387,7 +389,9 @@ describe('transformWithEsbuild', () => {
     })
 
     test('target: es2022 and tsconfig.target: undefined => false', async () => {
-      const actual = await transformClassCode('es2022', {})
+      const actual = await transformClassCode('es2022', {
+        target: undefined,
+      })
       expect(actual).toBe(defineForClassFieldsFalseTransformedCode)
     })
   })


### PR DESCRIPTION
### Description

This test case did not work when `process.cwd()` contained `tsconfig.json`. This PR fixes that.

`transformWithEsbuild` loads the tsconfig based on the file name and since the input filename was relative path, it tried to load the `tsconfig.json` in the `process.cwd()`. I've updated the code to always use `tsconfig.json` in the `packages/vite/src/node` directory so that the test passes regardless of `process.cwd()`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
