### PR TITLE
chore: "indentity" → "identity" in test description

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1065,7 +1065,7 @@ import foo from "foo"`,
   `)
 })
 
-test('indentity function helper injected after hashbang', async () => {
+test('identity function helper injected after hashbang', async () => {
   expect(
     await ssrTransformSimpleCode(
       `#!/usr/bin/env node


### PR DESCRIPTION
### Description



Corrected a minor typo in the test name from "indentity" to "identity" for clarity and consistency. 