### PR TITLE
chore: remove rolldown from onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
       "bcrypt",
       "esbuild",
       "playwright-chromium",
-      "rolldown",
       "sharp",
       "simple-git-hooks",
       "unrs-resolver",


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
refer to https://github.com/rolldown/rolldown/pull/4331. The rolldown version currently installed has no scripts that need to be pre-executed when installing it.