### PR TITLE
feat: apply some middlewares before `configurePreviewServer` hook

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -195,16 +195,6 @@ export async function preview(
 
   setupSIGTERMListener(closeServerAndExit)
 
-  // apply server hooks from plugins
-  const configurePreviewServerContext = new BasicMinimalPluginContext(
-    { ...basePluginContextMeta, watchMode: false },
-    config.logger,
-  )
-  const postHooks: ((() => void) | void)[] = []
-  for (const hook of config.getSortedPluginHooks('configurePreviewServer')) {
-    postHooks.push(await hook.call(configurePreviewServerContext, server))
-  }
-
   // cors
   const { cors } = config.preview
   if (cors !== false) {
@@ -216,6 +206,16 @@ export async function preview(
   // no need to check for HTTPS as HTTPS is not vulnerable to DNS rebinding attacks
   if (allowedHosts !== true && !config.preview.https) {
     app.use(hostValidationMiddleware(allowedHosts, true))
+  }
+
+  // apply server hooks from plugins
+  const configurePreviewServerContext = new BasicMinimalPluginContext(
+    { ...basePluginContextMeta, watchMode: false },
+    config.logger,
+  )
+  const postHooks: ((() => void) | void)[] = []
+  for (const hook of config.getSortedPluginHooks('configurePreviewServer')) {
+    postHooks.push(await hook.call(configurePreviewServerContext, server))
   }
 
   // proxy


### PR DESCRIPTION
### Description

Similar with #20222, but for the preview server.

The moved middlewares are:

- `corsMiddleware`
- `hostValidationMiddleware`

`timeMiddleware` and `rejectInvalidRequestMiddleware` does not exist in the preview server.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
