### PR TITLE
fix(dev): denied requests overly

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -310,21 +310,6 @@ export function checkLoadingAccess(
   return 'fallback'
 }
 
-export function checkServingAccess(
-  url: string,
-  server: ViteDevServer,
-): 'allowed' | 'denied' | 'fallback' {
-  if (isFileServingAllowed(url, server)) {
-    return 'allowed'
-  }
-  if (isFileReadable(cleanUrl(url))) {
-    return 'denied'
-  }
-  // if the file doesn't exist, we shouldn't restrict this path as it can
-  // be an API call. Middlewares would issue a 404 if the file isn't handled
-  return 'fallback'
-}
-
 export function respondWithAccessDenied(
   id: string,
   server: ViteDevServer,

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -13,7 +13,7 @@ import {
   isImportRequest,
   isInternalRequest,
   isParentDirectory,
-  isSameFileUri,
+  isSameFilePath,
   normalizePath,
   removeLeadingSlash,
   urlRE,
@@ -262,10 +262,22 @@ export function isFileServingAllowed(
   return isFileLoadingAllowed(config, filePath)
 }
 
-function isUriInFilePath(uri: string, filePath: string) {
-  return isSameFileUri(uri, filePath) || isParentDirectory(uri, filePath)
+/**
+ * Warning: parameters are not validated, only works with normalized absolute paths
+ *
+ * @param targetPath - normalized absolute path
+ * @param filePath - normalized absolute path
+ */
+function isFileInTargetPath(targetPath: string, filePath: string) {
+  return (
+    isSameFilePath(targetPath, filePath) ||
+    isParentDirectory(targetPath, filePath)
+  )
 }
 
+/**
+ * Warning: parameters are not validated, only works with normalized absolute paths
+ */
 export function isFileLoadingAllowed(
   config: ResolvedConfig,
   filePath: string,
@@ -278,7 +290,7 @@ export function isFileLoadingAllowed(
 
   if (config.safeModulePaths.has(filePath)) return true
 
-  if (fs.allow.some((uri) => isUriInFilePath(uri, filePath))) return true
+  if (fs.allow.some((uri) => isFileInTargetPath(uri, filePath))) return true
 
   return false
 }
@@ -314,11 +326,11 @@ export function checkServingAccess(
 }
 
 export function respondWithAccessDenied(
-  url: string,
+  id: string,
   server: ViteDevServer,
   res: ServerResponse,
 ): void {
-  const urlMessage = `The request url "${url}" is outside of Vite serving allow list.`
+  const urlMessage = `The request id "${id}" is outside of Vite serving allow list.`
   const hintMessage = `
 ${server.config.server.fs.allow.map((i) => `- ${i}`).join('\n')}
 

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -38,7 +38,7 @@ import {
   ERR_OUTDATED_OPTIMIZED_DEP,
   NULL_BYTE_PLACEHOLDER,
 } from '../../../shared/constants'
-import { checkServingAccess, respondWithAccessDenied } from './static'
+import { checkLoadingAccess, respondWithAccessDenied } from './static'
 
 const debugCache = createDebugger('vite:cache')
 
@@ -51,20 +51,15 @@ const inlineRE = /[?&]inline\b/
 const svgRE = /\.svg\b/
 
 function deniedServingAccessForTransform(
-  url: string,
+  id: string,
   server: ViteDevServer,
   res: ServerResponse,
   next: Connect.NextFunction,
 ) {
-  if (
-    rawRE.test(url) ||
-    urlRE.test(url) ||
-    inlineRE.test(url) ||
-    svgRE.test(url)
-  ) {
-    const servingAccessResult = checkServingAccess(url, server)
+  if (rawRE.test(id) || urlRE.test(id) || inlineRE.test(id) || svgRE.test(id)) {
+    const servingAccessResult = checkLoadingAccess(server.config, id)
     if (servingAccessResult === 'denied') {
-      respondWithAccessDenied(url, server, res)
+      respondWithAccessDenied(id, server, res)
       return true
     }
     if (servingAccessResult === 'fallback') {

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -43,7 +43,6 @@ import { checkServingAccess, respondWithAccessDenied } from './static'
 const debugCache = createDebugger('vite:cache')
 
 const knownIgnoreList = new Set(['/', '/favicon.ico'])
-const trailingQuerySeparatorsRE = /[?&]+$/
 
 // TODO: consolidate this regex pattern with the url, raw, and inline checks in plugins
 const urlRE = /[?&]url\b/
@@ -206,22 +205,6 @@ export function transformMiddleware(
 
       if (publicDirInRoot && url.startsWith(publicPath)) {
         warnAboutExplicitPublicPathInUrl(url)
-      }
-
-      const urlWithoutTrailingQuerySeparators = url.replace(
-        trailingQuerySeparatorsRE,
-        '',
-      )
-      if (
-        !url.startsWith('/@id/\0') &&
-        deniedServingAccessForTransform(
-          urlWithoutTrailingQuerySeparators,
-          server,
-          res,
-          next,
-        )
-      ) {
-        return
       }
 
       if (

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -21,7 +21,7 @@ import {
 } from '../utils'
 import { ssrTransform } from '../ssr/ssrTransform'
 import { checkPublicFile } from '../publicDir'
-import { cleanUrl, unwrapId } from '../../shared/utils'
+import { cleanUrl, slash, unwrapId } from '../../shared/utils'
 import {
   applySourcemapIgnoreList,
   extractSourcemapFromFile,
@@ -282,7 +282,7 @@ async function loadAndTransform(
     // like /service-worker.js or /api/users
     if (
       environment.config.consumer === 'server' ||
-      isFileLoadingAllowed(environment.getTopLevelConfig(), file)
+      isFileLoadingAllowed(environment.getTopLevelConfig(), slash(file))
     ) {
       try {
         code = await fsp.readFile(file, 'utf-8')

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -285,7 +285,7 @@ export function isParentDirectory(dir: string, file: string): boolean {
  * @param file2 - normalized absolute path
  * @returns true if both files url are identical
  */
-export function isSameFileUri(file1: string, file2: string): boolean {
+export function isSameFilePath(file1: string, file2: string): boolean {
   return (
     file1 === file2 ||
     (isCaseInsensitiveFS && file1.toLowerCase() === file2.toLowerCase())

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -208,7 +208,7 @@ describe.runIf(isServe)('main', () => {
       .poll(() =>
         page.textContent('.unsafe-fs-fetch-relative-path-after-query-status'),
       )
-      .toBe('403')
+      .toBe('404')
   })
 
   test('nested entry', async () => {


### PR DESCRIPTION
### Description

This line was not matching.
https://github.com/vitejs/vite/blob/6bc8bf634d4a2c9915da9813963dd80a4186daeb/packages/vite/src/node/server/middlewares/static.ts#L281

- 9df604b7f1b99c94d33e52037411b80cffa3c00d: added some comments and renamed some vars to make it clear that some function receives normalized absolute paths (this leads to requests denied more than needed. this does **not** lead to requests allowed more than needed)
- f73e0c60cd7155665b4a0ddccadd866b46fcf4c9: removed the check against non-resolved ids as this was no longer needed
- feb3040d35481753ce74bbeb6c9f20724b0d1764: changed from `checkServingAccess` to `checkLoadingAccess` for `deniedServingAccessForTransform` as this function receives a path instead of an URL (this leads to requests denied more than needed. this does **not** lead to requests allowed more than needed)
- 8fe09fd211dc9af12428d18641e3ab8dfa80880b: normalized paths before calling `isFileLoadingAllowed` (this isn't needed for the fix, but included as it's related to the change in 9df604b7f1b99c94d33e52037411b80cffa3c00d)

fixes #19795
fixes #20408
refs #20144

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
