### PR TITLE
docs: reference for `server.moduleGraph` in `per-environments-apis migrations`

### DIFF
--- a/docs/changes/per-environment-apis.md
+++ b/docs/changes/per-environment-apis.md
@@ -28,6 +28,6 @@ In Vite v6, it is now possible to create any number of custom environments (`cli
 
 ## Migration Guide
 
-- `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-environment#separate-module-graphs)
+- `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-environment-instances#separate-module-graphs)
 - `server.transformRequest(url, ssr)` -> `environment.transformRequest(url)`
 - `server.warmupRequest(url, ssr)` -> `environment.warmupRequest(url)`


### PR DESCRIPTION
…apis migrations

### Description

This PR fixes reference url for `server.moduleGraph` in migration section from `per-environments-apis`.
