### PR TITLE
docs: correct variable for NODE_ENV for the dev server

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -10,7 +10,7 @@ Some built-in constants are available in all cases:
 
 - **`import.meta.env.BASE_URL`**: {string} the base url the app is being served from. This is determined by the [`base` config option](/config/shared-options.md#base).
 
-- **`import.meta.env.PROD`**: {boolean} whether the app is running in production (running the dev server with `NODE_ENV='production'` or running an app built with `NODE_ENV='production'`).
+- **`import.meta.env.PROD`**: {boolean} whether the app is running in production (running the dev server with `NODE_ENV='development'` or running an app built with `NODE_ENV='production'`).
 
 - **`import.meta.env.DEV`**: {boolean} whether the app is running in development (always the opposite of `import.meta.env.PROD`)
 


### PR DESCRIPTION
### Description

Corrects variable used for NODE_ENV to use the development server on https://vite.dev/guide/env-and-mode

I could not find an open PR for this with a cursory search.

