### PR TITLE
feat(create-vite): update rsc template to use `@vitejs/plugin-rsc`

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -158,11 +158,11 @@ const FRAMEWORKS: Framework[] = [
           'npm exec degit redwoodjs/sdk/starters/standard TARGET_DIR',
       },
       {
-        name: '@hiogawa/vite-rsc',
-        display: '@hiogawa/vite-rsc ↗',
+        name: 'rsc',
+        display: 'RSC ↗',
         color: magenta,
         customCommand:
-          'npm exec degit hi-ogawa/vite-plugins/packages/rsc/examples/starter TARGET_DIR',
+          'npm exec degit vitejs/plugin-react/packages/plugin-rsc/examples/starter TARGET_DIR',
       },
     ],
   },


### PR DESCRIPTION
### Description

This updates create-vite to use `@vitejs/plugin-rsc` https://github.com/vitejs/vite-plugin-react/pull/521 instead of `@hiogawa/vite-rsc`. 
