### PR TITLE
docs(rolldown): update manualChunks status

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -103,7 +103,7 @@ If you don't pass the option in yourself, this must be fixed by the utilized fra
 
 #### `manualChunks` to `advancedChunks`
 
-Rolldown does not support the `manualChunks` option that was available in Rollup. Instead, it offers a more fine-grained setting via the [`advancedChunks` option](https://rolldown.rs/guide/in-depth/advanced-chunks#advanced-chunks), which is more similar to webpack's `splitChunk`:
+While Rolldown has support for the `manualChunks` option that is also exposed by Rollup, it is marked deprecated. Instead of it, Rolldown offers a more fine-grained setting via the [`advancedChunks` option](https://rolldown.rs/guide/in-depth/advanced-chunks#advanced-chunks), which is more similar to webpack's `splitChunk`:
 
 ```js
 // Old configuration (Rollup)


### PR DESCRIPTION
This pull request updates the documentation for Rolldown's chunking options to reflect the deprecation of the `manualChunks` option and emphasize the use of the `advancedChunks` option.