### PR TITLE
fix(define): replace optional values

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -10,6 +10,7 @@ const nonJsRe = /\.json(?:$|\?)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
 const importMetaEnvMarker = '__vite_import_meta_env__'
 const importMetaEnvKeyReCache = new Map<string, RegExp>()
+const escapedDotRE = /(?<!\\)\\./g
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
@@ -91,7 +92,12 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       patternKeys.push('import.meta.env', 'import.meta.hot')
     }
     const pattern = patternKeys.length
-      ? new RegExp(patternKeys.map(escapeRegex).join('|'))
+      ? new RegExp(
+          patternKeys
+            // replace `\.` (ignore `\\.`) with `\??\.` to match with `?.` as well
+            .map((key) => escapeRegex(key).replaceAll(escapedDotRE, '\\??\\.'))
+            .join('|'),
+        )
       : null
 
     return [define, pattern, importMetaEnvVal] as const

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -109,3 +109,9 @@ test('replace constants on import.meta.env when it is a invalid json', async () 
     ),
   ).toBe('true')
 })
+
+test('optional values are detected by pattern properly', async () => {
+  expect(await page.textContent('.optional-env')).toBe(
+    JSON.parse(defines['process.env.SOMEVAR']),
+  )
+})

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -72,6 +72,12 @@
   </p>
 </section>
 
+<h2>Optional values are detected by pattern properly</h2>
+<p>
+  process?.env?.SOMEVAR
+  <code class="optional-env"></code>
+</p>
+
 <script>
   // inject __VITE_SOME_IDENTIFIER__ to test if it's replaced
   window.__VITE_SOME_IDENTIFIER__ = true
@@ -154,6 +160,9 @@
     '.replace-undefined-constants-on-import-meta-env .import-meta-env-SOME_IDENTIFIER',
     `${import.meta.env.SOME_IDENTIFIER}`,
   )
+
+  import optionalEnv from './optional-env.js'
+  text('.optional-env', optionalEnv)
 </script>
 
 <style>

--- a/playground/define/optional-env.js
+++ b/playground/define/optional-env.js
@@ -1,0 +1,2 @@
+// separate file to test pattern filter
+export default process?.env?.SOMEVAR


### PR DESCRIPTION
### Description

`process?.env?.SOMEVAR` was not replaced if the file did not contain other values that would be replaced.
This was happening because the regex filter pattern did not match values with `?.`.
This PR improves the regex filter pattern to match those cases.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
