### PR TITLE
fix(legacy)!: remove `location.protocol!="file:"` condition for modern android webview

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -129,6 +129,8 @@ npm add -D terser
 
   Set to `false` to only output the legacy bundles that support all target browsers.
 
+  This is also useful when running the project locally using `file:` protocol, as loading modern chunks with `type="module"` may trigger CORS restrictions. To avoid this issue, simply set `renderModernChunks` to `false` to exclusively use legacy chunks instead.
+
 ## Browsers that supports ESM but does not support widely-available features
 
 The legacy plugin offers a way to use widely-available features natively in the modern build, while falling back to the legacy build in browsers with native ESM but without those features supported (e.g. Legacy Edge). This feature works by injecting a runtime check and loading the legacy bundle with SystemJs runtime if needed. There are the following drawbacks:

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -179,7 +179,7 @@ The current values are:
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
-- `sha256-VA8O2hAdooB288EpSTrGLl7z3QikbWU9wwoebO/QaYk=`
+- `sha256-ZxAi3a7m9Mzbc+Z1LGuCCK5Xee6reDkEPRas66H9KSo=`
 - `sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=`
 
 <!--

--- a/packages/plugin-legacy/src/snippets.ts
+++ b/packages/plugin-legacy/src/snippets.ts
@@ -8,7 +8,7 @@ export const systemJSInlineCode = `System.import(document.getElementById('${lega
 
 const detectModernBrowserVarName = '__vite_is_modern_browser'
 export const detectModernBrowserDetector = `import.meta.url;import("_").catch(()=>1);(async function*(){})().next()`
-export const detectModernBrowserCode = `${detectModernBrowserDetector};if(location.protocol!="file:"){window.${detectModernBrowserVarName}=true}`
+export const detectModernBrowserCode = `${detectModernBrowserDetector};window.${detectModernBrowserVarName}=true`
 export const dynamicFallbackInlineCode = `!function(){if(window.${detectModernBrowserVarName})return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}();`
 
 export const modernChunkLegacyGuard = `export function __vite_legacy_guard(){${detectModernBrowserDetector}};`


### PR DESCRIPTION
### Description

I'm packaging a static website generated by Vite into an Android app. I used plugin-legacy to support older Android phones. However, in modern WebViews, this causes both modern chunks and legacy chunks to be loaded, resulting in unexpected behavior.

### Reproduction Steps
1. Create a new Vite project and add plugin-legacy
2. In Vite config set `base: './'`
3. Add a line `console.log('App initializing...')` in `main.js` to track its execution
4. Create an Android project containing only a WebView
5. Place the Vite build output in the Android project's assets folder
6. Load this HTML file in the Android WebView `mWebView.loadUrl("file:///android_asset/index.html");`
7. Run the Android project and check Logcat to see the console log printed twice — once from the modern chunk and once from the legacy chunk
```
[INFO:CONSOLE:33] "App initializing...", source: file:///android_asset/assets/index.C48xOSVJ.js (33)
[INFO:CONSOLE:19] "App initializing...", source: file:///android_asset/assets/index-legacy.CqIw3Dqg.js (19)
```

### Root Cause
The `index.html` generated by Vite build contains the following code:
```html
<script type="module" crossorigin src="./assets/index.C48xOSVJ.js"></script>
<link rel="stylesheet" crossorigin href="./assets/index.0pCfBZ4Q.css">
<script type="module">import.meta.url;import("_").catch(()=>1);(async function*(){})().next();if(location.protocol!="file:"){window.__vite_is_modern_browser=true}</script>
<script type="module">!function(){if(window.__vite_is_modern_browser)return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("vite-legacy-polyfill"),n=document.createElement("script");n.src=e.src,n.onload=function(){System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))},document.body.appendChild(n)}();</script>
```

This means `__vite_is_modern_browser` is only set to `true` when `location.protocol!="file:"`. As a result, even if the modern chunk loads successfully, the legacy chunk is still loaded.

### Solution
This pull request essentially reverts #8524.

Determining whether a browser is modern should only depend on the browser's capabilities. There's no causal relationship between checking if the protocol is `file:` and whether the browser is modern.

I read the original pull request. Their core requirement was to use only legacy chunks (and skip modern chunks) in a specific scenario (in this case, when loading via the `file:` protocol). Now, plugin-legacy already has the `renderModernChunks` option to meet their needs.