### PR TITLE
fix: keep `import.meta.url` in bundled Vite

### DIFF
--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -344,7 +344,7 @@ function buildTimeImportMetaUrlPlugin(): Plugin {
         for (const { t, ss, se } of imports) {
           if (t === 3 && code.slice(se, se + 4) === '.url') {
             // ignore import.meta.url with /** #__KEEP__ */ comment
-            if (keepCommentRE.test(code.slice(0, se))) {
+            if (keepCommentRE.test(code.slice(0, ss))) {
               keepCommentRE.lastIndex = 0
               continue
             }


### PR DESCRIPTION
### Description

These `import.meta.url` should be kept,
https://github.com/vitejs/vite/blob/ea9aed7ebcb7f4be542bd2a384cbcb5a1e7b31bd/packages/vite/src/node/utils.ts#L180-L182
otherwise these would resolve from a different path.
https://github.com/vitejs/vite/blob/ea9aed7ebcb7f4be542bd2a384cbcb5a1e7b31bd/packages/vite/src/node/utils.ts#L1106
But these wasn't kept properly.

refs #19925

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
