### PR TITLE
feat: environmentConfigResolved hook

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -184,6 +184,8 @@ export default defineConfig({
 })
 ```
 
+The `applyToEnvironment` hook is called at config time, currently after `configResolved` due to projects in the ecosystem modifying the plugins in it. Environment plugins resolution may be moved before `configResolved` in the future.
+
 ## Environment in Build Hooks
 
 In the same way as during dev, plugin hooks also receive the environment instance during build, replacing the `ssr` boolean.

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -186,6 +186,8 @@ export default defineConfig({
 
 The `applyToEnvironment` hook is called at config time, currently after `configResolved` due to projects in the ecosystem modifying the plugins in it. Environment plugins resolution may be moved before `configResolved` in the future.
 
+Plugins can use the `environmentConfigResolved(environment)` hook to check the final state of the configuration for each environment, including the resolved environment plugins at `environment.config.plugins`. This hook is called for each resolved environment plugin.
+
 ## Environment in Build Hooks
 
 In the same way as during dev, plugin hooks also receive the environment instance during build, replacing the `ssr` boolean.

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -266,6 +266,14 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
     ) => void | Promise<void>
   >
   /**
+   * Use this hook to read and store the final resolved config for
+   * each environment
+   * @experimental
+   */
+  environmentConfigResolved?: (
+    environment: PartialEnvironment,
+  ) => boolean | Promise<boolean> | PluginOption
+  /**
    * Configure the vite server. The hook receives the {@link ViteDevServer}
    * instance. This can also be used to store a reference to the server
    * for use in other hooks.


### PR DESCRIPTION
### Description

After #20170, there isn't an easy way to get the resolved plugins for each environment before the post-config stage kicks in.

This PR introduces an experimental `environmentConfigResolved` hook that is called for each environment. The `environment.config.plugins` for each environment get called, meaning that plugins returned in `applyToEnvironment` would also participate (and that if a plugin was removed for an environment, their `environmentConfigResolved` will not be called for that environment).