### PR TITLE
fix(alias): can't alias URLs to local directories (#20381)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -509,9 +509,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // static import or valid string in dynamic import
           // If resolvable, let's resolve it
           if (specifier !== undefined) {
-            // skip external / data uri
+            // skip external / data uri, but allow if it matches an alias
             if (
-              (isExternalUrl(specifier) && !specifier.startsWith('file://')) ||
+              (isExternalUrl(specifier) &&
+                !specifier.startsWith('file://') &&
+                !matchAlias(specifier)) ||
               isDataUrl(specifier)
             ) {
               return


### PR DESCRIPTION
### Description
fix (#20381 )
Currently, URL-like aliases in `resolve.alias` configuration don't work because the `importAnalysis` plugin skips all external URLs before they reach the alias resolution stage.

Modified the importAnalysis plugin to check if external URLs match any configured aliases before skipping them.