### PR TITLE
chore: update deps in create-vite for 7.0-beta

### DIFF
--- a/packages/create-vite/template-lit-ts/package.json
+++ b/packages/create-vite/template-lit-ts/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-lit/package.json
+++ b/packages/create-vite/template-lit/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.3.0"
   },
   "devDependencies": {
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.10.1",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.1",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "serve": "^14.2.4",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.14.1"

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "serve": "^14.2.4",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.14.1"

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -24,6 +24,6 @@
     "globals": "^16.2.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.32.1",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -22,6 +22,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-solid-ts/package.json
+++ b/packages/create-vite/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "vite": "^6.3.5",
+    "vite": "^7.0.0-beta.0",
     "vite-plugin-solid": "^2.11.6"
   }
 }

--- a/packages/create-vite/template-solid/package.json
+++ b/packages/create-vite/template-solid/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.7"
   },
   "devDependencies": {
-    "vite": "^6.3.5",
+    "vite": "^7.0.0-beta.0",
     "vite-plugin-solid": "^2.11.6"
   }
 }

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -15,6 +15,6 @@
     "svelte": "^5.33.2",
     "svelte-check": "^4.2.1",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-svelte/package.json
+++ b/packages/create-vite/template-svelte/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "svelte": "^5.33.2",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -9,6 +9,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^6.3.5"
+    "vite": "^7.0.0-beta.0"
   }
 }

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -12,10 +12,10 @@
     "vue": "^3.5.14"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.4",
+    "@vitejs/plugin-vue": "^6.0.0-beta.1",
     "@vue/tsconfig": "^0.7.0",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5",
+    "vite": "^7.0.0-beta.0",
     "vue-tsc": "^2.2.10"
   }
 }

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.14"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.4",
-    "vite": "^6.3.5"
+    "@vitejs/plugin-vue": "^6.0.0-beta.1",
+    "vite": "^7.0.0-beta.0"
   }
 }


### PR DESCRIPTION
### Description

Updating deps in create-vite to 7.0 beta so we can release create-vite@7.0.0-beta.0.
We may need to update other plugins later.
