### PR TITLE
feat(ssr): support `import.meta.resolve` in module runner

### DIFF
--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -149,12 +149,17 @@ Module runner exposes `import` method. When Vite server triggers `full-reload` H
 **Example Usage:**
 
 ```js
-import { ModuleRunner, ESModulesEvaluator } from 'vite/module-runner'
+import {
+  ModuleRunner,
+  ESModulesEvaluator,
+  createNodeImportMeta,
+} from 'vite/module-runner'
 import { transport } from './rpc-implementation.js'
 
 const moduleRunner = new ModuleRunner(
   {
     transport,
+    createImportMeta: createNodeImportMeta, // if the module runner runs in Node.js
   },
   new ESModulesEvaluator(),
 )
@@ -274,7 +279,11 @@ You need to couple it with the `HotChannel` instance on the server like in this 
 ```js [worker.js]
 import { parentPort } from 'node:worker_threads'
 import { fileURLToPath } from 'node:url'
-import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import {
+  ESModulesEvaluator,
+  ModuleRunner,
+  createNodeImportMeta,
+} from 'vite/module-runner'
 
 /** @type {import('vite/module-runner').ModuleRunnerTransport} */
 const transport = {
@@ -290,6 +299,7 @@ const transport = {
 const runner = new ModuleRunner(
   {
     transport,
+    createImportMeta: createNodeImportMeta,
   },
   new ESModulesEvaluator(),
 )

--- a/packages/vite/src/module-runner/createImportMeta.ts
+++ b/packages/vite/src/module-runner/createImportMeta.ts
@@ -1,0 +1,64 @@
+import { isWindows } from '../shared/utils'
+import {
+  type ImportMetaResolver,
+  createImportMetaResolver,
+} from './importMetaResolver'
+import type { ModuleRunnerImportMeta } from './types'
+import { posixDirname, posixPathToFileHref, toWindowsPath } from './utils'
+
+const envProxy = new Proxy({} as any, {
+  get(_, p) {
+    throw new Error(
+      `[module runner] Dynamic access of "import.meta.env" is not supported. Please, use "import.meta.env.${String(p)}" instead.`,
+    )
+  },
+})
+
+export function createDefaultImportMeta(
+  modulePath: string,
+): ModuleRunnerImportMeta {
+  const href = posixPathToFileHref(modulePath)
+  const filename = modulePath
+  const dirname = posixDirname(modulePath)
+  return {
+    filename: isWindows ? toWindowsPath(filename) : filename,
+    dirname: isWindows ? toWindowsPath(dirname) : dirname,
+    url: href,
+    env: envProxy,
+    resolve(_id: string, _parent?: string) {
+      throw new Error('[module runner] "import.meta.resolve" is not supported.')
+    },
+    // should be replaced during transformation
+    glob() {
+      throw new Error(
+        `[module runner] "import.meta.glob" is statically replaced during ` +
+          `file transformation. Make sure to reference it by the full name.`,
+      )
+    },
+  }
+}
+
+let importMetaResolverCache: Promise<ImportMetaResolver | undefined> | undefined
+
+/**
+ * Create import.meta object for Node.js.
+ */
+export async function createNodeImportMeta(
+  modulePath: string,
+): Promise<ModuleRunnerImportMeta> {
+  const defaultMeta = createDefaultImportMeta(modulePath)
+  const href = defaultMeta.url
+
+  importMetaResolverCache ??= createImportMetaResolver()
+  const importMetaResolver = await importMetaResolverCache
+
+  return {
+    ...defaultMeta,
+    resolve(id: string, parent?: string) {
+      if (importMetaResolver) {
+        return importMetaResolver(id, parent ?? href)
+      }
+      return defaultMeta.resolve(id, parent ?? defaultMeta.url)
+    },
+  }
+}

--- a/packages/vite/src/module-runner/createImportMeta.ts
+++ b/packages/vite/src/module-runner/createImportMeta.ts
@@ -55,10 +55,8 @@ export async function createNodeImportMeta(
   return {
     ...defaultMeta,
     resolve(id: string, parent?: string) {
-      if (importMetaResolver) {
-        return importMetaResolver(id, parent ?? href)
-      }
-      return defaultMeta.resolve(id, parent ?? defaultMeta.url)
+      const resolver = importMetaResolver ?? defaultMeta.resolve
+      return resolver(id, parent ?? href)
     },
   }
 }

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -33,8 +33,16 @@ export async function createImportMetaResolver(): Promise<
     return
   }
 
-  const hookModuleContent = `data:text/javascript,${encodeURI(customizationHooksModule)}`
-  module.register(hookModuleContent)
+  try {
+    const hookModuleContent = `data:text/javascript,${encodeURI(customizationHooksModule)}`
+    module.register(hookModuleContent)
+  } catch (e) {
+    // For `--experimental-network-imports` flag that exists in Node before v22
+    if ('code' in e && e.code === 'ERR_NETWORK_IMPORT_DISALLOWED') {
+      return
+    }
+    throw e
+  }
 
   return (specifier: string, importer: string) =>
     import.meta.resolve(

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -11,11 +11,7 @@ export async function resolve(specifier, context, nextResolve) {
     context.parentURL = parsedImporter
   }
 
-  const result = await nextResolve(specifier, context)
-  return {
-    ...result,
-    shortCircuit: true,
-  }
+  return nextResolve(specifier, context)
 }
 
 `

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -1,0 +1,43 @@
+export type ImportMetaResolver = (specifier: string, importer: string) => string
+
+const customizationHookNamespace = 'vite-module-runner:import-meta-resolve/v1/'
+const customizationHooksModule = /* js */ `
+
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith(${JSON.stringify(customizationHookNamespace)})) {
+    const data = specifier.slice(${JSON.stringify(customizationHookNamespace)}.length)
+    const [parsedSpecifier, parsedImporter] = JSON.parse(data)
+    specifier = parsedSpecifier
+    context.parentURL = parsedImporter
+  }
+
+  const result = await nextResolve(specifier, context)
+  return {
+    ...result,
+    shortCircuit: true,
+  }
+}
+
+`
+
+export async function createImportMetaResolver(): Promise<
+  ImportMetaResolver | undefined
+> {
+  let module: typeof import('node:module')
+  try {
+    module = (await import('node:module')).Module
+  } catch {
+    return
+  }
+  if (!module.register) {
+    return
+  }
+
+  const hookModuleContent = `data:text/javascript,${encodeURI(customizationHooksModule)}`
+  module.register(hookModuleContent)
+
+  return (specifier: string, importer: string) =>
+    import.meta.resolve(
+      `${customizationHookNamespace}${JSON.stringify([specifier, importer])}`,
+    )
+}

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -25,7 +25,8 @@ export async function createImportMetaResolver(): Promise<
   } catch {
     return
   }
-  if (!module.register) {
+  // `module.Module` may be `undefined` when `node:module` is mocked
+  if (!module?.register) {
     return
   }
 

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -3,6 +3,10 @@
 export { EvaluatedModules, type EvaluatedModuleNode } from './evaluatedModules'
 export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
+export {
+  createDefaultImportMeta,
+  createNodeImportMeta,
+} from './createImportMeta'
 
 export { createWebSocketModuleRunnerTransport } from '../shared/moduleRunnerTransport'
 

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -106,6 +106,14 @@ export interface ModuleRunnerOptions {
    */
   hmr?: boolean | ModuleRunnerHmr
   /**
+   * Create import.meta object for the module.
+   *
+   * @default createImportMetaDefault
+   */
+  createImportMeta?: (
+    modulePath: string,
+  ) => ModuleRunnerImportMeta | Promise<ModuleRunnerImportMeta>
+  /**
    * Custom module cache. If not provided, creates a separate module cache for each ModuleRunner instance.
    */
   evaluatedModules?: EvaluatedModules

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -108,7 +108,7 @@ export interface ModuleRunnerOptions {
   /**
    * Create import.meta object for the module.
    *
-   * @default createImportMetaDefault
+   * @default createDefaultImportMeta
    */
   createImportMeta?: (
     modulePath: string,

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/worker.invoke.mjs
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/worker.invoke.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { BroadcastChannel, parentPort } from 'node:worker_threads'
-import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import { ESModulesEvaluator, ModuleRunner, createNodeImportMeta } from 'vite/module-runner'
 import { createBirpc } from 'birpc'
 
 if (!parentPort) {
@@ -22,6 +22,7 @@ const runner = new ModuleRunner(
     transport: {
       invoke(data) { return rpc.invoke(data) }
     },
+    createImportMeta: createNodeImportMeta,
     hmr: false,
   },
   new ESModulesEvaluator(),

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/worker.mjs
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/worker.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { BroadcastChannel, parentPort } from 'node:worker_threads'
-import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import { ESModulesEvaluator, ModuleRunner, createNodeImportMeta } from 'vite/module-runner'
 
 if (!parentPort) {
   throw new Error('File "worker.js" must be run in a worker thread')
@@ -24,6 +24,7 @@ const messagePortTransport = {
 const runner = new ModuleRunner(
   {
     transport: messagePortTransport,
+    createImportMeta: createNodeImportMeta,
   },
   new ESModulesEvaluator(),
 )

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import type { HotPayload } from 'types/hmrPayload'
-import { ModuleRunner } from 'vite/module-runner'
+import { ModuleRunner, createNodeImportMeta } from 'vite/module-runner'
 import type {
   ModuleEvaluator,
   ModuleRunnerHmr,
@@ -130,6 +130,7 @@ export function createServerModuleRunner(
         channel: environment.hot as NormalizedServerHotChannel,
       }),
       hmr,
+      createImportMeta: createNodeImportMeta,
       sourcemapInterceptor: resolveSourceMapOptions(options),
     },
     options.evaluator,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,6 +1,10 @@
 import colors from 'picocolors'
 import type { EvaluatedModuleNode } from 'vite/module-runner'
-import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
+import {
+  ESModulesEvaluator,
+  ModuleRunner,
+  createNodeImportMeta,
+} from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
 import { unwrapId } from '../../shared/utils'
 import type { DevEnvironment } from '../server/environment'
@@ -69,6 +73,7 @@ class SSRCompatModuleRunner extends ModuleRunner {
         transport: createServerModuleRunnerTransport({
           channel: environment.hot as NormalizedServerHotChannel,
         }),
+        createImportMeta: createNodeImportMeta,
         sourcemapInterceptor: false,
         hmr: false,
       },

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -44,6 +44,14 @@ test(`deadlock doesn't happen for dynamic imports`, async () => {
   )
 })
 
+test(`import.meta.resolve is supported`, async () => {
+  await page.goto(`${url}/import-meta`)
+
+  const metaUrl = await page.textContent('.import-meta-url')
+  expect(metaUrl).not.toBe('')
+  expect(await page.textContent('.import-meta-resolve')).toBe(metaUrl)
+})
+
 test.runIf(isServe)('html proxy is encoded', async () => {
   await page.goto(
     `${url}?%22%3E%3C/script%3E%3Cscript%3Econsole.log(%27html%20proxy%20is%20not%20encoded%27)%3C/script%3E`,

--- a/playground/ssr/src/app.js
+++ b/playground/ssr/src/app.js
@@ -7,6 +7,7 @@ const pathRenderers = {
   '/circular-import2': renderCircularImport2,
   '/forked-deadlock-static-imports': renderForkedDeadlockStaticImports,
   '/forked-deadlock-dynamic-imports': renderForkedDeadlockDynamicImports,
+  '/import-meta': renderImportMeta,
 }
 
 export async function render(url, rootDir) {
@@ -59,4 +60,13 @@ async function renderForkedDeadlockDynamicImports(rootDir) {
   )
   await commonModuleExport()
   return `<div class="forked-deadlock-dynamic-imports">rendered</div>`
+}
+
+async function renderImportMeta(rootDir) {
+  const metaUrl = import.meta.url
+  const resolveResult = import.meta.resolve('./app.js')
+  return (
+    `<div class="import-meta-url">${escapeHtml(metaUrl)}</div>` +
+    `<div class="import-meta-resolve">${escapeHtml(resolveResult)}</div>`
+  )
 }


### PR DESCRIPTION
### Description

This PR adds `import.meta.resolve` support to the module runner.

I recently encountered a similar problem and came up with this idea, so I implemented to see if it works 😀

This approach only works in Node as it relies on 1. module customization hooks, 2. the second parameter of `import.meta.resolve`. But I don't think there's a way to avoid "2" and then that limitation is impossible to avoid. Because of "2", https://github.com/vitest-dev/vitest/pull/5188 only works in Node as well.

The upside of this approach compared to https://github.com/vitest-dev/vitest/pull/5188 is that this approach does not require users to pass `--experimental-import-meta-resolve`.

refs https://github.com/vitest-dev/vitest/issues/6953
refs https://github.com/vitest-dev/vitest/pull/5188

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
