### PR TITLE
fix: applyToEnvironment after configResolved

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -184,6 +184,8 @@ export default defineConfig({
 })
 ```
 
+The `applyToEnvironment` hook is called at config time, currently after `configResolved` due to projects in the ecosystem modifying the plugins in it. Environment plugins resolution may be moved before `configResolved` in the future.
+
 ## Environment in Build Hooks
 
 In the same way as during dev, plugin hooks also receive the environment instance during build, replacing the `ssr` boolean.


### PR DESCRIPTION
### Description

@sapphi-red reported that https://github.com/vitejs/vite/pull/20120 is affecting Astro (due to [moving a plugin in `configResolved` hook](
https://github.com/withastro/astro/blob/a8e1c0a7402940e0fc5beef669522b315052df1b/packages/astro/src/env/vite-plugin-import-meta-env.ts#L84-L99)) and [others](https://github.com/search?q=resolvedconfig+%2Fplugins%5C.(%3F%3AfindIndex%7Csplice)%2F+NOT+is%3Afork&type=code).

This PR keeps the changes in #20120 but moves the resolution of environment plugins after `configResolved`, as a first step. Later on, it would be good to be able to revert this one in a future major.