### PR TITLE
feat(html): process HTML with the plugin container in dev

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -11,7 +11,7 @@ import { importAnalysisPlugin } from './importAnalysis'
 import { cssAnalysisPlugin, cssPlugin, cssPostPlugin } from './css'
 import { assetPlugin } from './asset'
 import { clientInjectionsPlugin } from './clientInjections'
-import { buildHtmlPlugin, htmlInlineProxyPlugin } from './html'
+import { htmlInlineProxyPlugin, htmlPlugin } from './html'
 import { wasmFallbackPlugin, wasmHelperPlugin } from './wasm'
 import { modulePreloadPolyfillPlugin } from './modulePreloadPolyfill'
 import { webWorkerPlugin } from './worker'
@@ -79,7 +79,7 @@ export async function resolvePlugins(
     wasmFallbackPlugin(),
     definePlugin(config),
     cssPostPlugin(config),
-    isBuild && buildHtmlPlugin(config),
+    htmlPlugin(config),
     workerImportMetaUrlPlugin(config),
     assetImportMetaUrlPlugin(config),
     ...buildPlugins.pre,

--- a/playground/assets/__tests__/relative-base/assets-relative-base.spec.ts
+++ b/playground/assets/__tests__/relative-base/assets-relative-base.spec.ts
@@ -162,7 +162,7 @@ describe('image', () => {
       expect(s).toMatch(
         isBuild
           ? /other-assets\/asset-[-\w]{8}\.png \dx/
-          : /\.\/nested\/asset\.png \dx/,
+          : /\/nested\/asset\.png \dx/,
       )
     })
   })

--- a/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
+++ b/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
@@ -157,7 +157,7 @@ describe('image', () => {
       expect(s).toMatch(
         isBuild
           ? /other-assets\/asset-[-\w]{8}\.png \dx/
-          : /\.\/nested\/asset\.png \dx/,
+          : /\/nested\/asset\.png \dx/,
       )
     })
   })

--- a/playground/assets/__tests__/url-base/assets-url-base.spec.ts
+++ b/playground/assets/__tests__/url-base/assets-url-base.spec.ts
@@ -151,7 +151,7 @@ describe('image', () => {
       expect(s).toMatch(
         isBuild
           ? /other-assets\/asset-[-\w]{8}\.png \dx/
-          : /\.\/nested\/asset\.png \dx/,
+          : /\/nested\/asset\.png \dx/,
       )
     })
   })


### PR DESCRIPTION
### Description

Currently, Vite does not process HTML in dev. When building, Vite processes HTML in rollup.

Processing HTML with the plugin container in dev has the following upsides:

- The behavior is more consistent with build. In full bundle mode, this would be how HTML be handled.
- It will be more friendly for Env API. `transformIndexHtml` cannot be called from the module runner side. But the result of plugin container can be obtained from the module runner side.
- This would make it easier for the user to customize the resolve / transform behavior
  - https://github.com/vitejs/vite/issues/2321
  - https://github.com/vitejs/vite/issues/8000
  - https://github.com/vitejs/vite/issues/18984

The concerns I can think of are:
- the plugin pipeline may not expect html files to be processed.
  - this won't be a big problem because in build we already process them.
- makes `transformIndexHtml` outdated. Maybe it should be deprecated? I'm not sure about the migration path now.

close https://github.com/vitejs/vite/issues/20308

TODO:

- check `fs.strict`
- ecosystem-ci

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
