### PR TITLE
fix: allow resolving bare specifiers to relative paths for entries

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -237,6 +237,7 @@ async function computeEntries(environment: ScanEnvironment) {
           p,
           path.join(process.cwd(), '*'),
           {
+            isEntry: true,
             scan: true,
           },
         )

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -254,7 +254,9 @@ export function resolvePlugin(
       // relative
       if (
         id[0] === '.' ||
-        ((preferRelative || importer?.endsWith('.html')) &&
+        ((preferRelative ||
+          resolveOpts.isEntry ||
+          importer?.endsWith('.html')) &&
           startsWithWordCharRE.test(id))
       ) {
         const basedir = importer ? path.dirname(importer) : process.cwd()


### PR DESCRIPTION
### Description

Rollup allows resolving bare specifiers to relative paths for entries (`build.rollupOptions.input`).
https://github.com/rollup/rollup/blob/9cebb0b6d9f03d11f53a8c3e7e9e3a79f567e3c6/src/utils/resolveId.ts#L47-L59
But the internal resolver plugin did not support that. That caused the entry to resolve to an id with `\\` and relative imports to an id with `/`, causing duplicate modules (#15153).

This PR aligns the behavior of the internal resolver plugin to rollup's behavior. This will make the id consistent (`/` will be used for both cases).
Also `isEntry` is now passed to fix #20377.

fixes #15153
fixes #20377
refs #20080

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
