### PR TITLE
test: use `expect.poll` instead of `withRetry`/`expectWithRetry`/`untilUpdated`

### DIFF
--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -31,7 +31,7 @@ test('css via link', async () => {
   expect(await getColor('body')).toBe('grey')
   if (isBuild) return
   editFile('dir/test.css', (code) => code.replace('grey', 'red'))
-  await expect.poll(() => getColor('body')).toMatch('red')
+  await expect.poll(() => getColor('body')).toBe('red')
 })
 
 test('optimized dep', async () => {

--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { editFile, getColor, isBuild, page, untilUpdated } from '~utils'
+import { editFile, getColor, isBuild, page } from '~utils'
 
 test('fs', async () => {
   expect(await page.textContent('.fs')).toMatch('[success] alias to fs path')
@@ -31,7 +31,7 @@ test('css via link', async () => {
   expect(await getColor('body')).toBe('grey')
   if (isBuild) return
   editFile('dir/test.css', (code) => code.replace('grey', 'red'))
-  await untilUpdated(() => getColor('body'), 'red')
+  await expect.poll(() => getColor('body')).toMatch('red')
 })
 
 test('optimized dep', async () => {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -14,7 +14,6 @@ import {
   readFile,
   readManifest,
   serverLogs,
-  untilUpdated,
   viteTestUrl,
   watcher,
 } from '~utils'
@@ -342,7 +341,7 @@ describe('css url() references', () => {
       editFile('nested/fragment-bg-hmr.svg', (code) =>
         code.replace('fill="blue"', 'fill="red"'),
       )
-      await untilUpdated(() => getBg('.css-url-svg'), 'red')
+      await expect.poll(() => getBg('.css-url-svg')).toMatch('red')
     }
   })
 
@@ -360,7 +359,7 @@ describe('css url() references', () => {
       editFile('nested/fragment-bg-hmr2.svg', (code) =>
         code.replace('fill="blue"', 'fill="red"'),
       )
-      await untilUpdated(() => getBg('.css-url-svg'), 'red')
+      await expect.poll(() => getBg('.css-url-svg')).toMatch('red')
     }
   })
 })
@@ -663,11 +662,11 @@ test('inline style test', async () => {
 
 if (!isBuild) {
   test('@import in html style tag hmr', async () => {
-    await untilUpdated(() => getColor('.import-css'), 'rgb(0, 136, 255)')
+    await expect.poll(() => getColor('.import-css')).toMatch('rgb(0, 136, 255)')
     const loadPromise = page.waitForEvent('load')
     editFile('./css/import.css', (code) => code.replace('#0088ff', '#00ff88'))
     await loadPromise
-    await untilUpdated(() => getColor('.import-css'), 'rgb(0, 255, 136)')
+    await expect.poll(() => getColor('.import-css')).toMatch('rgb(0, 255, 136)')
   })
 }
 

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -662,11 +662,11 @@ test('inline style test', async () => {
 
 if (!isBuild) {
   test('@import in html style tag hmr', async () => {
-    await expect.poll(() => getColor('.import-css')).toMatch('rgb(0, 136, 255)')
+    await expect.poll(() => getColor('.import-css')).toBe('rgb(0, 136, 255)')
     const loadPromise = page.waitForEvent('load')
     editFile('./css/import.css', (code) => code.replace('#0088ff', '#00ff88'))
     await loadPromise
-    await expect.poll(() => getColor('.import-css')).toMatch('rgb(0, 255, 136)')
+    await expect.poll(() => getColor('.import-css')).toBe('rgb(0, 255, 136)')
   })
 }
 

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -12,7 +12,6 @@ import {
   readManifest,
   serverLogs,
   untilBrowserLogAfter,
-  untilUpdated,
 } from '~utils'
 
 test('should have no 404s', () => {
@@ -107,11 +106,11 @@ describe.runIf(isServe)('serve', () => {
   })
 
   test('preserve the base in CSS HMR', async () => {
-    await untilUpdated(() => getColor('body'), 'black') // sanity check
+    await expect.poll(() => getColor('body')).toMatch('black') // sanity check
     editFile('frontend/entrypoints/global.css', (code) =>
       code.replace('black', 'red'),
     )
-    await untilUpdated(() => getColor('body'), 'red') // successful HMR
+    await expect.poll(() => getColor('body')).toMatch('red') // successful HMR
 
     // Verify that the base (/dev/) was added during the css-update
     const link = await page.$('link[rel="stylesheet"]:last-of-type')
@@ -127,6 +126,6 @@ describe.runIf(isServe)('serve', () => {
         ),
       '[vite] css hot updated: /global.css',
     )
-    await untilUpdated(() => getColor(el), 'rgb(204, 0, 0)')
+    await expect.poll(() => getColor(el)).toMatch('rgb(204, 0, 0)')
   })
 })

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -106,11 +106,11 @@ describe.runIf(isServe)('serve', () => {
   })
 
   test('preserve the base in CSS HMR', async () => {
-    await expect.poll(() => getColor('body')).toMatch('black') // sanity check
+    await expect.poll(() => getColor('body')).toBe('black') // sanity check
     editFile('frontend/entrypoints/global.css', (code) =>
       code.replace('black', 'red'),
     )
-    await expect.poll(() => getColor('body')).toMatch('red') // successful HMR
+    await expect.poll(() => getColor('body')).toBe('red') // successful HMR
 
     // Verify that the base (/dev/) was added during the css-update
     const link = await page.$('link[rel="stylesheet"]:last-of-type')
@@ -126,6 +126,6 @@ describe.runIf(isServe)('serve', () => {
         ),
       '[vite] css hot updated: /global.css',
     )
-    await expect.poll(() => getColor(el)).toMatch('rgb(204, 0, 0)')
+    await expect.poll(() => getColor(el)).toBe('rgb(204, 0, 0)')
   })
 })

--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, streams } from './serve'
-import { editFile, isServe, page, withRetry } from '~utils'
+import { editFile, isServe, page } from '~utils'
 
 test('cli should work', async () => {
   // this test uses a custom serve implementation, so regular helpers for browserLogs and goto don't work
@@ -23,17 +23,19 @@ test('cli should work', async () => {
 test.runIf(isServe)('should restart', async () => {
   const logsLengthBeforeEdit = streams.server.out.length
   editFile('./vite.config.js', (content) => content)
-  await withRetry(async () => {
-    const logs = streams.server.out.slice(logsLengthBeforeEdit)
-    expect(logs).toEqual(
-      expect.arrayContaining([expect.stringMatching('server restarted')]),
-    )
-    // Don't reprint the server URLs as they are the same
-    expect(logs).not.toEqual(
-      expect.arrayContaining([expect.stringMatching('http://localhost')]),
-    )
-    expect(logs).not.toEqual(
-      expect.arrayContaining([expect.stringMatching('error')]),
-    )
-  })
+  await expect
+    .poll(() => {
+      const logs = streams.server.out.slice(logsLengthBeforeEdit)
+      expect(logs).toEqual(
+        expect.arrayContaining([expect.stringMatching('server restarted')]),
+      )
+      // Don't reprint the server URLs as they are the same
+      expect(logs).not.toEqual(
+        expect.arrayContaining([expect.stringMatching('http://localhost')]),
+      )
+      expect(logs).not.toEqual(
+        expect.arrayContaining([expect.stringMatching('error')]),
+      )
+    })
+    .toSatisfy(() => true)
 })

--- a/playground/csp/__tests__/csp.spec.ts
+++ b/playground/csp/__tests__/csp.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { expectWithRetry, getColor, page } from '~utils'
+import { getColor, page } from '~utils'
 
 test('linked css', async () => {
   expect(await getColor('.linked')).toBe('blue')
@@ -18,27 +18,25 @@ test('dynamic css', async () => {
 })
 
 test('script tag', async () => {
-  await expectWithRetry(() => page.textContent('.js')).toBe('js: ok')
+  await expect.poll(() => page.textContent('.js')).toBe('js: ok')
 })
 
 test('dynamic js', async () => {
-  await expectWithRetry(() => page.textContent('.dynamic-js')).toBe(
-    'dynamic-js: ok',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-js'))
+    .toBe('dynamic-js: ok')
 })
 
 test('inline js', async () => {
-  await expectWithRetry(() => page.textContent('.inline-js')).toBe(
-    'inline-js: ok',
-  )
+  await expect.poll(() => page.textContent('.inline-js')).toBe('inline-js: ok')
 })
 
 test('nonce attributes are not repeated', async () => {
   const htmlSource = await page.content()
   expect(htmlSource).not.toContain(/nonce=""[^>]*nonce=""/)
-  await expectWithRetry(() => page.textContent('.double-nonce-js')).toBe(
-    'double-nonce-js: ok',
-  )
+  await expect
+    .poll(() => page.textContent('.double-nonce-js'))
+    .toBe('double-nonce-js: ok')
 })
 
 test('meta[property=csp-nonce] is injected', async () => {

--- a/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -33,7 +33,7 @@ test('should load dynamic import with module', async () => {
 test('style order should be consistent when style tag is inserted by JS', async () => {
   expect(await getColor('.order-bulk')).toBe('orange')
   await page.click('.order-bulk-update')
-  await expect.poll(() => getColor('.order-bulk')).toMatch('green')
+  await expect.poll(() => getColor('.order-bulk')).toBe('green')
 })
 
 describe.runIf(isBuild)('build', () => {

--- a/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -6,7 +6,6 @@ import {
   listAssets,
   page,
   readManifest,
-  untilUpdated,
 } from '~utils'
 
 test('should load all stylesheets', async () => {
@@ -34,7 +33,7 @@ test('should load dynamic import with module', async () => {
 test('style order should be consistent when style tag is inserted by JS', async () => {
   expect(await getColor('.order-bulk')).toBe('orange')
   await page.click('.order-bulk-update')
-  await untilUpdated(() => getColor('.order-bulk'), 'green')
+  await expect.poll(() => getColor('.order-bulk')).toMatch('green')
 })
 
 describe.runIf(isBuild)('build', () => {

--- a/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
@@ -20,12 +20,12 @@ test('linked css', async () => {
 
   if (isBuild) return
   editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
-  await expect.poll(() => getColor(linked)).toMatch('red')
+  await expect.poll(() => getColor(linked)).toBe('red')
 
   editFile('linked-at-import.css', (code) =>
     code.replace('color: red', 'color: blue'),
   )
-  await expect.poll(() => getColor(atImport)).toMatch('blue')
+  await expect.poll(() => getColor(atImport)).toBe('blue')
 })
 
 test('css import from js', async () => {
@@ -37,12 +37,12 @@ test('css import from js', async () => {
 
   if (isBuild) return
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
-  await expect.poll(() => getColor(imported)).toMatch('red')
+  await expect.poll(() => getColor(imported)).toBe('red')
 
   editFile('imported-at-import.css', (code) =>
     code.replace('color: purple', 'color: blue'),
   )
-  await expect.poll(() => getColor(atImport)).toMatch('blue')
+  await expect.poll(() => getColor(atImport)).toBe('blue')
 })
 
 test('css modules', async () => {
@@ -55,7 +55,7 @@ test('css modules', async () => {
   editFile('mod.module.css', (code) =>
     code.replace('color: turquoise', 'color: red'),
   )
-  await expect.poll(() => getColor(imported)).toMatch('red')
+  await expect.poll(() => getColor(imported)).toBe('red')
 })
 
 test('inline css modules', async () => {

--- a/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
@@ -6,7 +6,6 @@ import {
   getColor,
   isBuild,
   page,
-  untilUpdated,
   viteTestUrl,
 } from '~utils'
 
@@ -21,12 +20,12 @@ test('linked css', async () => {
 
   if (isBuild) return
   editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
-  await untilUpdated(() => getColor(linked), 'red')
+  await expect.poll(() => getColor(linked)).toMatch('red')
 
   editFile('linked-at-import.css', (code) =>
     code.replace('color: red', 'color: blue'),
   )
-  await untilUpdated(() => getColor(atImport), 'blue')
+  await expect.poll(() => getColor(atImport)).toMatch('blue')
 })
 
 test('css import from js', async () => {
@@ -38,12 +37,12 @@ test('css import from js', async () => {
 
   if (isBuild) return
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
-  await untilUpdated(() => getColor(imported), 'red')
+  await expect.poll(() => getColor(imported)).toMatch('red')
 
   editFile('imported-at-import.css', (code) =>
     code.replace('color: purple', 'color: blue'),
   )
-  await untilUpdated(() => getColor(atImport), 'blue')
+  await expect.poll(() => getColor(atImport)).toMatch('blue')
 })
 
 test('css modules', async () => {
@@ -56,7 +55,7 @@ test('css modules', async () => {
   editFile('mod.module.css', (code) =>
     code.replace('color: turquoise', 'color: red'),
   )
-  await untilUpdated(() => getColor(imported), 'red')
+  await expect.poll(() => getColor(imported)).toMatch('red')
 })
 
 test('inline css modules', async () => {

--- a/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
+++ b/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { expectWithRetry, getColor, isBuild, listAssets } from '~utils'
+import { getColor, isBuild, listAssets } from '~utils'
 
 test('should load all stylesheets', async () => {
   expect(await getColor('.shared-linked')).toBe('blue')
-  await expectWithRetry(() => getColor('.async-js')).toBe('blue')
+  await expect.poll(() => getColor('.async-js')).toBe('blue')
 })
 
 describe.runIf(isBuild)('build', () => {

--- a/playground/css/__tests__/sass-tests.ts
+++ b/playground/css/__tests__/sass-tests.ts
@@ -60,17 +60,17 @@ export const sassTest = () => {
     editFile('sass.scss', (code) =>
       code.replace('color: $injectedColor', 'color: red'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
 
     editFile('nested/_index.scss', (code) =>
       code.replace('color: olive', 'color: blue'),
     )
-    await expect.poll(() => getColor(atImport)).toMatch('blue')
+    await expect.poll(() => getColor(atImport)).toBe('blue')
 
     editFile('nested/_partial.scss', (code) =>
       code.replace('color: orchid', 'color: green'),
     )
-    await expect.poll(() => getColor(partialImport)).toMatch('green')
+    await expect.poll(() => getColor(partialImport)).toBe('green')
   })
 }
 
@@ -108,7 +108,7 @@ export const sassModuleTests = (enableHmrTests = false) => {
     editFile('mod.module.scss', (code) =>
       code.replace('color: orangered', 'color: blue'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('blue')
+    await expect.poll(() => getColor(imported)).toBe('blue')
   })
 }
 

--- a/playground/css/__tests__/sass-tests.ts
+++ b/playground/css/__tests__/sass-tests.ts
@@ -1,13 +1,5 @@
 import { expect, test } from 'vitest'
-import {
-  editFile,
-  getBg,
-  getColor,
-  isBuild,
-  page,
-  untilUpdated,
-  viteTestUrl,
-} from '~utils'
+import { editFile, getBg, getColor, isBuild, page, viteTestUrl } from '~utils'
 
 export const sassTest = () => {
   test('sass', async () => {
@@ -68,17 +60,17 @@ export const sassTest = () => {
     editFile('sass.scss', (code) =>
       code.replace('color: $injectedColor', 'color: red'),
     )
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
 
     editFile('nested/_index.scss', (code) =>
       code.replace('color: olive', 'color: blue'),
     )
-    await untilUpdated(() => getColor(atImport), 'blue')
+    await expect.poll(() => getColor(atImport)).toMatch('blue')
 
     editFile('nested/_partial.scss', (code) =>
       code.replace('color: orchid', 'color: green'),
     )
-    await untilUpdated(() => getColor(partialImport), 'green')
+    await expect.poll(() => getColor(partialImport)).toMatch('green')
   })
 }
 
@@ -101,7 +93,7 @@ export const sassModuleTests = (enableHmrTests = false) => {
     // editFile('composed.module.scss', (code) =>
     //   code.replace('color: orangered', 'color: red')
     // )
-    // await untilUpdated(() => getColor(imported), 'red')
+    // await expect.poll(() => getColor(imported)).toMatch('red')
   })
 
   test('css modules w/ sass', async () => {
@@ -116,7 +108,7 @@ export const sassModuleTests = (enableHmrTests = false) => {
     editFile('mod.module.scss', (code) =>
       code.replace('color: orangered', 'color: blue'),
     )
-    await untilUpdated(() => getColor(imported), 'blue')
+    await expect.poll(() => getColor(imported)).toMatch('blue')
   })
 }
 

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -13,7 +13,6 @@ import {
   serverLogs,
   untilUpdated,
   viteTestUrl,
-  withRetry,
 } from '~utils'
 
 export const tests = (isLightningCSS: boolean) => {
@@ -507,16 +506,18 @@ export const tests = (isLightningCSS: boolean) => {
 
   // NOTE: the match inline snapshot should generate by build mode
   test('async css order', async () => {
-    await withRetry(async () => {
-      expect(await getColor('.async-green')).toMatchInlineSnapshot('"green"')
-      expect(await getColor('.async-blue')).toMatchInlineSnapshot('"blue"')
-    })
+    await expect
+      .poll(() => getColor('.async-green'))
+      .toMatchInlineSnapshot('"green"')
+    await expect
+      .poll(() => getColor('.async-blue'))
+      .toMatchInlineSnapshot('"blue"')
   })
 
   test('async css order with css modules', async () => {
-    await withRetry(async () => {
-      expect(await getColor('.modules-pink')).toMatchInlineSnapshot('"pink"')
-    })
+    await expect
+      .poll(() => getColor('.modules-pink'))
+      .toMatchInlineSnapshot('"pink"')
   })
 
   test('@import scss', async () => {

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -11,7 +11,6 @@ import {
   page,
   removeFile,
   serverLogs,
-  untilUpdated,
   viteTestUrl,
 } from '~utils'
 
@@ -35,12 +34,12 @@ export const tests = (isLightningCSS: boolean) => {
     if (isBuild) return
 
     editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
-    await untilUpdated(() => getColor(linked), 'red')
+    await expect.poll(() => getColor(linked)).toMatch('red')
 
     editFile('linked-at-import.css', (code) =>
       code.replace('color: red', 'color: blue'),
     )
-    await untilUpdated(() => getColor(atImport), 'blue')
+    await expect.poll(() => getColor(atImport)).toMatch('blue')
   })
 
   test('css import from js', async () => {
@@ -55,12 +54,12 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('imported.css', (code) =>
       code.replace('color: green', 'color: red'),
     )
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
 
     editFile('imported-at-import.css', (code) =>
       code.replace('color: purple', 'color: blue'),
     )
-    await untilUpdated(() => getColor(atImport), 'blue')
+    await expect.poll(() => getColor(atImport)).toMatch('blue')
   })
 
   test('css import asset with space', async () => {
@@ -78,7 +77,7 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('imported.css', (code) =>
       code.replace('color: pink', 'color: red'),
     )
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
   })
 
   test('postcss plugin that injects url()', async () => {
@@ -121,12 +120,12 @@ export const tests = (isLightningCSS: boolean) => {
     if (isBuild) return
 
     editFile('less.less', (code) => code.replace('@color: blue', '@color: red'))
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
 
     editFile('nested/nested.less', (code) =>
       code.replace('color: darkslateblue', 'color: blue'),
     )
-    await untilUpdated(() => getColor(atImport), 'blue')
+    await expect.poll(() => getColor(atImport)).toMatch('blue')
   })
 
   test('less-plugin', async () => {
@@ -167,12 +166,12 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('stylus.styl', (code) =>
       code.replace('$color ?= blue', '$color ?= red'),
     )
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
 
     editFile('nested/nested.styl', (code) =>
       code.replace('color: darkslateblue', 'color: blue'),
     )
-    await untilUpdated(() => getColor(relativeImport), 'blue')
+    await expect.poll(() => getColor(relativeImport)).toMatch('blue')
   })
 
   test('css modules', async () => {
@@ -190,7 +189,7 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('mod.module.css', (code) =>
       code.replace('color: turquoise', 'color: red'),
     )
-    await untilUpdated(() => getColor(imported), 'red')
+    await expect.poll(() => getColor(imported)).toMatch('red')
   })
 
   test('css modules composes/from path resolving', async () => {
@@ -211,7 +210,7 @@ export const tests = (isLightningCSS: boolean) => {
     // editFile('composed.module.css', (code) =>
     //   code.replace('color: turquoise', 'color: red')
     // )
-    // await untilUpdated(() => getColor(imported), 'red')
+    // await expect.poll(() => getColor(imported)).toMatch('red')
   })
 
   sassModuleTests()
@@ -234,7 +233,7 @@ export const tests = (isLightningCSS: boolean) => {
     // editFile('composed.module.scss', (code) =>
     //   code.replace('color: orangered', 'color: red')
     // )
-    // await untilUpdated(() => getColor(imported), 'red')
+    // await expect.poll(() => getColor(imported)).toMatch('red')
   })
 
   test('inline css modules', async () => {
@@ -288,7 +287,7 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('async.css', (code) =>
         code.replace('color: teal', 'color: blue'),
       )
-      await untilUpdated(() => getColor(el), 'blue')
+      await expect.poll(() => getColor(el)).toMatch('blue')
     }
   })
 
@@ -316,7 +315,7 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('async-treeshaken.css', (code) =>
         code.replace('color: plum', 'color: blue'),
       )
-      await untilUpdated(() => getColor(el), 'blue')
+      await expect.poll(() => getColor(el)).toMatch('blue')
     }
   })
 
@@ -334,25 +333,25 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('glob-dep/foo.css', (code) =>
         code.replace('color: grey', 'color: blue'),
       )
-      await untilUpdated(() => getColor(el1), 'blue')
+      await expect.poll(() => getColor(el1)).toMatch('blue')
       expect(await getColor(el2)).toBe('grey')
 
       editFile('glob-dep/bar.css', (code) =>
         code.replace('color: grey', 'color: red'),
       )
-      await untilUpdated(() => getColor(el2), 'red')
+      await expect.poll(() => getColor(el2)).toMatch('red')
       expect(await getColor(el1)).toBe('blue')
 
       editFile('glob-dep/nested (dir)/baz.css', (code) =>
         code.replace('color: grey', 'color: green'),
       )
-      await untilUpdated(() => getColor(el3), 'green')
+      await expect.poll(() => getColor(el3)).toMatch('green')
       expect(await getColor(el1)).toBe('blue')
       expect(await getColor(el2)).toBe('red')
 
       // test add/remove
       removeFile('glob-dep/bar.css')
-      await untilUpdated(() => getColor(el2), 'black')
+      await expect.poll(() => getColor(el2)).toMatch('black')
     }
   })
 
@@ -429,10 +428,9 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('raw-imported.css', (code) =>
         code.replace('color: yellow', 'color: blue'),
       )
-      await untilUpdated(
-        () => page.textContent('.raw-imported-css'),
-        'color: blue',
-      )
+      await expect
+        .poll(() => page.textContent('.raw-imported-css'))
+        .toMatch('color: blue')
     }
   })
 
@@ -496,28 +494,22 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('sugarss.sss', (code) =>
       code.replace('color: blue', 'color: coral'),
     )
-    await untilUpdated(() => getColor(imported), 'coral')
+    await expect.poll(() => getColor(imported)).toMatch('coral')
 
     editFile('nested/nested.sss', (code) =>
       code.replace('color: darkslateblue', 'color: blue'),
     )
-    await untilUpdated(() => getColor(atImport), 'blue')
+    await expect.poll(() => getColor(atImport)).toMatch('blue')
   })
 
   // NOTE: the match inline snapshot should generate by build mode
   test('async css order', async () => {
-    await expect
-      .poll(() => getColor('.async-green'))
-      .toMatchInlineSnapshot('"green"')
-    await expect
-      .poll(() => getColor('.async-blue'))
-      .toMatchInlineSnapshot('"blue"')
+    await expect.poll(() => getColor('.async-green')).toBe('green')
+    await expect.poll(() => getColor('.async-blue')).toBe('blue')
   })
 
   test('async css order with css modules', async () => {
-    await expect
-      .poll(() => getColor('.modules-pink'))
-      .toMatchInlineSnapshot('"pink"')
+    await expect.poll(() => getColor('.modules-pink')).toBe('pink')
   })
 
   test('@import scss', async () => {

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -34,12 +34,12 @@ export const tests = (isLightningCSS: boolean) => {
     if (isBuild) return
 
     editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
-    await expect.poll(() => getColor(linked)).toMatch('red')
+    await expect.poll(() => getColor(linked)).toBe('red')
 
     editFile('linked-at-import.css', (code) =>
       code.replace('color: red', 'color: blue'),
     )
-    await expect.poll(() => getColor(atImport)).toMatch('blue')
+    await expect.poll(() => getColor(atImport)).toBe('blue')
   })
 
   test('css import from js', async () => {
@@ -54,12 +54,12 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('imported.css', (code) =>
       code.replace('color: green', 'color: red'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
 
     editFile('imported-at-import.css', (code) =>
       code.replace('color: purple', 'color: blue'),
     )
-    await expect.poll(() => getColor(atImport)).toMatch('blue')
+    await expect.poll(() => getColor(atImport)).toBe('blue')
   })
 
   test('css import asset with space', async () => {
@@ -77,7 +77,7 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('imported.css', (code) =>
       code.replace('color: pink', 'color: red'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
   })
 
   test('postcss plugin that injects url()', async () => {
@@ -120,12 +120,12 @@ export const tests = (isLightningCSS: boolean) => {
     if (isBuild) return
 
     editFile('less.less', (code) => code.replace('@color: blue', '@color: red'))
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
 
     editFile('nested/nested.less', (code) =>
       code.replace('color: darkslateblue', 'color: blue'),
     )
-    await expect.poll(() => getColor(atImport)).toMatch('blue')
+    await expect.poll(() => getColor(atImport)).toBe('blue')
   })
 
   test('less-plugin', async () => {
@@ -166,12 +166,12 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('stylus.styl', (code) =>
       code.replace('$color ?= blue', '$color ?= red'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
 
     editFile('nested/nested.styl', (code) =>
-      code.replace('color: darkslateblue', 'color: blue'),
+      code.replace('color darkslateblue', 'color blue'),
     )
-    await expect.poll(() => getColor(relativeImport)).toMatch('blue')
+    await expect.poll(() => getColor(relativeImport)).toBe('blue')
   })
 
   test('css modules', async () => {
@@ -189,7 +189,7 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('mod.module.css', (code) =>
       code.replace('color: turquoise', 'color: red'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('red')
+    await expect.poll(() => getColor(imported)).toBe('red')
   })
 
   test('css modules composes/from path resolving', async () => {
@@ -210,7 +210,7 @@ export const tests = (isLightningCSS: boolean) => {
     // editFile('composed.module.css', (code) =>
     //   code.replace('color: turquoise', 'color: red')
     // )
-    // await expect.poll(() => getColor(imported)).toMatch('red')
+    // await expect.poll(() => getColor(imported)).toBe('red')
   })
 
   sassModuleTests()
@@ -233,7 +233,7 @@ export const tests = (isLightningCSS: boolean) => {
     // editFile('composed.module.scss', (code) =>
     //   code.replace('color: orangered', 'color: red')
     // )
-    // await expect.poll(() => getColor(imported)).toMatch('red')
+    // await expect.poll(() => getColor(imported)).toBe('red')
   })
 
   test('inline css modules', async () => {
@@ -287,7 +287,7 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('async.css', (code) =>
         code.replace('color: teal', 'color: blue'),
       )
-      await expect.poll(() => getColor(el)).toMatch('blue')
+      await expect.poll(() => getColor(el)).toBe('blue')
     }
   })
 
@@ -315,7 +315,7 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('async-treeshaken.css', (code) =>
         code.replace('color: plum', 'color: blue'),
       )
-      await expect.poll(() => getColor(el)).toMatch('blue')
+      await expect.poll(() => getColor(el)).toBe('blue')
     }
   })
 
@@ -333,25 +333,25 @@ export const tests = (isLightningCSS: boolean) => {
       editFile('glob-dep/foo.css', (code) =>
         code.replace('color: grey', 'color: blue'),
       )
-      await expect.poll(() => getColor(el1)).toMatch('blue')
+      await expect.poll(() => getColor(el1)).toBe('blue')
       expect(await getColor(el2)).toBe('grey')
 
       editFile('glob-dep/bar.css', (code) =>
         code.replace('color: grey', 'color: red'),
       )
-      await expect.poll(() => getColor(el2)).toMatch('red')
+      await expect.poll(() => getColor(el2)).toBe('red')
       expect(await getColor(el1)).toBe('blue')
 
       editFile('glob-dep/nested (dir)/baz.css', (code) =>
         code.replace('color: grey', 'color: green'),
       )
-      await expect.poll(() => getColor(el3)).toMatch('green')
+      await expect.poll(() => getColor(el3)).toBe('green')
       expect(await getColor(el1)).toBe('blue')
       expect(await getColor(el2)).toBe('red')
 
       // test add/remove
       removeFile('glob-dep/bar.css')
-      await expect.poll(() => getColor(el2)).toMatch('black')
+      await expect.poll(() => getColor(el2)).toBe('black')
     }
   })
 
@@ -494,12 +494,12 @@ export const tests = (isLightningCSS: boolean) => {
     editFile('sugarss.sss', (code) =>
       code.replace('color: blue', 'color: coral'),
     )
-    await expect.poll(() => getColor(imported)).toMatch('coral')
+    await expect.poll(() => getColor(imported)).toBe('coral')
 
     editFile('nested/nested.sss', (code) =>
       code.replace('color: darkslateblue', 'color: blue'),
     )
-    await expect.poll(() => getColor(atImport)).toMatch('blue')
+    await expect.poll(() => getColor(atImport)).toBe('blue')
   })
 
   // NOTE: the match inline snapshot should generate by build mode

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -6,17 +6,16 @@ import {
   isBuild,
   page,
   serverLogs,
-  untilUpdated,
 } from '~utils'
 
 test('should load literal dynamic import', async () => {
   await page.click('.baz')
-  await untilUpdated(() => page.textContent('.view'), 'Baz view')
+  await expect.poll(() => page.textContent('.view')).toMatch('Baz view')
 })
 
 test('should load full dynamic import from public', async () => {
   await page.click('.qux')
-  await untilUpdated(() => page.textContent('.view'), 'Qux view')
+  await expect.poll(() => page.textContent('.view')).toMatch('Qux view')
   // No warning should be logged as we are using @vite-ignore
   expect(
     serverLogs.some((log) => log.includes('cannot be analyzed by vite')),
@@ -25,58 +24,56 @@ test('should load full dynamic import from public', async () => {
 
 test('should load data URL of `blob:`', async () => {
   await page.click('.issue-2658-1')
-  await untilUpdated(() => page.textContent('.view'), 'blob')
+  await expect.poll(() => page.textContent('.view')).toMatch('blob')
 })
 
 test('should load data URL of `data:`', async () => {
   await page.click('.issue-2658-2')
-  await untilUpdated(() => page.textContent('.view'), 'data')
+  await expect.poll(() => page.textContent('.view')).toMatch('data')
 })
 
 test('should have same reference on static and dynamic js import, .mxd', async () => {
   await page.click('.mxd')
-  await untilUpdated(() => page.textContent('.view'), 'true')
+  await expect.poll(() => page.textContent('.view')).toMatch('true')
 })
 
 // in this case, it is not possible to detect the correct module
 test('should have same reference on static and dynamic js import, .mxd2', async () => {
   await page.click('.mxd2')
-  await untilUpdated(() => page.textContent('.view'), 'false')
+  await expect.poll(() => page.textContent('.view')).toMatch('false')
 })
 
 test('should have same reference on static and dynamic js import, .mxdjson', async () => {
   await page.click('.mxdjson')
-  await untilUpdated(() => page.textContent('.view'), 'true')
+  await expect.poll(() => page.textContent('.view')).toMatch('true')
 })
 
 // since this test has a timeout, it should be put last so that it
 // does not bleed on the last
 test('should load dynamic import with vars', async () => {
   await page.click('.foo')
-  await untilUpdated(() => page.textContent('.view'), 'Foo view')
+  await expect.poll(() => page.textContent('.view')).toMatch('Foo view')
 
   await page.click('.bar')
-  await untilUpdated(() => page.textContent('.view'), 'Bar view')
+  await expect.poll(() => page.textContent('.view')).toMatch('Bar view')
 })
 
 // dynamic import css
 test('should load dynamic import with css', async () => {
   await page.click('.css')
-  await untilUpdated(() => getColor('.view'), 'red')
+  await expect.poll(() => getColor('.view')).toMatch('red')
 })
 
 test('should load dynamic import with vars', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars'),
-    'hello',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars'))
+    .toMatch('hello')
 })
 
 test('should load dynamic import with vars ignored', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-ignored'),
-    'hello',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-ignored'))
+    .toMatch('hello')
   // No warning should be logged as we are using @vite-ignore
   expect(
     serverLogs.some((log) =>
@@ -86,71 +83,64 @@ test('should load dynamic import with vars ignored', async () => {
 })
 
 test('should load dynamic import with double slash ignored', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-double-slash-ignored'),
-    'hello',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-double-slash-ignored'))
+    .toMatch('hello')
 })
 
 test('should load dynamic import with vars multiline', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-multiline'),
-    'hello',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-multiline'))
+    .toMatch('hello')
 })
 
 test('should load dynamic import with vars alias', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-alias'),
-    'hi',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-alias'))
+    .toMatch('hi')
 })
 
 test('should load dynamic import with vars raw', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-raw'),
-    'export function hello()',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-raw'))
+    .toMatch('export function hello()')
 })
 
 test('should load dynamic import with vars url', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-url'),
-    isBuild ? 'data:text/javascript' : '/alias/url.js',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-url'))
+    .toMatch(isBuild ? 'data:text/javascript' : '/alias/url.js')
 })
 
 test('should load dynamic import with vars worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-worker'),
-    'load worker',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-worker'))
+    .toMatch('load worker')
 })
 
 test('should load dynamic import with css in package', async () => {
   await page.click('.pkg-css')
-  await untilUpdated(() => getColor('.pkg-css'), 'blue')
+  await expect.poll(() => getColor('.pkg-css')).toMatch('blue')
 })
 
 test('should work with load ../ and itself directory', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-self'),
-    'dynamic-import-self-content',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-self'))
+    .toMatch('dynamic-import-self-content')
 })
 
 test('should work with load ../ and contain itself directory', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-nested-self'),
-    'dynamic-import-nested-self-content',
-  )
+  await expect
+    .poll(() => page.textContent('.dynamic-import-nested-self'))
+    .toMatch('dynamic-import-nested-self-content')
 })
 
 test('should work a load path that contains parentheses.', async () => {
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-with-vars-contains-parenthesis'),
-    'dynamic-import-with-vars-contains-parenthesis',
-  )
+  await expect
+    .poll(() =>
+      page.textContent('.dynamic-import-with-vars-contains-parenthesis'),
+    )
+    .toMatch('dynamic-import-with-vars-contains-parenthesis')
 })
 
 test.runIf(isBuild)(

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -61,7 +61,7 @@ test('should load dynamic import with vars', async () => {
 // dynamic import css
 test('should load dynamic import with css', async () => {
   await page.click('.css')
-  await expect.poll(() => getColor('.view')).toMatch('red')
+  await expect.poll(() => getColor('.view')).toBe('red')
 })
 
 test('should load dynamic import with vars', async () => {
@@ -120,7 +120,7 @@ test('should load dynamic import with vars worker', async () => {
 
 test('should load dynamic import with css in package', async () => {
   await page.click('.pkg-css')
-  await expect.poll(() => getColor('.pkg-css')).toMatch('blue')
+  await expect.poll(() => getColor('.pkg-css')).toBe('blue')
 })
 
 test('should work with load ../ and itself directory', async () => {

--- a/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
+++ b/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
@@ -84,10 +84,9 @@ describe.runIf(!isBuild)('pre-bundling', () => {
                 /new dependencies optimized: (react-fake-.*)/,
               )?.[1],
           )
-          .filter(Boolean)
-          .join(', '),
+          .filter(Boolean),
       )
-      .toMatch('react-fake-server, react-fake-client')
+      .toStrictEqual(['react-fake-server', 'react-fake-client'])
 
     const clientMetaNew = readDepOptimizationMetadata('client')
     const ssrMetaNew = readDepOptimizationMetadata('ssr')

--- a/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
+++ b/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
@@ -9,7 +9,6 @@ import {
   readFile,
   serverLogs,
   testDir,
-  untilUpdated,
 } from '~utils'
 
 test('basic', async () => {
@@ -76,8 +75,8 @@ describe.runIf(!isBuild)('pre-bundling', () => {
       })
     })
 
-    await untilUpdated(
-      () =>
+    await expect
+      .poll(() =>
         serverLogs
           .map(
             (log) =>
@@ -87,8 +86,8 @@ describe.runIf(!isBuild)('pre-bundling', () => {
           )
           .filter(Boolean)
           .join(', '),
-      'react-fake-server, react-fake-client',
-    )
+      )
+      .toMatch('react-fake-server, react-fake-client')
 
     const clientMetaNew = readDepOptimizationMetadata('client')
     const ssrMetaNew = readDepOptimizationMetadata('ssr')

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -202,15 +202,13 @@ if (!isBuild) {
 
     addFile('pkg-pages/bar.js', '// empty')
     await expect
-      .poll(() => resultElement.textContent())
-      .toMatch(
-        JSON.stringify(['/pkg-pages/foo.js', '/pkg-pages/bar.js'].sort()),
-      )
+      .poll(async () => JSON.parse(await resultElement.textContent()))
+      .toStrictEqual(['/pkg-pages/foo.js', '/pkg-pages/bar.js'].sort())
 
     removeFile('pkg-pages/bar.js')
     await expect
-      .poll(() => resultElement.textContent())
-      .toMatch(JSON.stringify(['/pkg-pages/foo.js']))
+      .poll(async () => JSON.parse(await resultElement.textContent()))
+      .toStrictEqual(['/pkg-pages/foo.js'])
   })
 }
 

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -8,7 +8,6 @@ import {
   isBuild,
   page,
   removeFile,
-  untilUpdated,
 } from '~utils'
 
 const filteredResult = {
@@ -202,16 +201,16 @@ if (!isBuild) {
     const resultElement = page.locator('.in-package')
 
     addFile('pkg-pages/bar.js', '// empty')
-    await untilUpdated(
-      () => resultElement.textContent(),
-      JSON.stringify(['/pkg-pages/foo.js', '/pkg-pages/bar.js'].sort()),
-    )
+    await expect
+      .poll(() => resultElement.textContent())
+      .toMatch(
+        JSON.stringify(['/pkg-pages/foo.js', '/pkg-pages/bar.js'].sort()),
+      )
 
     removeFile('pkg-pages/bar.js')
-    await untilUpdated(
-      () => resultElement.textContent(),
-      JSON.stringify(['/pkg-pages/foo.js']),
-    )
+    await expect
+      .poll(() => resultElement.textContent())
+      .toMatch(JSON.stringify(['/pkg-pages/foo.js']))
   })
 }
 

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -9,7 +9,6 @@ import {
   page,
   removeFile,
   untilUpdated,
-  withRetry,
 } from '~utils'
 
 const filteredResult = {
@@ -90,18 +89,17 @@ const baseRawResult = {
 }
 
 test('should work', async () => {
-  await withRetry(async () => {
-    const actual = await page.textContent('.result')
-    expect(JSON.parse(actual)).toStrictEqual(allResult)
-  })
-  await withRetry(async () => {
-    const actualEager = await page.textContent('.result-eager')
-    expect(JSON.parse(actualEager)).toStrictEqual(allResult)
-  })
-  await withRetry(async () => {
-    const actualNodeModules = await page.textContent('.result-node_modules')
-    expect(JSON.parse(actualNodeModules)).toStrictEqual(nodeModulesResult)
-  })
+  await expect
+    .poll(async () => JSON.parse(await page.textContent('.result')))
+    .toStrictEqual(allResult)
+  await expect
+    .poll(async () => JSON.parse(await page.textContent('.result-eager')))
+    .toStrictEqual(allResult)
+  await expect
+    .poll(async () =>
+      JSON.parse(await page.textContent('.result-node_modules')),
+    )
+    .toStrictEqual(nodeModulesResult)
 })
 
 test('import glob raw', async () => {
@@ -139,9 +137,12 @@ if (!isBuild) {
     const resultElement = page.locator('.result')
 
     addFile('dir/a.js', '')
-    await withRetry(async () => {
-      const actualAdd = await resultElement.textContent()
-      expect(JSON.parse(actualAdd)).toStrictEqual({
+    await expect
+      .poll(async () => {
+        const actualAdd = await resultElement.textContent()
+        return JSON.parse(actualAdd)
+      })
+      .toStrictEqual({
         '/dir/a.js': {},
         ...allResult,
         '/dir/index.js': {
@@ -152,13 +153,15 @@ if (!isBuild) {
           },
         },
       })
-    })
 
     // edit the added file
     editFile('dir/a.js', () => 'export const msg ="a"')
-    await withRetry(async () => {
-      const actualEdit = await resultElement.textContent()
-      expect(JSON.parse(actualEdit)).toStrictEqual({
+    await expect
+      .poll(async () => {
+        const actualEdit = await resultElement.textContent()
+        return JSON.parse(actualEdit)
+      })
+      .toStrictEqual({
         '/dir/a.js': {
           msg: 'a',
         },
@@ -173,13 +176,14 @@ if (!isBuild) {
           },
         },
       })
-    })
 
     removeFile('dir/a.js')
-    await withRetry(async () => {
-      const actualRemove = await resultElement.textContent()
-      expect(JSON.parse(actualRemove)).toStrictEqual(allResult)
-    })
+    await expect
+      .poll(async () => {
+        const actualRemove = await resultElement.textContent()
+        return JSON.parse(actualRemove)
+      })
+      .toStrictEqual(allResult)
   })
 
   test('no hmr for adding/removing files', async () => {

--- a/playground/hmr-root/__tests__/hmr-root.spec.ts
+++ b/playground/hmr-root/__tests__/hmr-root.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
 
-import { editFile, isServe, page, untilUpdated } from '~utils'
+import { editFile, isServe, page } from '~utils'
 
 test.runIf(isServe)('should watch files outside root', async () => {
   expect(await page.textContent('#foo')).toBe('foo')
   editFile('foo.js', (code) => code.replace("'foo'", "'foobar'"))
   await page.waitForEvent('load')
-  await untilUpdated(async () => await page.textContent('#foo'), 'foobar')
+  await expect.poll(() => page.textContent('#foo')).toMatch('foobar')
 })

--- a/playground/hmr-root/__tests__/hmr-root.spec.ts
+++ b/playground/hmr-root/__tests__/hmr-root.spec.ts
@@ -6,5 +6,5 @@ test.runIf(isServe)('should watch files outside root', async () => {
   expect(await page.textContent('#foo')).toBe('foo')
   editFile('foo.js', (code) => code.replace("'foo'", "'foobar'"))
   await page.waitForEvent('load')
-  await expect.poll(() => page.textContent('#foo')).toMatch('foobar')
+  await expect.poll(() => page.textContent('#foo')).toBe('foobar')
 })

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -211,7 +211,7 @@ if (!isBuild) {
       )
       await expect
         .poll(() => el())
-        .toMatch(
+        .toBe(
           'soft-invalidation/index.js is transformed 1 times. child is updated',
         )
     })
@@ -263,8 +263,8 @@ if (!isBuild) {
       expect(query2()).toBe('query2')
 
       editFile('queries/multi-query.js', (code) => code + '//comment')
-      await expect.poll(() => query1()).toMatch('//commentquery1')
-      await expect.poll(() => query2()).toMatch('//commentquery2')
+      await expect.poll(() => query1()).toBe('//commentquery1')
+      await expect.poll(() => query2()).toBe('//commentquery2')
     })
   })
 
@@ -721,7 +721,7 @@ if (!isBuild) {
     const el = () => hmr('.virtual')
     expect(el()).toBe('[success]0')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await expect.poll(el).toMatch('[wow]')
+    await expect.poll(el).toBe('[wow]0')
   })
 
   test('invalidate virtual module', async () => {
@@ -729,7 +729,7 @@ if (!isBuild) {
     const el = () => hmr('.virtual')
     expect(el()).toBe('[wow]0')
     globalThis.__HMR__['virtual:increment']()
-    await expect.poll(el).toMatch('[wow]1')
+    await expect.poll(el).toBe('[wow]1')
   })
 
   test('should hmr when file is deleted and restored', async () => {
@@ -873,12 +873,11 @@ if (!isBuild) {
     )
     // it throws a same error as browser case,
     // but it doesn't auto reload and it calls `hot.accept(nextExports)` with `nextExports = undefined`
-    await expect.poll(() => el()).toMatch('')
 
     // test reloading manually for now
     server.moduleGraph.invalidateAll() // TODO: why is `runner.clearCache()` not enough?
     await runner.import('/self-accept-within-circular/index')
-    await expect.poll(() => el()).toMatch('cc')
+    await expect.poll(() => el()).toBe('cc')
   })
 
   test('hmr should not reload if no accepted within circular imported files', async () => {
@@ -893,9 +892,7 @@ if (!isBuild) {
     )
     await expect
       .poll(() => el())
-      .toMatch(
-        'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
-      )
+      .toBe('mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)')
   })
 
   test('not inlined assets HMR', async () => {

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -23,7 +23,6 @@ import {
   removeFile,
   slash,
   testDir,
-  untilUpdated,
 } from '~utils'
 
 let server: ViteDevServer
@@ -73,7 +72,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '2')
+      await expect.poll(() => el()).toMatch('2')
 
       await untilConsoleLogAfter(
         () =>
@@ -90,7 +89,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '3')
+      await expect.poll(() => el()).toMatch('3')
     })
 
     test('accept dep', async () => {
@@ -113,7 +112,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '2')
+      await expect.poll(() => el()).toMatch('2')
 
       await untilConsoleLogAfter(
         () =>
@@ -133,7 +132,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '3')
+      await expect.poll(() => el()).toMatch('3')
     })
 
     test('nested dep propagation', async () => {
@@ -156,7 +155,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '2')
+      await expect.poll(() => el()).toMatch('2')
 
       await untilConsoleLogAfter(
         () =>
@@ -176,7 +175,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), '3')
+      await expect.poll(() => el()).toMatch('3')
     })
 
     test('invalidate', async () => {
@@ -199,7 +198,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el(), 'child updated')
+      await expect.poll(() => el()).toMatch('child updated')
     })
 
     test('soft invalidate', async () => {
@@ -210,49 +209,50 @@ if (!isBuild) {
       editFile('soft-invalidation/child.js', (code) =>
         code.replace('bar', 'updated'),
       )
-      await untilUpdated(
-        () => el(),
-        'soft-invalidation/index.js is transformed 1 times. child is updated',
-      )
+      await expect
+        .poll(() => el())
+        .toMatch(
+          'soft-invalidation/index.js is transformed 1 times. child is updated',
+        )
     })
 
     test('invalidate in circular dep should not trigger infinite HMR', async () => {
       const el = () => hmr('.invalidation-circular-deps')
-      await untilUpdated(() => el(), 'child')
+      await expect.poll(() => el()).toMatch('child')
       editFile(
         'invalidation-circular-deps/circular-invalidate/child.js',
         (code) => code.replace('child', 'child updated'),
       )
-      await untilUpdated(() => el(), 'child updated')
+      await expect.poll(() => el()).toMatch('child updated')
     })
 
     test('invalidate in circular dep should be hot updated if possible', async () => {
       const el = () => hmr('.invalidation-circular-deps-handled')
-      await untilUpdated(() => el(), 'child')
+      await expect.poll(() => el()).toMatch('child')
       editFile(
         'invalidation-circular-deps/invalidate-handled-in-circle/child.js',
         (code) => code.replace('child', 'child updated'),
       )
-      await untilUpdated(() => el(), 'child updated')
+      await expect.poll(() => el()).toMatch('child updated')
     })
 
     test('plugin hmr handler + custom event', async () => {
       const el = () => hmr('.custom')
       editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-      await untilUpdated(() => el(), 'edited')
+      await expect.poll(() => el()).toMatch('edited')
     })
 
     test('plugin hmr remove custom events', async () => {
       const el = () => hmr('.toRemove')
       editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-      await untilUpdated(() => el(), 'edited')
+      await expect.poll(() => el()).toMatch('edited')
       editFile('customFile.js', (code) => code.replace('edited', 'custom'))
-      await untilUpdated(() => el(), 'edited')
+      await expect.poll(() => el()).toMatch('edited')
     })
 
     test('plugin client-server communication', async () => {
       const el = () => hmr('.custom-communication')
-      await untilUpdated(() => el(), '3')
+      await expect.poll(() => el()).toMatch('3')
     })
 
     test('queries are correctly resolved', async () => {
@@ -263,8 +263,8 @@ if (!isBuild) {
       expect(query2()).toBe('query2')
 
       editFile('queries/multi-query.js', (code) => code + '//comment')
-      await untilUpdated(() => query1(), '//commentquery1')
-      await untilUpdated(() => query2(), '//commentquery2')
+      await expect.poll(() => query1()).toMatch('//commentquery1')
+      await expect.poll(() => query2()).toMatch('//commentquery2')
     })
   })
 
@@ -294,7 +294,7 @@ if (!isBuild) {
           ],
           true,
         )
-        await untilUpdated(() => el(), '2')
+        await expect.poll(() => el()).toMatch('2')
 
         await untilConsoleLogAfter(
           () =>
@@ -309,7 +309,7 @@ if (!isBuild) {
           ],
           true,
         )
-        await untilUpdated(() => el(), '3')
+        await expect.poll(() => el()).toMatch('3')
       },
     )
   })
@@ -721,7 +721,7 @@ if (!isBuild) {
     const el = () => hmr('.virtual')
     expect(el()).toBe('[success]0')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await untilUpdated(el, '[wow]')
+    await expect.poll(el).toMatch('[wow]')
   })
 
   test('invalidate virtual module', async () => {
@@ -729,7 +729,7 @@ if (!isBuild) {
     const el = () => hmr('.virtual')
     expect(el()).toBe('[wow]0')
     globalThis.__HMR__['virtual:increment']()
-    await untilUpdated(el, '[wow]1')
+    await expect.poll(el).toMatch('[wow]1')
   })
 
   test('should hmr when file is deleted and restored', async () => {
@@ -738,12 +738,14 @@ if (!isBuild) {
     const parentFile = 'file-delete-restore/parent.js'
     const childFile = 'file-delete-restore/child.js'
 
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:child')
+    await expect.poll(() => hmr('.file-delete-restore')).toMatch('parent:child')
 
     editFile(childFile, (code) =>
       code.replace("value = 'child'", "value = 'child1'"),
     )
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:child1')
+    await expect
+      .poll(() => hmr('.file-delete-restore'))
+      .toMatch('parent:child1')
 
     // delete the file
     editFile(parentFile, (code) =>
@@ -754,7 +756,9 @@ if (!isBuild) {
     )
     const originalChildFileCode = readFile(childFile)
     removeFile(childFile)
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:not-child')
+    await expect
+      .poll(() => hmr('.file-delete-restore'))
+      .toMatch('parent:not-child')
 
     // restore the file
     addFile(childFile, originalChildFileCode)
@@ -764,7 +768,7 @@ if (!isBuild) {
         "export { value as childValue } from './child'",
       ),
     )
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:child')
+    await expect.poll(() => hmr('.file-delete-restore')).toMatch('parent:child')
   })
 
   test('delete file should not break hmr', async () => {
@@ -772,17 +776,15 @@ if (!isBuild) {
       '.intermediate-file-delete-increment': '1',
     })
 
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 1',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 1')
 
     // add state
     globalThis.__HMR__['.delete-intermediate-file']()
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 2',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 2')
 
     // update import, hmr works
     editFile('intermediate-file-delete/index.js', (code) =>
@@ -791,34 +793,30 @@ if (!isBuild) {
     editFile('intermediate-file-delete/display.js', (code) =>
       code.replace('count is ${count}', 'count is ${count}!'),
     )
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 2!',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 2!')
 
     // remove unused file
     removeFile('intermediate-file-delete/re-export.js')
     __HMR__['.intermediate-file-delete-increment'] = '1' // reset state
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 1!',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 1!')
 
     // re-add state
     globalThis.__HMR__['.delete-intermediate-file']()
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 2!',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 2!')
 
     // hmr works after file deletion
     editFile('intermediate-file-delete/display.js', (code) =>
       code.replace('count is ${count}!', 'count is ${count}'),
     )
-    await untilUpdated(
-      () => hmr('.intermediate-file-delete-display'),
-      'count is 2',
-    )
+    await expect
+      .poll(() => hmr('.intermediate-file-delete-display'))
+      .toMatch('count is 2')
   })
 
   test('deleted file should trigger dispose and prune callbacks', async () => {
@@ -837,7 +835,9 @@ if (!isBuild) {
     const originalChildFileCode = readFile(childFile)
     removeFile(childFile)
 
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:not-child')
+    await expect
+      .poll(() => hmr('.file-delete-restore'))
+      .toMatch('parent:not-child')
     expect(clientLogs).to.include('file-delete-restore/child.js is disposed')
     expect(clientLogs).to.include('file-delete-restore/child.js is pruned')
 
@@ -849,7 +849,7 @@ if (!isBuild) {
         "export { value as childValue } from './child'",
       ),
     )
-    await untilUpdated(() => hmr('.file-delete-restore'), 'parent:child')
+    await expect.poll(() => hmr('.file-delete-restore')).toMatch('parent:child')
   })
 
   test('import.meta.hot?.accept', async () => {
@@ -861,7 +861,7 @@ if (!isBuild) {
         ),
       '(optional-chaining) child update',
     )
-    await untilUpdated(() => hmr('.optional-chaining')?.toString(), '2')
+    await expect.poll(() => hmr('.optional-chaining')?.toString()).toMatch('2')
   })
 
   test('hmr works for self-accepted module within circular imported files', async () => {
@@ -873,12 +873,12 @@ if (!isBuild) {
     )
     // it throws a same error as browser case,
     // but it doesn't auto reload and it calls `hot.accept(nextExports)` with `nextExports = undefined`
-    await untilUpdated(() => el(), '')
+    await expect.poll(() => el()).toMatch('')
 
     // test reloading manually for now
     server.moduleGraph.invalidateAll() // TODO: why is `runner.clearCache()` not enough?
     await runner.import('/self-accept-within-circular/index')
-    await untilUpdated(() => el(), 'cc')
+    await expect.poll(() => el()).toMatch('cc')
   })
 
   test('hmr should not reload if no accepted within circular imported files', async () => {
@@ -891,10 +891,11 @@ if (!isBuild) {
     editFile('circular/mod-b.js', (code) =>
       code.replace(`mod-b ->`, `mod-b (edited) ->`),
     )
-    await untilUpdated(
-      () => el(),
-      'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
-    )
+    await expect
+      .poll(() => el())
+      .toMatch(
+        'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
+      )
   })
 
   test('not inlined assets HMR', async () => {

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -225,7 +225,7 @@ if (!isBuild) {
     )
     await expect
       .poll(() => el.textContent())
-      .toMatch(
+      .toBe(
         'soft-invalidation/index.js is transformed 1 times. child is updated',
       )
 
@@ -237,7 +237,7 @@ if (!isBuild) {
     )
     await expect
       .poll(() => el.textContent())
-      .toMatch(
+      .toBe(
         'soft-invalidation/index.js is transformed 2 times. child is now updated?',
       )
   })
@@ -296,7 +296,7 @@ if (!isBuild) {
     await page.waitForEvent('load')
     await expect
       .poll(async () => (await page.$('#app')).textContent())
-      .toMatch('title2')
+      .toBe('title2')
   })
 
   test('CSS update preserves query params', async () => {
@@ -790,7 +790,7 @@ if (!isBuild) {
         const el = await page.$('.virtual')
         return await el.textContent()
       })
-      .toMatch('[wow]')
+      .toBe('[wow]0')
   })
 
   test('invalidate virtual module', async () => {
@@ -804,7 +804,7 @@ if (!isBuild) {
         const el = await page.$('.virtual')
         return await el.textContent()
       })
-      .toMatch('[wow]1')
+      .toBe('[wow]1')
   })
 
   test('handle virtual module accept updates', async () => {
@@ -817,7 +817,7 @@ if (!isBuild) {
         const el = await page.$('.virtual-dep')
         return await el.textContent()
       })
-      .toMatch('[wow]')
+      .toBe('[wow]0')
   })
 
   test('invalidate virtual module and accept', async () => {
@@ -831,7 +831,7 @@ if (!isBuild) {
         const el = await page.$('.virtual-dep')
         return await el.textContent()
       })
-      .toMatch('[wow]2')
+      .toBe('[wow]2')
   })
 
   test('keep hmr reload after missing import on server startup', async () => {
@@ -1020,7 +1020,7 @@ if (!isBuild) {
     )
     await expect
       .poll(() => page.textContent('.self-accept-within-circular'))
-      .toMatch('cc')
+      .toBe('cc')
     expect(serverLogs.length).greaterThanOrEqual(1)
     // Should still keep hmr update, but it'll error on the browser-side and will refresh itself.
     // Match on full log not possible because of color markers
@@ -1038,7 +1038,7 @@ if (!isBuild) {
     )
     await expect
       .poll(() => el.textContent())
-      .toMatch('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
+      .toBe('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
   })
 
   test('not inlined assets HMR', async () => {
@@ -1073,9 +1073,9 @@ if (!isBuild) {
 
   test('CSS HMR with this.addWatchFile', async () => {
     await page.goto(viteTestUrl + '/css-deps/index.html')
-    expect(await getColor('.css-deps')).toMatch('red')
+    expect(await getColor('.css-deps')).toBe('red')
     editFile('css-deps/dep.js', (code) => code.replace(`red`, `green`))
-    await expect.poll(() => getColor('.css-deps')).toMatch('green')
+    await expect.poll(() => getColor('.css-deps')).toBe('green')
   })
 
   test('hmr should happen after missing file is created', async () => {

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -13,7 +13,6 @@ import {
   removeFile,
   serverLogs,
   untilBrowserLogAfter,
-  untilUpdated,
   viteTestUrl,
 } from '~utils'
 
@@ -47,7 +46,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '2')
+    await expect.poll(() => el.textContent()).toMatch('2')
 
     await untilBrowserLogAfter(
       () =>
@@ -64,7 +63,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '3')
+    await expect.poll(() => el.textContent()).toMatch('3')
   })
 
   test('accept dep', async () => {
@@ -87,7 +86,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '2')
+    await expect.poll(() => el.textContent()).toMatch('2')
 
     await untilBrowserLogAfter(
       () =>
@@ -107,7 +106,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '3')
+    await expect.poll(() => el.textContent()).toMatch('3')
   })
 
   test('nested dep propagation', async () => {
@@ -130,7 +129,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '2')
+    await expect.poll(() => el.textContent()).toMatch('2')
 
     await untilBrowserLogAfter(
       () =>
@@ -150,7 +149,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), '3')
+    await expect.poll(() => el.textContent()).toMatch('3')
   })
 
   test('invalidate', async () => {
@@ -173,7 +172,7 @@ if (!isBuild) {
       ],
       true,
     )
-    await untilUpdated(() => el.textContent(), 'child updated')
+    await expect.poll(() => el.textContent()).toMatch('child updated')
   })
 
   test('invalidate works with multiple tabs', async () => {
@@ -202,7 +201,7 @@ if (!isBuild) {
         ],
         true,
       )
-      await untilUpdated(() => el.textContent(), 'child updated')
+      await expect.poll(() => el.textContent()).toMatch('child updated')
     } finally {
       await page2.close()
     }
@@ -211,10 +210,9 @@ if (!isBuild) {
   test('invalidate on root triggers page reload', async () => {
     editFile('invalidation/root.js', (code) => code.replace('Init', 'Updated'))
     await page.waitForEvent('load')
-    await untilUpdated(
-      async () => (await page.$('.invalidation-root')).textContent(),
-      'Updated',
-    )
+    await expect
+      .poll(async () => (await page.$('.invalidation-root')).textContent())
+      .toMatch('Updated')
   })
 
   test('soft invalidate', async () => {
@@ -225,10 +223,11 @@ if (!isBuild) {
     editFile('soft-invalidation/child.js', (code) =>
       code.replace('bar', 'updated'),
     )
-    await untilUpdated(
-      () => el.textContent(),
-      'soft-invalidation/index.js is transformed 1 times. child is updated',
-    )
+    await expect
+      .poll(() => el.textContent())
+      .toMatch(
+        'soft-invalidation/index.js is transformed 1 times. child is updated',
+      )
 
     editFile('soft-invalidation/index.js', (code) =>
       code.replace('child is', 'child is now'),
@@ -236,53 +235,53 @@ if (!isBuild) {
     editFile('soft-invalidation/child.js', (code) =>
       code.replace('updated', 'updated?'),
     )
-    await untilUpdated(
-      () => el.textContent(),
-      'soft-invalidation/index.js is transformed 2 times. child is now updated?',
-    )
+    await expect
+      .poll(() => el.textContent())
+      .toMatch(
+        'soft-invalidation/index.js is transformed 2 times. child is now updated?',
+      )
   })
 
   test('invalidate in circular dep should not trigger infinite HMR', async () => {
     const el = await page.$('.invalidation-circular-deps')
-    await untilUpdated(() => el.textContent(), 'child')
+    await expect.poll(() => el.textContent()).toMatch('child')
     editFile(
       'invalidation-circular-deps/circular-invalidate/child.js',
       (code) => code.replace('child', 'child updated'),
     )
     await page.waitForEvent('load')
-    await untilUpdated(
-      () => page.textContent('.invalidation-circular-deps'),
-      'child updated',
-    )
+    await expect
+      .poll(() => page.textContent('.invalidation-circular-deps'))
+      .toMatch('child updated')
   })
 
   test('invalidate in circular dep should be hot updated if possible', async () => {
     const el = await page.$('.invalidation-circular-deps-handled')
-    await untilUpdated(() => el.textContent(), 'child')
+    await expect.poll(() => el.textContent()).toMatch('child')
     editFile(
       'invalidation-circular-deps/invalidate-handled-in-circle/child.js',
       (code) => code.replace('child', 'child updated'),
     )
-    await untilUpdated(() => el.textContent(), 'child updated')
+    await expect.poll(() => el.textContent()).toMatch('child updated')
   })
 
   test('plugin hmr handler + custom event', async () => {
     const el = await page.$('.custom')
     editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await untilUpdated(() => el.textContent(), 'edited')
+    await expect.poll(() => el.textContent()).toMatch('edited')
   })
 
   test('plugin hmr remove custom events', async () => {
     const el = await page.$('.toRemove')
     editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await untilUpdated(() => el.textContent(), 'edited')
+    await expect.poll(() => el.textContent()).toMatch('edited')
     editFile('customFile.js', (code) => code.replace('edited', 'custom'))
-    await untilUpdated(() => el.textContent(), 'edited')
+    await expect.poll(() => el.textContent()).toMatch('edited')
   })
 
   test('plugin client-server communication', async () => {
     const el = await page.$('.custom-communication')
-    await untilUpdated(() => el.textContent(), '3')
+    await expect.poll(() => el.textContent()).toMatch('3')
   })
 
   test('full-reload encodeURI path', async () => {
@@ -295,10 +294,9 @@ if (!isBuild) {
       code.replace('title', 'title2'),
     )
     await page.waitForEvent('load')
-    await untilUpdated(
-      async () => (await page.$('#app')).textContent(),
-      'title2',
-    )
+    await expect
+      .poll(async () => (await page.$('#app')).textContent())
+      .toMatch('title2')
   })
 
   test('CSS update preserves query params', async () => {
@@ -308,8 +306,8 @@ if (!isBuild) {
 
     const elprev = await page.$('.css-prev')
     const elpost = await page.$('.css-post')
-    await untilUpdated(() => elprev.textContent(), 'param=required')
-    await untilUpdated(() => elpost.textContent(), 'param=required')
+    await expect.poll(() => elprev.textContent()).toMatch('param=required')
+    await expect.poll(() => elpost.textContent()).toMatch('param=required')
     const textprev = await elprev.textContent()
     const textpost = await elpost.textContent()
     expect(textprev).not.toBe(textpost)
@@ -323,10 +321,10 @@ if (!isBuild) {
     editFile('global.css', (code) => code.replace('white', 'tomato'))
 
     let el = await page.$('.link-tag-added')
-    await untilUpdated(() => el.textContent(), 'yes')
+    await expect.poll(() => el.textContent()).toMatch('yes')
 
     el = await page.$('.link-tag-removed')
-    await untilUpdated(() => el.textContent(), 'yes')
+    await expect.poll(() => el.textContent()).toMatch('yes')
 
     expect((await page.$$('link')).length).toBe(1)
   })
@@ -373,22 +371,24 @@ if (!isBuild) {
       return outputEle.innerHTML()
     }
 
-    await untilUpdated(getOutput, ['a.js: a0', 'b.js: b0,a0'].join('<br>'))
+    await expect
+      .poll(getOutput)
+      .toMatch(['a.js: a0', 'b.js: b0,a0'].join('<br>'))
 
     editFile('importing-updated/a.js', (code) => code.replace("'a0'", "'a1'"))
-    await untilUpdated(
-      getOutput,
-      ['a.js: a0', 'b.js: b0,a0', 'a.js: a1'].join('<br>'),
-    )
+    await expect
+      .poll(getOutput)
+      .toMatch(['a.js: a0', 'b.js: b0,a0', 'a.js: a1'].join('<br>'))
 
     editFile('importing-updated/b.js', (code) =>
       code.replace('`b0,${a}`', '`b1,${a}`'),
     )
     // note that "a.js: a1" should not happen twice after "b.js: b0,a0'"
-    await untilUpdated(
-      getOutput,
-      ['a.js: a0', 'b.js: b0,a0', 'a.js: a1', 'b.js: b1,a1'].join('<br>'),
-    )
+    await expect
+      .poll(getOutput)
+      .toMatch(
+        ['a.js: a0', 'b.js: b0,a0', 'a.js: a1', 'b.js: b1,a1'].join('<br>'),
+      )
   })
 
   describe('acceptExports', () => {
@@ -785,10 +785,12 @@ if (!isBuild) {
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[success]0')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await untilUpdated(async () => {
-      const el = await page.$('.virtual')
-      return await el.textContent()
-    }, '[wow]')
+    await expect
+      .poll(async () => {
+        const el = await page.$('.virtual')
+        return await el.textContent()
+      })
+      .toMatch('[wow]')
   })
 
   test('invalidate virtual module', async () => {
@@ -797,10 +799,12 @@ if (!isBuild) {
     expect(await el.textContent()).toBe('[wow]0')
     const btn = await page.$('.virtual-update')
     btn.click()
-    await untilUpdated(async () => {
-      const el = await page.$('.virtual')
-      return await el.textContent()
-    }, '[wow]1')
+    await expect
+      .poll(async () => {
+        const el = await page.$('.virtual')
+        return await el.textContent()
+      })
+      .toMatch('[wow]1')
   })
 
   test('handle virtual module accept updates', async () => {
@@ -808,10 +812,12 @@ if (!isBuild) {
     const el = await page.$('.virtual-dep')
     expect(await el.textContent()).toBe('0')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await untilUpdated(async () => {
-      const el = await page.$('.virtual-dep')
-      return await el.textContent()
-    }, '[wow]')
+    await expect
+      .poll(async () => {
+        const el = await page.$('.virtual-dep')
+        return await el.textContent()
+      })
+      .toMatch('[wow]')
   })
 
   test('invalidate virtual module and accept', async () => {
@@ -820,10 +826,12 @@ if (!isBuild) {
     expect(await el.textContent()).toBe('0')
     const btn = await page.$('.virtual-update-dep')
     btn.click()
-    await untilUpdated(async () => {
-      const el = await page.$('.virtual-dep')
-      return await el.textContent()
-    }, '[wow]2')
+    await expect
+      .poll(async () => {
+        const el = await page.$('.virtual-dep')
+        return await el.textContent()
+      })
+      .toMatch('[wow]2')
   })
 
   test('keep hmr reload after missing import on server startup', async () => {
@@ -858,18 +866,16 @@ if (!isBuild) {
     const parentFile = 'file-delete-restore/parent.js'
     const childFile = 'file-delete-restore/child.js'
 
-    await untilUpdated(
-      () => page.textContent('.file-delete-restore'),
-      'parent:child',
-    )
+    await expect
+      .poll(() => page.textContent('.file-delete-restore'))
+      .toMatch('parent:child')
 
     editFile(childFile, (code) =>
       code.replace("value = 'child'", "value = 'child1'"),
     )
-    await untilUpdated(
-      () => page.textContent('.file-delete-restore'),
-      'parent:child1',
-    )
+    await expect
+      .poll(() => page.textContent('.file-delete-restore'))
+      .toMatch('parent:child1')
 
     // delete the file
     editFile(parentFile, (code) =>
@@ -884,10 +890,9 @@ if (!isBuild) {
         () => removeFile(childFile),
         `${childFile} is disposed`,
       ),
-      untilUpdated(
-        () => page.textContent('.file-delete-restore'),
-        'parent:not-child',
-      ),
+      expect
+        .poll(() => page.textContent('.file-delete-restore'))
+        .toMatch('parent:not-child'),
     ])
 
     await untilBrowserLogAfter(async () => {
@@ -901,26 +906,23 @@ if (!isBuild) {
       )
       await loadPromise
     }, [/connected/])
-    await untilUpdated(
-      () => page.textContent('.file-delete-restore'),
-      'parent:child',
-    )
+    await expect
+      .poll(() => page.textContent('.file-delete-restore'))
+      .toMatch('parent:child')
   })
 
   test('delete file should not break hmr', async () => {
     await page.goto(viteTestUrl)
 
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 1',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 1')
 
     // add state
     await page.click('.intermediate-file-delete-increment')
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 2',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 2')
 
     // update import, hmr works
     editFile('intermediate-file-delete/index.js', (code) =>
@@ -929,33 +931,29 @@ if (!isBuild) {
     editFile('intermediate-file-delete/display.js', (code) =>
       code.replace('count is ${count}', 'count is ${count}!'),
     )
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 2!',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 2!')
 
     // remove unused file, page reload because it's considered entry point now
     removeFile('intermediate-file-delete/re-export.js')
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 1!',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 1!')
 
     // re-add state
     await page.click('.intermediate-file-delete-increment')
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 2!',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 2!')
 
     // hmr works after file deletion
     editFile('intermediate-file-delete/display.js', (code) =>
       code.replace('count is ${count}!', 'count is ${count}'),
     )
-    await untilUpdated(
-      () => page.textContent('.intermediate-file-delete-display'),
-      'count is 2',
-    )
+    await expect
+      .poll(() => page.textContent('.intermediate-file-delete-display'))
+      .toMatch('count is 2')
   })
 
   test('deleted file should trigger dispose and prune callbacks', async () => {
@@ -982,10 +980,9 @@ if (!isBuild) {
       ],
       false,
     )
-    await untilUpdated(
-      () => page.textContent('.file-delete-restore'),
-      'parent:not-child',
-    )
+    await expect
+      .poll(() => page.textContent('.file-delete-restore'))
+      .toMatch('parent:not-child')
 
     // restore the file
     addFile(childFile, originalChildFileCode)
@@ -995,10 +992,9 @@ if (!isBuild) {
         "export { value as childValue } from './child'",
       ),
     )
-    await untilUpdated(
-      () => page.textContent('.file-delete-restore'),
-      'parent:child',
-    )
+    await expect
+      .poll(() => page.textContent('.file-delete-restore'))
+      .toMatch('parent:child')
   })
 
   test('import.meta.hot?.accept', async () => {
@@ -1012,7 +1008,7 @@ if (!isBuild) {
         ),
       '(optional-chaining) child update',
     )
-    await untilUpdated(() => el.textContent(), '2')
+    await expect.poll(() => el.textContent()).toMatch('2')
   })
 
   test('hmr works for self-accepted module within circular imported files', async () => {
@@ -1022,10 +1018,9 @@ if (!isBuild) {
     editFile('self-accept-within-circular/c.js', (code) =>
       code.replace(`export const c = 'c'`, `export const c = 'cc'`),
     )
-    await untilUpdated(
-      () => page.textContent('.self-accept-within-circular'),
-      'cc',
-    )
+    await expect
+      .poll(() => page.textContent('.self-accept-within-circular'))
+      .toMatch('cc')
     expect(serverLogs.length).greaterThanOrEqual(1)
     // Should still keep hmr update, but it'll error on the browser-side and will refresh itself.
     // Match on full log not possible because of color markers
@@ -1041,10 +1036,9 @@ if (!isBuild) {
     editFile('circular/mod-b.js', (code) =>
       code.replace(`mod-b ->`, `mod-b (edited) ->`),
     )
-    await untilUpdated(
-      () => el.textContent(),
-      'mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)',
-    )
+    await expect
+      .poll(() => el.textContent())
+      .toMatch('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
   })
 
   test('not inlined assets HMR', async () => {
@@ -1057,7 +1051,9 @@ if (!isBuild) {
         ),
       /Logo-no-inline updated/,
     )
-    await untilUpdated(() => el.evaluate((it) => `${it.clientHeight}`), '40')
+    await expect
+      .poll(() => el.evaluate((it) => `${it.clientHeight}`))
+      .toMatch('40')
   })
 
   test('inlined assets HMR', async () => {
@@ -1070,14 +1066,16 @@ if (!isBuild) {
         ),
       /Logo updated/,
     )
-    await untilUpdated(() => el.evaluate((it) => `${it.clientHeight}`), '40')
+    await expect
+      .poll(() => el.evaluate((it) => `${it.clientHeight}`))
+      .toMatch('40')
   })
 
   test('CSS HMR with this.addWatchFile', async () => {
     await page.goto(viteTestUrl + '/css-deps/index.html')
     expect(await getColor('.css-deps')).toMatch('red')
     editFile('css-deps/dep.js', (code) => code.replace(`red`, `green`))
-    await untilUpdated(() => getColor('.css-deps'), 'green')
+    await expect.poll(() => getColor('.css-deps')).toMatch('green')
   })
 
   test('hmr should happen after missing file is created', async () => {

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -2,7 +2,6 @@ import { beforeAll, describe, expect, test } from 'vitest'
 import {
   browserLogs,
   editFile,
-  expectWithRetry,
   getColor,
   isBuild,
   isServe,
@@ -11,7 +10,6 @@ import {
   untilBrowserLogAfter,
   viteServer,
   viteTestUrl,
-  withRetry,
 } from '~utils'
 
 function fetchHtml(p: string) {
@@ -419,7 +417,7 @@ describe('relative input', () => {
   })
 
   test('passing relative path to rollupOptions.input works', async () => {
-    await expectWithRetry(() => page.textContent('.relative-input')).toBe('OK')
+    await expect.poll(() => page.textContent('.relative-input')).toBe('OK')
   })
 })
 
@@ -427,13 +425,13 @@ describe.runIf(isServe)('warmup', () => {
   test('should warmup /warmup/warm.js', async () => {
     // warmup transform files async during server startup, so the module check
     // here might take a while to load
-    await withRetry(async () => {
-      const mod =
-        await viteServer.environments.client.moduleGraph.getModuleByUrl(
+    await expect
+      .poll(() =>
+        viteServer.environments.client.moduleGraph.getModuleByUrl(
           '/warmup/warm.js',
-        )
-      expect(mod).toBeTruthy()
-    })
+        ),
+      )
+      .toBeTruthy()
   })
 })
 

--- a/playground/json/__tests__/csr/json-csr.spec.ts
+++ b/playground/json/__tests__/csr/json-csr.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest'
 import deepJson from 'vue/package.json'
 import testJson from '../../test.json'
 import hmrJson from '../../hmr.json'
-import { editFile, isBuild, isServe, page, untilUpdated } from '~utils'
+import { editFile, isBuild, isServe, page } from '~utils'
 
 const stringified = JSON.stringify(testJson)
 const deepStringified = JSON.stringify(deepJson)
@@ -55,8 +55,7 @@ test.runIf(isServe)('should full reload', async () => {
   editFile('hmr.json', (code) =>
     code.replace('"this is hmr json"', '"this is hmr update json"'),
   )
-  await untilUpdated(
-    () => page.textContent('.hmr'),
-    '"this is hmr update json"',
-  )
+  await expect
+    .poll(() => page.textContent('.hmr'))
+    .toMatch('"this is hmr update json"')
 })

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -73,7 +73,7 @@ test('correctly emits styles', async () => {
 // dynamic import css
 test('should load dynamic import with css', async () => {
   await page.click('#dynamic-css-button')
-  await expect.poll(() => getColor('#dynamic-css')).toMatch('red')
+  await expect.poll(() => getColor('#dynamic-css')).toBe('red')
 })
 
 test('asset url', async () => {

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -6,61 +6,64 @@ import {
   listAssets,
   page,
   readManifest,
-  untilUpdated,
 } from '~utils'
 
 test('should load the worker', async () => {
-  await untilUpdated(() => page.textContent('.worker-message'), 'module')
+  await expect.poll(() => page.textContent('.worker-message')).toMatch('module')
 })
 
 test('should work', async () => {
-  await untilUpdated(() => page.textContent('#app'), 'Hello')
+  await expect.poll(() => page.textContent('#app')).toMatch('Hello')
 })
 
 test('import.meta.env.LEGACY', async () => {
-  await untilUpdated(() => page.textContent('#env'), isBuild ? 'true' : 'false')
-  await untilUpdated(() => page.textContent('#env-equal'), 'true')
+  await expect
+    .poll(() => page.textContent('#env'))
+    .toMatch(isBuild ? 'true' : 'false')
+  await expect.poll(() => page.textContent('#env-equal')).toMatch('true')
 })
 
 // https://github.com/vitejs/vite/issues/3400
 test('transpiles down iterators correctly', async () => {
-  await untilUpdated(() => page.textContent('#iterators'), 'hello')
+  await expect.poll(() => page.textContent('#iterators')).toMatch('hello')
 })
 
 test('async generator', async () => {
-  await untilUpdated(() => page.textContent('#async-generator'), '[0,1,2]')
+  await expect
+    .poll(() => page.textContent('#async-generator'))
+    .toMatch('[0,1,2]')
 })
 
 test('wraps with iife', async () => {
-  await untilUpdated(
-    () => page.textContent('#babel-helpers'),
-    'exposed babel helpers: false',
-  )
+  await expect
+    .poll(() => page.textContent('#babel-helpers'))
+    .toMatch('exposed babel helpers: false')
 })
 
 test('generates assets', async () => {
-  await untilUpdated(
-    () => page.textContent('#assets'),
-    isBuild
-      ? [
-          'index: text/html',
-          'index-legacy: text/html',
-          'chunk-async: text/html',
-          'chunk-async-legacy: text/html',
-          'immutable-chunk: text/javascript',
-          'immutable-chunk-legacy: text/javascript',
-          'polyfills-legacy: text/html',
-        ].join('\n')
-      : [
-          'index: text/html',
-          'index-legacy: text/html',
-          'chunk-async: text/html',
-          'chunk-async-legacy: text/html',
-          'immutable-chunk: text/html',
-          'immutable-chunk-legacy: text/html',
-          'polyfills-legacy: text/html',
-        ].join('\n'),
-  )
+  await expect
+    .poll(() => page.textContent('#assets'))
+    .toMatch(
+      isBuild
+        ? [
+            'index: text/html',
+            'index-legacy: text/html',
+            'chunk-async: text/html',
+            'chunk-async-legacy: text/html',
+            'immutable-chunk: text/javascript',
+            'immutable-chunk-legacy: text/javascript',
+            'polyfills-legacy: text/html',
+          ].join('\n')
+        : [
+            'index: text/html',
+            'index-legacy: text/html',
+            'chunk-async: text/html',
+            'chunk-async-legacy: text/html',
+            'immutable-chunk: text/html',
+            'immutable-chunk-legacy: text/html',
+            'polyfills-legacy: text/html',
+          ].join('\n'),
+    )
 })
 
 test('correctly emits styles', async () => {
@@ -70,7 +73,7 @@ test('correctly emits styles', async () => {
 // dynamic import css
 test('should load dynamic import with css', async () => {
   await page.click('#dynamic-css-button')
-  await untilUpdated(() => getColor('#dynamic-css'), 'red')
+  await expect.poll(() => getColor('#dynamic-css')).toMatch('red')
 })
 
 test('asset url', async () => {

--- a/playground/legacy/__tests__/no-polyfills-no-systemjs/legacy-no-polyfills-no-systemjs.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills-no-systemjs/legacy-no-polyfills-no-systemjs.spec.ts
@@ -1,13 +1,12 @@
 import { expect, test } from 'vitest'
-import { isBuild, page, untilUpdated, viteTestUrl } from '~utils'
+import { isBuild, page, viteTestUrl } from '~utils'
 
 test.runIf(isBuild)('includes only a single script tag', async () => {
   await page.goto(viteTestUrl + '/no-polyfills-no-systemjs.html')
 
-  await untilUpdated(
-    () => page.getAttribute('#vite-legacy-entry', 'data-src'),
-    /.\/assets\/index-legacy-(.+)\.js/,
-  )
+  await expect
+    .poll(() => page.getAttribute('#vite-legacy-entry', 'data-src'))
+    .toMatch(/.\/assets\/index-legacy-(.+)\.js/)
 
   expect(await page.locator('script').count()).toBe(1)
   expect(await page.locator('#vite-legacy-polyfill').count()).toBe(0)

--- a/playground/legacy/__tests__/no-polyfills/legacy-no-polyfills.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills/legacy-no-polyfills.spec.ts
@@ -1,18 +1,16 @@
-import { test } from 'vitest'
-import { isBuild, page, untilUpdated, viteTestUrl } from '~utils'
+import { expect, test } from 'vitest'
+import { isBuild, page, viteTestUrl } from '~utils'
 
 test('should load and execute the JS file', async () => {
   await page.goto(viteTestUrl + '/no-polyfills.html')
-  await untilUpdated(() => page.textContent('main'), '👋')
+  await expect.poll(() => page.textContent('main')).toMatch('👋')
 })
 
 test.runIf(isBuild)('includes a script tag for SystemJS', async () => {
-  await untilUpdated(
-    () => page.getAttribute('#vite-legacy-polyfill', 'src'),
-    /.\/assets\/polyfills-legacy-(.+)\.js/,
-  )
-  await untilUpdated(
-    () => page.getAttribute('#vite-legacy-entry', 'data-src'),
-    /.\/assets\/index-legacy-(.+)\.js/,
-  )
+  await expect
+    .poll(() => page.getAttribute('#vite-legacy-polyfill', 'src'))
+    .toMatch(/.\/assets\/polyfills-legacy-(.+)\.js/)
+  await expect
+    .poll(() => page.getAttribute('#vite-legacy-entry', 'data-src'))
+    .toMatch(/.\/assets\/index-legacy-(.+)\.js/)
 })

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -1,12 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import {
-  isBuild,
-  isServe,
-  page,
-  readFile,
-  serverLogs,
-  untilUpdated,
-} from '~utils'
+import { isBuild, isServe, page, readFile, serverLogs } from '~utils'
 
 describe.runIf(isBuild)('build', () => {
   test('es', async () => {
@@ -55,10 +48,9 @@ describe.runIf(isBuild)('build', () => {
   })
 
   test('Library mode does not include `preload`', async () => {
-    await untilUpdated(
-      () => page.textContent('.dynamic-import-message'),
-      'hello vite',
-    )
+    await expect
+      .poll(() => page.textContent('.dynamic-import-message'))
+      .toMatch('hello vite')
     const code = readFile('dist/lib/dynamic-import-message.es.mjs')
     expect(code).not.toMatch('__vitePreload')
 

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -6,7 +6,6 @@ import {
   readFile,
   serverLogs,
   untilUpdated,
-  withRetry,
 } from '~utils'
 
 describe.runIf(isBuild)('build', () => {
@@ -131,7 +130,5 @@ describe.runIf(isBuild)('build', () => {
 })
 
 test.runIf(isServe)('dev', async () => {
-  await withRetry(async () => {
-    expect(await page.textContent('.demo')).toBe('It works')
-  })
+  await expect.poll(() => page.textContent('.demo')).toBe('It works')
 })

--- a/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
+++ b/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { getColor, page, untilUpdated } from '~utils'
+import { getColor, page } from '~utils'
 
 test('should have css applied on second dynamic import', async () => {
-  await untilUpdated(() => page.textContent('.content'), 'Initial')
+  await expect.poll(() => page.textContent('.content')).toMatch('Initial')
   await page.click('.b')
 
-  await untilUpdated(() => page.textContent('.content'), 'Reference')
+  await expect.poll(() => page.textContent('.content')).toMatch('Reference')
   expect(await getColor('.content')).toBe('red')
 })

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest'
 import {
   browserErrors,
   browserLogs,
-  expectWithRetry,
   getColor,
   isBuild,
   isServe,
@@ -13,224 +12,206 @@ import {
 } from '~utils'
 
 test('default + named imports from cjs dep (react)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs button')).toBe(
-    'count is 0',
-  )
+  await expect.poll(() => page.textContent('.cjs button')).toBe('count is 0')
   await page.click('.cjs button')
-  await expectWithRetry(() => page.textContent('.cjs button')).toBe(
-    'count is 1',
-  )
+  await expect.poll(() => page.textContent('.cjs button')).toBe('count is 1')
 })
 
 test('named imports from webpacked cjs (phoenix)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-phoenix')).toBe('ok')
+  await expect.poll(() => page.textContent('.cjs-phoenix')).toBe('ok')
 })
 
 test('default import from webpacked cjs (clipboard)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-clipboard')).toBe('ok')
+  await expect.poll(() => page.textContent('.cjs-clipboard')).toBe('ok')
 })
 
 test('default import from cjs (cjs-dep-cjs-compiled-from-esm)', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.cjs-dep-cjs-compiled-from-esm'),
-  ).toBe('ok')
+  await expect
+    .poll(() => page.textContent('.cjs-dep-cjs-compiled-from-esm'))
+    .toBe('ok')
 })
 
 test('default import from cjs (cjs-dep-cjs-compiled-from-cjs)', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.cjs-dep-cjs-compiled-from-cjs'),
-  ).toBe('ok')
+  await expect
+    .poll(() => page.textContent('.cjs-dep-cjs-compiled-from-cjs'))
+    .toBe('ok')
 })
 
 test('dynamic imports from cjs dep (react)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-dynamic button')).toBe(
-    'count is 0',
-  )
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic button'))
+    .toBe('count is 0')
   await page.click('.cjs-dynamic button')
-  await expectWithRetry(() => page.textContent('.cjs-dynamic button')).toBe(
-    'count is 1',
-  )
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic button'))
+    .toBe('count is 1')
 })
 
 test('dynamic named imports from webpacked cjs (phoenix)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-dynamic-phoenix')).toBe(
-    'ok',
-  )
+  await expect.poll(() => page.textContent('.cjs-dynamic-phoenix')).toBe('ok')
 })
 
 test('dynamic default import from webpacked cjs (clipboard)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-dynamic-clipboard')).toBe(
-    'ok',
-  )
+  await expect.poll(() => page.textContent('.cjs-dynamic-clipboard')).toBe('ok')
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-esm)', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm'),
-  ).toBe('ok')
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm'))
+    .toBe('ok')
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-cjs)', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs'),
-  ).toBe('ok')
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs'))
+    .toBe('ok')
 })
 
 test('dedupe', async () => {
-  await expectWithRetry(() => page.textContent('.dedupe button')).toBe(
-    'count is 0',
-  )
+  await expect.poll(() => page.textContent('.dedupe button')).toBe('count is 0')
   await page.click('.dedupe button')
-  await expectWithRetry(() => page.textContent('.dedupe button')).toBe(
-    'count is 1',
-  )
+  await expect.poll(() => page.textContent('.dedupe button')).toBe('count is 1')
 })
 
 test('cjs browser field (axios)', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-browser-field')).toBe(
-    'pong',
-  )
+  await expect.poll(() => page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
 test('cjs browser field bare', async () => {
-  await expectWithRetry(() => page.textContent('.cjs-browser-field-bare')).toBe(
-    'pong',
-  )
+  await expect
+    .poll(() => page.textContent('.cjs-browser-field-bare'))
+    .toBe('pong')
 })
 
 test('dep from linked dep (lodash-es)', async () => {
-  await expectWithRetry(() => page.textContent('.deps-linked')).toBe(
-    'fooBarBaz',
-  )
+  await expect.poll(() => page.textContent('.deps-linked')).toBe('fooBarBaz')
 })
 
 test('forced include', async () => {
-  await expectWithRetry(() => page.textContent('.force-include')).toMatch(
-    `[success]`,
-  )
+  await expect
+    .poll(() => page.textContent('.force-include'))
+    .toMatch(`[success]`)
 })
 
 test('import * from optimized dep', async () => {
-  await expectWithRetry(() => page.textContent('.import-star')).toMatch(
-    `[success]`,
-  )
+  await expect.poll(() => page.textContent('.import-star')).toMatch(`[success]`)
 })
 
 test('import from dep with process.env.NODE_ENV', async () => {
-  await expectWithRetry(() => page.textContent('.node-env')).toMatch(
-    isBuild ? 'prod' : 'dev',
-  )
+  await expect
+    .poll(() => page.textContent('.node-env'))
+    .toMatch(isBuild ? 'prod' : 'dev')
 })
 
 test('import from dep with .notjs files', async () => {
-  await expectWithRetry(() => page.textContent('.not-js')).toMatch(`[success]`)
+  await expect.poll(() => page.textContent('.not-js')).toMatch(`[success]`)
 })
 
 test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
-  await expectWithRetry(() => page.textContent('.relative-to-main')).toMatch(
-    `[success]`,
-  )
+  await expect
+    .poll(() => page.textContent('.relative-to-main'))
+    .toMatch(`[success]`)
 })
 
 test('dep with dynamic import', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-dynamic-import'),
-  ).toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-dynamic-import'))
+    .toMatch(`[success]`)
 })
 
 test('dep with optional peer dep', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-optional-peer-dep'),
-  ).toMatch(`[success]`)
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-optional-peer-dep-error'),
-  ).toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-optional-peer-dep'))
+    .toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-optional-peer-dep-error'))
+    .toMatch(`[success]`)
 })
 
 test('dep with optional peer dep submodule', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-optional-peer-dep-submodule'),
-  ).toMatch(`[success]`)
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-optional-peer-dep-submodule-error'),
-  ).toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-optional-peer-dep-submodule'))
+    .toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-optional-peer-dep-submodule-error'))
+    .toMatch(`[success]`)
 })
 
 test('dep with optional peer dep (cjs)', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-optional-peer-dep-cjs'),
-  ).toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.dep-with-optional-peer-dep-cjs'))
+    .toMatch(`[success]`)
   // FIXME
-  // await expectWithRetry(() =>
-  //   page.textContent('.dep-with-optional-peer-dep-cjs-error'),
-  // ).toMatch(`[success]`)
+  // await expect
+  //   .poll(() => page.textContent('.dep-with-optional-peer-dep-cjs-error'))
+  //   .toMatch(`[success]`)
 })
 
 test('dep with css import', async () => {
-  await expectWithRetry(() => getColor('.dep-linked-include')).toBe('red')
+  await expect.poll(() => getColor('.dep-linked-include')).toBe('red')
 })
 
 test('CJS dep with css import', async () => {
-  await expectWithRetry(() => getColor('.cjs-with-assets')).toBe('blue')
+  await expect.poll(() => getColor('.cjs-with-assets')).toBe('blue')
 })
 
 test('externalize known non-js files in optimize included dep', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.externalize-known-non-js'),
-  ).toMatch(`[success]`)
+  await expect
+    .poll(() => page.textContent('.externalize-known-non-js'))
+    .toMatch(`[success]`)
 })
 
 test('vue + vuex', async () => {
-  await expectWithRetry(() => page.textContent('.vue')).toMatch(`[success]`)
+  await expect.poll(() => page.textContent('.vue')).toMatch(`[success]`)
 })
 
 // When we use the Rollup CommonJS plugin instead of esbuild prebundling,
 // the esbuild plugins won't apply to dependencies
 test.runIf(isServe)('esbuild-plugin', async () => {
-  await expectWithRetry(() => page.textContent('.esbuild-plugin')).toMatch(
-    `Hello from an esbuild plugin`,
-  )
+  await expect
+    .poll(() => page.textContent('.esbuild-plugin'))
+    .toMatch(`Hello from an esbuild plugin`)
 })
 
 test('import from hidden dir', async () => {
-  await expectWithRetry(() => page.textContent('.hidden-dir')).toBe('hello!')
+  await expect.poll(() => page.textContent('.hidden-dir')).toBe('hello!')
 })
 
 test('import optimize-excluded package that imports optimized-included package', async () => {
-  await expectWithRetry(() => page.textContent('.nested-include')).toBe(
-    'nested-include',
-  )
+  await expect
+    .poll(() => page.textContent('.nested-include'))
+    .toBe('nested-include')
 })
 
 test('import aliased package with colon', async () => {
-  await expectWithRetry(() => page.textContent('.url')).toBe('vite.dev')
+  await expect.poll(() => page.textContent('.url')).toBe('vite.dev')
 })
 
 test('import aliased package using absolute path', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.alias-using-absolute-path'),
-  ).toBe('From dep-alias-using-absolute-path')
+  await expect
+    .poll(() => page.textContent('.alias-using-absolute-path'))
+    .toBe('From dep-alias-using-absolute-path')
 })
 
 test('variable names are reused in different scripts', async () => {
-  await expectWithRetry(() => page.textContent('.reused-variable-names')).toBe(
-    'reused',
-  )
+  await expect
+    .poll(() => page.textContent('.reused-variable-names'))
+    .toBe('reused')
 })
 
 test('flatten id should generate correctly', async () => {
-  await expectWithRetry(() => page.textContent('.clonedeep-slash')).toBe(
-    'clonedeep-slash',
-  )
-  await expectWithRetry(() => page.textContent('.clonedeep-dot')).toBe(
-    'clonedeep-dot',
-  )
+  await expect
+    .poll(() => page.textContent('.clonedeep-slash'))
+    .toBe('clonedeep-slash')
+  await expect
+    .poll(() => page.textContent('.clonedeep-dot'))
+    .toBe('clonedeep-dot')
 })
 
 test('non optimized module is not duplicated', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.non-optimized-module-is-not-duplicated'),
-  ).toBe('from-absolute-path, from-relative-path')
+  await expect
+    .poll(() => page.textContent('.non-optimized-module-is-not-duplicated'))
+    .toBe('from-absolute-path, from-relative-path')
 })
 
 test.runIf(isServe)('error on builtin modules usage', () => {
@@ -280,8 +261,8 @@ test('pre bundle css require', async () => {
     )
   }
 
-  await expectWithRetry(() => getColor('.css-require')).toBe('red')
-  await expectWithRetry(() => getColor('.css-module-require')).toBe('red')
+  await expect.poll(() => getColor('.css-require')).toBe('red')
+  await expect.poll(() => getColor('.css-module-require')).toBe('red')
 })
 
 test.runIf(isBuild)('no missing deps during build', async () => {
@@ -330,9 +311,9 @@ describe.runIf(isServe)('optimizeDeps config', () => {
 })
 
 test('long file name should work', async () => {
-  await expectWithRetry(() => page.textContent('.long-file-name')).toMatch(
-    `hello world`,
-  )
+  await expect
+    .poll(() => page.textContent('.long-file-name'))
+    .toMatch(`hello world`)
 })
 
 test.runIf(isServe)('warn on incompatible dependency', () => {
@@ -344,34 +325,32 @@ test.runIf(isServe)('warn on incompatible dependency', () => {
 })
 
 test('import the CommonJS external package that omits the js suffix', async () => {
-  await expectWithRetry(() => page.textContent('.external-package-js')).toBe(
-    'okay',
-  )
-  await expectWithRetry(() =>
-    page.textContent('.external-package-scss-js'),
-  ).toBe('scss')
-  await expectWithRetry(() =>
-    page.textContent('.external-package-astro-js'),
-  ).toBe('astro')
-  await expectWithRetry(() =>
-    page.textContent('.external-package-tsx-js'),
-  ).toBe('tsx')
+  await expect.poll(() => page.textContent('.external-package-js')).toBe('okay')
+  await expect
+    .poll(() => page.textContent('.external-package-scss-js'))
+    .toBe('scss')
+  await expect
+    .poll(() => page.textContent('.external-package-astro-js'))
+    .toBe('astro')
+  await expect
+    .poll(() => page.textContent('.external-package-tsx-js'))
+    .toBe('tsx')
 })
 
 test('external package name with asset extension', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-asset-ext-no-dual-package'),
-  ).toBe('true')
-  await expectWithRetry(() =>
-    page.textContent('.dep-with-asset-ext-prebundled'),
-  ).toBe(String(isServe))
+  await expect
+    .poll(() => page.textContent('.dep-with-asset-ext-no-dual-package'))
+    .toBe('true')
+  await expect
+    .poll(() => page.textContent('.dep-with-asset-ext-prebundled'))
+    .toBe(String(isServe))
 })
 
 test('dependency with external sub-dependencies', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.dep-cjs-with-external-deps-object'),
-  ).toBe('ok')
-  await expectWithRetry(() =>
-    page.textContent('.dep-cjs-with-external-deps-node-builtin'),
-  ).toBe('foo bar')
+  await expect
+    .poll(() => page.textContent('.dep-cjs-with-external-deps-object'))
+    .toBe('ok')
+  await expect
+    .poll(() => page.textContent('.dep-cjs-with-external-deps-node-builtin'))
+    .toBe('foo bar')
 })

--- a/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
+++ b/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port } from './serve'
-import { isBuild, page, untilUpdated } from '~utils'
+import { isBuild, page } from '~utils'
 
 const url = `http://localhost:${port}/`
 
@@ -8,7 +8,7 @@ test.runIf(!isBuild)('optimize', async () => {
   await page.goto(url)
   // reload page to get optimized missing deps
   await page.reload()
-  await untilUpdated(() => page.textContent('div'), 'Client')
+  await expect.poll(() => page.textContent('div')).toMatch('Client')
 
   // raw http request
   const aboutHtml = await (await fetch(url)).text()

--- a/playground/proxy-hmr/__tests__/proxy-hmr.spec.ts
+++ b/playground/proxy-hmr/__tests__/proxy-hmr.spec.ts
@@ -1,10 +1,9 @@
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 import {
   editFile,
   isBuild,
   page,
   untilBrowserLogAfter,
-  untilUpdated,
   viteTestUrl,
 } from '~utils'
 
@@ -16,12 +15,13 @@ test.runIf(!isBuild)('proxy-hmr', async () => {
   )
 
   const otherAppTextLocator = page.frameLocator('iframe').locator('.content')
-  await untilUpdated(() => otherAppTextLocator.textContent(), 'other app')
+  await expect
+    .poll(() => otherAppTextLocator.textContent())
+    .toMatch('other app')
   editFile('other-app/index.html', (code) =>
     code.replace('app', 'modified app'),
   )
-  await untilUpdated(
-    () => otherAppTextLocator.textContent(),
-    'other modified app',
-  )
+  await expect
+    .poll(() => otherAppTextLocator.textContent())
+    .toMatch('other modified app')
 })

--- a/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
+++ b/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port } from './serve'
-import { isServe, page, withRetry } from '~utils'
+import { isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -22,14 +22,10 @@ test.runIf(isServe)(
 
 test('ssr.resolve settings do not affect non-ssr imports', async () => {
   await page.goto(url)
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-no-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
+  await expect
+    .poll(() => page.textContent('.browser-no-external-react-server'))
+    .toMatch('default.js')
+  await expect
+    .poll(() => page.textContent('.browser-external-react-server'))
+    .toMatch('default.js')
 })

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { port } from './serve'
-import { editFile, getColor, isServe, page, untilUpdated } from '~utils'
+import { editFile, getColor, isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -139,24 +139,30 @@ describe.runIf(isServe)('hmr', () => {
     )
     // Allowing additional time for this element to be filled in
     // by a client script that is loaded using dynamic import
-    await untilUpdated(async () => {
-      return page.textContent('.isomorphic-module-browser')
-    }, '[browser]')
+    await expect
+      .poll(async () => {
+        return page.textContent('.isomorphic-module-browser')
+      })
+      .toMatch('[browser]')
 
     editFile('src/isomorphic-module-browser.js', (code) =>
       code.replace('[browser]', '[browser-hmr]'),
     )
     await page.waitForNavigation()
-    await untilUpdated(async () => {
-      return page.textContent('.isomorphic-module-browser')
-    }, '[browser-hmr]')
+    await expect
+      .poll(async () => {
+        return page.textContent('.isomorphic-module-browser')
+      })
+      .toMatch('[browser-hmr]')
 
     editFile('src/isomorphic-module-server.js', (code) =>
       code.replace('[server]', '[server-hmr]'),
     )
     await page.waitForNavigation()
-    await untilUpdated(async () => {
-      return page.textContent('.isomorphic-module-server')
-    }, '[server-hmr]')
+    await expect
+      .poll(async () => {
+        return page.textContent('.isomorphic-module-server')
+      })
+      .toMatch('[server-hmr]')
   })
 })

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { port } from './serve'
-import { editFile, isServe, page, untilUpdated } from '~utils'
+import { editFile, isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -55,10 +55,12 @@ describe.runIf(isServe)('hmr', () => {
     )
     await loadPromise
 
-    await untilUpdated(async () => {
-      const el = await page.$('.virtual')
-      return await el.textContent()
-    }, '[wow]')
+    await expect
+      .poll(async () => {
+        const el = await page.$('.virtual')
+        return await el.textContent()
+      })
+      .toMatch('[wow]')
   })
 })
 

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, serverLogs } from './serve'
-import { browserLogs, editFile, isServe, page, withRetry } from '~utils'
+import { browserLogs, editFile, isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -55,12 +55,14 @@ test.runIf(isServe)('html proxy is encoded', async () => {
 // run this at the end to reduce flakiness
 test.runIf(isServe)('should restart ssr', async () => {
   editFile('./vite.config.ts', (content) => content)
-  await withRetry(async () => {
-    expect(serverLogs).toEqual(
-      expect.arrayContaining([expect.stringMatching('server restarted')]),
-    )
-    expect(serverLogs).not.toEqual(
-      expect.arrayContaining([expect.stringMatching('error')]),
-    )
-  })
+  await expect
+    .poll(() => {
+      expect(serverLogs).toEqual(
+        expect.arrayContaining([expect.stringMatching('server restarted')]),
+      )
+      expect(serverLogs).not.toEqual(
+        expect.arrayContaining([expect.stringMatching('error')]),
+      )
+    })
+    .toSatisfy(() => true)
 })

--- a/playground/tailwind-v3/__test__/tailwind-v3.spec.ts
+++ b/playground/tailwind-v3/__test__/tailwind-v3.spec.ts
@@ -33,7 +33,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await expect.poll(() => getColor(el)).toMatch('rgb(234, 88, 12)')
+  await expect.poll(() => getColor(el)).toBe('rgb(234, 88, 12)')
 })
 
 test.runIf(isServe)(
@@ -54,7 +54,7 @@ test.runIf(isServe)(
       ],
       false,
     )
-    await expect.poll(() => getColor(el)).toMatch('rgb(37, 99, 235)')
+    await expect.poll(() => getColor(el)).toBe('rgb(37, 99, 235)')
   },
 )
 
@@ -70,5 +70,5 @@ test.runIf(isServe)('regenerate CSS and HMR (relative path)', async () => {
     ['[vite] css hot updated: /index.css', '[vite] hot updated: /src/main.js'],
     false,
   )
-  await expect.poll(() => getColor(el)).toMatch('rgb(8, 145, 178)')
+  await expect.poll(() => getColor(el)).toBe('rgb(8, 145, 178)')
 })

--- a/playground/tailwind-v3/__test__/tailwind-v3.spec.ts
+++ b/playground/tailwind-v3/__test__/tailwind-v3.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from 'vitest'
-import {
-  editFile,
-  getColor,
-  isServe,
-  page,
-  untilBrowserLogAfter,
-  untilUpdated,
-} from '~utils'
+import { editFile, getColor, isServe, page, untilBrowserLogAfter } from '~utils'
 
 test('should render', async () => {
   expect(await page.textContent('#pagetitle')).toBe('Page title')
@@ -27,7 +20,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await untilUpdated(() => el.textContent(), '|view1 updated|')
+  await expect.poll(() => el.textContent()).toMatch('|view1 updated|')
 
   await untilBrowserLogAfter(
     () =>
@@ -40,7 +33,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await untilUpdated(async () => getColor(el), 'rgb(234, 88, 12)')
+  await expect.poll(() => getColor(el)).toMatch('rgb(234, 88, 12)')
 })
 
 test.runIf(isServe)(
@@ -61,7 +54,7 @@ test.runIf(isServe)(
       ],
       false,
     )
-    await untilUpdated(() => getColor(el), 'rgb(37, 99, 235)')
+    await expect.poll(() => getColor(el)).toMatch('rgb(37, 99, 235)')
   },
 )
 
@@ -77,5 +70,5 @@ test.runIf(isServe)('regenerate CSS and HMR (relative path)', async () => {
     ['[vite] css hot updated: /index.css', '[vite] hot updated: /src/main.js'],
     false,
   )
-  await untilUpdated(() => getColor(el), 'rgb(8, 145, 178)')
+  await expect.poll(() => getColor(el)).toMatch('rgb(8, 145, 178)')
 })

--- a/playground/tailwind/__test__/tailwind.spec.ts
+++ b/playground/tailwind/__test__/tailwind.spec.ts
@@ -1,12 +1,5 @@
 import { expect, test } from 'vitest'
-import {
-  editFile,
-  getColor,
-  isServe,
-  page,
-  untilBrowserLogAfter,
-  untilUpdated,
-} from '~utils'
+import { editFile, getColor, isServe, page, untilBrowserLogAfter } from '~utils'
 
 test('should render', async () => {
   expect(await page.textContent('#pagetitle')).toBe('Page title')
@@ -27,7 +20,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await untilUpdated(() => el.textContent(), '|view1 updated|')
+  await expect.poll(() => el.textContent()).toMatch('|view1 updated|')
 
   await untilBrowserLogAfter(
     () =>
@@ -40,7 +33,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await untilUpdated(async () => getColor(el), 'oklch(0.646 0.222 41.116)')
+  await expect.poll(() => getColor(el)).toMatch('oklch(0.646 0.222 41.116)')
 })
 
 test.runIf(isServe)(
@@ -61,7 +54,7 @@ test.runIf(isServe)(
       ],
       false,
     )
-    await untilUpdated(() => getColor(el), 'oklch(0.546 0.245 262.881)')
+    await expect.poll(() => getColor(el)).toMatch('oklch(0.546 0.245 262.881)')
   },
 )
 
@@ -77,5 +70,5 @@ test.runIf(isServe)('regenerate CSS and HMR (relative path)', async () => {
     ['[vite] css hot updated: /index.css', '[vite] hot updated: /src/main.js'],
     false,
   )
-  await untilUpdated(() => getColor(el), 'oklch(0.609 0.126 221.723)')
+  await expect.poll(() => getColor(el)).toMatch('oklch(0.609 0.126 221.723)')
 })

--- a/playground/tailwind/__test__/tailwind.spec.ts
+++ b/playground/tailwind/__test__/tailwind.spec.ts
@@ -33,7 +33,7 @@ test.runIf(isServe)('regenerate CSS and HMR (glob pattern)', async () => {
     ],
     false,
   )
-  await expect.poll(() => getColor(el)).toMatch('oklch(0.646 0.222 41.116)')
+  await expect.poll(() => getColor(el)).toBe('oklch(0.646 0.222 41.116)')
 })
 
 test.runIf(isServe)(
@@ -54,7 +54,7 @@ test.runIf(isServe)(
       ],
       false,
     )
-    await expect.poll(() => getColor(el)).toMatch('oklch(0.546 0.245 262.881)')
+    await expect.poll(() => getColor(el)).toBe('oklch(0.546 0.245 262.881)')
   },
 )
 
@@ -70,5 +70,5 @@ test.runIf(isServe)('regenerate CSS and HMR (relative path)', async () => {
     ['[vite] css hot updated: /index.css', '[vite] hot updated: /src/main.js'],
     false,
   )
-  await expect.poll(() => getColor(el)).toMatch('oklch(0.609 0.126 221.723)')
+  await expect.poll(() => getColor(el)).toBe('oklch(0.609 0.126 221.723)')
 })

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -88,8 +88,6 @@ function rgbToHex(rgb: string): string | undefined {
   return undefined
 }
 
-const timeout = (n: number) => new Promise((r) => setTimeout(r, n))
-
 async function toEl(
   el: string | ElementHandle | Locator,
 ): Promise<ElementHandle> {
@@ -212,30 +210,6 @@ export function readDepOptimizationMetadata(
       'utf-8',
     ),
   )
-}
-
-/**
- * Poll a getter until the value it returns includes the expected value.
- */
-export async function untilUpdated(
-  poll: () => string | Promise<string>,
-  expected: string | RegExp,
-): Promise<void> {
-  const maxTries = process.env.CI ? 200 : 50
-  for (let tries = 0; tries < maxTries; tries++) {
-    const actual = (await poll()) ?? ''
-    if (
-      (typeof expected === 'string'
-        ? actual.indexOf(expected) > -1
-        : actual.match(expected)) ||
-      tries === maxTries - 1
-    ) {
-      expect(actual).toMatch(expected)
-      break
-    } else {
-      await timeout(50)
-    }
-  }
 }
 
 type UntilBrowserLogAfterCallback = (logs: string[]) => PromiseLike<void> | void

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -12,7 +12,6 @@ import type {
 import type { DepOptimizationMetadata, Manifest } from 'vite'
 import { normalizePath } from 'vite'
 import { fromComment } from 'convert-source-map'
-import type { Assertion } from 'vitest'
 import { expect } from 'vitest'
 import type { ResultPromise as ExecaResultPromise } from 'execa'
 import { isWindows, page, testDir } from './vitestSetup'
@@ -237,36 +236,6 @@ export async function untilUpdated(
       await timeout(50)
     }
   }
-}
-
-/**
- * Retry `func` until it does not throw error.
- */
-export async function withRetry(func: () => Promise<void>): Promise<void> {
-  const maxTries = process.env.CI ? 200 : 50
-  for (let tries = 0; tries < maxTries; tries++) {
-    try {
-      await func()
-      return
-    } catch {}
-    await timeout(50)
-  }
-  await func()
-}
-
-export const expectWithRetry = <T>(getActual: () => Promise<T>) => {
-  return new Proxy(
-    {},
-    {
-      get(_target, key) {
-        return async (...args) => {
-          await withRetry(async () => expect(await getActual())[key](...args))
-        }
-      },
-    },
-  ) as Assertion<T>['resolves']
-  // NOTE: `Assertion<T>['resolves']` has the special "promisify all assertion property functions"
-  // behaviour that we're lending here, which is the same as `PromisifyAssertion<T>` if Vitest exposes it
 }
 
 type UntilBrowserLogAfterCallback = (logs: string[]) => PromiseLike<void> | void

--- a/playground/transform-plugin/__tests__/tests.ts
+++ b/playground/transform-plugin/__tests__/tests.ts
@@ -7,9 +7,9 @@ export const tests = () => {
 
     if (isBuild) return
     editFile('plugin-dep.js', (str) => str)
-    await expect.poll(() => page.textContent('#transform-count')).toMatch('2')
+    await expect.poll(() => page.textContent('#transform-count')).toBe('2')
 
     editFile('plugin-dep-load.js', (str) => str)
-    await expect.poll(() => page.textContent('#transform-count')).toMatch('3')
+    await expect.poll(() => page.textContent('#transform-count')).toBe('3')
   })
 }

--- a/playground/transform-plugin/__tests__/tests.ts
+++ b/playground/transform-plugin/__tests__/tests.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { editFile, isBuild, page, untilUpdated } from '~utils'
+import { editFile, isBuild, page } from '~utils'
 
 export const tests = () => {
   test('should re-run transform when dependencies are edited', async () => {
@@ -7,9 +7,9 @@ export const tests = () => {
 
     if (isBuild) return
     editFile('plugin-dep.js', (str) => str)
-    await untilUpdated(() => page.textContent('#transform-count'), '2')
+    await expect.poll(() => page.textContent('#transform-count')).toMatch('2')
 
     editFile('plugin-dep-load.js', (str) => str)
-    await untilUpdated(() => page.textContent('#transform-count'), '3')
+    await expect.poll(() => page.textContent('#transform-count')).toMatch('3')
   })
 }

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -1,14 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { clearServeError, serveError } from './serve'
-import {
-  browserLogs,
-  editFile,
-  isBuild,
-  isServe,
-  page,
-  readFile,
-  untilUpdated,
-} from '~utils'
+import { browserLogs, editFile, isBuild, isServe, page, readFile } from '~utils'
 
 const unexpectedTokenSyntaxErrorRE =
   /(\[vite:esbuild\] )*parsing .* failed: SyntaxError: Unexpected token.*\}.*/
@@ -53,8 +45,10 @@ describe.runIf(isServe)('server', () => {
     editFile('has-error/tsconfig.json', (content) => {
       return content.replace('"compilerOptions":', '"compilerOptions":{}')
     })
-    await untilUpdated(() => {
-      return browserLogs.find((x) => x === 'tsconfig error fixed, file loaded')
-    }, 'tsconfig error fixed, file loaded')
+    await expect
+      .poll(() =>
+        browserLogs.find((x) => x === 'tsconfig error fixed, file loaded'),
+      )
+      .toMatch('tsconfig error fixed, file loaded')
   })
 })

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -46,9 +46,7 @@ describe.runIf(isServe)('server', () => {
       return content.replace('"compilerOptions":', '"compilerOptions":{}')
     })
     await expect
-      .poll(() =>
-        browserLogs.find((x) => x === 'tsconfig error fixed, file loaded'),
-      )
-      .toMatch('tsconfig error fixed, file loaded')
+      .poll(() => browserLogs)
+      .toContain('tsconfig error fixed, file loaded')
   })
 })

--- a/playground/wasm/__tests__/wasm.spec.ts
+++ b/playground/wasm/__tests__/wasm.spec.ts
@@ -1,22 +1,25 @@
 import { expect, test } from 'vitest'
-import { isBuild, page, untilUpdated } from '~utils'
+import { isBuild, page } from '~utils'
 
 test('should work when inlined', async () => {
   await page.click('.inline-wasm .run')
-  await untilUpdated(() => page.textContent('.inline-wasm .result'), '42')
+  await expect
+    .poll(() => page.textContent('.inline-wasm .result'))
+    .toMatch('42')
 })
 
 test('should work when output', async () => {
   await page.click('.output-wasm .run')
-  await untilUpdated(() => page.textContent('.output-wasm .result'), '24')
+  await expect
+    .poll(() => page.textContent('.output-wasm .result'))
+    .toMatch('24')
 })
 
 test('init function returns WebAssembly.Instance', async () => {
   await page.click('.init-returns-instance .run')
-  await untilUpdated(
-    () => page.textContent('.init-returns-instance .result'),
-    'true',
-  )
+  await expect
+    .poll(() => page.textContent('.init-returns-instance .result'))
+    .toMatch('true')
 })
 
 test('?url', async () => {
@@ -26,5 +29,5 @@ test('?url', async () => {
 })
 
 test('should work when wasm in worker', async () => {
-  await untilUpdated(() => page.textContent('.worker-wasm .result'), '3')
+  await expect.poll(() => page.textContent('.worker-wasm .result')).toMatch('3')
 })

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -1,92 +1,94 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { isBuild, page, testDir, untilUpdated } from '~utils'
+import { isBuild, page, testDir } from '~utils'
 
 test('normal', async () => {
-  await untilUpdated(() => page.textContent('.pong'), 'pong')
-  await untilUpdated(() => page.textContent('.mode'), process.env.NODE_ENV)
-  await untilUpdated(
-    () => page.textContent('.bundle-with-plugin'),
-    'worker bundle with plugin success!',
-  )
-  await untilUpdated(
-    () => page.textContent('.asset-url'),
-    isBuild ? /\/es\/assets\/worker_asset-vite-[\w-]{8}\.svg/ : '/es/vite.svg',
-  )
-  await untilUpdated(() => page.textContent('.dep-cjs'), '[cjs ok]')
+  await expect.poll(() => page.textContent('.pong')).toMatch('pong')
+  await expect
+    .poll(() => page.textContent('.mode'))
+    .toMatch(process.env.NODE_ENV)
+  await expect
+    .poll(() => page.textContent('.bundle-with-plugin'))
+    .toMatch('worker bundle with plugin success!')
+  await expect
+    .poll(() => page.textContent('.asset-url'))
+    .toMatch(
+      isBuild
+        ? /\/es\/assets\/worker_asset-vite-[\w-]{8}\.svg/
+        : '/es/vite.svg',
+    )
+  await expect.poll(() => page.textContent('.dep-cjs')).toMatch('[cjs ok]')
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
+  await expect
+    .poll(() => page.textContent('.pong-named'))
+    .toMatch('namedWorker')
 })
 
 test('TS output', async () => {
-  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
+  await expect.poll(() => page.textContent('.pong-ts-output')).toMatch('pong')
 })
 
 test('inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
+  await expect.poll(() => page.textContent('.pong-inline')).toMatch('pong')
 })
 
 test('named inlined', async () => {
-  await untilUpdated(
-    () => page.textContent('.pong-inline-named'),
-    'namedInlineWorker',
-  )
+  await expect
+    .poll(() => page.textContent('.pong-inline-named'))
+    .toMatch('namedInlineWorker')
 })
 
 test('import meta url', async () => {
-  await untilUpdated(
-    () => page.textContent('.pong-inline-url'),
-    /^(blob|http):/,
-  )
+  await expect
+    .poll(() => page.textContent('.pong-inline-url'))
+    .toMatch(/^(blob|http):/)
 })
 
 test('unicode inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline-unicode'), '•pong•')
+  await expect
+    .poll(() => page.textContent('.pong-inline-unicode'))
+    .toMatch('•pong•')
 })
 
 test('shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count')).toMatch('pong')
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count-named')).toMatch('pong')
 })
 
 test('inline shared worker', async () => {
-  await untilUpdated(() => page.textContent('.pong-shared-inline'), 'pong')
+  await expect
+    .poll(() => page.textContent('.pong-shared-inline'))
+    .toMatch('pong')
 })
 
 test('worker emitted and import.meta.url in nested worker (serve)', async () => {
-  await untilUpdated(
-    () => page.textContent('.nested-worker'),
-    'worker-nested-worker',
-  )
-  await untilUpdated(
-    () => page.textContent('.nested-worker-module'),
-    'sub-worker',
-  )
-  await untilUpdated(
-    () => page.textContent('.nested-worker-constructor'),
-    '"type":"constructor"',
-  )
+  await expect
+    .poll(() => page.textContent('.nested-worker'))
+    .toMatch('worker-nested-worker')
+  await expect
+    .poll(() => page.textContent('.nested-worker-module'))
+    .toMatch('sub-worker')
+  await expect
+    .poll(() => page.textContent('.nested-worker-constructor'))
+    .toMatch('"type":"constructor"')
 })
 
 test('deeply nested workers', async () => {
-  await untilUpdated(
-    async () => page.textContent('.deeply-nested-worker'),
-    /Hello\sfrom\sroot.*\/es\/.+deeply-nested-worker\.js/,
-  )
-  await untilUpdated(
-    async () => page.textContent('.deeply-nested-second-worker'),
-    /Hello\sfrom\ssecond.*\/es\/.+second-worker\.js/,
-  )
-  await untilUpdated(
-    async () => page.textContent('.deeply-nested-third-worker'),
-    /Hello\sfrom\sthird.*\/es\/.+third-worker\.js/,
-  )
+  await expect
+    .poll(() => page.textContent('.deeply-nested-worker'))
+    .toMatch(/Hello\sfrom\sroot.*\/es\/.+deeply-nested-worker\.js/)
+  await expect
+    .poll(() => page.textContent('.deeply-nested-second-worker'))
+    .toMatch(/Hello\sfrom\ssecond.*\/es\/.+second-worker\.js/)
+  await expect
+    .poll(() => page.textContent('.deeply-nested-third-worker'))
+    .toMatch(/Hello\sfrom\sthird.*\/es\/.+third-worker\.js/)
 })
 
 describe.runIf(isBuild)('build', () => {
@@ -122,87 +124,81 @@ describe.runIf(isBuild)('build', () => {
   })
 
   test('worker emitted and import.meta.url in nested worker (build)', async () => {
-    await untilUpdated(
-      () => page.textContent('.nested-worker-module'),
-      '"type":"module"',
-    )
-    await untilUpdated(
-      () => page.textContent('.nested-worker-constructor'),
-      '"type":"constructor"',
-    )
+    await expect
+      .poll(() => page.textContent('.nested-worker-module'))
+      .toMatch('"type":"module"')
+    await expect
+      .poll(() => page.textContent('.nested-worker-constructor'))
+      .toMatch('"type":"constructor"')
   })
 })
 
 test('module worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.worker-import-meta-url'),
-    'A string',
-  )
-  await untilUpdated(
-    () => page.textContent('.worker-import-meta-url-resolve'),
-    'A string',
-  )
-  await untilUpdated(
-    () => page.textContent('.worker-import-meta-url-without-extension'),
-    'A string',
-  )
-  await untilUpdated(
-    () => page.textContent('.shared-worker-import-meta-url'),
-    'A string',
-  )
+  await expect
+    .poll(() => page.textContent('.worker-import-meta-url'))
+    .toMatch('A string')
+  await expect
+    .poll(() => page.textContent('.worker-import-meta-url-resolve'))
+    .toMatch('A string')
+  await expect
+    .poll(() => page.textContent('.worker-import-meta-url-without-extension'))
+    .toMatch('A string')
+  await expect
+    .poll(() => page.textContent('.shared-worker-import-meta-url'))
+    .toMatch('A string')
 })
 
 test('classic worker', async () => {
-  await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  await expect
+    .poll(() => page.textContent('.classic-worker'))
+    .toMatch('A classic')
   if (!isBuild) {
-    await untilUpdated(
-      () => page.textContent('.classic-worker-import'),
-      '[success] classic-esm',
-    )
+    await expect
+      .poll(() => page.textContent('.classic-worker-import'))
+      .toMatch('[success] classic-esm')
   }
-  await untilUpdated(
-    () => page.textContent('.classic-shared-worker'),
-    'A classic',
-  )
+  await expect
+    .poll(() => page.textContent('.classic-shared-worker'))
+    .toMatch('A classic')
 })
 
 test('emit chunk', async () => {
-  await untilUpdated(
-    () => page.textContent('.emit-chunk-worker'),
-    '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
-  )
-  await untilUpdated(
-    () => page.textContent('.emit-chunk-dynamic-import-worker'),
-    '"A stringmodule1/es/"',
-  )
+  await expect
+    .poll(() => page.textContent('.emit-chunk-worker'))
+    .toMatch(
+      '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
+    )
+  await expect
+    .poll(() => page.textContent('.emit-chunk-dynamic-import-worker'))
+    .toMatch('"A stringmodule1/es/"')
 })
 
 test('url query worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.simple-worker-url'),
-    'Hello from simple worker!',
-  )
+  await expect
+    .poll(() => page.textContent('.simple-worker-url'))
+    .toMatch('Hello from simple worker!')
 })
 
 test('import.meta.glob in worker', async () => {
-  await untilUpdated(() => page.textContent('.importMetaGlob-worker'), '["')
+  await expect
+    .poll(() => page.textContent('.importMetaGlob-worker'))
+    .toMatch('["')
 })
 
 test('import.meta.glob with eager in worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.importMetaGlobEager-worker'),
-    '["',
-  )
+  await expect
+    .poll(() => page.textContent('.importMetaGlobEager-worker'))
+    .toMatch('["')
 })
 
 test('self reference worker', async () => {
   await expect
     .poll(() => page.textContent('.self-reference-worker'))
-    .toBe('pong: main\npong: nested\n')
+    .toMatch('pong: main\npong: nested\n')
 })
 
 test('self reference url worker', async () => {
   await expect
     .poll(() => page.textContent('.self-reference-url-worker'))
-    .toBe('pong: main\npong: nested\n')
+    .toMatch('pong: main\npong: nested\n')
 })

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
+import { isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
@@ -196,13 +196,13 @@ test('import.meta.glob with eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expect
+    .poll(() => page.textContent('.self-reference-worker'))
+    .toBe('pong: main\npong: nested\n')
 })
 
 test('self reference url worker', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.self-reference-url-worker'),
-  ).toBe('pong: main\npong: nested\n')
+  await expect
+    .poll(() => page.textContent('.self-reference-url-worker'))
+    .toBe('pong: main\npong: nested\n')
 })

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
-  expectWithRetry,
   isBuild,
   isServe,
   page,
@@ -166,21 +165,21 @@ test('import.meta.glob eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expect
+    .poll(() => page.textContent('.self-reference-worker'))
+    .toBe('pong: main\npong: nested\n')
 })
 
 test('self reference url worker', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.self-reference-url-worker'),
-  ).toBe('pong: main\npong: nested\n')
+  await expect
+    .poll(() => page.textContent('.self-reference-url-worker'))
+    .toBe('pong: main\npong: nested\n')
 })
 
 test('self reference url worker in dependency', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.self-reference-url-worker-dep'),
-  ).toBe('pong: main\npong: nested\n')
+  await expect
+    .poll(() => page.textContent('.self-reference-url-worker-dep'))
+    .toBe('pong: main\npong: nested\n')
 })
 
 test.runIf(isServe)('sourcemap is correct after env is injected', async () => {

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -7,71 +7,72 @@ import {
   page,
   readManifest,
   testDir,
-  untilUpdated,
   viteTestUrl,
 } from '~utils'
 
 test('normal', async () => {
-  await untilUpdated(() => page.textContent('.pong'), 'pong')
-  await untilUpdated(() => page.textContent('.mode'), process.env.NODE_ENV)
-  await untilUpdated(
-    () => page.textContent('.bundle-with-plugin'),
-    'worker bundle with plugin success!',
-  )
-  await untilUpdated(
-    () => page.textContent('.asset-url'),
-    isBuild
-      ? /\/iife\/assets\/worker_asset-vite-[\w-]{8}\.svg/
-      : '/iife/vite.svg',
-  )
+  await expect.poll(() => page.textContent('.pong')).toMatch('pong')
+  await expect
+    .poll(() => page.textContent('.mode'))
+    .toMatch(process.env.NODE_ENV)
+  await expect
+    .poll(() => page.textContent('.bundle-with-plugin'))
+    .toMatch('worker bundle with plugin success!')
+  await expect
+    .poll(() => page.textContent('.asset-url'))
+    .toMatch(
+      isBuild
+        ? /\/iife\/assets\/worker_asset-vite-[\w-]{8}\.svg/
+        : '/iife/vite.svg',
+    )
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
+  await expect
+    .poll(() => page.textContent('.pong-named'))
+    .toMatch('namedWorker')
 })
 
 test('TS output', async () => {
-  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
+  await expect.poll(() => page.textContent('.pong-ts-output')).toMatch('pong')
 })
 
 test('inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
+  await expect.poll(() => page.textContent('.pong-inline')).toMatch('pong')
 })
 
 test('named inlined', async () => {
-  await untilUpdated(
-    () => page.textContent('.pong-inline-named'),
-    'namedInlineWorker',
-  )
+  await expect
+    .poll(() => page.textContent('.pong-inline-named'))
+    .toMatch('namedInlineWorker')
 })
 
 test('shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count')).toMatch('pong')
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count-named')).toMatch('pong')
 })
 
 test('inline shared worker', async () => {
-  await untilUpdated(() => page.textContent('.pong-shared-inline'), 'pong')
+  await expect
+    .poll(() => page.textContent('.pong-shared-inline'))
+    .toMatch('pong')
 })
 
 test.runIf(!isBuild)(
   'worker emitted and import.meta.url in nested worker (serve)',
   async () => {
-    await untilUpdated(
-      () => page.textContent('.nested-worker'),
-      '/worker-nested',
-    )
-    await untilUpdated(
-      () => page.textContent('.nested-worker-module'),
-      '/sub-worker',
-    )
-    await untilUpdated(
-      () => page.textContent('.nested-worker-constructor'),
-      '"type":"constructor"',
-    )
+    await expect
+      .poll(() => page.textContent('.nested-worker'))
+      .toMatch('/worker-nested')
+    await expect
+      .poll(() => page.textContent('.nested-worker-module'))
+      .toMatch('/sub-worker')
+    await expect
+      .poll(() => page.textContent('.nested-worker-constructor'))
+      .toMatch('"type":"constructor"')
   },
 )
 
@@ -101,14 +102,12 @@ describe.runIf(isBuild)('build', () => {
   })
 
   test('worker emitted and import.meta.url in nested worker (build)', async () => {
-    await untilUpdated(
-      () => page.textContent('.nested-worker-module'),
-      '"type":"module"',
-    )
-    await untilUpdated(
-      () => page.textContent('.nested-worker-constructor'),
-      '"type":"constructor"',
-    )
+    await expect
+      .poll(() => page.textContent('.nested-worker-module'))
+      .toMatch('"type":"module"')
+    await expect
+      .poll(() => page.textContent('.nested-worker-constructor'))
+      .toMatch('"type":"constructor"')
   })
 
   test('should not emit worker manifest', async () => {
@@ -118,50 +117,44 @@ describe.runIf(isBuild)('build', () => {
 })
 
 test('module worker', async () => {
-  await untilUpdated(
-    async () => page.textContent('.worker-import-meta-url'),
-    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-  )
-  await untilUpdated(
-    () => page.textContent('.worker-import-meta-url-resolve'),
-    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-  )
-  await untilUpdated(
-    () => page.textContent('.worker-import-meta-url-without-extension'),
-    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-  )
-  await untilUpdated(
-    () => page.textContent('.shared-worker-import-meta-url'),
-    'A string',
-  )
+  await expect
+    .poll(async () => page.textContent('.worker-import-meta-url'))
+    .toMatch(/A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/)
+  await expect
+    .poll(() => page.textContent('.worker-import-meta-url-resolve'))
+    .toMatch(/A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/)
+  await expect
+    .poll(() => page.textContent('.worker-import-meta-url-without-extension'))
+    .toMatch(/A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/)
+  await expect
+    .poll(() => page.textContent('.shared-worker-import-meta-url'))
+    .toMatch('A string')
 })
 
 test('classic worker', async () => {
-  await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  await expect
+    .poll(() => page.textContent('.classic-worker'))
+    .toMatch('A classic')
   if (!isBuild) {
-    await untilUpdated(
-      () => page.textContent('.classic-worker-import'),
-      '[success] classic-esm',
-    )
+    await expect
+      .poll(() => page.textContent('.classic-worker-import'))
+      .toMatch('[success] classic-esm')
   }
-  await untilUpdated(
-    () => page.textContent('.classic-shared-worker'),
-    'A classic',
-  )
+  await expect
+    .poll(() => page.textContent('.classic-shared-worker'))
+    .toMatch('A classic')
 })
 
 test('url query worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.simple-worker-url'),
-    'Hello from simple worker!',
-  )
+  await expect
+    .poll(() => page.textContent('.simple-worker-url'))
+    .toMatch('Hello from simple worker!')
 })
 
 test('import.meta.glob eager in worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.importMetaGlobEager-worker'),
-    '["',
-  )
+  await expect
+    .poll(() => page.textContent('.importMetaGlobEager-worker'))
+    .toMatch('["')
 })
 
 test('self reference worker', async () => {

--- a/playground/worker/__tests__/relative-base-iife/worker-relative-base-iife.spec.ts
+++ b/playground/worker/__tests__/relative-base-iife/worker-relative-base-iife.spec.ts
@@ -1,9 +1,8 @@
-import { test } from 'vitest'
-import { isBuild, page, untilUpdated } from '~utils'
+import { expect, test } from 'vitest'
+import { isBuild, page } from '~utils'
 
 test('asset url', async () => {
-  await untilUpdated(
-    () => page.textContent('.asset-url'),
-    isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg',
-  )
+  await expect
+    .poll(() => page.textContent('.asset-url'))
+    .toMatch(isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg')
 })

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
+import { isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
@@ -141,13 +141,13 @@ test('import.meta.glob with eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expect
+    .poll(() => page.textContent('.self-reference-worker'))
+    .toBe('pong: main\npong: nested\n')
 })
 
 test('self reference url worker', async () => {
-  await expectWithRetry(() =>
-    page.textContent('.self-reference-url-worker'),
-  ).toBe('pong: main\npong: nested\n')
+  await expect
+    .poll(() => page.textContent('.self-reference-url-worker'))
+    .toBe('pong: main\npong: nested\n')
 })

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -1,59 +1,60 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { isBuild, page, testDir, untilUpdated } from '~utils'
+import { isBuild, page, testDir } from '~utils'
 
 test('normal', async () => {
-  await untilUpdated(() => page.textContent('.pong'), 'pong')
-  await untilUpdated(() => page.textContent('.mode'), process.env.NODE_ENV)
-  await untilUpdated(
-    () => page.textContent('.bundle-with-plugin'),
-    'worker bundle with plugin success!',
-  )
-  await untilUpdated(
-    () => page.textContent('.asset-url'),
-    isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg',
-  )
+  await expect.poll(() => page.textContent('.pong')).toMatch('pong')
+  await expect
+    .poll(() => page.textContent('.mode'))
+    .toMatch(process.env.NODE_ENV)
+  await expect
+    .poll(() => page.textContent('.bundle-with-plugin'))
+    .toMatch('worker bundle with plugin success!')
+  await expect
+    .poll(() => page.textContent('.asset-url'))
+    .toMatch(isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg')
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
+  await expect
+    .poll(() => page.textContent('.pong-named'))
+    .toMatch('namedWorker')
 })
 
 test('TS output', async () => {
-  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
+  await expect.poll(() => page.textContent('.pong-ts-output')).toMatch('pong')
 })
 
 // TODO: inline worker should inline assets
 test.skip('inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
+  await expect.poll(() => page.textContent('.pong-inline')).toMatch('pong')
 })
 
 test('shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count')).toMatch('pong')
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
+  await expect.poll(() => page.textContent('.tick-count-named')).toMatch('pong')
 })
 
 test('inline shared worker', async () => {
-  await untilUpdated(() => page.textContent('.pong-shared-inline'), 'pong')
+  await expect
+    .poll(() => page.textContent('.pong-shared-inline'))
+    .toMatch('pong')
 })
 
 test('worker emitted and import.meta.url in nested worker (serve)', async () => {
-  await untilUpdated(
-    () => page.textContent('.nested-worker'),
-    'worker-nested-worker',
-  )
-  await untilUpdated(
-    () => page.textContent('.nested-worker-module'),
-    'sub-worker',
-  )
-  await untilUpdated(
-    () => page.textContent('.nested-worker-constructor'),
-    '"type":"constructor"',
-  )
+  await expect
+    .poll(() => page.textContent('.nested-worker'))
+    .toMatch('worker-nested-worker')
+  await expect
+    .poll(() => page.textContent('.nested-worker-module'))
+    .toMatch('sub-worker')
+  await expect
+    .poll(() => page.textContent('.nested-worker-constructor'))
+    .toMatch('"type":"constructor"')
 })
 
 describe.runIf(isBuild)('build', () => {
@@ -86,58 +87,56 @@ describe.runIf(isBuild)('build', () => {
   })
 
   test('worker emitted and import.meta.url in nested worker (build)', async () => {
-    await untilUpdated(
-      () => page.textContent('.nested-worker-module'),
-      '"type":"module"',
-    )
-    await untilUpdated(
-      () => page.textContent('.nested-worker-constructor'),
-      '"type":"constructor"',
-    )
+    await expect
+      .poll(() => page.textContent('.nested-worker-module'))
+      .toMatch('"type":"module"')
+    await expect
+      .poll(() => page.textContent('.nested-worker-constructor'))
+      .toMatch('"type":"constructor"')
   })
 })
 
 test('module worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.shared-worker-import-meta-url'),
-    'A string',
-  )
+  await expect
+    .poll(() => page.textContent('.shared-worker-import-meta-url'))
+    .toMatch('A string')
 })
 
 test('classic worker', async () => {
-  await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  await expect
+    .poll(() => page.textContent('.classic-worker'))
+    .toMatch('A classic')
   if (!isBuild) {
-    await untilUpdated(
-      () => page.textContent('.classic-worker-import'),
-      '[success] classic-esm',
-    )
+    await expect
+      .poll(() => page.textContent('.classic-worker-import'))
+      .toMatch('[success] classic-esm')
   }
-  await untilUpdated(
-    () => page.textContent('.classic-shared-worker'),
-    'A classic',
-  )
+  await expect
+    .poll(() => page.textContent('.classic-shared-worker'))
+    .toMatch('A classic')
 })
 
 test.runIf(isBuild)('emit chunk', async () => {
-  await untilUpdated(
-    () => page.textContent('.emit-chunk-worker'),
-    '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
-  )
-  await untilUpdated(
-    () => page.textContent('.emit-chunk-dynamic-import-worker'),
-    '"A stringmodule1./"',
-  )
+  await expect
+    .poll(() => page.textContent('.emit-chunk-worker'))
+    .toMatch(
+      '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
+    )
+  await expect
+    .poll(() => page.textContent('.emit-chunk-dynamic-import-worker'))
+    .toMatch('"A stringmodule1./"')
 })
 
 test('import.meta.glob in worker', async () => {
-  await untilUpdated(() => page.textContent('.importMetaGlob-worker'), '["')
+  await expect
+    .poll(() => page.textContent('.importMetaGlob-worker'))
+    .toMatch('["')
 })
 
 test('import.meta.glob with eager in worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.importMetaGlobEager-worker'),
-    '["',
-  )
+  await expect
+    .poll(() => page.textContent('.importMetaGlobEager-worker'))
+    .toMatch('["')
 })
 
 test('self reference worker', async () => {

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -20,6 +20,11 @@ export default defineConfig({
       // Prevent Vitest from running the workspace packages in Vite's SSR runtime
       moduleDirectories: ['node_modules', 'packages'],
     },
+    expect: {
+      poll: {
+        timeout: 50 * (process.env.CI ? 200 : 50),
+      },
+    },
   },
   esbuild: {
     target: 'node20',


### PR DESCRIPTION
### Description

Replaced all `withRetry`/`expectWithRetry`/`untilUpdated` usage with `expect.poll`.
`expect.poll` is a builtin feature of Vitest and has the same functionality of `expectWithRetry` (`withRetry` / `untilUpdated` has less functionality).

This will make the tests more consistent and easier to understand.

Second commit is done by replacing `untilUpdated($CB,$EXPECTED)` with `expect.poll($CB).toMatch($EXPECTED)` using ast-grep.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
