### PR TITLE
refactor: extract prepareOutDir as a plugin

### DIFF
--- a/packages/vite/src/node/plugins/prepareOutDir.ts
+++ b/packages/vite/src/node/plugins/prepareOutDir.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import colors from 'picocolors'
+import type { Plugin } from '../plugin'
+import { getResolvedOutDirs, resolveEmptyOutDir } from '../watch'
+import type { Environment } from '../environment'
+import { copyDir, emptyDir, normalizePath } from '../utils'
+import { withTrailingSlash } from '../../shared/utils'
+
+export function prepareOutDirPlugin(): Plugin {
+  const rendered = new Set<Environment>()
+  return {
+    name: 'vite:prepare-out-dir',
+    options() {
+      rendered.delete(this.environment)
+    },
+    renderStart: {
+      order: 'pre',
+      handler() {
+        if (rendered.has(this.environment)) {
+          return
+        }
+        rendered.add(this.environment)
+
+        const { config } = this.environment
+        if (config.build.write) {
+          const { root, build: options } = config
+          const resolvedOutDirs = getResolvedOutDirs(
+            root,
+            options.outDir,
+            options.rollupOptions.output,
+          )
+          const emptyOutDir = resolveEmptyOutDir(
+            options.emptyOutDir,
+            root,
+            resolvedOutDirs,
+            this.environment.logger,
+          )
+          prepareOutDir(resolvedOutDirs, emptyOutDir, this.environment)
+        }
+      },
+    },
+  }
+}
+
+function prepareOutDir(
+  outDirs: Set<string>,
+  emptyOutDir: boolean | null,
+  environment: Environment,
+) {
+  const { publicDir } = environment.config
+  const outDirsArray = [...outDirs]
+  for (const outDir of outDirs) {
+    if (emptyOutDir !== false && fs.existsSync(outDir)) {
+      // skip those other outDirs which are nested in current outDir
+      const skipDirs = outDirsArray
+        .map((dir) => {
+          const relative = path.relative(outDir, dir)
+          if (
+            relative &&
+            !relative.startsWith('..') &&
+            !path.isAbsolute(relative)
+          ) {
+            return relative
+          }
+          return ''
+        })
+        .filter(Boolean)
+      emptyDir(outDir, [...skipDirs, '.git'])
+    }
+    if (
+      environment.config.build.copyPublicDir &&
+      publicDir &&
+      fs.existsSync(publicDir)
+    ) {
+      if (!areSeparateFolders(outDir, publicDir)) {
+        environment.logger.warn(
+          colors.yellow(
+            `\n${colors.bold(
+              `(!)`,
+            )} The public directory feature may not work correctly. outDir ${colors.white(
+              colors.dim(outDir),
+            )} and publicDir ${colors.white(
+              colors.dim(publicDir),
+            )} are not separate folders.\n`,
+          ),
+        )
+      }
+      copyDir(publicDir, outDir)
+    }
+  }
+}
+
+function areSeparateFolders(a: string, b: string) {
+  const na = normalizePath(a)
+  const nb = normalizePath(b)
+  return (
+    na !== nb &&
+    !na.startsWith(withTrailingSlash(nb)) &&
+    !nb.startsWith(withTrailingSlash(na))
+  )
+}


### PR DESCRIPTION
### Description

Extracted `prepareOutDir` related code as a plugin so that it is handled consistently in both normal build and watch build.

Previously,
- in normal build, `prepareOutDir` was called after `buildEnd` and before `outputOptions`
- in watch build, `prepareOutDir` was called before `options` hook

With this PR, `prepareOutDir` will be called in the first `renderStart` hook, which is after `outputOptions`, for both normal build and watch build.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
