### PR TITLE
feat: export `defaultExternalConditions`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_CLIENT_CONDITIONS,
   DEFAULT_CLIENT_MAIN_FIELDS,
   DEFAULT_CONFIG_FILES,
+  DEFAULT_EXTERNAL_CONDITIONS,
   DEFAULT_PREVIEW_PORT,
   DEFAULT_SERVER_CONDITIONS,
   DEFAULT_SERVER_MAIN_FIELDS,
@@ -651,7 +652,7 @@ export const configDefaults = Object.freeze({
   resolve: {
     // mainFields
     // conditions
-    externalConditions: ['node'],
+    externalConditions: [...DEFAULT_EXTERNAL_CONDITIONS],
     extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
     dedupe: [],
     /** @experimental */

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -64,6 +64,8 @@ export const DEFAULT_SERVER_CONDITIONS = Object.freeze(
   DEFAULT_CONDITIONS.filter((c) => c !== 'browser'),
 )
 
+export const DEFAULT_EXTERNAL_CONDITIONS = Object.freeze(['node'])
+
 /**
  * The browser versions that are included in the Baseline Widely Available on 2025-05-01.
  *

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -53,6 +53,7 @@ export {
   VERSION as version,
   DEFAULT_CLIENT_CONDITIONS as defaultClientConditions,
   DEFAULT_CLIENT_MAIN_FIELDS as defaultClientMainFields,
+  DEFAULT_EXTERNAL_CONDITIONS as defaultExternalConditions,
   DEFAULT_SERVER_CONDITIONS as defaultServerConditions,
   DEFAULT_SERVER_MAIN_FIELDS as defaultServerMainFields,
   defaultAllowedOrigins,

--- a/packages/vite/src/node/ssr/index.ts
+++ b/packages/vite/src/node/ssr/index.ts
@@ -40,7 +40,7 @@ export interface SSROptions {
     /**
      * Conditions that are used during ssr import (including `ssrLoadModule`) of externalized dependencies.
      *
-     * @default []
+     * @default ['node']
      */
     externalConditions?: string[]
 


### PR DESCRIPTION
### Description

Frameworks like React Router want to extend the Vite options and they use exports like `defaultServerConditions` to accomplish that:
https://github.com/remix-run/react-router/blob/f33e6b7e2bb46e264ea3235606f1aec6cbce236a/packages/react-router-dev/vite/plugin.ts#L3454-L3457
https://github.com/remix-run/react-router/blob/f33e6b7e2bb46e264ea3235606f1aec6cbce236a/packages/react-router-dev/vite/plugin.ts#L3513-L3526

But the problem is there is no export like that for the default external conditions. This closes the gap.