### PR TITLE
docs: fix regular expression on the Rolldown page

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -127,7 +127,7 @@ export default {
     rollupOptions: {
       output: {
         advancedChunks: {
-          groups: [{ name: 'vendor', test: /\/react(?:-dom)?// }]
+          groups: [{ name: 'vendor', test: /\/react(?:-dom)?/ }]
         }
       }
     }


### PR DESCRIPTION
### Description

Removed an extra forward slash at the end of `/\/react(?:-dom)?//`, correcting it to` /\/react(?:-dom)?/`.