### PR TITLE
chore: remove atob polyfill

### DIFF
--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -1,6 +1,5 @@
 import { cleanUrl, isWindows, slash, unwrapId } from '../shared/utils'
 import { SOURCEMAPPING_URL } from '../shared/constants'
-import { decodeBase64 } from './utils'
 import { DecodedMap } from './sourcemap/decoder'
 import type { ResolvedResult } from './types'
 
@@ -112,7 +111,7 @@ export class EvaluatedModules {
       mod.meta.code,
     )?.[1]
     if (!mapString) return null
-    mod.map = new DecodedMap(JSON.parse(decodeBase64(mapString)), mod.file)
+    mod.map = new DecodedMap(JSON.parse(atob(mapString)), mod.file)
     return mod.map
   }
 

--- a/packages/vite/src/module-runner/utils.ts
+++ b/packages/vite/src/module-runner/utils.ts
@@ -1,11 +1,6 @@
 import * as pathe from 'pathe'
 import { isWindows } from '../shared/utils'
 
-export const decodeBase64 =
-  typeof atob !== 'undefined'
-    ? atob
-    : (str: string) => Buffer.from(str, 'base64').toString('utf-8')
-
 const CHAR_FORWARD_SLASH = 47
 const CHAR_BACKWARD_SLASH = 92
 


### PR DESCRIPTION
### Description

Remove atob polyfill. 

atob is available in node from v16
https://developer.mozilla.org/en-US/docs/Web/API/Window/atob#browser_compatibility

Are there any other runtimes that vite support?