### PR TITLE
chore: typos in comments

### DIFF
--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -298,7 +298,7 @@ function CallSiteToString(this: CallSite) {
   const isMethodCall = !(this.isToplevel() || isConstructor)
   if (isMethodCall) {
     let typeName = this.getTypeName()
-    // Fixes shim to be backward compatable with Node v0 to v4
+    // Fixes shim to be backward compatible with Node v0 to v4
     if (typeName === '[object Object]') typeName = 'null'
 
     const methodName = this.getMethodName()

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -26,7 +26,7 @@ describe.runIf(isBuild)('build', () => {
 
 describe.runIf(isServe)('server', () => {
   test('should log 500 error in browser for malformed tsconfig', () => {
-    // don't test for actual complete message as this might be locale dependant. chrome does log 500 consistently though
+    // don't test for actual complete message as this might be locale dependent. chrome does log 500 consistently though
     expect(browserLogs.find((x) => x.includes('500'))).toBeTruthy()
     expect(browserLogs).not.toContain('tsconfig error fixed, file loaded')
   })


### PR DESCRIPTION


This PR corrects a couple of typos found in code comments.

- Corrected `compatable` to `compatible` in `packages/vite/src/module-runner/sourcemap/interceptor.ts`.
- Corrected `dependant` to `dependent` in `playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts`.
