### PR TITLE
feat(create-vite): validate project name

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -363,9 +363,14 @@ async function init() {
       message: 'Project name:',
       defaultValue: defaultTargetDir,
       placeholder: defaultTargetDir,
+      validate: (value) => {
+        return value.length === 0 || formatTargetDir(value).length > 0
+          ? undefined
+          : 'Invalid project name'
+      },
     })
     if (prompts.isCancel(projectName)) return cancel()
-    targetDir = formatTargetDir(projectName as string) || defaultTargetDir
+    targetDir = formatTargetDir(projectName)
   }
 
   // 2. Handle directory if exist and not empty


### PR DESCRIPTION
### Description
When you enter a project name with a string of spaces in the terminal, the terminal prints nothing. The actual name you use is `defaultTargetDir`, which seems inconsistent with the context. So, add a `validate` function to check for inappropriate names in advance.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
