### PR TITLE
chore: use `n/prefer-node-protocol` rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { builtinModules, createRequire } from 'node:module'
+import { createRequire } from 'node:module'
 import eslint from '@eslint/js'
 import pluginN from 'eslint-plugin-n'
 import pluginImportX from 'eslint-plugin-import-x'
@@ -113,6 +113,7 @@ export default tseslint.config(
           allowModules: ['vite'],
         },
       ],
+      'n/prefer-node-protocol': 'error',
 
       '@typescript-eslint/ban-ts-comment': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'off',
@@ -157,10 +158,6 @@ export default tseslint.config(
       '@typescript-eslint/prefer-for-of': 'off',
       '@typescript-eslint/prefer-function-type': 'off',
 
-      'import-x/no-nodejs-modules': [
-        'error',
-        { allow: builtinModules.map((mod) => `node:${mod}`) },
-      ],
       'import-x/no-duplicates': 'error',
       'import-x/order': [
         'error',

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/native.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/native.js
@@ -1,3 +1,3 @@
 export { existsSync } from 'node:fs'
-// eslint-disable-next-line import-x/no-nodejs-modules -- testing that importing without node prefix works
+// eslint-disable-next-line n/prefer-node-protocol -- testing that importing without node prefix works
 export { readdirSync } from 'fs'

--- a/playground/cli-module/vite.config.js
+++ b/playground/cli-module/vite.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 import { URL } from 'url'
 import { defineConfig } from 'vite'
 

--- a/playground/object-hooks/vite.config.ts
+++ b/playground/object-hooks/vite.config.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import-x/no-nodejs-modules */
+/* eslint-disable n/prefer-node-protocol */
 import assert from 'assert'
 import { defineConfig } from 'vite'
 

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 const events = require('events')
 
 module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-with-external-deps/index.js
+++ b/playground/optimize-deps/dep-cjs-with-external-deps/index.js
@@ -1,5 +1,5 @@
 // `stream` is used as the package name for `@vitejs/test-dep-esm-dummy-node-builtin` so that it is treated like a Node builtin
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 const externalDummyNodeBuiltin = require('stream')
 const external = require('@vitejs/test-dep-esm-external')
 // eslint-disable-next-line no-prototype-builtins

--- a/playground/optimize-deps/dep-with-builtin-module-cjs/index.js
+++ b/playground/optimize-deps/dep-with-builtin-module-cjs/index.js
@@ -1,7 +1,7 @@
 // no node: protocol intentionally
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 const fs = require('fs')
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 const path = require('path')
 
 // NOTE: require destructure would error immediately because of how esbuild

--- a/playground/optimize-deps/dep-with-builtin-module-esm/index.js
+++ b/playground/optimize-deps/dep-with-builtin-module-esm/index.js
@@ -1,7 +1,7 @@
 // no node: protocol intentionally
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 import { readFileSync } from 'fs'
-// eslint-disable-next-line import-x/no-nodejs-modules
+// eslint-disable-next-line n/prefer-node-protocol
 import path from 'path'
 
 // access from named import


### PR DESCRIPTION
### Description

There's now a rule that covers this.
https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/prefer-node-protocol.md
Also this rule supports auto-fix.

refs #9514

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
