### PR TITLE
fix(legacy): `modernTargets` should set `build.target`

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -51,11 +51,13 @@ npm add -D terser
 - **Type:** `string | string[]`
 - **Default:** [`'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'`](https://browsersl.ist/#q=edge%3E%3D79%2C+firefox%3E%3D67%2C+chrome%3E%3D64%2C+safari%3E%3D12%2C+chromeAndroid%3E%3D64%2C+iOS%3E%3D12)
 
-  It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when collecting polyfills for **modern chunks**.
+  It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when collecting polyfills for **modern chunks**. The value set here will override the `build.target` option.
 
   The query is also [Browserslist compatible](https://github.com/browserslist/browserslist). See [Browserslist Best Practices](https://github.com/browserslist/browserslist#best-practices) for more details.
 
   If it's not set, plugin-legacy will fallback to the default value.
+
+  Note that this options should not be set unless `renderLegacyChunks` is set to `false`.
 
 ### `polyfills`
 

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -40,7 +40,7 @@ npm add -D terser
 - **Type:** `string | string[] | { [key: string]: string }`
 - **Default:** [`'last 2 versions and not dead, > 0.3%, Firefox ESR'`](https://browsersl.ist/#q=last+2+versions+and+not+dead%2C+%3E+0.3%25%2C+Firefox+ESR)
 
-  If explicitly set, it's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when rendering **legacy chunks**.
+  It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when rendering **legacy chunks**.
 
   The query is also [Browserslist compatible](https://github.com/browserslist/browserslist). See [Browserslist Best Practices](https://github.com/browserslist/browserslist#best-practices) for more details.
 
@@ -51,7 +51,7 @@ npm add -D terser
 - **Type:** `string | string[]`
 - **Default:** [`'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'`](https://browsersl.ist/#q=edge%3E%3D79%2C+firefox%3E%3D67%2C+chrome%3E%3D64%2C+safari%3E%3D12%2C+chromeAndroid%3E%3D64%2C+iOS%3E%3D12)
 
-  If explicitly set, it's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when rendering **modern chunks**.
+  It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when collecting polyfills for **modern chunks**.
 
   The query is also [Browserslist compatible](https://github.com/browserslist/browserslist). See [Browserslist Best Practices](https://github.com/browserslist/browserslist#best-practices) for more details.
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -124,24 +124,25 @@ const _require = createRequire(import.meta.url)
 const nonLeadingHashInFileNameRE = /[^/]+\[hash(?::\d+)?\]/
 const prefixedHashInFileNameRE = /\W?\[hash(?::\d+)?\]/
 
+// browsers supporting ESM + dynamic import + import.meta + async generator
+const modernTargetsEsbuild = [
+  'es2020',
+  'edge79',
+  'firefox67',
+  'chrome64',
+  'safari12',
+]
+// same with above but by browserslist syntax
+// es2020 = chrome 80+, safari 13.1+, firefox 72+, edge 80+
+// https://github.com/evanw/esbuild/issues/121#issuecomment-646956379
+const modernTargetsBabel =
+  'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'
+
 function viteLegacyPlugin(options: Options = {}): Plugin[] {
   let config: ResolvedConfig
   let targets: Options['targets']
-  let modernTargets: Options['modernTargets']
-
-  // browsers supporting ESM + dynamic import + import.meta + async generator
-  const modernTargetsEsbuild = [
-    'es2020',
-    'edge79',
-    'firefox67',
-    'chrome64',
-    'safari12',
-  ]
-  // same with above but by browserslist syntax
-  // es2020 = chrome 80+, safari 13.1+, firefox 72+, edge 80+
-  // https://github.com/evanw/esbuild/issues/121#issuecomment-646956379
-  const modernTargetsBabel =
-    'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'
+  const modernTargets: Options['modernTargets'] =
+    options.modernTargets || modernTargetsBabel
 
   const genLegacy = options.renderLegacyChunks !== false
   const genModern = options.renderModernChunks !== false
@@ -199,6 +200,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   }
 
   let overriddenBuildTarget = false
+  let overriddenBuildTargetOnlyModern = false
   let overriddenDefaultModernTargets = false
   const legacyConfigPlugin: Plugin = {
     name: 'vite:legacy-config',
@@ -223,16 +225,18 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           // See https://github.com/vitejs/vite/pull/10052#issuecomment-1242076461
           overriddenBuildTarget = config.build.target !== undefined
           overriddenDefaultModernTargets = options.modernTargets !== undefined
+        } else {
+          overriddenBuildTargetOnlyModern = config.build.target !== undefined
+        }
 
-          if (options.modernTargets) {
-            // Package is ESM only
-            const { default: browserslistToEsbuild } = await import(
-              'browserslist-to-esbuild'
-            )
-            config.build.target = browserslistToEsbuild(options.modernTargets)
-          } else {
-            config.build.target = modernTargetsEsbuild
-          }
+        if (options.modernTargets) {
+          // Package is ESM only
+          const { default: browserslistToEsbuild } = await import(
+            'browserslist-to-esbuild'
+          )
+          config.build.target = browserslistToEsbuild(options.modernTargets)
+        } else {
+          config.build.target = modernTargetsEsbuild
         }
       }
 
@@ -250,6 +254,13 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         config.logger.warn(
           colors.yellow(
             `plugin-legacy overrode 'build.target'. You should pass 'targets' as an option to this plugin with the list of legacy browsers to support instead.`,
+          ),
+        )
+      }
+      if (overriddenBuildTargetOnlyModern) {
+        config.logger.warn(
+          colors.yellow(
+            `plugin-legacy overrode 'build.target'. You should pass 'modernTargets' as an option to this plugin with the list of browsers to support instead.`,
           ),
         )
       }
@@ -376,7 +387,6 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
       config = _config
 
-      modernTargets = options.modernTargets || modernTargetsBabel
       if (isDebug) {
         console.log(`[@vitejs/plugin-legacy] modernTargets:`, modernTargets)
       }


### PR DESCRIPTION
### Description

`modernTargets` option is when collecting polyfills for modern chunks. On the other hand, `build.target` option is used when lowering by esbuild for modern chunks.

This means these two options should be synced. When `renderLegacyChunks` is `true`, these two were synced. The value of `modernTargets` were converted and set to `build.target`.

But when `renderLegacyChunks` is `false`, that did not happen. This causes more / less polyfills to be injected than needed.

This PR makes the legacy plugin to set `build.target` to the value converted from `modernTargets` option.
This will cause `build.target` to be set to a lower version in applications that didn't set `modernTargets` option (before `['chrome107', 'edge107', 'firefox104', 'safari16']`, after `['es2020', 'edge79', 'firefox67', 'chrome64', 'safari12']`).

The alternative is to set `modernTargets` based on `build.target`. This will make `modernTargets` option no-op. Also we need to make a function that converts esbuild target syntax to browserslist syntax.

refs #15506

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
