### PR TITLE
perf(client): reduce reload debounce

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -132,7 +132,7 @@ const debounceReload = (time: number) => {
     }, time)
   }
 }
-const pageReload = debounceReload(10)
+const pageReload = debounceReload(20)
 
 const hmrClient = new HMRClient(
   {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -132,7 +132,7 @@ const debounceReload = (time: number) => {
     }, time)
   }
 }
-const pageReload = debounceReload(50)
+const pageReload = debounceReload(10)
 
 const hmrClient = new HMRClient(
   {


### PR DESCRIPTION
### Description

This debounce makes all reload requests to be deferred at least 50ms, which is a bit long.
Given that this was introduced for #13512, I guess 10ms is enough. #13512 isn't clear what happened there, and if it is caused by `git switch`, I think the multiple reload requests would be sent within 10ms.

refs #13545

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
