### PR TITLE
fix(resolve): don't use exports field for dir imports

### DIFF
--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -256,3 +256,7 @@ test.runIf(isBuild)('public dir is not copied', async () => {
 test('import utf8-bom package', async () => {
   expect(await page.textContent('.utf8-bom-package')).toMatch('[success]')
 })
+
+test('exports field of package.json should not be used for relative dir imports', async () => {
+  expect(await page.textContent('.dir-with-pkgjson')).toMatch('[success]')
+})

--- a/playground/resolve/dir-with-pkgjson/exports.js
+++ b/playground/resolve/dir-with-pkgjson/exports.js
@@ -1,0 +1,1 @@
+export default '[fail] exports field should not be used'

--- a/playground/resolve/dir-with-pkgjson/main.js
+++ b/playground/resolve/dir-with-pkgjson/main.js
@@ -1,0 +1,1 @@
+export default '[success] main field is used'

--- a/playground/resolve/dir-with-pkgjson/package.json
+++ b/playground/resolve/dir-with-pkgjson/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vitejs/test-dir-with-pkgjson",
+  "main": "./main.js",
+  "exports": "./exports.js"
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -182,6 +182,9 @@
 <h2>utf8-bom-package</h2>
 <p class="utf8-bom-package">fail</p>
 
+<h2>resolve package with dir with pkg.json</h2>
+<p class="dir-with-pkgjson">fail</p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -411,6 +414,9 @@
 
   import { msg as utf8BomPackage } from '@vitejs/test-utf8-bom-package'
   text('.utf8-bom-package', utf8BomPackage)
+
+  import dirWithPkgJson from './dir-with-pkgjson'
+  text('.dir-with-pkgjson', dirWithPkgJson)
 </script>
 
 <style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1324,6 +1324,8 @@ importers:
 
   playground/resolve/custom-main-field: {}
 
+  playground/resolve/dir-with-pkgjson: {}
+
   playground/resolve/exports-and-nested-scope: {}
 
   playground/resolve/exports-and-nested-scope/nested-scope: {}


### PR DESCRIPTION
### Description

For `require('./dir')`, Node.js does not use the `exports` field of `dir/package.json`.
(Spec: [`LOAD_AS_DIRECTORY(X) step 1.b`](https://nodejs.org/docs/latest/api/modules.html#all-together))
But Vite currently uses the `exports` field in that case.

This PR aligns the behavior to Node.js. This also aligns with oxc-resolver's behavior.

Note that this PR will break this line in nuxt.
https://github.com/nuxt/nuxt/blob/a7d21ece19e69703aac5fbb1f7bf53f0dfc5751f/test/setup-env.ts#L3

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
