### PR TITLE
fix(types): prefer sass-embedded types over sass types for `preprocessorOptions.sass` (fix #20150)

### DIFF
--- a/packages/vite/types/internal/cssPreprocessorOptions.d.ts
+++ b/packages/vite/types/internal/cssPreprocessorOptions.d.ts
@@ -17,9 +17,9 @@ type IsAny<T> = boolean extends (T extends never ? true : false) ? true : false
 type DartSassStringOptionsAsync = DartSass.StringOptions<'async'>
 type SassEmbeddedStringOptionsAsync = SassEmbedded.StringOptions<'async'>
 type SassStringOptionsAsync =
-  IsAny<DartSassStringOptionsAsync> extends false
-    ? DartSassStringOptionsAsync
-    : SassEmbeddedStringOptionsAsync
+  IsAny<SassEmbeddedStringOptionsAsync> extends false
+    ? SassEmbeddedStringOptionsAsync
+    : DartSassStringOptionsAsync
 
 export type SassModernPreprocessBaseOptions = Omit<
   SassStringOptionsAsync,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Prefers types from `sass-embedded` in `css.preprocessorOptions.scss` when installed.

* fixes #20150 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
