### PR TITLE
chore: fix source map support when developing Vite

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -3,10 +3,8 @@ import { performance } from 'node:perf_hooks'
 import module from 'node:module'
 
 if (!import.meta.url.includes('node_modules')) {
-  try {
-    // only available as dev dependency
-    await import('source-map-support').then((r) => r.default.install())
-  } catch {}
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins -- only used in dev
+  process.setSourceMapsEnabled(true)
 
   process.on('unhandledRejection', (err) => {
     throw new Error('UNHANDLED PROMISE REJECTION', { cause: err })

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -144,7 +144,6 @@
     "sass": "^1.89.0",
     "sass-embedded": "^1.89.0",
     "sirv": "^3.0.1",
-    "source-map-support": "^0.5.21",
     "strip-literal": "^3.0.0",
     "terser": "^5.39.2",
     "tsconfck": "^3.1.6",

--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -10,7 +10,6 @@ import licensePlugin from './rollupLicensePlugin'
 const pkg = JSON.parse(
   readFileSync(new URL('./package.json', import.meta.url)).toString(),
 )
-
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 const envConfig = defineConfig({
@@ -143,6 +142,7 @@ const nodeConfig = defineConfig({
       'Vite',
     ) as Plugin,
     writeTypesPlugin(),
+    enableSourceMapsInWatchModePlugin(),
     externalizeDepsInWatchPlugin(),
   ],
 })
@@ -158,7 +158,7 @@ const moduleRunnerConfig = defineConfig({
     'rollup/parseAst',
     ...Object.keys(pkg.dependencies),
   ],
-  plugins: [bundleSizeLimit(54)],
+  plugins: [bundleSizeLimit(54), enableSourceMapsInWatchModePlugin()],
   output: {
     ...sharedNodeOptions.output,
     minify: {
@@ -177,6 +177,17 @@ export default defineConfig([
 ])
 
 // #region Plugins
+
+function enableSourceMapsInWatchModePlugin(): Plugin {
+  return {
+    name: 'enable-source-maps',
+    outputOptions(options) {
+      if (this.meta.watchMode) {
+        options.sourcemap = 'inline'
+      }
+    },
+  }
+}
 
 function writeTypesPlugin(): Plugin {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,9 +389,6 @@ importers:
       sirv:
         specifier: ^3.0.1
         version: 3.0.1(patch_hash=95b663b930c5cc6e609c7fa15b69a86ff3b30df68978611d1d3d724c65135cb1)
-      source-map-support:
-        specifier: ^0.5.21
-        version: 0.5.21
       strip-literal:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
### Description

source map support when developing Vite was not working because the sourcemap was not output. This PR fixes that.
This PR also replaces `source-map-support` with `process.setSourceMapsEnabled(true)` because `source-map-support` does not support [`cause` property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) (https://github.com/evanw/node-source-map-support/issues/337).

refs #19925

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
