### PR TITLE
fix: remove special handling for `Accept: text/html`

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -144,10 +144,6 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       id: string,
       options?: {
         ssr?: boolean
-        /**
-         * @internal
-         */
-        html?: boolean
       },
     ) => Promise<LoadResult> | LoadResult,
     { filter?: { id?: StringFilter } }

--- a/packages/vite/src/node/publicDir.ts
+++ b/packages/vite/src/node/publicDir.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import { cleanUrl, withTrailingSlash } from '../shared/utils'
 import type { ResolvedConfig } from './config'
@@ -6,6 +5,7 @@ import {
   ERR_SYMLINK_IN_RECURSIVE_READDIR,
   normalizePath,
   recursiveReaddir,
+  tryStatSync,
 } from './utils'
 
 const publicFilesMap = new WeakMap<ResolvedConfig, Set<string>>()
@@ -60,5 +60,5 @@ export function checkPublicFile(
     return
   }
 
-  return fs.existsSync(publicFile) ? publicFile : undefined
+  return tryStatSync(publicFile)?.isFile() ? publicFile : undefined
 }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -263,7 +263,6 @@ export function transformMiddleware(
 
         // resolve, load and transform using the plugin container
         const result = await transformRequest(environment, url, {
-          html: req.headers.accept?.includes('text/html'),
           allowId(id) {
             return (
               id.startsWith('\0') ||

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -277,10 +277,7 @@ async function loadAndTransform(
         code = await fsp.readFile(file, 'utf-8')
         debugLoad?.(`${timeFrom(loadStart)} [fs] ${prettyUrl}`)
       } catch (e) {
-        if (e.code !== 'ENOENT') {
-          if (e.code === 'EISDIR') {
-            e.message = `${e.message} ${file}`
-          }
+        if (e.code !== 'ENOENT' && e.code !== 'EISDIR') {
           throw e
         }
       }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -56,10 +56,6 @@ export interface TransformOptions {
   /**
    * @internal
    */
-  html?: boolean
-  /**
-   * @internal
-   */
   allowId?: (id: string) => boolean
 }
 
@@ -84,8 +80,6 @@ export function transformRequest(
   if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
 
-  const cacheKey = `${options.html ? 'html:' : ''}${url}`
-
   // This module may get invalidated while we are processing it. For example
   // when a full page reload is needed after the re-processing of pre-bundled
   // dependencies when a missing dep is discovered. We save the current time
@@ -108,7 +102,7 @@ export function transformRequest(
   // last time this module is invalidated
   const timestamp = monotonicDateNow()
 
-  const pending = environment._pendingRequests.get(cacheKey)
+  const pending = environment._pendingRequests.get(url)
   if (pending) {
     return environment.moduleGraph
       .getModuleByUrl(removeTimestampQuery(url))
@@ -135,13 +129,13 @@ export function transformRequest(
   let cleared = false
   const clearCache = () => {
     if (!cleared) {
-      environment._pendingRequests.delete(cacheKey)
+      environment._pendingRequests.delete(url)
       cleared = true
     }
   }
 
   // Cache the request and clear it once processing is done
-  environment._pendingRequests.set(cacheKey, {
+  environment._pendingRequests.set(url, {
     request,
     timestamp,
     abort: clearCache,
@@ -270,11 +264,6 @@ async function loadAndTransform(
   if (loadResult == null) {
     const file = cleanUrl(id)
 
-    // if this is an html request and there is no load result, skip ahead to
-    // SPA fallback.
-    if (options.html && !id.endsWith('.html')) {
-      return null
-    }
     // try fallback loading it from fs as string
     // if the file is a binary, there should be a plugin that already loaded it
     // as string


### PR DESCRIPTION
### Description

This special handling for `Accept: text/html` was added by https://github.com/vitejs/vite/commit/44a30d5df8257bed9c59360b9751bf63151880b4 for #2051.

But the original issue seems to be working without this code. Also only checking for `Accept: text/html` is problematic (#15025).

So I removed this code. I think there won't be any problem, because when you access the path twice, the same behavior happens without this change.

fixes #17340

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
