### PR TITLE
fix(module-runner): expose `normalizeModuleId`

### DIFF
--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -139,7 +139,7 @@ const prefixedBuiltins = new Set([
 // /root/id.js -> /id.js
 // C:/root/id.js -> /id.js
 // C:\root\id.js -> /id.js
-function normalizeModuleId(file: string): string {
+export function normalizeModuleId(file: string): string {
   if (prefixedBuiltins.has(file)) return file
 
   // unix style, but Windows path still starts with the drive letter to check the root

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -1,6 +1,10 @@
 // this file should re-export only things that don't rely on Node.js or other runner features
 
-export { EvaluatedModules, type EvaluatedModuleNode } from './evaluatedModules'
+export {
+  EvaluatedModules,
+  normalizeModuleId,
+  type EvaluatedModuleNode,
+} from './evaluatedModules'
 export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 


### PR DESCRIPTION
### Description

`pluginContainer.resolveId` has to be processed with `normalizeModuleId` if you want the same string that module runner uses internally.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
