### PR TITLE
build: remove `@oxc-project/runtime` devDep

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,6 @@
     "node",
     "typescript",
     "@rollup/plugin-dynamic-import-vars", // prefer version using tinyglobby
-    "@oxc-project/runtime", // align version with rolldown
     "@oxc-project/types", // align version with rolldown
 
     // pinned

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -95,7 +95,6 @@
     "@ampproject/remapping": "^2.3.0",
     "@babel/parser": "^7.28.0",
     "@jridgewell/trace-mapping": "^0.3.29",
-    "@oxc-project/runtime": "0.75.1",
     "@oxc-project/types": "0.75.1",
     "@polka/compression": "^1.0.0-next.25",
     "@rollup/plugin-alias": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,9 +239,6 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.29
         version: 0.3.29
-      '@oxc-project/runtime':
-        specifier: 0.75.1
-        version: 0.75.1
       '@oxc-project/types':
         specifier: 0.75.1
         version: 0.75.1


### PR DESCRIPTION
### Description

Rolldown now has `@oxc-project/runtime` as a dep instead of peerDep so we don't need to have it in devDep.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
