### PR TITLE
docs: per-environment state in plugins

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -138,7 +138,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
     perEnvironmentStartEndDuringDev: true,
     buildStart() {
       state.set(this.environment, { count: 0 })
-    }
+    },
     transform(id) {
       state.get(this.environment).count++
     },

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -149,8 +149,6 @@ function PerEnvironmentCountTransformedModulesPlugin() {
 }
 ```
 
-Note: Currently, plugins are only shared during dev; see [Shared Plugins During Build](./api-environment-plugins/#shared-plugins-during-build) for more information.
-
 ## Per-environment Plugins
 
 A plugin can define what are the environments it should apply to with the `applyToEnvironment` function.

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -126,6 +126,31 @@ The hook can choose to:
   }
   ```
 
+## Per-environment State in Plugins
+
+Given that the same plugin instance is used for different environments, the plugin state needs to be keyed with `this.environment`. This is the same pattern the ecosystem has already been using to keep state about modules using the `ssr` boolean as key to avoid mixing client and ssr modules state. A `Map<Environment, State>` can be used to keep the state for each environment separately. Note that for backward compatibility, `buildStart` and `buildEnd` are only called for the client environment without the `perEnvironmentStartEndDuringDev: true` flag.
+
+```js
+function PerEnvironmentCountTransformedModulesPlugin() {
+  const state = new Map<Environment, { count: number }>()
+  return {
+    name: 'count-transformed-modules',
+    perEnvironmentStartEndDuringDev: true,
+    buildStart() {
+      state.set(this.environment, { count: 0 })
+    }
+    transform(id) {
+      state.get(this.environment).count++
+    },
+    buildEnd() {
+      console.log(this.environment.name, state.get(this.environment).count)
+    }
+  }
+}
+```
+
+Note: Currently, plugins are only shared during dev; see [Shared Plugins During Build](./api-environment-plugins/#shared-plugins-during-build) for more information.
+
 ## Per-environment Plugins
 
 A plugin can define what are the environments it should apply to with the `applyToEnvironment` function.


### PR DESCRIPTION
### Description

Adds a section about per-environment state handling in plugins. We didn't have a reference to `perEnvironmentStartEndDuringDev: true` without this section.

This was already document under future breaking changes here https://vite.dev/changes/shared-plugins-during-build.html, including the `perEnvironmentState` helper.

I didn't include the `perEnvironmentState` helper in the guide because I'm unsure if we should be promoting it. The explicit `Map<Environment, State>` may be better and less magical. The helper currently takes a `init` function to create the state of each environment, but a reset should also be added to `buildStart` for build watch mode leading to the state being inited twice (just a detail, but still)

A note, during build watch, this plugin counts how many modules have been re-transformed. We use this pattern in our internal plugins, but for many use cases it could break if the whole state is busted on `buildStart` and only some modules get re-transformed and people expect the whole state to be there. In the case of keeping state per module, I don't know if we have a good answer that is compatible with watch mode.

Maybe we shouldn't promote per environment state at all and instead have users return `meta` info in hooks. This documents what we have been doing internally and how the ecosystem also did things even without environments so probably it is fine to have it (same issue between state and build watch mode could happen only for the client). Long term, @sapphi-red maybe this is something to review for rolldown-vite and how state in plugins would be shared between Rust and JS, how it interacts with build watch mode, and the future full-bundle mode too.