### PR TITLE
docs: pass --bun flag when running with bun

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -171,7 +171,7 @@ $ pnpm vite
 ```
 
 ```bash [Bun]
-$ bunx vite
+$ bunx --bun vite
 ```
 
 ```bash [Deno]


### PR DESCRIPTION
### Description
The --bun flag tells Bun to run Vite's CLI using bun instead of node; by default Bun respects Vite's #!/usr/bin/env node

