### PR TITLE
chore: improve perf of normalizeModuleId

### DIFF
--- a/packages/vite/src/module-runner/__tests__/utils.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/utils.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test, vi } from 'vitest'
+import { normalizeModuleId } from '../utils'
+
+vi.mock('../shared/utils', async (importOriginal) => {
+  const mod: object = await importOriginal()
+  return {
+    ...mod,
+    isWindows: true,
+  }
+})
+
+describe('normalizeModuleId', () => {
+  test('normalizes file paths', () => {
+    expect(normalizeModuleId('/root/id')).toBe('/root/id')
+    expect(normalizeModuleId('C:/root/id')).toBe('C:/root/id')
+    expect(normalizeModuleId('C:\\root\\id')).toBe('C:/root/id')
+  })
+
+  test('removes @fs prefix', () => {
+    expect(normalizeModuleId('/@fs/root/id')).toBe('/root/id')
+  })
+
+  test('preserves virtual module IDs', () => {
+    expect(normalizeModuleId('virtual:custom')).toBe('virtual:custom')
+  })
+
+  test('removes node: prefix', () => {
+    expect(normalizeModuleId('node:fs')).toBe('fs')
+    expect(normalizeModuleId('node:path')).toBe('path')
+  })
+
+  test('removes file: protocol', () => {
+    expect(normalizeModuleId('file:/root/id')).toBe('/root/id')
+    expect(normalizeModuleId('file:///root/id.js')).toBe('/root/id.js')
+  })
+
+  test('normalizes multiple leading slashes', () => {
+    expect(normalizeModuleId('//root/id')).toBe('/root/id')
+    expect(normalizeModuleId('///root/id')).toBe('/root/id')
+  })
+
+  test('preserves prefixed builtins', () => {
+    const prefixedBuiltins = [
+      'node:sea',
+      'node:sqlite',
+      'node:test',
+      'node:test/reporters',
+    ]
+    for (const builtin of prefixedBuiltins) {
+      expect(normalizeModuleId(builtin)).toBe(builtin)
+    }
+  })
+})

--- a/packages/vite/src/module-runner/__tests__/utils.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/utils.spec.ts
@@ -8,6 +8,9 @@ describe('normalizeModuleId', () => {
     expect(normalizeModuleId('C:\\root\\id')).toBe('C:/root/id')
   })
 
+  /**
+   * Because test are running with isolate: false these test and stubGlobal are causing "spooky action at a distance” failing other random tests.
+   */
   test.skip('removes @fs prefix on windows', async () => {
     vi.stubGlobal('process', {
       ...globalThis.process,

--- a/packages/vite/src/module-runner/__tests__/utils.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/utils.spec.ts
@@ -8,7 +8,7 @@ describe('normalizeModuleId', () => {
     expect(normalizeModuleId('C:\\root\\id')).toBe('C:/root/id')
   })
 
-  test('removes @fs prefix on windows', async () => {
+  test.skip('removes @fs prefix on windows', async () => {
     vi.stubGlobal('process', {
       ...globalThis.process,
       platform: 'win32',
@@ -20,14 +20,14 @@ describe('normalizeModuleId', () => {
     vi.unstubAllGlobals()
   })
 
-  test('removes @fs prefix on linux', async () => {
+  test.skip('removes @fs prefix on linux', async () => {
     vi.stubGlobal('process', {
       ...globalThis.process,
       platform: 'linux',
     })
     vi.resetModules()
     const normalize = await import('../utils').then((m) => m.normalizeModuleId)
-    expect(normalize('/@fs/root/id')).toBe('/root/id')
+    expect(normalize('/@fs/D:\\a\\fixtures\\c.ts')).toBe('D:/a/fixtures/c.ts')
 
     vi.unstubAllGlobals()
   })

--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -1,6 +1,6 @@
-import { cleanUrl, isWindows, slash, unwrapId } from '../shared/utils'
+import { cleanUrl, unwrapId } from '../shared/utils'
 import { SOURCEMAPPING_URL } from '../shared/constants'
-import { decodeBase64 } from './utils'
+import { decodeBase64, normalizeModuleId } from './utils'
 import { DecodedMap } from './sourcemap/decoder'
 import type { ResolvedResult } from './types'
 
@@ -121,33 +121,4 @@ export class EvaluatedModules {
     this.fileToModulesMap.clear()
     this.urlToIdModuleMap.clear()
   }
-}
-
-// unique id that is not available as "$bare_import" like "test"
-// https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix
-const prefixedBuiltins = new Set([
-  'node:sea',
-  'node:sqlite',
-  'node:test',
-  'node:test/reporters',
-])
-
-// transform file url to id
-// virtual:custom -> virtual:custom
-// \0custom -> \0custom
-// /root/id -> /id
-// /root/id.js -> /id.js
-// C:/root/id.js -> /id.js
-// C:\root\id.js -> /id.js
-function normalizeModuleId(file: string): string {
-  if (prefixedBuiltins.has(file)) return file
-
-  // unix style, but Windows path still starts with the drive letter to check the root
-  const unixFile = slash(file)
-    .replace(/^\/@fs\//, isWindows ? '' : '/')
-    .replace(/^node:/, '')
-    .replace(/^\/+/, '/')
-
-  // if it's not in the root, keep it as a path, not a URL
-  return unixFile.replace(/^file:\//, '/')
 }

--- a/packages/vite/src/module-runner/utils.ts
+++ b/packages/vite/src/module-runner/utils.ts
@@ -1,5 +1,5 @@
 import * as pathe from 'pathe'
-import { isWindows } from '../shared/utils'
+import { isWindows, slash } from '../shared/utils'
 
 export const decodeBase64 =
   typeof atob !== 'undefined'
@@ -62,4 +62,49 @@ export function posixPathToFileHref(posixPath: string): string {
 
 export function toWindowsPath(path: string): string {
   return path.replace(/\//g, '\\')
+}
+
+// Unique id that is not available as "$bare_import" like "test"
+// @see https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix
+const prefixedBuiltins = new Set([
+  'node:sea',
+  'node:sqlite',
+  'node:test',
+  'node:test/reporters',
+])
+
+const nodeSliceStart = 5
+const fileSliceStart = 5
+const multipleSlashRe = /^\/+/
+
+// Cache the OS-specific replacement
+const fsSliceStart = isWindows ? 5 : 4
+
+export function normalizeModuleId(file: string): string {
+  // For prefixed builtins, return as is it, otherwise remove node: prefix
+  if (file.startsWith('node:')) {
+    if (prefixedBuiltins.has(file)) {
+      return file
+    }
+    return file.slice(nodeSliceStart)
+  }
+
+  let id = slash(file)
+
+  // Replace /@fs/ prefix to "" or "/"
+  if (id.startsWith('/@fs/')) {
+    id = id.slice(fsSliceStart)
+  }
+
+  // Remove file:/ prefix
+  if (id.startsWith('file:/')) {
+    id = id.slice(fileSliceStart)
+  }
+
+  // Normalize multiple leading slashes
+  if (id.startsWith('//')) {
+    id = id.replace(multipleSlashRe, '/')
+  }
+
+  return id
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
@@ -29,7 +29,7 @@ describe(
       expect(runner.hmrClient!.hotModulesMap.size).toBe(2)
       expect(runner.hmrClient!.dataMap.size).toBe(2)
       expect(runner.hmrClient!.ctxToListenersMap.size).toBe(2)
-
+      console.log(runner.hmrClient!.hotModulesMap)
       for (const fixture of [fixtureC, fixtureD]) {
         expect(runner.hmrClient!.hotModulesMap.has(fixture)).toBe(true)
         expect(runner.hmrClient!.dataMap.has(fixture)).toBe(true)

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
@@ -29,7 +29,7 @@ describe(
       expect(runner.hmrClient!.hotModulesMap.size).toBe(2)
       expect(runner.hmrClient!.dataMap.size).toBe(2)
       expect(runner.hmrClient!.ctxToListenersMap.size).toBe(2)
-      console.log(runner.hmrClient!.hotModulesMap)
+
       for (const fixture of [fixtureC, fixtureD]) {
         expect(runner.hmrClient!.hotModulesMap.has(fixture)).toBe(true)
         expect(runner.hmrClient!.dataMap.has(fixture)).toBe(true)


### PR DESCRIPTION
### Description

Improve performance of normalizeModuleId and added tests.

On synthetic benchmark it is 4x faster.
https://jsbm.dev/oPV5Dx9Iun2OX

I was hoping for better results in real life application, but change there is minimal. 
Let me know if like a change, or you prefer to keep current version.