### PR TITLE
refactor: remove picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "execa": "^9.6.0",
     "globals": "^16.2.0",
     "lint-staged": "^16.1.2",
-    "picocolors": "^1.1.1",
     "playwright-chromium": "^1.53.1",
     "prettier": "3.6.0",
     "rollup": "^4.40.0",

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -36,7 +36,6 @@
     "@clack/prompts": "^0.11.0",
     "cross-spawn": "^7.0.6",
     "mri": "^1.2.0",
-    "picocolors": "^1.1.1",
     "tsdown": "^0.12.8"
   }
 }

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -1,23 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { styleText } from 'node:util'
 import spawn from 'cross-spawn'
 import mri from 'mri'
 import * as prompts from '@clack/prompts'
-import colors from 'picocolors'
 
-const {
-  blue,
-  blueBright,
-  cyan,
-  green,
-  greenBright,
-  magenta,
-  red,
-  redBright,
-  reset,
-  yellow,
-} = colors
+const blue = (str: string | number) => styleText('blue', String(str))
+const blueBright = (str: string | number) =>
+  styleText('blueBright', String(str))
+const cyan = (str: string | number) => styleText('cyan', String(str))
+const green = (str: string | number) => styleText('green', String(str))
+const greenBright = (str: string | number) =>
+  styleText('greenBright', String(str))
+const magenta = (str: string | number) => styleText('magenta', String(str))
+const red = (str: string | number) => styleText('red', String(str))
+const redBright = (str: string | number) => styleText('redBright', String(str))
+const yellow = (str: string | number) => styleText('yellow', String(str))
+const reset = (str: string | number) => styleText('reset', String(str))
 
 const argv = mri<{
   template?: string

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "acorn": "^8.15.0",
-    "picocolors": "^1.1.1",
     "tsdown": "^0.12.8",
     "vite": "workspace:*"
   }

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import crypto from 'node:crypto'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
+import { styleText } from 'node:util'
 import { build, normalizePath } from 'vite'
 import MagicString from 'magic-string'
 import type {
@@ -24,7 +25,6 @@ import type {
   PluginItem as BabelPlugin,
   types as BabelTypes,
 } from '@babel/core'
-import colors from 'picocolors'
 import browserslist from 'browserslist'
 import type { Options } from './types'
 import {
@@ -257,21 +257,24 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     configResolved(config) {
       if (overriddenBuildTarget) {
         config.logger.warn(
-          colors.yellow(
+          styleText(
+            'yellow',
             `plugin-legacy overrode 'build.target'. You should pass 'targets' as an option to this plugin with the list of legacy browsers to support instead.`,
           ),
         )
       }
       if (overriddenDefaultModernTargets) {
         config.logger.warn(
-          colors.yellow(
+          styleText(
+            'yellow',
             `plugin-legacy 'modernTargets' option overrode the builtin targets of modern chunks. Some versions of browsers between legacy and modern may not be supported.`,
           ),
         )
       }
       if (config.isWorker) {
         config.logger.warn(
-          colors.yellow(
+          styleText(
+            'yellow',
             `plugin-legacy should not be passed to 'worker.plugins'. Pass to 'plugins' instead. Note that generating legacy chunks for workers are not supported by plugin-legacy.`,
           ),
         )

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -132,7 +132,6 @@
     "parse5": "^7.3.0",
     "pathe": "^2.0.3",
     "periscopic": "^4.0.2",
-    "picocolors": "^1.1.1",
     "postcss-import": "^16.1.1",
     "postcss-load-config": "^6.0.1",
     "postcss-modules": "^6.0.1",

--- a/packages/vite/rollupLicensePlugin.ts
+++ b/packages/vite/rollupLicensePlugin.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
+import { styleText } from 'node:util'
 import license from 'rollup-plugin-license'
 import type { Dependency } from 'rollup-plugin-license'
-import colors from 'picocolors'
 import type { Plugin, PluginContext } from 'rollup'
 
 export default function licensePlugin(
@@ -108,7 +108,8 @@ export default function licensePlugin(
       if (existingLicenseText !== licenseText) {
         fs.writeFileSync(licenseFilePath, licenseText)
         console.warn(
-          colors.yellow(
+          styleText(
+            'yellow',
             '\nLICENSE.md updated. You should commit the updated file.\n',
           ),
         )

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,8 +1,7 @@
 import { basename, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { stripVTControlCharacters } from 'node:util'
+import { stripVTControlCharacters, styleText } from 'node:util'
 import fsp from 'node:fs/promises'
-import colors from 'picocolors'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type {
   LogLevel,
@@ -675,7 +674,8 @@ describe('resolveBuildOutputs', () => {
       ),
     ).toEqual([{ name: 'A' }])
     expect(log.warn).toHaveBeenLastCalledWith(
-      colors.yellow(
+      styleText(
+        'yellow',
         `"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.`,
       ),
     )

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -1,14 +1,9 @@
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
 import type { Plugin } from './plugin'
 
-const environmentColors = [
-  colors.blue,
-  colors.magenta,
-  colors.green,
-  colors.gray,
-]
+const environmentColors = ['blue', 'magenta', 'green', 'gray'] as const
 
 export class PartialEnvironment {
   name: string
@@ -58,7 +53,7 @@ export class PartialEnvironment {
         },
       },
     )
-    const environment = colors.dim(`(${this.name})`)
+    const environment = styleText('dim', `(${this.name})`)
     const colorIndex =
       [...this.name].reduce((acc, c) => acc + c.charCodeAt(0), 0) %
       environmentColors.length
@@ -70,25 +65,25 @@ export class PartialEnvironment {
       info(msg, opts) {
         return topLevelConfig.logger.info(msg, {
           ...opts,
-          environment: infoColor(environment),
+          environment: styleText(infoColor, environment),
         })
       },
       warn(msg, opts) {
         return topLevelConfig.logger.warn(msg, {
           ...opts,
-          environment: colors.yellow(environment),
+          environment: styleText('yellow', environment),
         })
       },
       warnOnce(msg, opts) {
         return topLevelConfig.logger.warnOnce(msg, {
           ...opts,
-          environment: colors.yellow(environment),
+          environment: styleText('yellow', environment),
         })
       },
       error(msg, opts) {
         return topLevelConfig.logger.error(msg, {
           ...opts,
-          environment: colors.red(environment),
+          environment: styleText('red', environment),
         })
       },
       clearScreen(type) {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type {
   ExternalOption,
   InputOption,
@@ -538,8 +538,10 @@ async function buildEnvironment(
   const ssr = environment.config.consumer === 'server'
 
   logger.info(
-    colors.cyan(
-      `vite v${VERSION} ${colors.green(
+    styleText(
+      'cyan',
+      `vite v${VERSION} ${styleText(
+        'green',
         `building ${ssr ? `SSR bundle ` : ``}for ${environment.config.mode}...`,
       )}`,
     ),
@@ -639,19 +641,21 @@ async function buildEnvironment(
   const enhanceRollupError = (e: RollupError) => {
     const stackOnly = extractStack(e)
 
-    let msg = colors.red((e.plugin ? `[${e.plugin}] ` : '') + e.message)
+    let msg = styleText('red', (e.plugin ? `[${e.plugin}] ` : '') + e.message)
     if (e.loc && e.loc.file && e.loc.file !== e.id) {
-      msg += `\nfile: ${colors.cyan(
+      msg += `\nfile: ${styleText(
+        'cyan',
         `${e.loc.file}:${e.loc.line}:${e.loc.column}` +
           (e.id ? ` (${e.id})` : ''),
       )}`
     } else if (e.id) {
-      msg += `\nfile: ${colors.cyan(
+      msg += `\nfile: ${styleText(
+        'cyan',
         e.id + (e.loc ? `:${e.loc.line}:${e.loc.column}` : ''),
       )}`
     }
     if (e.frame) {
-      msg += `\n` + colors.yellow(normalizeCodeFrame(e.frame))
+      msg += `\n` + styleText('yellow', normalizeCodeFrame(e.frame))
     }
 
     e.message = msg
@@ -695,7 +699,8 @@ async function buildEnvironment(
       }
       if (output.sourcemap) {
         logger.warnOnce(
-          colors.yellow(
+          styleText(
+            'yellow',
             `Vite does not support "rollupOptions.output.sourcemap". ` +
               `Please use "build.sourcemap" instead.`,
           ),
@@ -780,7 +785,7 @@ async function buildEnvironment(
 
     // watch file changes with rollup
     if (options.watch) {
-      logger.info(colors.cyan(`\nwatching for file changes...`))
+      logger.info(styleText('cyan', `\nwatching for file changes...`))
 
       const resolvedChokidarOptions = resolveChokidarOptions(
         options.watch.chokidar,
@@ -801,13 +806,13 @@ async function buildEnvironment(
 
       watcher.on('event', (event) => {
         if (event.code === 'BUNDLE_START') {
-          logger.info(colors.cyan(`\nbuild started...`))
+          logger.info(styleText('cyan', `\nbuild started...`))
           if (options.write) {
             prepareOutDir(resolvedOutDirs, emptyOutDir, environment)
           }
         } else if (event.code === 'BUNDLE_END') {
           event.result.close()
-          logger.info(colors.cyan(`built in ${event.duration}ms.`))
+          logger.info(styleText('cyan', `built in ${event.duration}ms.`))
         } else if (event.code === 'ERROR') {
           outputBuildError(event.error)
         }
@@ -830,7 +835,7 @@ async function buildEnvironment(
       res.push(await bundle[options.write ? 'write' : 'generate'](output))
     }
     logger.info(
-      `${colors.green(`✓ built in ${displayTime(Date.now() - startTime)}`)}`,
+      `${styleText('green', `✓ built in ${displayTime(Date.now() - startTime)}`)}`,
     )
     return Array.isArray(outputs) ? res : res[0]
   } catch (e) {
@@ -838,7 +843,7 @@ async function buildEnvironment(
     clearLine()
     if (startTime) {
       logger.error(
-        `${colors.red('✗')} Build failed in ${displayTime(Date.now() - startTime)}`,
+        `${styleText('red', '✗')} Build failed in ${displayTime(Date.now() - startTime)}`,
       )
       startTime = undefined
     }
@@ -880,13 +885,17 @@ function prepareOutDir(
     ) {
       if (!areSeparateFolders(outDir, publicDir)) {
         environment.logger.warn(
-          colors.yellow(
-            `\n${colors.bold(
+          styleText(
+            'yellow',
+            `\n${styleText(
+              'bold',
               `(!)`,
-            )} The public directory feature may not work correctly. outDir ${colors.white(
-              colors.dim(outDir),
-            )} and publicDir ${colors.white(
-              colors.dim(publicDir),
+            )} The public directory feature may not work correctly. outDir ${styleText(
+              'white',
+              styleText('dim', outDir),
+            )} and publicDir ${styleText(
+              'white',
+              styleText('dim', publicDir),
             )} are not separate folders.\n`,
           ),
         )
@@ -976,7 +985,8 @@ export function resolveBuildOutputs(
     // By this point, we know "outputs" is an Array.
     if (libOptions.formats) {
       logger.warn(
-        colors.yellow(
+        styleText(
+          'yellow',
           '"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.',
         ),
       )
@@ -1055,10 +1065,10 @@ export function onRollupLog(
         environment.logger.info(logging.message)
         return
       case 'warn':
-        environment.logger.warn(colors.yellow(logging.message))
+        environment.logger.warn(styleText('yellow', logging.message))
         return
       case 'error':
-        environment.logger.error(colors.red(logging.message))
+        environment.logger.error(styleText('red', logging.message))
         return
       case 'debug':
         debugLogger?.(logging.message)

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 import fs from 'node:fs'
 import { performance } from 'node:perf_hooks'
+import { styleText } from 'node:util'
 import { cac } from 'cac'
-import colors from 'picocolors'
 import { VERSION } from './constants'
 import type { BuildEnvironmentOptions } from './build'
 import type { ServerOptions } from './server'
@@ -54,8 +54,9 @@ export const stopProfiler = (
         )
         fs.writeFileSync(outPath, JSON.stringify(profile))
         log(
-          colors.yellow(
-            `CPU profile written to ${colors.white(colors.dim(outPath))}`,
+          styleText(
+            'yellow',
+            `CPU profile written to ${styleText('white', styleText('dim', outPath))}`,
           ),
         )
         profileSession = undefined
@@ -204,13 +205,18 @@ cli
 
       const modeString =
         options.mode && options.mode !== 'development'
-          ? `  ${colors.bgGreen(` ${colors.bold(options.mode)} `)}`
+          ? `  ${styleText('bgGreen', ` ${styleText('bold', options.mode)} `)}`
           : ''
       const viteStartTime = global.__vite_start_time ?? false
       const startupDurationString = viteStartTime
-        ? colors.dim(
-            `ready in ${colors.reset(
-              colors.bold(Math.ceil(performance.now() - viteStartTime)),
+        ? styleText(
+            'dim',
+            `ready in ${styleText(
+              'reset',
+              styleText(
+                'bold',
+                String(Math.ceil(performance.now() - viteStartTime)),
+              ),
             )} ms`,
           )
         : ''
@@ -218,8 +224,9 @@ cli
         process.stdout.bytesWritten > 0 || process.stderr.bytesWritten > 0
 
       info(
-        `\n  ${colors.green(
-          `${colors.bold('VITE')} v${VERSION}`,
+        `\n  ${styleText(
+          'green',
+          `${styleText('bold', 'VITE')} v${VERSION}`,
         )}${modeString}  ${startupDurationString}\n`,
         {
           clear: !hasExistingLogs,
@@ -256,9 +263,12 @@ cli
       server.bindCLIShortcuts({ print: true, customShortcuts })
     } catch (e) {
       const logger = createLogger(options.logLevel)
-      logger.error(colors.red(`error when starting dev server:\n${e.stack}`), {
-        error: e,
-      })
+      logger.error(
+        styleText('red', `error when starting dev server:\n${e.stack}`),
+        {
+          error: e,
+        },
+      )
       stopProfiler(logger.info)
       process.exit(1)
     }
@@ -329,7 +339,7 @@ cli
         await builder.buildApp()
       } catch (e) {
         createLogger(options.logLevel).error(
-          colors.red(`error during build:\n${e.stack}`),
+          styleText('red', `error during build:\n${e.stack}`),
           { error: e },
         )
         process.exit(1)
@@ -368,7 +378,7 @@ cli
         await optimizeDeps(config, options.force, true)
       } catch (e) {
         createLogger(options.logLevel).error(
-          colors.red(`error when optimizing deps:\n${e.stack}`),
+          styleText('red', `error when optimizing deps:\n${e.stack}`),
           { error: e },
         )
         process.exit(1)
@@ -419,7 +429,7 @@ cli
         server.bindCLIShortcuts({ print: true })
       } catch (e) {
         createLogger(options.logLevel).error(
-          colors.red(`error when starting preview server:\n${e.stack}`),
+          styleText('red', `error when starting preview server:\n${e.stack}`),
           { error: e },
         )
         process.exit(1)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2,11 +2,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import fsp from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
-import { promisify } from 'node:util'
+import { promisify, styleText } from 'node:util'
 import { performance } from 'node:perf_hooks'
 import { createRequire } from 'node:module'
 import crypto from 'node:crypto'
-import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'dep-types/alias'
 import type { PluginContextMeta, RollupOptions } from 'rollup'
 import picomatch from 'picomatch'
@@ -794,7 +793,8 @@ function resolveEnvironmentOptions(
       )?.[0]
       if (pathKey) {
         logger.warnOnce(
-          colors.yellow(
+          styleText(
+            'yellow',
             `The \`define\` option contains an object with ${JSON.stringify(pathKey)} for "process.env" key. ` +
               'It looks like you may have passed the entire `process.env` object to `define`, ' +
               'which can unintentionally expose all environment variables. ' +
@@ -899,8 +899,10 @@ function checkBadCharactersInPath(
     const inflectedChars = badChars.length > 1 ? 'characters' : 'character'
 
     logger.warn(
-      colors.yellow(
-        `${name} contains the ${charString} ${inflectedChars} (${colors.cyan(
+      styleText(
+        'yellow',
+        `${name} contains the ${charString} ${inflectedChars} (${styleText(
+          'cyan',
           path,
         )}), which may not work when running Vite. Consider renaming the directory / file to remove the characters.`,
       ),
@@ -967,7 +969,8 @@ function resolveEnvironmentResolveOptions(
     resolvedResolve.mainFields.includes('browser')
   ) {
     logger.warn(
-      colors.yellow(
+      styleText(
+        'yellow',
         `\`resolve.browserField\` is set to false, but the option is removed in favour of ` +
           `the 'browser' string in \`resolve.mainFields\`. You may want to update \`resolve.mainFields\` ` +
           `to remove the 'browser' string and preserve the previous browser behaviour.`,
@@ -990,7 +993,8 @@ function resolveResolveOptions(
 
   if (alias.some((a) => a.find === '/')) {
     logger.warn(
-      colors.yellow(
+      styleText(
+        'yellow',
         `\`resolve.alias\` contains an alias that maps \`/\`. ` +
           `This is not recommended as it can cause unexpected behavior when resolving paths.`,
       ),
@@ -1385,7 +1389,8 @@ export async function resolveConfig(
     createUserWorkerPlugins = () => config.worker?.plugins
 
     logger.warn(
-      colors.yellow(
+      styleText(
+        'yellow',
         `worker.plugins is now a function that returns an array of plugins. ` +
           `Please update your Vite config accordingly.\n`,
       ),
@@ -1664,9 +1669,12 @@ export async function resolveConfig(
       )
       if (hasDifferentReference) {
         resolved.logger.warn(
-          colors.yellow(`
+          styleText(
+            'yellow',
+            `
 assetFileNames isn't equal for every build.rollupOptions.output. A single pattern across all outputs is supported by Vite.
-`),
+`,
+          ),
         )
       }
     }
@@ -1680,10 +1688,13 @@ assetFileNames isn't equal for every build.rollupOptions.output. A single patter
     config.ssr?.format === 'cjs'
   ) {
     resolved.logger.warn(
-      colors.yellow(`
+      styleText(
+        'yellow',
+        `
 (!) Experimental legacy.buildSsrCjsExternalHeuristics and ssr.format were be removed in Vite 5.
     The only SSR Output format is ESM. Find more information at https://github.com/vitejs/vite/discussions/13816.
-`),
+`,
+      ),
     )
   }
 
@@ -1695,9 +1706,12 @@ assetFileNames isn't equal for every build.rollupOptions.output. A single patter
     resolvedBuildOutDir === resolved.root
   ) {
     resolved.logger.warn(
-      colors.yellow(`
+      styleText(
+        'yellow',
+        `
 (!) build.outDir must not be the same directory of root or a parent directory of root as this could cause Vite to overwriting source files with build outputs.
-`),
+`,
+      ),
     )
   }
 
@@ -1715,8 +1729,10 @@ export function resolveBaseUrl(
 ): string {
   if (base[0] === '.') {
     logger.warn(
-      colors.yellow(
-        colors.bold(
+      styleText(
+        'yellow',
+        styleText(
+          'bold',
           `(!) invalid "base" option: "${base}". The value can only be an absolute ` +
             `URL, "./", or an empty string.`,
         ),
@@ -1730,8 +1746,9 @@ export function resolveBaseUrl(
   // no leading slash warn
   if (!isExternal && base[0] !== '/') {
     logger.warn(
-      colors.yellow(
-        colors.bold(`(!) "base" option should start with a slash.`),
+      styleText(
+        'yellow',
+        styleText('bold', `(!) "base" option should start with a slash.`),
       ),
     )
   }
@@ -1848,9 +1865,12 @@ export async function loadConfigFromFile(
   } catch (e) {
     const logger = createLogger(logLevel, { customLogger })
     checkBadCharactersInPath('The config path', resolvedPath, logger)
-    logger.error(colors.red(`failed to load config from ${resolvedPath}`), {
-      error: e,
-    })
+    logger.error(
+      styleText('red', `failed to load config from ${resolvedPath}`),
+      {
+        error: e,
+      },
+    )
     throw e
   }
 }
@@ -2185,7 +2205,9 @@ function optimizeDepsDisabledBackwardCompatibility(
         resolved.build.commonjsOptions.include = undefined
       }
       resolved.logger.warn(
-        colors.yellow(`(!) Experimental ${optimizeDepsPath}optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
+        styleText(
+          'yellow',
+          `(!) Experimental ${optimizeDepsPath}optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
     To disable the deps optimizer, set ${optimizeDepsPath}optimizeDeps.noDiscovery to true and ${optimizeDepsPath}optimizeDeps.include as undefined or empty.
     Please remove ${optimizeDepsPath}optimizeDeps.disabled from your config.
     ${
@@ -2193,17 +2215,21 @@ function optimizeDepsDisabledBackwardCompatibility(
         ? 'Empty config.build.commonjsOptions.include will be ignored to support CJS during build. This config should also be removed.'
         : ''
     }
-  `),
+  `,
+        ),
       )
     } else if (
       optimizeDepsDisabled === false ||
       optimizeDepsDisabled === 'build'
     ) {
       resolved.logger.warn(
-        colors.yellow(`(!) Experimental ${optimizeDepsPath}optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
+        styleText(
+          'yellow',
+          `(!) Experimental ${optimizeDepsPath}optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
     Setting it to ${optimizeDepsDisabled} now has no effect.
     Please remove ${optimizeDepsPath}optimizeDeps.disabled from your config.
-  `),
+  `,
+        ),
       )
     }
   }

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -1,4 +1,4 @@
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { FutureOptions, ResolvedConfig } from './config'
 
 const docsURL = 'https://vite.dev'
@@ -53,12 +53,12 @@ export function warnFutureDeprecation(
   if (extraMessage) {
     msg += ` ${extraMessage}`
   }
-  msg = colors.yellow(msg)
+  msg = styleText('yellow', msg)
 
   const docs = `${docsURL}/changes/${deprecationCode[type].toLowerCase()}`
   msg +=
-    colors.gray(`\n  ${stacktrace ? '├' : '└'}─── `) +
-    colors.underline(docs) +
+    styleText('gray', `\n  ${stacktrace ? '├' : '└'}─── `) +
+    styleText('underline', docs) +
     '\n'
 
   if (stacktrace) {
@@ -74,7 +74,7 @@ export function warnFutureDeprecation(
       stacks = stacks.map(
         (i, idx) => `  ${idx === stacks.length - 1 ? '└' : '│'} ${i.trim()}`,
       )
-      msg += colors.dim(stacks.join('\n')) + '\n'
+      msg += styleText('dim', stacks.join('\n')) + '\n'
     }
   }
   config.logger.warnOnce(msg)

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -1,9 +1,9 @@
 import fsp from 'node:fs/promises'
 import path from 'node:path'
+import { styleText } from 'node:util'
 import type { OutgoingHttpHeaders as HttpServerHeaders } from 'node:http'
 import type { ServerOptions as HttpsServerOptions } from 'node:https'
 import type { Connect } from 'dep-types/connect'
-import colors from 'picocolors'
 import type { ProxyOptions } from './server/middlewares/proxy'
 import type { Logger } from './logger'
 import type { HttpServer } from './server'
@@ -210,7 +210,8 @@ export function setClientErrorHandler(
     if ((err as any).code === 'HPE_HEADER_OVERFLOW') {
       msg = '431 Request Header Fields Too Large'
       logger.warn(
-        colors.yellow(
+        styleText(
+          'yellow',
           'Server responded with status code 431. ' +
             'See https://vite.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.',
         ),

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -1,7 +1,7 @@
 /* eslint no-console: 0 */
 
 import readline from 'node:readline'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { RollupError } from 'rollup'
 import type { ResolvedServerUrls } from './server'
 
@@ -88,14 +88,14 @@ export function createLogger(
     if (options.timestamp) {
       let tag = ''
       if (type === 'info') {
-        tag = colors.cyan(colors.bold(prefix))
+        tag = styleText('cyan', styleText('bold', prefix))
       } else if (type === 'warn') {
-        tag = colors.yellow(colors.bold(prefix))
+        tag = styleText('yellow', styleText('bold', prefix))
       } else {
-        tag = colors.red(colors.bold(prefix))
+        tag = styleText('red', styleText('bold', prefix))
       }
       const environment = options.environment ? options.environment + ' ' : ''
-      return `${colors.dim(getTimeFormatter().format(new Date()))} ${tag} ${environment}${msg}`
+      return `${styleText('dim', getTimeFormatter().format(new Date()))} ${tag} ${environment}${msg}`
     } else {
       return msg
     }
@@ -114,7 +114,7 @@ export function createLogger(
           clear()
           console[method](
             format(type, msg, options),
-            colors.yellow(`(x${sameCount + 1})`),
+            styleText('yellow', `(x${sameCount + 1})`),
           )
         } else {
           sameCount = 0
@@ -171,18 +171,28 @@ export function printServerUrls(
   info: Logger['info'],
 ): void {
   const colorUrl = (url: string) =>
-    colors.cyan(url.replace(/:(\d+)\//, (_, port) => `:${colors.bold(port)}/`))
+    styleText(
+      'cyan',
+      url.replace(/:(\d+)\//, (_, port) => `:${styleText('bold', port)}/`),
+    )
   for (const url of urls.local) {
-    info(`  ${colors.green('➜')}  ${colors.bold('Local')}:   ${colorUrl(url)}`)
+    info(
+      `  ${styleText('green', '➜')}  ${styleText('bold', 'Local')}:   ${colorUrl(url)}`,
+    )
   }
   for (const url of urls.network) {
-    info(`  ${colors.green('➜')}  ${colors.bold('Network')}: ${colorUrl(url)}`)
+    info(
+      `  ${styleText('green', '➜')}  ${styleText('bold', 'Network')}: ${colorUrl(url)}`,
+    )
   }
   if (urls.network.length === 0 && optionsHost === undefined) {
     info(
-      colors.dim(`  ${colors.green('➜')}  ${colors.bold('Network')}: use `) +
-        colors.bold('--host') +
-        colors.dim(' to expose'),
+      styleText(
+        'dim',
+        `  ${styleText('green', '➜')}  ${styleText('bold', 'Network')}: use `,
+      ) +
+        styleText('bold', '--host') +
+        styleText('dim', ' to expose'),
     )
   }
 }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
-import { promisify } from 'node:util'
+import { promisify, styleText } from 'node:util'
 import { performance } from 'node:perf_hooks'
-import colors from 'picocolors'
 import type { BuildContext, BuildOptions as EsbuildBuildOptions } from 'esbuild'
 import esbuild, { build } from 'esbuild'
 import { init, parse } from 'es-module-lexer'
@@ -260,7 +259,8 @@ export async function optimizeDeps(
   const log = asCommand ? config.logger.info : debug
 
   config.logger.warn(
-    colors.yellow(
+    styleText(
+      'yellow',
       'manually calling optimizeDeps is deprecated. This is done automatically and does not need to be called manually.',
     ),
   )
@@ -282,7 +282,7 @@ export async function optimizeDeps(
   await addManuallyIncludedOptimizeDeps(environment, deps)
 
   const depsString = depsLogString(Object.keys(deps))
-  log?.(colors.green(`Optimizing dependencies:\n  ${depsString}`))
+  log?.(styleText('green', `Optimizing dependencies:\n  ${depsString}`))
 
   const depsInfo = toDiscoveredDependencies(environment, deps)
 
@@ -411,7 +411,7 @@ export async function loadCachedDepOptimizationMetadata(
 
   // Start with a fresh cache
   debug?.(
-    `(${environment.name}) ${colors.green(`removing old cache dir ${depsCacheDir}`)}`,
+    `(${environment.name}) ${styleText('green', `removing old cache dir ${depsCacheDir}`)}`,
   )
   await fsp.rm(depsCacheDir, { recursive: true, force: true })
 }
@@ -435,8 +435,9 @@ export function discoverProjectDependencies(environment: ScanEnvironment): {
           `The following dependencies are imported but could not be resolved:\n\n  ${missingIds
             .map(
               (id) =>
-                `${colors.cyan(id)} ${colors.white(
-                  colors.dim(`(imported by ${missing[id]})`),
+                `${styleText('cyan', id)} ${styleText(
+                  'white',
+                  styleText('dim', `(imported by ${missing[id]})`),
                 )}`,
             )
             .join(`\n  `)}\n\nAre they installed?`,
@@ -473,7 +474,7 @@ export function toDiscoveredDependencies(
 }
 
 export function depsLogString(qualifiedIds: string[]): string {
-  return colors.yellow(qualifiedIds.join(`, `))
+  return styleText('yellow', qualifiedIds.join(`, `))
 }
 
 /**
@@ -499,7 +500,7 @@ export function runOptimizeDeps(
 
   // a hint for Node.js
   // all files in the cache directory should be recognized as ES modules
-  debug?.(colors.green(`creating package.json in ${processingCacheDir}`))
+  debug?.(styleText('green', `creating package.json in ${processingCacheDir}`))
   fs.writeFileSync(
     path.resolve(processingCacheDir, 'package.json'),
     `{\n  "type": "module"\n}\n`,
@@ -526,7 +527,7 @@ export function runOptimizeDeps(
       cleaned = true
       // No need to wait, we can clean up in the background because temp folders
       // are unique per run
-      debug?.(colors.green(`removing cache dir ${processingCacheDir}`))
+      debug?.(styleText('green', `removing cache dir ${processingCacheDir}`))
       try {
         // When exiting the process, `fsp.rm` may not take effect, so we use `fs.rmSync`
         fs.rmSync(processingCacheDir, { recursive: true, force: true })
@@ -553,7 +554,10 @@ export function runOptimizeDeps(
       // Rewire the file paths from the temporary processing dir to the final deps cache dir
       const dataPath = path.join(processingCacheDir, METADATA_FILENAME)
       debug?.(
-        colors.green(`creating ${METADATA_FILENAME} in ${processingCacheDir}`),
+        styleText(
+          'green',
+          `creating ${METADATA_FILENAME} in ${processingCacheDir}`,
+        ),
       )
       fs.writeFileSync(
         dataPath,
@@ -572,27 +576,37 @@ export function runOptimizeDeps(
       const depsCacheDirPresent = fs.existsSync(depsCacheDir)
       if (isWindows) {
         if (depsCacheDirPresent) {
-          debug?.(colors.green(`renaming ${depsCacheDir} to ${temporaryPath}`))
+          debug?.(
+            styleText('green', `renaming ${depsCacheDir} to ${temporaryPath}`),
+          )
           await safeRename(depsCacheDir, temporaryPath)
         }
         debug?.(
-          colors.green(`renaming ${processingCacheDir} to ${depsCacheDir}`),
+          styleText(
+            'green',
+            `renaming ${processingCacheDir} to ${depsCacheDir}`,
+          ),
         )
         await safeRename(processingCacheDir, depsCacheDir)
       } else {
         if (depsCacheDirPresent) {
-          debug?.(colors.green(`renaming ${depsCacheDir} to ${temporaryPath}`))
+          debug?.(
+            styleText('green', `renaming ${depsCacheDir} to ${temporaryPath}`),
+          )
           fs.renameSync(depsCacheDir, temporaryPath)
         }
         debug?.(
-          colors.green(`renaming ${processingCacheDir} to ${depsCacheDir}`),
+          styleText(
+            'green',
+            `renaming ${processingCacheDir} to ${depsCacheDir}`,
+          ),
         )
         fs.renameSync(processingCacheDir, depsCacheDir)
       }
 
       // Delete temporary path in the background
       if (depsCacheDirPresent) {
-        debug?.(colors.green(`removing cache temp dir ${temporaryPath}`))
+        debug?.(styleText('green', `removing cache temp dir ${temporaryPath}`))
         fsp.rm(temporaryPath, { recursive: true, force: true })
       }
     },
@@ -866,7 +880,7 @@ export async function addManuallyIncludedOptimizeDeps(
     const unableToOptimize = (id: string, msg: string) => {
       if (optimizeDepsInclude.includes(id)) {
         logger.warn(
-          `${msg}: ${colors.cyan(id)}, present in ${environment.name} 'optimizeDeps.include'`,
+          `${msg}: ${styleText('cyan', id)}, present in ${environment.name} 'optimizeDeps.include'`,
         )
       }
     }

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -1,4 +1,4 @@
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { createDebugger, getHash } from '../utils'
 import {
   type PromiseWithResolvers,
@@ -76,7 +76,8 @@ export function createDepsOptimizer(
   const logNewlyDiscoveredDeps = () => {
     if (newDepsToLog.length) {
       logger.info(
-        colors.green(
+        styleText(
+          'green',
           `✨ new dependencies optimized: ${depsLogString(newDepsToLog)}`,
         ),
         {
@@ -91,7 +92,8 @@ export function createDepsOptimizer(
   const logDiscoveredDepsWhileScanning = () => {
     if (discoveredDepsWhileScanning.length) {
       logger.info(
-        colors.green(
+        styleText(
+          'green',
           `✨ discovered while scanning: ${depsLogString(
             discoveredDepsWhileScanning,
           )}`,
@@ -198,7 +200,7 @@ export function createDepsOptimizer(
           // Runs in the background in case blocking high priority tasks
           ;(async () => {
             try {
-              debug?.(colors.green(`scanning for dependencies...`))
+              debug?.(styleText('green', `scanning for dependencies...`))
 
               let deps: Record<string, string>
               try {
@@ -209,7 +211,8 @@ export function createDepsOptimizer(
                 discover = undefined
               } catch (e) {
                 environment.logger.error(
-                  colors.red(
+                  styleText(
+                    'red',
                     '(!) Failed to run dependency scan. ' +
                       'Skipping dependency pre-bundling. ' +
                       e.stack,
@@ -431,7 +434,8 @@ export function createDepsOptimizer(
             if (warnAboutMissedDependencies) {
               logDiscoveredDepsWhileScanning()
               logger.info(
-                colors.magenta(
+                styleText(
+                  'magenta',
                   `❗ add these dependencies to optimizeDeps.include to speed up cold start`,
                 ),
                 { timestamp: true },
@@ -441,7 +445,8 @@ export function createDepsOptimizer(
           }, 2 * debounceMs)
         } else {
           debug(
-            colors.green(
+            styleText(
+              'green',
               `✨ ${
                 !isRerun
                   ? `dependencies optimized`
@@ -459,7 +464,8 @@ export function createDepsOptimizer(
           processingResult.cancel()
 
           debug?.(
-            colors.green(
+            styleText(
+              'green',
               `✨ delaying reload as new dependencies have been found...`,
             ),
           )
@@ -473,7 +479,8 @@ export function createDepsOptimizer(
             if (warnAboutMissedDependencies) {
               logDiscoveredDepsWhileScanning()
               logger.info(
-                colors.magenta(
+                styleText(
+                  'magenta',
                   `❗ add these dependencies to optimizeDeps.include to avoid a full page reload during cold start`,
                 ),
                 { timestamp: true },
@@ -483,14 +490,15 @@ export function createDepsOptimizer(
           }
 
           logger.info(
-            colors.green(`✨ optimized dependencies changed. reloading`),
+            styleText('green', `✨ optimized dependencies changed. reloading`),
             {
               timestamp: true,
             },
           )
           if (needsInteropMismatch.length > 0) {
             logger.warn(
-              `Mixed ESM and CJS detected in ${colors.yellow(
+              `Mixed ESM and CJS detected in ${styleText(
+                'yellow',
                 needsInteropMismatch.join(', '),
               )}, add ${
                 needsInteropMismatch.length === 1 ? 'it' : 'them'
@@ -506,7 +514,7 @@ export function createDepsOptimizer(
       }
     } catch (e) {
       logger.error(
-        colors.red(`error while updating dependencies:\n${e.stack}`),
+        styleText('red', `error while updating dependencies:\n${e.stack}`),
         { timestamp: true, error: e },
       )
       resolveEnqueuedProcessingPromises()
@@ -538,7 +546,7 @@ export function createDepsOptimizer(
     // optimizeDeps processing is finished
     const deps = Object.keys(metadata.discovered)
     const depsString = depsLogString(deps)
-    debug?.(colors.green(`new dependencies found: ${depsString}`))
+    debug?.(styleText('green', `new dependencies found: ${depsString}`))
     runOptimizer()
   }
 
@@ -635,7 +643,7 @@ export function createDepsOptimizer(
     // switch after this point to a simple debounce strategy
     waitingForCrawlEnd = false
 
-    debug?.(colors.green(`✨ static imports crawl ended`))
+    debug?.(styleText('green', `✨ static imports crawl ended`))
     if (closed) {
       return
     }
@@ -663,7 +671,8 @@ export function createDepsOptimizer(
 
       if (scanDeps.length === 0 && crawlDeps.length === 0) {
         debug?.(
-          colors.green(
+          styleText(
+            'green',
             `✨ no dependencies found by the scanner or crawling static imports`,
           ),
         )
@@ -694,16 +703,18 @@ export function createDepsOptimizer(
         }
         if (scannerMissedDeps) {
           debug?.(
-            colors.yellow(
+            styleText(
+              'yellow',
               `✨ new dependencies were found while crawling that weren't detected by the scanner`,
             ),
           )
         }
-        debug?.(colors.green(`✨ re-running optimizer`))
+        debug?.(styleText('green', `✨ re-running optimizer`))
         debouncedProcessing(0)
       } else {
         debug?.(
-          colors.green(
+          styleText(
+            'green',
             `✨ using post-scan optimizer result, the scanner found every used dependency`,
           ),
         )
@@ -717,7 +728,8 @@ export function createDepsOptimizer(
       // optimize result is compatible in this case
       if (newDepsDiscovered) {
         debug?.(
-          colors.green(
+          styleText(
+            'green',
             `✨ new dependencies were found while crawling static imports, re-running optimizer`,
           ),
         )
@@ -730,7 +742,8 @@ export function createDepsOptimizer(
 
       if (crawlDeps.length === 0) {
         debug?.(
-          colors.green(
+          styleText(
+            'green',
             `✨ no dependencies found while crawling the static imports`,
           ),
         )
@@ -796,7 +809,7 @@ function findInteropMismatches(
       // This only happens when a discovered dependency has mixed ESM and CJS syntax
       // and it hasn't been manually added to optimizeDeps.needsInterop
       needsInteropMismatch.push(dep)
-      debug?.(colors.cyan(`✨ needsInterop mismatch detected for ${dep}`))
+      debug?.(styleText('cyan', `✨ needsInterop mismatch detected for ${dep}`))
     }
   }
   return needsInteropMismatch

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
+import { styleText } from 'node:util'
 import type {
   BuildContext,
   Loader,
@@ -11,7 +12,6 @@ import type {
 } from 'esbuild'
 import esbuild, { formatMessages, transform } from 'esbuild'
 import type { PartialResolvedId } from 'rollup'
-import colors from 'picocolors'
 import { glob } from 'tinyglobby'
 import {
   CSS_LANGS_RE,
@@ -135,7 +135,8 @@ export function scanImports(environment: ScanEnvironment): {
     if (!entries.length) {
       if (!config.optimizeDeps.entries && !config.optimizeDeps.include) {
         environment.logger.warn(
-          colors.yellow(
+          styleText(
+            'yellow',
             '(!) Could not auto-determine entry point from rollupOptions or html files ' +
               'and there are no explicit optimizeDeps.include patterns. ' +
               'Skipping dependency pre-bundling.',
@@ -148,7 +149,7 @@ export function scanImports(environment: ScanEnvironment): {
 
     debug?.(
       `Crawling dependencies using entries: ${entries
-        .map((entry) => `\n  ${colors.dim(entry)}`)
+        .map((entry) => `\n  ${styleText('dim', entry)}`)
         .join('')}`,
     )
     const deps: Record<string, string> = {}
@@ -179,11 +180,14 @@ export function scanImports(environment: ScanEnvironment): {
           return
         }
 
-        const prependMessage = colors.red(`\
+        const prependMessage = styleText(
+          'red',
+          `\
   Failed to scan for dependencies from entries:
   ${entries.join('\n')}
 
-  `)
+  `,
+        )
         if (e.errors) {
           const msgs = await formatMessages(e.errors, {
             kind: 'error',
@@ -200,8 +204,11 @@ export function scanImports(environment: ScanEnvironment): {
           const depsStr =
             Object.keys(orderedDependencies(deps))
               .sort()
-              .map((id) => `\n  ${colors.cyan(id)} -> ${colors.dim(deps[id])}`)
-              .join('') || colors.dim('no dependencies found')
+              .map(
+                (id) =>
+                  `\n  ${styleText('cyan', id)} -> ${styleText('dim', deps[id])}`,
+              )
+              .join('') || styleText('dim', 'no dependencies found')
           debug(`Scan completed in ${duration}ms: ${depsStr}`)
         }
       }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
+import { styleText } from 'node:util'
 import * as mrmime from 'mrmime'
 import type {
   NormalizedOutputOptions,
@@ -8,7 +9,6 @@ import type {
   RenderedChunk,
 } from 'rollup'
 import MagicString from 'magic-string'
-import colors from 'picocolors'
 import {
   createToImportMetaURLBasedRelativeRuntime,
   toOutputFilePathInJS,
@@ -501,7 +501,10 @@ function assetToDataURL(
 ) {
   if (environment.config.build.lib && isGitLfsPlaceholder(content)) {
     environment.logger.warn(
-      colors.yellow(`Inlined file ${file} was not downloaded via Git LFS`),
+      styleText(
+        'yellow',
+        `Inlined file ${file} was not downloaded via Git LFS`,
+      ),
     )
   }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { styleText } from 'node:util'
 import postcssrc from 'postcss-load-config'
 import type {
   ExistingRawSourceMap,
@@ -15,7 +16,6 @@ import type {
   SourceMapInput,
 } from 'rollup'
 import { dataToEsm } from '@rollup/pluginutils'
-import colors from 'picocolors'
 import MagicString from 'magic-string'
 import type * as PostCSS from 'postcss'
 import type Sass from 'sass'
@@ -1474,7 +1474,8 @@ async function compilePostCSS(
           // warn here to provide a better error message.
           if (!path.isAbsolute(id)) {
             environment.logger.error(
-              colors.red(
+              styleText(
+                'red',
                 `Unable to resolve \`@import "${id}"\` from ${basedir}`,
               ),
             )
@@ -1664,7 +1665,7 @@ async function runPostCSS(
               }
             : undefined,
         )}`
-        logger.warn(colors.yellow(msg))
+        logger.warn(styleText('yellow', msg))
       }
     }
   } catch (e) {
@@ -2134,7 +2135,7 @@ async function minifyCSS(
           line: warning.loc.line,
           column: warning.loc.column - 1, // 1-based
         })}`
-        config.logger.warn(colors.yellow(msg))
+        config.logger.warn(styleText('yellow', msg))
       }
 
       // NodeJS res.code = Buffer
@@ -2168,7 +2169,7 @@ async function minifyCSS(
     if (warnings.length) {
       const msgs = await formatMessages(warnings, { kind: 'warning' })
       config.logger.warn(
-        colors.yellow(`[esbuild css minify]\n${msgs.join('\n')}`),
+        styleText('yellow', `[esbuild css minify]\n${msgs.join('\n')}`),
       )
     }
     // esbuild output does return a linebreak at the end
@@ -3203,7 +3204,7 @@ async function compileLightningCSS(
       line: warning.loc.line,
       column: warning.loc.column - 1, // 1-based
     })}`
-    environment.logger.warn(colors.yellow(msg))
+    environment.logger.warn(styleText('yellow', msg))
   }
 
   // NodeJS res.code = Buffer

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type {
   Loader,
   Message,
@@ -467,7 +467,7 @@ export function resolveEsbuildTranspileOptions(
 }
 
 function prettifyMessage(m: Message, code: string): string {
-  let res = colors.yellow(m.text)
+  let res = styleText('yellow', m.text)
   if (m.location) {
     res += `\n` + generateCodeFrame(code, m.location)
   }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { URL } from 'node:url'
+import { styleText } from 'node:util'
 import type {
   OutputAsset,
   OutputBundle,
@@ -8,7 +9,6 @@ import type {
   SourceMapInput,
 } from 'rollup'
 import MagicString from 'magic-string'
-import colors from 'picocolors'
 import type { DefaultTreeAdapterMap, ParserError, Token } from 'parse5'
 import { stripLiteral } from 'strip-literal'
 import escapeHtml from 'escape-html'
@@ -1140,8 +1140,10 @@ export function preImportMapHook(
         path.relative(config.root, ctx.filename),
       )
       config.logger.warnOnce(
-        colors.yellow(
-          colors.bold(
+        styleText(
+          'yellow',
+          styleText(
+            'bold',
             `(!) <script type="importmap"> should come before <script type="module"> and <link rel="modulepreload"> in /${relativeHtml}`,
           ),
         ),
@@ -1226,8 +1228,10 @@ export function htmlEnvHook(config: ResolvedConfig): IndexHtmlTransformHook {
             path.relative(config.root, ctx.filename),
           )
           config.logger.warn(
-            colors.yellow(
-              colors.bold(
+            styleText(
+              'yellow',
+              styleText(
+                'bold',
                 `(!) ${text} is not defined in env variables found in /${relativeHtml}. ` +
                   `Is the variable mistyped?`,
               ),
@@ -1347,8 +1351,10 @@ function headTagInsertCheck(
       disallowedTags.map((tagDescriptor) => `<${tagDescriptor.tag}>`),
     )
     logger?.warn(
-      colors.yellow(
-        colors.bold(
+      styleText(
+        'yellow',
+        styleText(
+          'bold',
           `[${dedupedTags.join(',')}] can not be used inside the <head> Element, please check the 'injectTo' value`,
         ),
       ),

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import fs from 'node:fs'
 import { performance } from 'node:perf_hooks'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import MagicString from 'magic-string'
 import type {
   ParseError as EsModuleLexerParseError,
@@ -259,7 +259,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const moduleGraph = environment.moduleGraph
 
       if (canSkipImportAnalysis(importer)) {
-        debug?.(colors.dim(`[skipped] ${prettifyUrl(importer, root)}`))
+        debug?.(styleText('dim', `[skipped] ${prettifyUrl(importer, root)}`))
         return null
       }
 
@@ -298,7 +298,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       ) {
         importerModule.isSelfAccepting = false
         debug?.(
-          `${timeFrom(msAtStart)} ${colors.dim(
+          `${timeFrom(msAtStart)} ${styleText(
+            'dim',
             `[no imports] ${prettifyUrl(importer, root)}`,
           )}`,
         )
@@ -584,7 +585,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // a dynamic import, then it is an internal Vite error
                   if (!optimizedDepDynamicRE.test(file)) {
                     config.logger.error(
-                      colors.red(
+                      styleText(
+                        'red',
                         `Vite Error, ${url} optimized info should be defined`,
                       ),
                     )
@@ -667,12 +669,14 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               if (!hasViteIgnore) {
                 this.warn(
                   `\n` +
-                    colors.cyan(importerModule.file) +
+                    styleText('cyan', importerModule.file || '') +
                     `\n` +
-                    colors.reset(generateCodeFrame(source, start, end)) +
-                    colors.yellow(
+                    styleText('reset', generateCodeFrame(source, start, end)) +
+                    styleText(
+                      'yellow',
                       `\nThe above dynamic import cannot be analyzed by Vite.\n` +
-                        `See ${colors.blue(
+                        `See ${styleText(
+                          'blue',
                           `https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations`,
                         )} ` +
                         `for supported dynamic import formats. ` +
@@ -840,7 +844,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       debug?.(
-        `${timeFrom(msAtStart)} ${colors.dim(
+        `${timeFrom(msAtStart)} ${styleText(
+          'dim',
           `[${importedUrls.size} imports rewritten] ${prettifyUrl(
             importer,
             root,
@@ -991,7 +996,8 @@ export function transformCjsImport(
     !node.exported
   ) {
     config.logger.warn(
-      colors.yellow(
+      styleText(
+        'yellow',
         `\nUnable to interop \`${importExp}\` in ${importer}, this may lose module exports. Please export "${rawUrl}" as ESM or use named exports instead, e.g. \`export { A, B } from "${rawUrl}"\``,
       ),
     )

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, posix } from 'node:path'
+import { styleText } from 'node:util'
 import picomatch from 'picomatch'
 import { stripLiteral } from 'strip-literal'
-import colors from 'picocolors'
 import type {
   ArrayExpression,
   Expression,
@@ -200,7 +200,8 @@ function parseGlobOptions(
       ? `, import: 'default'`
       : ''
     logger.warn(
-      colors.yellow(
+      styleText(
+        'yellow',
         `The glob option "as" has been deprecated in favour of "query". Please update \`as: '${opts.as}'\` to \`query: '?${opts.as}'${importSuggestion}\`.`,
       ),
     )

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -1,5 +1,5 @@
 import fsp from 'node:fs/promises'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { DevEnvironment } from '..'
 import type { Plugin } from '../plugin'
 import {
@@ -70,7 +70,7 @@ export function optimizedDepsPlugin(): Plugin {
             }
           }
         }
-        debug?.(`load ${colors.cyan(file)}`)
+        debug?.(`load ${styleText('cyan', file)}`)
         // Load the file from the cache instead of waiting for other plugin
         // load hooks to avoid race conditions, once processing is resolved,
         // we are sure that the file has been properly save to disk

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { gzip } from 'node:zlib'
-import { promisify } from 'node:util'
-import colors from 'picocolors'
+import { promisify, styleText } from 'node:util'
 import type { OutputBundle } from 'rollup'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
@@ -12,10 +11,10 @@ import { LogLevels } from '../logger'
 import { withTrailingSlash } from '../../shared/utils'
 
 const groups = [
-  { name: 'Assets', color: colors.green },
-  { name: 'CSS', color: colors.magenta },
-  { name: 'JS', color: colors.cyan },
-]
+  { name: 'Assets', color: 'green' },
+  { name: 'CSS', color: 'magenta' },
+  { name: 'JS', color: 'cyan' },
+] as const
 type LogEntry = {
   name: string
   group: (typeof groups)[number]['name']
@@ -47,7 +46,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
 
         const logTransform = throttle((id: string) => {
           writeLine(
-            `transforming (${transformedCount}) ${colors.dim(
+            `transforming (${transformedCount}) ${styleText(
+              'dim',
               path.relative(config.root, id),
             )}`,
           )
@@ -74,7 +74,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
               clearLine()
             }
             environment.logger.info(
-              `${colors.green(`✓`)} ${transformedCount} modules transformed.`,
+              `${styleText('green', `✓`)} ${transformedCount} modules transformed.`,
             )
           },
         }
@@ -213,30 +213,34 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
               const isLarge =
                 group.name === 'JS' && entry.size / 1000 > chunkLimit
               if (isLarge) hasLargeChunks = true
-              const sizeColor = isLarge ? colors.yellow : colors.dim
-              let log = colors.dim(withTrailingSlash(relativeOutDir))
+              const sizeColor = isLarge ? 'yellow' : 'dim'
+              let log = styleText('dim', withTrailingSlash(relativeOutDir))
               log +=
                 !config.build.lib &&
                 entry.name.startsWith(withTrailingSlash(assetsDir))
-                  ? colors.dim(assetsDir) +
-                    group.color(
+                  ? styleText('dim', assetsDir) +
+                    styleText(
+                      group.color,
                       entry.name
                         .slice(assetsDir.length)
                         .padEnd(longest + 2 - assetsDir.length),
                     )
-                  : group.color(entry.name.padEnd(longest + 2))
-              log += colors.bold(
-                sizeColor(displaySize(entry.size).padStart(sizePad)),
+                  : styleText(group.color, entry.name.padEnd(longest + 2))
+              log += styleText(
+                'bold',
+                styleText(sizeColor, displaySize(entry.size).padStart(sizePad)),
               )
               if (entry.compressedSize) {
-                log += colors.dim(
+                log += styleText(
+                  'dim',
                   ` │ gzip: ${displaySize(entry.compressedSize).padStart(
                     compressPad,
                   )}`,
                 )
               }
               if (entry.mapSize) {
-                log += colors.dim(
+                log += styleText(
+                  'dim',
                   ` │ map: ${displaySize(entry.mapSize).padStart(mapPad)}`,
                 )
               }
@@ -258,7 +262,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
           environment.config.consumer === 'client'
         ) {
           environment.logger.warn(
-            colors.yellow(
+            styleText(
+              'yellow',
               `\n(!) Some chunks are larger than ${chunkLimit} kB after minification. Consider:\n` +
                 `- Using dynamic import() to code-split the application\n` +
                 `- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks\n` +

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { PartialResolvedId } from 'rollup'
 import { exports, imports } from 'resolve.exports'
 import { hasESMSyntax } from 'mlly'
@@ -233,7 +233,7 @@ export function resolvePlugin(
         // We don't need to resolve these paths since they are already resolved
         // always return here even if res doesn't exist since /@fs/ is explicit
         // if the file doesn't exist it should be a 404.
-        debug?.(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(`[@fs] ${styleText('cyan', id)} -> ${styleText('dim', res)}`)
         return ensureVersionQuery(res, id, options, depsOptimizer)
       }
 
@@ -246,7 +246,7 @@ export function resolvePlugin(
       ) {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
-          debug?.(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(`[url] ${styleText('cyan', id)} -> ${styleText('dim', res)}`)
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
       }
@@ -287,7 +287,9 @@ export function resolvePlugin(
 
         if ((res = tryFsResolve(fsPath, options))) {
           res = ensureVersionQuery(res, id, options, depsOptimizer)
-          debug?.(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(
+            `[relative] ${styleText('cyan', id)} -> ${styleText('dim', res)}`,
+          )
 
           if (!options.idOnly && !options.scan && options.isBuild) {
             const resPkg = findNearestPackageData(
@@ -316,7 +318,9 @@ export function resolvePlugin(
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)
         if ((res = tryFsResolve(fsPath, options))) {
-          debug?.(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(
+            `[drive-relative] ${styleText('cyan', id)} -> ${styleText('dim', res)}`,
+          )
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
       }
@@ -326,7 +330,7 @@ export function resolvePlugin(
         isNonDriveRelativeAbsolutePath(id) &&
         (res = tryFsResolve(id, options))
       ) {
-        debug?.(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(`[fs] ${styleText('cyan', id)} -> ${styleText('dim', res)}`)
         return ensureVersionQuery(res, id, options, depsOptimizer)
       }
 
@@ -435,7 +439,7 @@ export function resolvePlugin(
           if (!asSrc) {
             debug?.(
               `externalized node built-in "${id}" to empty module. ` +
-                `(imported by: ${colors.white(colors.dim(importer))})`,
+                `(imported by: ${styleText('white', styleText('dim', importer || ''))})`,
             )
           } else if (isProduction) {
             this.warn(
@@ -447,7 +451,7 @@ export function resolvePlugin(
         }
       }
 
-      debug?.(`[fallthrough] ${colors.dim(id)}`)
+      debug?.(`[fallthrough] ${styleText('dim', id)}`)
     },
 
     load: {
@@ -778,7 +782,7 @@ export function tryNodeResolve(
       if (index > -1) {
         resolvedId = resolved.id.slice(index)
         debug?.(
-          `[processResult] ${colors.cyan(id)} -> ${colors.dim(resolvedId)}`,
+          `[processResult] ${styleText('cyan', id)} -> ${styleText('dim', resolvedId)}`,
         )
       }
     }
@@ -958,7 +962,8 @@ export function resolvePackageEntry(
       )
       if (resolvedEntryPoint) {
         debug?.(
-          `[package entry] ${colors.cyan(idWithoutPostfix)} -> ${colors.dim(
+          `[package entry] ${styleText('cyan', idWithoutPostfix)} -> ${styleText(
+            'dim',
             resolvedEntryPoint,
           )}${postfix !== '' ? ` (postfix: ${postfix})` : ''}`,
         )
@@ -1060,7 +1065,7 @@ function resolveDeepImport(
     )
     if (resolved) {
       debug?.(
-        `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
+        `[node/deep-import] ${styleText('cyan', id)} -> ${styleText('dim', resolved)}`,
       )
       setResolvedCache(id, resolved, options)
       return resolved
@@ -1094,7 +1099,9 @@ function tryResolveBrowserMapping(
             )?.id
           : tryFsResolve(path.join(pkg.dir, browserMappedPath), options))
       ) {
-        debug?.(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(
+          `[browser mapped] ${styleText('cyan', id)} -> ${styleText('dim', res)}`,
+        )
         let result: PartialResolvedId = { id: res }
         if (options.idOnly) {
           return result

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
+import { styleText } from 'node:util'
 import MagicString from 'magic-string'
 import type { OutputChunk, RollupError } from 'rollup'
-import colors from 'picocolors'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
@@ -62,7 +62,8 @@ function saveEmitWorkerAsset(
     if (!isSameContent(duplicateAsset.source, asset.source)) {
       config.logger.warn(
         `\n` +
-          colors.yellow(
+          styleText(
+            'yellow',
             `The emitted file ${JSON.stringify(asset.fileName)} overwrites a previously emitted file of the same name.`,
           ),
       )

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -1,5 +1,5 @@
+import { styleText } from 'node:util'
 import type { FSWatcher } from 'dep-types/chokidar'
-import colors from 'picocolors'
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
 import { BaseEnvironment } from '../baseEnvironment'
 import type {
@@ -290,8 +290,8 @@ function invalidateModule(
   ) {
     mod.lastHMRInvalidationReceived = true
     environment.logger.info(
-      colors.yellow(`hmr invalidate `) +
-        colors.dim(m.path) +
+      styleText('yellow', `hmr invalidate `) +
+        styleText('dim', m.path) +
         (m.message ? ` ${m.message}` : ''),
       { timestamp: true },
     )

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1,7 +1,7 @@
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { EventEmitter } from 'node:events'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { CustomPayload, HotPayload, Update } from 'types/hmrPayload'
 import type { RollupError } from 'rollup'
 import type {
@@ -392,9 +392,10 @@ export async function handleHMRUpdate(
     getEnvFilesForMode(config.mode, config.envDir).includes(file)
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
-    debugHmr?.(`[config change] ${colors.dim(shortFile)}`)
+    debugHmr?.(`[config change] ${styleText('dim', shortFile)}`)
     config.logger.info(
-      colors.green(
+      styleText(
+        'green',
         `${normalizePath(
           path.relative(process.cwd(), file),
         )} changed, restarting server...`,
@@ -404,12 +405,12 @@ export async function handleHMRUpdate(
     try {
       await restartServerWithUrls(server)
     } catch (e) {
-      config.logger.error(colors.red(e))
+      config.logger.error(styleText('red', e))
     }
     return
   }
 
-  debugHmr?.(`[file change] ${colors.dim(shortFile)}`)
+  debugHmr?.(`[file change] ${styleText('dim', shortFile)}`)
 
   // (dev only) the client itself cannot be hot updated.
   if (file.startsWith(withTrailingSlash(normalizedClientDir))) {
@@ -582,7 +583,7 @@ export async function handleHMRUpdate(
         // html file cannot be hot updated
         if (file.endsWith('.html') && environment.name === 'client') {
           environment.logger.info(
-            colors.green(`page reload `) + colors.dim(shortFile),
+            styleText('green', `page reload `) + styleText('dim', shortFile),
             {
               clear: true,
               timestamp: true,
@@ -597,7 +598,7 @@ export async function handleHMRUpdate(
         } else {
           // loaded but not in the module graph, probably not js
           debugHmr?.(
-            `(${environment.name}) [no modules matched] ${colors.dim(shortFile)}`,
+            `(${environment.name}) [no modules matched] ${styleText('dim', shortFile)}`,
           )
         }
         return
@@ -696,10 +697,10 @@ export function updateModules(
   if (needFullReload) {
     const reason =
       typeof needFullReload === 'string'
-        ? colors.dim(` (${needFullReload})`)
+        ? styleText('dim', ` (${needFullReload})`)
         : ''
     environment.logger.info(
-      colors.green(`page reload `) + colors.dim(file) + reason,
+      styleText('green', `page reload `) + styleText('dim', file) + reason,
       { clear: !firstInvalidatedBy, timestamp: true },
     )
     hot.send({
@@ -710,13 +711,15 @@ export function updateModules(
   }
 
   if (updates.length === 0) {
-    debugHmr?.(colors.yellow(`no update happened `) + colors.dim(file))
+    debugHmr?.(
+      styleText('yellow', `no update happened `) + styleText('dim', file),
+    )
     return
   }
 
   environment.logger.info(
-    colors.green(`hmr update `) +
-      colors.dim([...new Set(updates.map((u) => u.path))].join(', ')),
+    styleText('green', `hmr update `) +
+      styleText('dim', [...new Set(updates.map((u) => u.path))].join(', ')),
     { clear: !firstInvalidatedBy, timestamp: true },
   )
   hot.send({
@@ -753,7 +756,8 @@ function propagateUpdate(
   // been loaded in the browser and we should stop propagation.
   if (node.id && node.isSelfAccepting === undefined) {
     debugHmr?.(
-      `[propagate update] stop propagation because not analyzed: ${colors.dim(
+      `[propagate update] stop propagation because not analyzed: ${styleText(
+        'dim',
         node.id,
       )}`,
     )
@@ -907,8 +911,8 @@ function isNodeWithinCircularImports(
           ...nodeChain.slice(importerIndex, -1).reverse(),
         ]
         debugHmr(
-          colors.yellow(`circular imports detected: `) +
-            importChain.map((m) => colors.dim(m.url)).join(' -> '),
+          styleText('yellow', `circular imports detected: `) +
+            importChain.map((m) => styleText('dim', m.url)).join(' -> '),
         )
       }
       return true
@@ -939,7 +943,7 @@ export function handlePrunedModules(
   mods.forEach((mod) => {
     mod.lastHMRTimestamp = t
     mod.lastHMRInvalidationReceived = false
-    debugHmr?.(`[dispose] ${colors.dim(mod.file)}`)
+    debugHmr?.(`[dispose] ${styleText('dim', mod.file || '')}`)
   })
   hot.send({
     type: 'prune',

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -6,9 +6,9 @@ import { get as httpsGet } from 'node:https'
 import type * as http from 'node:http'
 import { performance } from 'node:perf_hooks'
 import type { Http2SecureServer } from 'node:http2'
+import { styleText } from 'node:util'
 import connect from 'connect'
 import corsMiddleware from 'cors'
-import colors from 'picocolors'
 import chokidar from 'chokidar'
 import type { FSWatcher, WatchOptions } from 'dep-types/chokidar'
 import type { Connect } from 'dep-types/connect'
@@ -1168,8 +1168,9 @@ export function resolveServerOptions(
   if (server.origin?.endsWith('/')) {
     server.origin = server.origin.slice(0, -1)
     logger.warn(
-      colors.yellow(
-        `${colors.bold('(!)')} server.origin should not end with "/". Using "${
+      styleText(
+        'yellow',
+        `${styleText('bold', '(!)')} server.origin should not end with "/". Using "${
           server.origin
         }" instead.`,
       ),

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
-import { stripVTControlCharacters as strip } from 'node:util'
-import colors from 'picocolors'
+import { stripVTControlCharacters as strip, styleText } from 'node:util'
 import type { RollupError } from 'rollup'
 import type { Connect } from 'dep-types/connect'
 import type { ErrorPayload } from 'types/hmrPayload'
@@ -27,10 +26,10 @@ export function buildErrorMessage(
   args: string[] = [],
   includeStack = true,
 ): string {
-  if (err.plugin) args.push(`  Plugin: ${colors.magenta(err.plugin)}`)
+  if (err.plugin) args.push(`  Plugin: ${styleText('magenta', err.plugin)}`)
   const loc = err.loc ? `:${err.loc.line}:${err.loc.column}` : ''
-  if (err.id) args.push(`  File: ${colors.cyan(err.id)}${loc}`)
-  if (err.frame) args.push(colors.yellow(pad(err.frame)))
+  if (err.id) args.push(`  File: ${styleText('cyan', err.id)}${loc}`)
+  if (err.frame) args.push(styleText('yellow', pad(err.frame)))
   if (includeStack && err.stack) args.push(pad(cleanStack(err.stack)))
   return args.join('\n')
 }
@@ -44,7 +43,7 @@ function cleanStack(stack: string) {
 
 export function logError(server: ViteDevServer, err: RollupError): void {
   const msg = buildErrorMessage(err, [
-    colors.red(`Internal server error: ${err.message}`),
+    styleText('red', `Internal server error: ${err.message}`),
   ])
 
   server.config.logger.error(msg, {

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -1,9 +1,9 @@
 import type * as http from 'node:http'
 import type * as net from 'node:net'
+import { styleText } from 'node:util'
 import httpProxy from 'http-proxy'
 import type { Connect } from 'dep-types/connect'
 import type { HttpProxy } from 'dep-types/http-proxy'
-import colors from 'picocolors'
 import { createDebugger } from '../../utils'
 import type { CommonServerOptions, ResolvedConfig } from '../..'
 import type { HttpServer } from '..'
@@ -56,7 +56,8 @@ const rewriteOriginHeader = (
 
     if (proxyReq.headersSent) {
       config.logger.warn(
-        colors.yellow(
+        styleText(
+          'yellow',
           `Unable to rewrite Origin header as headers are already sent.`,
         ),
       )
@@ -102,7 +103,7 @@ export function proxyMiddleware(
       const res = originalRes as http.ServerResponse | net.Socket | undefined
       if (!res) {
         config.logger.error(
-          `${colors.red(`http proxy error: ${err.message}`)}\n${err.stack}`,
+          `${styleText('red', `http proxy error: ${err.message}`)}\n${err.stack}`,
           {
             timestamp: true,
             error: err,
@@ -110,7 +111,7 @@ export function proxyMiddleware(
         )
       } else if ('req' in res) {
         config.logger.error(
-          `${colors.red(`http proxy error: ${originalRes.req.url}`)}\n${
+          `${styleText('red', `http proxy error: ${originalRes.req.url}`)}\n${
             err.stack
           }`,
           {
@@ -126,10 +127,13 @@ export function proxyMiddleware(
             .end()
         }
       } else {
-        config.logger.error(`${colors.red(`ws proxy error:`)}\n${err.stack}`, {
-          timestamp: true,
-          error: err,
-        })
+        config.logger.error(
+          `${styleText('red', `ws proxy error:`)}\n${err.stack}`,
+          {
+            timestamp: true,
+            error: err,
+          },
+        )
         res.end()
       }
     })
@@ -139,7 +143,7 @@ export function proxyMiddleware(
 
       socket.on('error', (err) => {
         config.logger.error(
-          `${colors.red(`ws proxy socket error:`)}\n${err.stack}`,
+          `${styleText('red', `ws proxy socket error:`)}\n${err.stack}`,
           {
             timestamp: true,
             error: err,
@@ -189,7 +193,7 @@ export function proxyMiddleware(
                 }
               } catch (err) {
                 config.logger.error(
-                  `${colors.red(`ws proxy bypass error:`)}\n${err.stack}`,
+                  `${styleText('red', `ws proxy bypass error:`)}\n${err.stack}`,
                   {
                     timestamp: true,
                     error: err,

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 import fsp from 'node:fs/promises'
 import type { ServerResponse } from 'node:http'
+import { styleText } from 'node:util'
 import type { Connect } from 'dep-types/connect'
-import colors from 'picocolors'
 import type { ExistingRawSourceMap } from 'rollup'
 import type { ViteDevServer } from '..'
 import {
@@ -137,7 +137,7 @@ export function transformMiddleware(
     } catch (e) {
       if (e instanceof URIError) {
         server.config.logger.warn(
-          colors.yellow('Malformed URI sequence in request URL'),
+          styleText('yellow', 'Malformed URI sequence in request URL'),
         )
         return next()
       }
@@ -333,7 +333,7 @@ export function transformMiddleware(
           res.statusCode = 404
           res.end()
         }
-        server.config.logger.warn(colors.yellow(e.message))
+        server.config.logger.warn(styleText('yellow', e.message))
         return
       }
       if (e?.code === ERR_LOAD_URL) {
@@ -358,27 +358,31 @@ export function transformMiddleware(
       if (urlRE.test(url)) {
         warning =
           `Assets in the public directory are served at the root path.\n` +
-          `Instead of ${colors.cyan(rawUrl)}, use ${colors.cyan(
+          `Instead of ${styleText('cyan', rawUrl)}, use ${styleText(
+            'cyan',
             rawUrl.replace(publicPath, '/'),
           )}.`
       } else {
         warning =
           'Assets in public directory cannot be imported from JavaScript.\n' +
-          `If you intend to import that asset, put the file in the src directory, and use ${colors.cyan(
+          `If you intend to import that asset, put the file in the src directory, and use ${styleText(
+            'cyan',
             rawUrl.replace(publicPath, '/src/'),
-          )} instead of ${colors.cyan(rawUrl)}.\n` +
-          `If you intend to use the URL of that asset, use ${colors.cyan(
+          )} instead of ${styleText('cyan', rawUrl)}.\n` +
+          `If you intend to use the URL of that asset, use ${styleText(
+            'cyan',
             injectQuery(rawUrl.replace(publicPath, '/'), 'url'),
           )}.`
       }
     } else {
       warning =
         `Files in the public directory are served at the root path.\n` +
-        `Instead of ${colors.cyan(url)}, use ${colors.cyan(
+        `Instead of ${styleText('cyan', url)}, use ${styleText(
+          'cyan',
           url.replace(publicPath, '/'),
         )}.`
     }
 
-    server.config.logger.warn(colors.yellow(warning))
+    server.config.logger.warn(styleText('yellow', warning))
   }
 }

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -11,10 +11,10 @@
 import { join } from 'node:path'
 import { exec } from 'node:child_process'
 import type { ExecOptions } from 'node:child_process'
+import { styleText } from 'node:util'
 import open from 'open'
 import type { Options } from 'open'
 import spawn from 'cross-spawn'
-import colors from 'picocolors'
 import type { Logger } from '../logger'
 import { VITE_PACKAGE_DIR } from '../constants'
 
@@ -47,8 +47,10 @@ function executeNodeScript(scriptPath: string, url: string, logger: Logger) {
   child.on('close', (code) => {
     if (code !== 0) {
       logger.error(
-        colors.red(
-          `\nThe script specified as BROWSER environment variable failed.\n\n${colors.cyan(
+        styleText(
+          'red',
+          `\nThe script specified as BROWSER environment variable failed.\n\n${styleText(
+            'cyan',
             scriptPath,
           )} exited with code ${code}.`,
         ),

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -32,6 +32,7 @@ SOFTWARE.
 import fs from 'node:fs'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
+import { styleText } from 'node:util'
 import { parseAst as rollupParseAst } from 'rollup/parseAst'
 import type {
   AsyncPluginHooks,
@@ -62,7 +63,6 @@ import type { RawSourceMap } from '@ampproject/remapping'
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import MagicString from 'magic-string'
 import type { FSWatcher } from 'dep-types/chokidar'
-import colors from 'picocolors'
 import type { Plugin } from '../plugin'
 import {
   combineSourcemaps,
@@ -424,8 +424,9 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
       if (!this._seenResolves[key]) {
         this._seenResolves[key] = true
         debugResolve(
-          `${timeFrom(resolveStart)} ${colors.cyan(rawId)} -> ${colors.dim(
-            id,
+          `${timeFrom(resolveStart)} ${styleText('cyan', rawId)} -> ${styleText(
+            'dim',
+            id || '',
           )}`,
         )
       }
@@ -587,7 +588,7 @@ export class BasicMinimalPluginContext<Meta = PluginContextMeta> {
     const log = this._normalizeRawLog(rawLog)
     const msg = buildErrorMessage(
       log,
-      [colors.yellow(`warning: ${log.message}`)],
+      [styleText('yellow', `warning: ${log.message}`)],
       false,
     )
     this._logger.warn(msg, { clear: true, timestamp: true })
@@ -808,7 +809,8 @@ class PluginContext
           errLocation = numberToPos(this._activeCode, pos)
         } catch (err2) {
           this.environment.logger.error(
-            colors.red(
+            styleText(
+              'red',
               `Error in error handler:\n${err2.stack || err2.message}\n`,
             ),
             // print extra newline to separate the two errors
@@ -890,9 +892,11 @@ class PluginContext
 
   _warnIncompatibleMethod(method: string): void {
     this.environment.logger.warn(
-      colors.cyan(`[plugin:${this._plugin.name}] `) +
-        colors.yellow(
-          `context method ${colors.bold(
+      styleText('cyan', `[plugin:${this._plugin.name}] `) +
+        styleText(
+          'yellow',
+          `context method ${styleText(
+            'bold',
             `${method}()`,
           )} is not supported in serve mode. This plugin is likely not vite-compatible.`,
         ),

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -1,11 +1,11 @@
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
+import { styleText } from 'node:util'
 import getEtag from 'etag'
 import MagicString from 'magic-string'
 import { init, parse as parseImports } from 'es-module-lexer'
 import type { PartialResolvedId, SourceDescription, SourceMap } from 'rollup'
-import colors from 'picocolors'
 import type { EnvironmentModuleNode } from '../server/moduleGraph'
 import {
   createDebugger,
@@ -362,7 +362,7 @@ async function loadAndTransform(
   if (transformResult.code === originalCode) {
     // no transform applied, keep code as-is
     debugTransform?.(
-      timeFrom(transformStart) + colors.dim(` [skipped] ${prettyUrl}`),
+      timeFrom(transformStart) + styleText('dim', ` [skipped] ${prettyUrl}`),
     )
   } else {
     debugTransform?.(`${timeFrom(transformStart)} ${prettyUrl}`)

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { glob, isDynamicPattern } from 'tinyglobby'
 import { FS_PREFIX } from '../constants'
 import { normalizePath } from '../utils'
@@ -36,7 +36,7 @@ async function warmupFile(
       } catch (e) {
         // Unexpected error, log the issue but avoid an unhandled exception
         environment.logger.error(
-          `Pre-transform error (${colors.cyan(file)}): ${e.message}`,
+          `Pre-transform error (${styleText('cyan', file)}): ${e.message}`,
           {
             error: e,
             timestamp: true,

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -6,7 +6,7 @@ import { createServer as createHttpsServer } from 'node:https'
 import type { Socket } from 'node:net'
 import type { Duplex } from 'node:stream'
 import crypto from 'node:crypto'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { WebSocket as WebSocketRaw } from 'ws'
 import { WebSocketServer as WebSocketServerRaw_ } from 'ws'
 import type { WebSocket as WebSocketTypes } from 'dep-types/ws'
@@ -267,14 +267,15 @@ export function createWebSocketServer(
     wsHttpServer.on('error', (e: Error & { code: string; port: number }) => {
       if (e.code === 'EADDRINUSE') {
         config.logger.error(
-          colors.red(
+          styleText(
+            'red',
             `WebSocket server error: Port ${e.port} is already in use`,
           ),
           { error: e },
         )
       } else {
         config.logger.error(
-          colors.red(`WebSocket server error:\n${e.stack || e.message}`),
+          styleText('red', `WebSocket server error:\n${e.stack || e.message}`),
           { error: e },
         )
       }
@@ -297,7 +298,7 @@ export function createWebSocketServer(
       )
     })
     socket.on('error', (err) => {
-      config.logger.error(`${colors.red(`ws error:`)}\n${err.stack}`, {
+      config.logger.error(`${styleText('red', `ws error:`)}\n${err.stack}`, {
         timestamp: true,
         error: err,
       })
@@ -312,12 +313,15 @@ export function createWebSocketServer(
   wss.on('error', (e: Error & { code: string; port: number }) => {
     if (e.code === 'EADDRINUSE') {
       config.logger.error(
-        colors.red(`WebSocket server error: Port ${e.port} is already in use`),
+        styleText(
+          'red',
+          `WebSocket server error: Port ${e.port} is already in use`,
+        ),
         { error: e },
       )
     } else {
       config.logger.error(
-        colors.red(`WebSocket server error:\n${e.stack || e.message}`),
+        styleText('red', `WebSocket server error:\n${e.stack || e.message}`),
         { error: e },
       )
     }

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -1,5 +1,5 @@
 import readline from 'node:readline'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { restartServerWithUrls } from './server'
 import type { ViteDevServer } from './server'
 import { isDevServer } from './utils'
@@ -41,10 +41,10 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
 
   if (opts?.print) {
     server.config.logger.info(
-      colors.dim(colors.green('  ➜')) +
-        colors.dim('  press ') +
-        colors.bold('h + enter') +
-        colors.dim(' to show help'),
+      styleText('dim', styleText('green', '  ➜')) +
+        styleText('dim', '  press ') +
+        styleText('bold', 'h + enter') +
+        styleText('dim', ' to show help'),
     )
   }
 
@@ -70,9 +70,9 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
         if (shortcut.action == null) continue
 
         server.config.logger.info(
-          colors.dim('  press ') +
-            colors.bold(`${shortcut.key} + enter`) +
-            colors.dim(` to ${shortcut.description}`),
+          styleText('dim', '  press ') +
+            styleText('bold', `${shortcut.key} + enter`) +
+            styleText('dim', ` to ${shortcut.description}`),
         )
       }
 

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,4 +1,4 @@
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { EvaluatedModuleNode } from 'vite/module-runner'
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
@@ -49,7 +49,10 @@ async function instantiateModule(
 
     environment.logger.error(
       buildErrorMessage(e, [
-        colors.red(`Error when evaluating SSR module ${url}: ${e.message}`),
+        styleText(
+          'red',
+          `Error when evaluating SSR module ${url}: ${e.message}`,
+        ),
       ]),
       {
         timestamp: true,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -11,10 +11,10 @@ import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
 import type { AddressInfo, Server } from 'node:net'
 import fsp from 'node:fs/promises'
+import { styleText } from 'node:util'
 import type { FSWatcher } from 'dep-types/chokidar'
 import remapping from '@ampproject/remapping'
 import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping'
-import colors from 'picocolors'
 import debug from 'debug'
 import type { Alias, AliasOptions } from 'dep-types/alias'
 import type MagicString from 'magic-string'
@@ -382,11 +382,11 @@ export function timeFrom(start: number, subtract = 0): string {
   const time: number | string = performance.now() - start - subtract
   const timeString = (time.toFixed(2) + `ms`).padEnd(5, ' ')
   if (time < 10) {
-    return colors.green(timeString)
+    return styleText('green', timeString)
   } else if (time < 50) {
-    return colors.yellow(timeString)
+    return styleText('yellow', timeString)
   } else {
-    return colors.red(timeString)
+    return styleText('red', timeString)
   }
 }
 
@@ -401,9 +401,9 @@ export function prettifyUrl(url: string, root: string): string {
       root,
       isAbsoluteFile ? url : fsPathFromId(url),
     )
-    return colors.dim(file)
+    return styleText('dim', file)
   } else {
-    return colors.dim(url)
+    return styleText('dim', url)
   }
 }
 

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'node:events'
 import path from 'node:path'
+import { styleText } from 'node:util'
 import type { FSWatcher, WatchOptions } from 'dep-types/chokidar'
 import type { OutputOptions } from 'rollup'
-import colors from 'picocolors'
 import { escapePath } from 'tinyglobby'
 import { withTrailingSlash } from '../shared/utils'
 import { arraify, normalizePath } from './utils'
@@ -35,9 +35,11 @@ export function resolveEmptyOutDir(
     if (!normalizePath(outDir).startsWith(withTrailingSlash(root))) {
       // warn if outDir is outside of root
       logger?.warn(
-        colors.yellow(
-          `\n${colors.bold(`(!)`)} outDir ${colors.white(
-            colors.dim(outDir),
+        styleText(
+          'yellow',
+          `\n${styleText('bold', `(!)`)} outDir ${styleText(
+            'white',
+            styleText('dim', outDir),
           )} is not inside project root and will not be emptied.\n` +
             `Use --emptyOutDir to override.\n`,
         ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,16 +77,16 @@ importers:
         version: 5.0.0(conventional-commits-filter@5.0.0)
       eslint:
         specifier: ^9.29.0
-        version: 9.29.0
+        version: 9.29.0(jiti@2.4.2)
       eslint-plugin-import-x:
         specifier: ^4.15.2
-        version: 4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)
+        version: 4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))
       eslint-plugin-n:
         specifier: ^17.20.0
-        version: 17.20.0(eslint@9.29.0)(typescript@5.7.3)
+        version: 17.20.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       eslint-plugin-regexp:
         specifier: ^2.9.0
-        version: 2.9.0(eslint@9.29.0)
+        version: 2.9.0(eslint@9.29.0(jiti@2.4.2))
       execa:
         specifier: ^9.6.0
         version: 9.6.0
@@ -116,7 +116,7 @@ importers:
         version: 5.7.3
       typescript-eslint:
         specifier: ^8.34.1
-        version: 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+        version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
         specifier: workspace:*
         version: link:packages/vite
@@ -162,9 +162,6 @@ importers:
       mri:
         specifier: ^1.2.0
         version: 1.2.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       tsdown:
         specifier: ^0.12.8
         version: 0.12.8(publint@0.3.5)(typescript@5.7.3)
@@ -199,9 +196,6 @@ importers:
       acorn:
         specifier: ^8.15.0
         version: 8.15.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       tsdown:
         specifier: ^0.12.8
         version: 0.12.8(publint@0.3.5)(typescript@5.7.3)
@@ -355,7 +349,7 @@ importers:
         version: 16.1.1(postcss@8.5.6)
       postcss-load-config:
         specifier: ^6.0.1
-        version: 6.0.1(postcss@8.5.6)
+        version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0)
       postcss-modules:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.5.6)
@@ -370,7 +364,7 @@ importers:
         version: 1.0.0-beta.19
       rolldown-plugin-dts:
         specifier: ^0.13.12
-        version: 0.13.12(rolldown@1.0.0-beta.19)
+        version: 0.13.12(rolldown@1.0.0-beta.19)(typescript@5.7.3)
       rollup-plugin-license:
         specifier: ^3.6.0
         version: 3.6.0(picomatch@4.0.2)(rollup@4.40.1)
@@ -391,7 +385,7 @@ importers:
         version: 5.43.1
       tsconfck:
         specifier: ^3.1.6
-        version: 3.1.6
+        version: 3.1.6(typescript@5.7.3)
       types:
         specifier: link:./types
         version: link:types
@@ -8447,9 +8441,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -9323,15 +9317,15 @@ snapshots:
     dependencies:
       '@types/node': 22.15.32
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.34.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.4
       natural-compare: 1.4.0
@@ -9340,14 +9334,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -9388,12 +9382,12 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9435,24 +9429,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.0(eslint@9.29.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.7.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10672,9 +10666,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.29.0):
+  eslint-compat-utils@0.5.1(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       semver: 7.7.2
 
   eslint-import-context@0.1.8(unrs-resolver@1.9.0):
@@ -10684,19 +10678,19 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.9.0
 
-  eslint-plugin-es-x@7.8.0(eslint@9.29.0):
+  eslint-plugin-es-x@7.8.0(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.29.0
-      eslint-compat-utils: 0.5.1(eslint@9.29.0)
+      eslint: 9.29.0(jiti@2.4.2)
+      eslint-compat-utils: 0.5.1(eslint@9.29.0(jiti@2.4.2))
 
-  eslint-plugin-import-x@4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0):
+  eslint-plugin-import-x@4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
       '@typescript-eslint/types': 8.34.0
       comment-parser: 1.4.1
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       eslint-import-context: 0.1.8(unrs-resolver@1.9.0)
       is-glob: 4.0.3
       minimatch: 10.0.1
@@ -10704,17 +10698,17 @@ snapshots:
       stable-hash-x: 0.1.1
       unrs-resolver: 1.9.0
     optionalDependencies:
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.20.0(eslint@9.29.0)(typescript@5.7.3):
+  eslint-plugin-n@17.20.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
-      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0)(typescript@5.7.3)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
       enhanced-resolve: 5.18.1
-      eslint: 9.29.0
-      eslint-plugin-es-x: 7.8.0(eslint@9.29.0)
+      eslint: 9.29.0(jiti@2.4.2)
+      eslint-plugin-es-x: 7.8.0(eslint@9.29.0(jiti@2.4.2))
       get-tsconfig: 4.10.1
       globals: 15.15.0
       ignore: 5.3.2
@@ -10725,12 +10719,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-regexp@2.9.0(eslint@9.29.0):
+  eslint-plugin-regexp@2.9.0(eslint@9.29.0(jiti@2.4.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       jsdoc-type-pratt-parser: 4.1.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
@@ -10747,9 +10741,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.29.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.1
@@ -10784,6 +10778,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12120,11 +12116,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(postcss@8.5.6):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      jiti: 2.4.2
       postcss: 8.5.6
+      tsx: 4.20.3
+      yaml: 2.8.0
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
@@ -12465,7 +12464,7 @@ snapshots:
       - oxc-resolver
       - supports-color
 
-  rolldown-plugin-dts@0.13.12(rolldown@1.0.0-beta.19):
+  rolldown-plugin-dts@0.13.12(rolldown@1.0.0-beta.19)(typescript@5.7.3):
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.5
@@ -12476,6 +12475,8 @@ snapshots:
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.19
+    optionalDependencies:
+      typescript: 5.7.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
@@ -13103,7 +13104,9 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6: {}
+  tsconfck@3.1.6(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
 
   tsdown@0.12.8(publint@0.3.5)(typescript@5.7.3):
     dependencies:
@@ -13181,12 +13184,12 @@ snapshots:
 
   type@2.7.3: {}
 
-  typescript-eslint@8.34.1(eslint@9.29.0)(typescript@5.7.3):
+  typescript-eslint@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,16 +77,16 @@ importers:
         version: 5.0.0(conventional-commits-filter@5.0.0)
       eslint:
         specifier: ^9.29.0
-        version: 9.29.0(jiti@2.4.2)
+        version: 9.29.0
       eslint-plugin-import-x:
         specifier: ^4.15.2
-        version: 4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))
+        version: 4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)
       eslint-plugin-n:
         specifier: ^17.20.0
-        version: 17.20.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+        version: 17.20.0(eslint@9.29.0)(typescript@5.7.3)
       eslint-plugin-regexp:
         specifier: ^2.9.0
-        version: 2.9.0(eslint@9.29.0(jiti@2.4.2))
+        version: 2.9.0(eslint@9.29.0)
       execa:
         specifier: ^9.6.0
         version: 9.6.0
@@ -96,9 +96,6 @@ importers:
       lint-staged:
         specifier: ^16.1.2
         version: 16.1.2
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       playwright-chromium:
         specifier: ^1.53.1
         version: 1.53.1
@@ -119,7 +116,7 @@ importers:
         version: 5.7.3
       typescript-eslint:
         specifier: ^8.34.1
-        version: 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+        version: 8.34.1(eslint@9.29.0)(typescript@5.7.3)
       vite:
         specifier: workspace:*
         version: link:packages/vite
@@ -353,15 +350,12 @@ importers:
       periscopic:
         specifier: ^4.0.2
         version: 4.0.2
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       postcss-import:
         specifier: ^16.1.1
         version: 16.1.1(postcss@8.5.6)
       postcss-load-config:
         specifier: ^6.0.1
-        version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0)
+        version: 6.0.1(postcss@8.5.6)
       postcss-modules:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.5.6)
@@ -376,7 +370,7 @@ importers:
         version: 1.0.0-beta.19
       rolldown-plugin-dts:
         specifier: ^0.13.12
-        version: 0.13.12(rolldown@1.0.0-beta.19)(typescript@5.7.3)
+        version: 0.13.12(rolldown@1.0.0-beta.19)
       rollup-plugin-license:
         specifier: ^3.6.0
         version: 3.6.0(picomatch@4.0.2)(rollup@4.40.1)
@@ -397,7 +391,7 @@ importers:
         version: 5.43.1
       tsconfck:
         specifier: ^3.1.6
-        version: 3.1.6(typescript@5.7.3)
+        version: 3.1.6
       types:
         specifier: link:./types
         version: link:types
@@ -8453,9 +8447,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@2.4.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
     dependencies:
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -9329,15 +9323,15 @@ snapshots:
     dependencies:
       '@types/node': 22.15.32
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.34.1
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       graphemer: 1.4.0
       ignore: 7.0.4
       natural-compare: 1.4.0
@@ -9346,14 +9340,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -9394,12 +9388,12 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
       debug: 4.4.1
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -9441,24 +9435,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.34.0(eslint@9.29.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
       '@typescript-eslint/scope-manager': 8.34.0
       '@typescript-eslint/types': 8.34.0
       '@typescript-eslint/typescript-estree': 8.34.0(typescript@5.7.3)
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.7.3)
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10678,9 +10672,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.29.0(jiti@2.4.2)):
+  eslint-compat-utils@0.5.1(eslint@9.29.0):
     dependencies:
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       semver: 7.7.2
 
   eslint-import-context@0.1.8(unrs-resolver@1.9.0):
@@ -10690,19 +10684,19 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.9.0
 
-  eslint-plugin-es-x@7.8.0(eslint@9.29.0(jiti@2.4.2)):
+  eslint-plugin-es-x@7.8.0(eslint@9.29.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.29.0(jiti@2.4.2)
-      eslint-compat-utils: 0.5.1(eslint@9.29.0(jiti@2.4.2))
+      eslint: 9.29.0
+      eslint-compat-utils: 0.5.1(eslint@9.29.0)
 
-  eslint-plugin-import-x@4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2)):
+  eslint-plugin-import-x@4.15.2(@typescript-eslint/utils@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0):
     dependencies:
       '@typescript-eslint/types': 8.34.0
       comment-parser: 1.4.1
       debug: 4.4.1
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       eslint-import-context: 0.1.8(unrs-resolver@1.9.0)
       is-glob: 4.0.3
       minimatch: 10.0.1
@@ -10710,17 +10704,17 @@ snapshots:
       stable-hash-x: 0.1.1
       unrs-resolver: 1.9.0
     optionalDependencies:
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.20.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3):
+  eslint-plugin-n@17.20.0(eslint@9.29.0)(typescript@5.7.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
-      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@typescript-eslint/utils': 8.34.0(eslint@9.29.0)(typescript@5.7.3)
       enhanced-resolve: 5.18.1
-      eslint: 9.29.0(jiti@2.4.2)
-      eslint-plugin-es-x: 7.8.0(eslint@9.29.0(jiti@2.4.2))
+      eslint: 9.29.0
+      eslint-plugin-es-x: 7.8.0(eslint@9.29.0)
       get-tsconfig: 4.10.1
       globals: 15.15.0
       ignore: 5.3.2
@@ -10731,12 +10725,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-regexp@2.9.0(eslint@9.29.0(jiti@2.4.2)):
+  eslint-plugin-regexp@2.9.0(eslint@9.29.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.29.0(jiti@2.4.2)
+      eslint: 9.29.0
       jsdoc-type-pratt-parser: 4.1.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
@@ -10753,9 +10747,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0(jiti@2.4.2):
+  eslint@9.29.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.1
@@ -10790,8 +10784,6 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12128,14 +12120,11 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.0):
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.4.2
       postcss: 8.5.6
-      tsx: 4.20.3
-      yaml: 2.8.0
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
@@ -12476,7 +12465,7 @@ snapshots:
       - oxc-resolver
       - supports-color
 
-  rolldown-plugin-dts@0.13.12(rolldown@1.0.0-beta.19)(typescript@5.7.3):
+  rolldown-plugin-dts@0.13.12(rolldown@1.0.0-beta.19):
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.5
@@ -12487,8 +12476,6 @@ snapshots:
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
       rolldown: 1.0.0-beta.19
-    optionalDependencies:
-      typescript: 5.7.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
@@ -13116,9 +13103,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6(typescript@5.7.3):
-    optionalDependencies:
-      typescript: 5.7.3
+  tsconfck@3.1.6: {}
 
   tsdown@0.12.8(publint@0.3.5)(typescript@5.7.3):
     dependencies:
@@ -13196,12 +13181,12 @@ snapshots:
 
   type@2.7.3: {}
 
-  typescript-eslint@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3):
+  typescript-eslint@8.34.1(eslint@9.29.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.7.3)
-      eslint: 9.29.0(jiti@2.4.2)
+      '@typescript-eslint/eslint-plugin': 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0)(typescript@5.7.3))(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0)(typescript@5.7.3)
+      eslint: 9.29.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color

--- a/scripts/extendCommitHash.ts
+++ b/scripts/extendCommitHash.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs'
 import { execSync } from 'node:child_process'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 
 export default function extendCommitHash(path: string): void {
   let content = fs.readFileSync(path, 'utf-8')
   const base = 'https://github.com/vitejs/vite/commit/'
   const matchHashReg = new RegExp(`${base}(\\w{7})\\)`, 'g')
-  console.log(colors.cyan(`\nextending commit hash in ${path}...`))
+  console.log(styleText('cyan', `\nextending commit hash in ${path}...`))
   let match
   while ((match = matchHashReg.exec(content))) {
     const shortHash = match[1]
@@ -18,5 +18,5 @@ export default function extendCommitHash(path: string): void {
     } catch {}
   }
   fs.writeFileSync(path, content)
-  console.log(colors.green(`${path} update success!`))
+  console.log(styleText('green', `${path} update success!`))
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,5 +1,5 @@
+import { styleText } from 'node:util'
 import { release } from '@vitejs/release-scripts'
-import colors from 'picocolors'
 import { logRecentCommits, run, updateTemplateVersions } from './releaseUtils'
 import extendCommitHash from './extendCommitHash'
 
@@ -12,7 +12,7 @@ release({
   generateChangelog: async (pkgName) => {
     if (pkgName === 'create-vite') await updateTemplateVersions()
 
-    console.log(colors.cyan('\nGenerating changelog...'))
+    console.log(styleText('cyan', '\nGenerating changelog...'))
     const changelogArgs = [
       'conventional-changelog',
       '-p',

--- a/scripts/releaseUtils.ts
+++ b/scripts/releaseUtils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import type { Options as ExecaOptions, ResultPromise } from 'execa'
 import { execa } from 'execa'
 
@@ -29,10 +29,12 @@ export async function logRecentCommits(pkgName: string): Promise<void> {
     stdio: 'pipe',
   }).then((res) => res.stdout.trim())
   console.log(
-    colors.bold(
-      `\n${colors.blue(`i`)} Commits of ${colors.green(
+    styleText(
+      'bold',
+      `\n${styleText('blue', `i`)} Commits of ${styleText(
+        'green',
         pkgName,
-      )} since ${colors.green(tag)} ${colors.gray(`(${sha.slice(0, 5)})`)}`,
+      )} since ${styleText('green', tag)} ${styleText('gray', `(${sha.slice(0, 5)})`)}`,
     ),
   )
   await run(


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
The minimum version of Node we currently support already natively supports the styleText function, so I think we can remove picocolors.
https://nodejs.org/docs/latest/api/util.html#utilstyletextformat-text-options