### PR TITLE
fix(hmr): use monotonicDateNow for timestamp

### DIFF
--- a/docs/guide/api-environment-instances.md
+++ b/docs/guide/api-environment-instances.md
@@ -185,7 +185,7 @@ export class EnvironmentModuleGraph {
   invalidateModule(
     mod: EnvironmentModuleNode,
     seen: Set<EnvironmentModuleNode> = new Set(),
-    timestamp: number = Date.now(),
+    timestamp: number = monotonicDateNow(),
     isHmr: boolean = false,
   ): void
 

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -7,7 +7,7 @@ import type {
   ResolvedConfig,
   ResolvedEnvironmentOptions,
 } from '../config'
-import { mergeConfig } from '../utils'
+import { mergeConfig, monotonicDateNow } from '../utils'
 import { fetchModule } from '../ssr/fetchModule'
 import type { DepsOptimizer } from '../optimizer'
 import { isDepOptimizationDisabled } from '../optimizer'
@@ -202,7 +202,7 @@ export class DevEnvironment extends BaseEnvironment {
 
   async reloadModule(module: EnvironmentModuleNode): Promise<void> {
     if (this.config.server.hmr !== false && module.file) {
-      updateModules(this, module.file, [module], Date.now())
+      updateModules(this, module.file, [module], monotonicDateNow())
     }
   }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -10,7 +10,12 @@ import type {
   InvokeSendData,
 } from '../../shared/invokeMethods'
 import { CLIENT_DIR } from '../constants'
-import { createDebugger, isCSSRequest, normalizePath } from '../utils'
+import {
+  createDebugger,
+  isCSSRequest,
+  monotonicDateNow,
+  normalizePath,
+} from '../utils'
 import type { InferCustomEventPayload, ViteDevServer } from '..'
 import { getHookHandler } from '../plugins'
 import { isExplicitImportRequired } from '../plugins/importAnalysis'
@@ -418,7 +423,7 @@ export async function handleHMRUpdate(
     return
   }
 
-  const timestamp = Date.now()
+  const timestamp = monotonicDateNow()
   const contextMeta = {
     type,
     file,
@@ -930,7 +935,7 @@ export function handlePrunedModules(
   // update the disposed modules' hmr timestamp
   // since if it's re-imported, it should re-apply side effects
   // and without the timestamp the browser will not re-import it!
-  const t = Date.now()
+  const t = monotonicDateNow()
   mods.forEach((mod) => {
     mod.lastHMRTimestamp = t
     mod.lastHMRInvalidationReceived = false

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -32,6 +32,7 @@ import {
   isParentDirectory,
   mergeConfig,
   mergeWithDefaults,
+  monotonicDateNow,
   normalizePath,
   resolveHostname,
   resolveServerUrls,
@@ -650,7 +651,7 @@ export async function _createServer(
           environments[environmentModule.environment]!,
           module.file,
           [environmentModule],
-          Date.now(),
+          monotonicDateNow(),
         )
       }
     },

--- a/packages/vite/src/node/server/mixedModuleGraph.ts
+++ b/packages/vite/src/node/server/mixedModuleGraph.ts
@@ -1,4 +1,5 @@
 import type { ModuleInfo } from 'rollup'
+import { monotonicDateNow } from '../utils'
 import type { TransformResult } from './transformRequest'
 import type {
   EnvironmentModuleGraph,
@@ -387,7 +388,7 @@ export class ModuleGraph {
   invalidateModule(
     mod: ModuleNode,
     seen = new Set<ModuleNode>(),
-    timestamp: number = Date.now(),
+    timestamp: number = monotonicDateNow(),
     isHmr: boolean = false,
     /** @internal */
     softInvalidate = false,

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -2,6 +2,7 @@ import { extname } from 'node:path'
 import type { ModuleInfo, PartialResolvedId } from 'rollup'
 import { isDirectCSSRequest } from '../plugins/css'
 import {
+  monotonicDateNow,
   normalizePath,
   removeImportQuery,
   removeTimestampQuery,
@@ -165,7 +166,7 @@ export class EnvironmentModuleGraph {
   invalidateModule(
     mod: EnvironmentModuleNode,
     seen = new Set<EnvironmentModuleNode>(),
-    timestamp: number = Date.now(),
+    timestamp: number = monotonicDateNow(),
     isHmr: boolean = false,
     /** @internal */
     softInvalidate = false,
@@ -233,7 +234,7 @@ export class EnvironmentModuleGraph {
   }
 
   invalidateAll(): void {
-    const timestamp = Date.now()
+    const timestamp = monotonicDateNow()
     const seen = new Set<EnvironmentModuleNode>()
     this.idToModuleMap.forEach((mod) => {
       this.invalidateModule(mod, seen, timestamp)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -12,6 +12,7 @@ import {
   ensureWatchedFile,
   injectQuery,
   isObject,
+  monotonicDateNow,
   prettifyUrl,
   removeImportQuery,
   removeTimestampQuery,
@@ -105,7 +106,7 @@ export function transformRequest(
   //
   // We save the timestamp when we start processing and compare it with the
   // last time this module is invalidated
-  const timestamp = Date.now()
+  const timestamp = monotonicDateNow()
 
   const pending = environment._pendingRequests.get(cacheKey)
   if (pending) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1647,3 +1647,23 @@ export function getServerUrlByHost(
   }
   return resolvedUrls?.local[0] ?? resolvedUrls?.network[0]
 }
+
+let lastDateNow = 0
+/**
+ * Similar to `Date.now()`, but strictly monotonically increasing.
+ *
+ * This function will never return the same value.
+ * Thus, the value may differ from the actual time.
+ *
+ * related: https://github.com/vitejs/vite/issues/19804
+ */
+export function monotonicDateNow(): number {
+  const now = Date.now()
+  if (now > lastDateNow) {
+    lastDateNow = now
+    return lastDateNow
+  }
+
+  lastDateNow++
+  return lastDateNow
+}

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -864,8 +864,7 @@ if (!isBuild) {
     await untilUpdated(() => hmr('.optional-chaining')?.toString(), '2')
   })
 
-  // TODO: this is flaky due to https://github.com/vitejs/vite/issues/19804
-  test.skip('hmr works for self-accepted module within circular imported files', async () => {
+  test('hmr works for self-accepted module within circular imported files', async () => {
     await setupModuleRunner('/self-accept-within-circular/index')
     const el = () => hmr('.self-accept-within-circular')
     expect(el()).toBe('c')
@@ -882,12 +881,7 @@ if (!isBuild) {
     await untilUpdated(() => el(), 'cc')
   })
 
-  test('hmr should not reload if no accepted within circular imported files', async (ctx) => {
-    // TODO: Investigate race condition that causes an inconsistent behaviour for the last `untilUpdated`
-    // assertion where it'll sometimes receive "mod-a -> mod-b (edited) -> mod-c -> mod-a (expected no error)"
-    // This is probably related to https://github.com/vitejs/vite/issues/19804
-    ctx.skip()
-
+  test('hmr should not reload if no accepted within circular imported files', async () => {
     await setupModuleRunner('/circular/index')
     const el = () => hmr('.circular')
     expect(el()).toBe(


### PR DESCRIPTION
### Description

I encountered a flaky failure related to these tests and once thought the cause is #19804. But it turned out, it wasn't 😅.
Anyway, it would be good to fix this issue, so I made this PR.

This PR changes `Date.now()` to `monotinicDateNow()` so that the timestamp is always different for each update.

fixes #19804

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
