### PR TITLE
docs(rolldown): update to reflect the latest changes

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -89,15 +89,15 @@ After adding these overrides, reinstall your dependencies and start your develop
 
 While Rolldown aims to be a drop-in replacement for Rollup, there are features that are still being implemented and minor intentional behavior differences. For a comprehensive list, please refer to [this GitHub PR](https://github.com/vitejs/rolldown-vite/pull/84#issue-2903144667) which is regularly updated.
 
-### Option Validation Errors
+### Option Validation Warnings
 
-Rolldown throws an error when unknown or invalid options are passed. Because some options available in Rollup are not supported by Rolldown, you may encounter errors based on the options you or the meta framework you use set. Below, you can find an example of such an error message:
+Rolldown outputs an warning when unknown or invalid options are passed. Because some options available in Rollup are not supported by Rolldown, you may encounter warnings based on the options you or the meta framework you use set. Below, you can find an example of such an warning message:
 
-> Error: Failed validate input options.
+> Warning validate output options.
 >
-> - For the "preserveEntrySignatures". Invalid key: Expected never but received "preserveEntrySignatures".
+> - For the "generatedCode". Invalid key: Expected never but received "generatedCode".
 
-If you don't pass the option in yourself, this must be fixed by the utilized framework. You can suppress this error in the meantime by setting the `ROLLDOWN_OPTIONS_VALIDATION=loose` environment variable.
+If you don't pass the option in yourself, this must be fixed by the utilized framework.
 
 ### API Differences
 
@@ -257,6 +257,12 @@ const plugin = {
 }
 ```
 
+::: tip
+
+Since Vite 7.0.0, `this.meta` is available in all hooks. In previous versions, `this.meta` was not available in Vite-specific hooks, such as the `config` hook.
+
+:::
+
 <br>
 
 Checking the existence of the `rolldownVersion` export:
@@ -275,16 +281,15 @@ If you have `vite` as a dependency (not a peer dependency), the `rolldownVersion
 
 ### Ignoring option validation in Rolldown
 
-As [mentioned above](#option-validation-errors), Rolldown throws an error when unknown or invalid options are passed.
+As [mentioned above](#option-validation-errors), Rolldown outputs a warning when unknown or invalid options are passed.
 
 This can be fixed by conditionally passing the option by checking whether it's running with `rolldown-vite` as [shown above](#detecting-rolldown-vite).
 
-Suppressing the error by setting the `ROLLDOWN_OPTIONS_VALIDATION=loose` environment variable also works in this case.
-However, keep in mind that you will **eventually need to stop passing the options not supported by Rolldown**.
-
 ### `transformWithEsbuild` requires `esbuild` to be installed separately
 
-A similar function called `transformWithOxc`, which uses Oxc instead of `esbuild`, is exported from `rolldown-vite`.
+Since Vite itself does not use `esbuild` any more, `esbuild` is now an optional peer dependency. If your plugin uses `transformWithEsbuild`, the plugin needs to add `esbuild` to its dependencies or the user needs to install it manually.
+
+The recommended migration is to use the newly exported `transformWithOxc` function, which utilizes Oxc instead of `esbuild`.
 
 ### Compatibility layer for `esbuild` options
 
@@ -306,6 +311,12 @@ const plugin = {
 Rolldown introduced a [hook filter feature](https://rolldown.rs/guide/plugin-development#plugin-hook-filters) to reduce the communication overhead the between Rust and JavaScript runtimes. By using this feature you can make your plugin more performant.
 This is also supported by Rollup 4.38.0+ and Vite 6.3.0+. To make your plugin backward compatible with the older versions, make sure to also run the filter inside the hook handlers.
 
+::: tip
+
+[`@rolldown/pluginutils`](https://www.npmjs.com/package/@rolldown/pluginutils) exports some utilities for hook filters like `exactRegex` and `prefixRegex`.
+
+:::
+
 ### Converting content to JavaScript in `load` or `transform` hooks
 
 If you are converting the content to JavaScript from other types in `load` or `transform` hooks, you may need to add `moduleType: 'js'` to the returned value.
@@ -325,4 +336,4 @@ const plugin = {
 }
 ```
 
-This is because [Rolldown supports non-JavaScript modules](https://rolldown.rs/guide/in-depth/module-types) and infers the module type from extensions unless specified. Note that `rolldown-vite` does not support ModuleTypes in dev.
+This is because [Rolldown supports non-JavaScript modules](https://rolldown.rs/guide/in-depth/module-types) and infers the module type from extensions unless specified.


### PR DESCRIPTION
Updated the rolldown integration page to reflect the latest changes.

- option validation now emits a warning rather than an error
- clarified some text around optional `esbuild` dep
- added a note about `this.meta`
- added a link to `@rolldown/pluginutils`
- removed the note about ModuleTypes support in dev (as it's now supported)
