### PR TITLE
perf(legacy): skip lowering when detecting polyfills

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -35,6 +35,8 @@
   "dependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
+    "babel-plugin-polyfill-corejs3": "^0.13.0",
+    "babel-plugin-polyfill-regenerator": "^0.6.5",
     "browserslist": "^4.25.1",
     "browserslist-to-esbuild": "^2.1.1",
     "core-js": "^3.43.0",

--- a/packages/plugin-legacy/src/shims.d.ts
+++ b/packages/plugin-legacy/src/shims.d.ts
@@ -1,0 +1,3 @@
+declare module 'babel-plugin-polyfill-corejs3'
+
+declare module 'babel-plugin-polyfill-regenerator'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,12 @@ importers:
       '@babel/preset-env':
         specifier: ^7.28.0
         version: 7.28.0(@babel/core@7.28.0)
+      babel-plugin-polyfill-corejs3:
+        specifier: ^0.13.0
+        version: 0.13.0(@babel/core@7.28.0)
+      babel-plugin-polyfill-regenerator:
+        specifier: ^0.6.5
+        version: 0.6.5(@babel/core@7.28.0)
       browserslist:
         specifier: ^4.25.1
         version: 4.25.1


### PR DESCRIPTION
### Description

When detecting polyfills for modern build, plugin-legacy was lowering the code as `@babel/preset-env` does.
This PR changes that part to use `babel-plugin-polyfill-corejs3` and `babel-plugin-polyfill-regenerator`, which is used internally by `@babel/preset-env`, so that the lowering is not done.

I tested this PR with https://github.com/mastodon/mastodon and it reduced the build time from 27.25s to 24.17s.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
