### PR TITLE
fix(css): resolve relative paths in sass, revert #20300

### DIFF
--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -64,7 +64,7 @@ export default defineConfig({
   resolve: {
     alias: [
       { find: '=', replacement: __dirname },
-      { find: /=replace\/(.*)/, replacement: `${__dirname}/$1` },
+      { find: /^=replace\/(.*)/, replacement: `${__dirname}/$1` },
       { find: 'spacefolder', replacement: __dirname + '/folder with space' },
       { find: '#alias', replacement: __dirname + '/aliased/foo.css' },
       {


### PR DESCRIPTION
### Description

This PR reverts the changes in #20300.

I noticed that https://github.com/vitejs/vite/issues/20292 just happened to work. The alias should have `^`, otherwise it'll match anywhere.

fixes #20346

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
