### PR TITLE
docs: mention `bun.lock` for lockfile

### DIFF
--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -70,7 +70,7 @@ You can further customize esbuild too with the [`optimizeDeps.esbuildOptions` op
 
 Vite caches the pre-bundled dependencies in `node_modules/.vite`. It determines whether it needs to re-run the pre-bundling step based on a few sources:
 
-- Package manager lockfile content, e.g. `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` or `bun.lockb`.
+- Package manager lockfile content, e.g. `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` or `bun.lock`.
 - Patches folder modification time.
 - Relevant fields in your `vite.config.js`, if present.
 - `NODE_ENV` value.


### PR DESCRIPTION
bun generates `bun.lock` by default from bun v1.2.
https://bun.sh/docs/install/lockfile