### PR TITLE
fix: error starting project with TanStack Router template

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -148,7 +148,7 @@ const FRAMEWORKS: Framework[] = [
         display: 'TanStack Router ↗',
         color: cyan,
         customCommand:
-          'npm create -- tsrouter-app@latest TARGET_DIR --framework react --interactive',
+          'npm create -- tsrouter-app@latest TARGET_DIR --framework React --interactive',
       },
       {
         name: 'redwoodsdk-standard',


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
When running `pnpm create vite` and selecting the TanStack Router variant, an error is thrown.

### Reproduction Steps
1. Create a new Vite project by running `npx create vite` or `pnpm create vite`
2. Select React as the framework
3. Select TanStack Router as the variant and see the error displays:
```
error: option '--framework <type>' argument 'react' is invalid. Invalid framework: react. Only the following are allowed: React, Solid
```
![image](https://github.com/user-attachments/assets/ad5e3711-404a-4779-8d15-383e79168394)

### Root Cause
The framework arguments for TanStack Router are case sensitive. There is a [recent update](https://github.com/TanStack/create-tsrouter-app/commit/b6d591e5142e79f0d25ba134510da69f006f6b90) that changes `react` to `React`. 

### Solution
Update the custom command for TanStack Router to `npm create -- tsrouter-app@latest TARGET_DIR --framework React --interactive`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
