### PR TITLE
fix(create-vite): targetDir is empty fallback defaultTargetDir

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -358,7 +358,7 @@ async function init() {
       placeholder: defaultTargetDir,
     })
     if (prompts.isCancel(projectName)) return cancel()
-    targetDir = formatTargetDir(projectName as string)
+    targetDir = formatTargetDir(projectName as string) || defaultTargetDir
   }
 
   // 2. Handle directory if exist and not empty


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

When `projectName` is a space, `targetDir` is an empty string.

https://github.com/vitejs/vite/blob/4b77d008aca457944f583ba8a1ff530d5df87cc1/packages/create-vite/src/index.ts#L355