### PR TITLE
fix(types): add a global interface for Worker

### DIFF
--- a/packages/vite/tsconfig.check.json
+++ b/packages/vite/tsconfig.check.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "moduleResolution": "node16",
     "module": "Node16",
-    "lib": ["ES2020", "WebWorker"], // ES2020 is very conservative check for client types, could be bumped if needed
+    "lib": ["ES2020"], // ES2020 is very conservative check for client types, could be bumped if needed
     "types": [], // Avoid checking unrelated node_modules types
     "noEmit": true,
     "strict": true,

--- a/packages/vite/types/importGlob.d.ts
+++ b/packages/vite/types/importGlob.d.ts
@@ -42,6 +42,7 @@ export type GeneralImportGlobOptions = ImportGlobOptions<boolean, string>
  * the Worker interface will be merged correctly.
  */
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface Worker {}
 }
 

--- a/packages/vite/types/importGlob.d.ts
+++ b/packages/vite/types/importGlob.d.ts
@@ -36,7 +36,11 @@ export interface ImportGlobOptions<
 
 export type GeneralImportGlobOptions = ImportGlobOptions<boolean, string>
 
-// provide a fallback in case the Worker interface isn't provided in the environment
+/**
+ * Declare Worker in case DOM is not added to the tsconfig lib causing
+ * Worker interface is not defined. For developers with DOM lib added,
+ * the Worker interface will be merged correctly.
+ */
 declare global {
   interface Worker {}
 }

--- a/packages/vite/types/importGlob.d.ts
+++ b/packages/vite/types/importGlob.d.ts
@@ -36,6 +36,11 @@ export interface ImportGlobOptions<
 
 export type GeneralImportGlobOptions = ImportGlobOptions<boolean, string>
 
+// provide a fallback in case the Worker interface isn't provided in the environment
+declare global {
+  interface Worker {}
+}
+
 export interface KnownAsTypeMap {
   raw: string
   url: string


### PR DESCRIPTION
### Description

Resolves https://github.com/vitejs/vite/issues/9813

Hey there 👋 , we're on our journey of dropping CJS and we switched to Vitest for ESM. We have `skipLibCheck` disabled by default and noticed a compiler issue when we used `vitest` without the `dom` lib.

This PR adds a type global to allow users to use vitest without the `dom` lib. Users who already have a `dom` lib defined simply have their types merge.

This is used by many different libraries like Zod and the aws-sdk:

https://github.com/aws/aws-sdk-js-v3/blob/0fd639bc4bd06d08c2f99b9f154daa91b237e017/packages/util-dynamodb/src/models.ts#L41
https://github.com/colinhacks/zod/blob/d5e23683cab94dfd89be8a57193e33187a09ee2d/packages/zod/src/v4/core/schemas.ts#L2818
