### PR TITLE
feat(create-vite): add `@hiogawa/vite-rsc`

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -157,6 +157,13 @@ const FRAMEWORKS: Framework[] = [
         customCommand:
           'npm exec degit redwoodjs/sdk/starters/standard TARGET_DIR',
       },
+      {
+        name: '@hiogawa/vite-rsc',
+        display: '@hiogawa/vite-rsc ↗',
+        color: magenta,
+        customCommand:
+          'npm exec degit hi-ogawa/vite-plugins/packages/rsc/examples/starter TARGET_DIR',
+      },
     ],
   },
   {


### PR DESCRIPTION
### Description

This PR adds `@hiogawa/vite-rsc`'s example to `create-vite`. I wrote a documentation in https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc if anyone interested.

The example is conceptually an RSC equivalent of current React SPA templates (i.e. minimal React app on Vite using React API). Not only for Vite users, but I'm hoping that this can serve as a general RSC concept overview for wider React community. I'll probably have to communicate with Vite React framework folks separately, but I think having this included here makes it easier for me to spread the word for starter. Thanks for the consideration!