### PR TITLE
perf(utils): improve performance of `numberToPos`

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -17,6 +17,7 @@ import {
   isFileReadable,
   mergeWithDefaults,
   normalizePath,
+  numberToPos,
   posToNumber,
   processSrcSetSync,
   resolveHostname,
@@ -242,6 +243,34 @@ describe('posToNumber', () => {
   test('out of range', () => {
     const actual = posToNumber('a\nb', { line: 4, column: 0 })
     expect(actual).toBe(4)
+  })
+})
+
+describe('numberToPos', () => {
+  test('simple', () => {
+    const actual = numberToPos('a\nb', 2)
+    expect(actual).toEqual({ line: 2, column: 0 })
+  })
+  test('pass though pos', () => {
+    const actual = numberToPos('a\nb', { line: 2, column: 0 })
+    expect(actual).toEqual({ line: 2, column: 0 })
+  })
+  test('empty line', () => {
+    const actual = numberToPos('a\n\nb', 3)
+    expect(actual).toEqual({ line: 3, column: 0 })
+  })
+  test('middle of line', () => {
+    const actual = numberToPos('abc\ndef', 5)
+    expect(actual).toEqual({ line: 2, column: 1 })
+  })
+  test('end of line', () => {
+    const actual = numberToPos('abc\ndef', 3)
+    expect(actual).toEqual({ line: 1, column: 3 })
+  })
+  test('out of range', () => {
+    expect(() => numberToPos('a\nb', 5)).toThrowError(
+      'offset is longer than source length',
+    )
   })
 })
 

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -26,12 +26,12 @@ exports[`parse error 2`] = `
 2  |  ",
   "id": "/fixtures/errors/syntax-error.js",
   "loc": {
-    "column": 9,
+    "column": 8,
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
   "message": "Parse failure: Expected ';', '}' or <eof>
-At file: /fixtures/errors/syntax-error.js:1:9",
+At file: /fixtures/errors/syntax-error.js:1:8",
 }
 `;
 
@@ -61,11 +61,11 @@ exports[`parse error 4`] = `
 2  |  ",
   "id": "/fixtures/errors/syntax-error.js",
   "loc": {
-    "column": 9,
+    "column": 8,
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
   "message": "Parse failure: Expected ';', '}' or <eof>
-At file: /fixtures/errors/syntax-error.js:1:9",
+At file: /fixtures/errors/syntax-error.js:1:8",
 }
 `;

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -493,19 +493,12 @@ export function numberToPos(source: string, offset: number | Pos): Pos {
       `offset is longer than source length! offset ${offset} > length ${source.length}`,
     )
   }
-  const lines = source.split(splitRE)
-  let counted = 0
-  let line = 0
-  let column = 0
-  for (; line < lines.length; line++) {
-    const lineLength = lines[line].length + 1
-    if (counted + lineLength >= offset) {
-      column = offset - counted + 1
-      break
-    }
-    counted += lineLength
+
+  const lines = source.slice(0, offset).split(splitRE)
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1].length,
   }
-  return { line: line + 1, column }
 }
 
 export function generateCodeFrame(


### PR DESCRIPTION
### Description

This PR optimizes the `numberToPos` function, achieving 1.66x-2.27x performance improvement across different JavaScript runtimes. The refactored implementation also provides clearer and more maintainable code.

### Benchmarks

The code of benchmarks is shown at [Stackblitz](https://stackblitz.com/edit/unjs-h3-whebbsek?file=index.ts).

Performance was measured using a 9,179-character test file across multiple runtimes locally.

![result of bun](https://github.com/user-attachments/assets/5e0fa66b-0e82-4162-bd72-01276dcbde88)

![result of nodejs](https://github.com/user-attachments/assets/8c3cb412-b55d-4267-ab46-1e4f1cfbf6af)

![result of deno](https://github.com/user-attachments/assets/bf961424-74d2-4005-b9cb-0cbc7a4bac2b)

### Behavior Changes

The current implementation return positions like `{ line: /* previous line */, column: /* line length including newline */ }`. The new implementation consistently return the start position of the next line like `{ line: /* exact the line */, column: 0 }`, which better aligns with the `0-based` column described in the `Pos` type comments.

https://github.com/vitejs/vite/blob/657c2fa1af8f63553c5a3622f6d4cda846415b5e/packages/vite/src/node/utils.ts#L471-L476