### PR TITLE
fix(css): skip resolving resolved paths in sass

### DIFF
--- a/playground/css/__tests__/sass-tests.ts
+++ b/playground/css/__tests__/sass-tests.ts
@@ -7,6 +7,9 @@ export const sassTest = () => {
     const atImport = await page.$('.sass-at-import')
     const atImportAlias = await page.$('.sass-at-import-alias')
     const atImportRelative = await page.$('.sass-at-import-relative')
+    const atImportReplacementAlias = await page.$(
+      '.sass-at-import-replacement-alias',
+    )
     const urlStartsWithVariable = await page.$('.sass-url-starts-with-variable')
     const urlStartsWithVariableInterpolation1 = await page.$(
       '.sass-url-starts-with-interpolation1',
@@ -35,6 +38,7 @@ export const sassTest = () => {
     expect(await getBg(atImportRelative)).toMatch(
       isBuild ? /base64/ : '/nested/icon.png',
     )
+    expect(await getColor(atImportReplacementAlias)).toBe('olive')
     expect(await getBg(urlStartsWithVariable)).toMatch(
       isBuild ? /ok-[-\w]+\.png/ : `${viteTestUrl}/ok.png`,
     )

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -37,7 +37,7 @@
     @import from SASS relative: This should be olive and have bg image
   </p>
   <p class="sass-at-import-replacement-alias">
-    @import with replement alias from SASS: This should be olive
+    @import with replacement alias from SASS: This should be olive
   </p>
   <p class="sass-partial">@import from SASS _partial: This should be orchid</p>
   <p class="sass-url-starts-with-variable">url starts with variable</p>

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -36,6 +36,9 @@
   <p class="sass-at-import-relative">
     @import from SASS relative: This should be olive and have bg image
   </p>
+  <p class="sass-at-import-replacement-alias">
+    @import with replement alias from SASS: This should be olive
+  </p>
   <p class="sass-partial">@import from SASS _partial: This should be orchid</p>
   <p class="sass-url-starts-with-variable">url starts with variable</p>
   <p class="sass-url-starts-with-interpolation1">

--- a/playground/css/nested/replacement-alias.scss
+++ b/playground/css/nested/replacement-alias.scss
@@ -1,0 +1,3 @@
+.sass-at-import-replacement-alias {
+  color: olive;
+}

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -9,6 +9,7 @@
 @use '=/weapp.wxss'; // wxss file
 @use 'virtual-file-absolute';
 @use '=/scss-dir/main.scss'; // "./dir" reference from vite custom importer
+@use '=replace/nested/replacement-alias.scss';
 
 .sass {
   /* injected via vite.config.js */

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -62,13 +62,20 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: {
-      '=': __dirname,
-      spacefolder: __dirname + '/folder with space',
-      '#alias': __dirname + '/aliased/foo.css',
-      '#alias?inline': __dirname + '/aliased/foo.css?inline',
-      '#alias-module': __dirname + '/aliased/bar.module.css',
-    },
+    alias: [
+      { find: '=', replacement: __dirname },
+      { find: /=replace\/(.*)/, replacement: `${__dirname}/$1` },
+      { find: 'spacefolder', replacement: __dirname + '/folder with space' },
+      { find: '#alias', replacement: __dirname + '/aliased/foo.css' },
+      {
+        find: '#alias?inline',
+        replacement: __dirname + '/aliased/foo.css?inline',
+      },
+      {
+        find: '#alias-module',
+        replacement: __dirname + '/aliased/bar.module.css',
+      },
+    ],
   },
   css: {
     modules: {


### PR DESCRIPTION
### Description

sass passes resolved paths to our importer. This caused the resolver to resolve from a different path.

fixes #20292
refs #20067

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
