### PR TITLE
docs: correct heading level in `ssr-options.md`

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -54,7 +54,7 @@ For example, when setting `['node', 'custom']`, you should run `NODE_OPTIONS='--
 
 :::
 
-### ssr.resolve.mainFields
+## ssr.resolve.mainFields
 
 - **Type:** `string[]`
 - **Default:** `['module', 'jsnext:main', 'jsnext']`


### PR DESCRIPTION
### Description

Hello, I’ve fixed a typo in `ssr-options.md`. I think the heading level should be `h2`, not `h3`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
