### PR TITLE
refactor: use environment transform request

### DIFF
--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -22,7 +22,10 @@ import { EnvironmentModuleGraph } from './moduleGraph'
 import type { EnvironmentModuleNode } from './moduleGraph'
 import type { HotChannel, NormalizedHotChannel } from './hmr'
 import { getShortName, normalizeHotChannel, updateModules } from './hmr'
-import type { TransformResult } from './transformRequest'
+import type {
+  TransformOptionsInternal,
+  TransformResult,
+} from './transformRequest'
 import { transformRequest } from './transformRequest'
 import type { EnvironmentPluginContainer } from './pluginContainer'
 import {
@@ -206,8 +209,12 @@ export class DevEnvironment extends BaseEnvironment {
     }
   }
 
-  transformRequest(url: string): Promise<TransformResult | null> {
-    return transformRequest(this, url)
+  transformRequest(
+    url: string,
+    /** @internal */
+    options?: TransformOptionsInternal,
+  ): Promise<TransformResult | null> {
+    return transformRequest(this, url, options)
   }
 
   async warmupRequest(url: string): Promise<void> {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -45,7 +45,6 @@ import { ssrTransform } from '../ssr/ssrTransform'
 import { reloadOnTsconfigChange } from '../plugins/esbuild'
 import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
-import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
 import {
   CLIENT_DIR,
   DEFAULT_DEV_PORT,
@@ -67,7 +66,6 @@ import type { MinimalPluginContextWithoutEnvironment } from '../plugin'
 import type { PluginContainer } from './pluginContainer'
 import {
   BasicMinimalPluginContext,
-  ERR_CLOSED_SERVER,
   basePluginContextMeta,
   createPluginContainer,
 } from './pluginContainer'
@@ -93,12 +91,11 @@ import { timeMiddleware } from './middlewares/time'
 import { ModuleGraph } from './mixedModuleGraph'
 import type { ModuleNode } from './mixedModuleGraph'
 import { notFoundMiddleware } from './middlewares/notFound'
-import { buildErrorMessage, errorMiddleware } from './middlewares/error'
+import { errorMiddleware } from './middlewares/error'
 import type { HmrOptions, NormalizedHotChannel } from './hmr'
 import { handleHMRUpdate, updateModules } from './hmr'
 import { openBrowser as _openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
-import { transformRequest } from './transformRequest'
 import { searchForPackageRoot, searchForWorkspaceRoot } from './searchRoot'
 import type { DevEnvironment } from './environment'
 import { hostValidationMiddleware } from './middlewares/hostCheck'
@@ -606,29 +603,11 @@ export async function _createServer(
         'server.transformRequest() is deprecated. Use environment.transformRequest() instead.',
       )
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
-      return transformRequest(environment, url, options)
+      return environment.transformRequest(url)
     },
-    async warmupRequest(url, options) {
-      try {
-        const environment = server.environments[options?.ssr ? 'ssr' : 'client']
-        await transformRequest(environment, url, options)
-      } catch (e) {
-        if (
-          e?.code === ERR_OUTDATED_OPTIMIZED_DEP ||
-          e?.code === ERR_CLOSED_SERVER
-        ) {
-          // these are expected errors
-          return
-        }
-        // Unexpected error, log the issue but avoid an unhandled exception
-        server.config.logger.error(
-          buildErrorMessage(e, [`Pre-transform error: ${e.message}`], false),
-          {
-            error: e,
-            timestamp: true,
-          },
-        )
-      }
+    warmupRequest(url, options) {
+      const environment = server.environments[options?.ssr ? 'ssr' : 'client']
+      return environment.warmupRequest(url)
     },
     transformIndexHtml(url, html, originalUrl) {
       return devHtmlTransformFn(server, url, html, originalUrl)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -591,11 +591,6 @@ export async function _createServer(
         },
       })
     },
-    // environment.transformRequest and .warmupRequest don't take an options param for now,
-    // so the logic and error handling needs to be duplicated here.
-    // The only param in options that could be important is `html`, but we may remove it as
-    // that is part of the internal control flow for the vite dev server to be able to bail
-    // out and do the html fallback
     transformRequest(url, options) {
       warnFutureDeprecation(
         config,

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -18,11 +18,7 @@ import {
   removeTimestampQuery,
 } from '../../utils'
 import { send } from '../send'
-import {
-  ERR_DENIED_ID,
-  ERR_LOAD_URL,
-  transformRequest,
-} from '../transformRequest'
+import { ERR_DENIED_ID, ERR_LOAD_URL } from '../transformRequest'
 import { applySourcemapIgnoreList } from '../sourcemap'
 import { isHTMLProxy } from '../../plugins/html'
 import {
@@ -262,7 +258,7 @@ export function transformMiddleware(
         }
 
         // resolve, load and transform using the plugin container
-        const result = await transformRequest(environment, url, {
+        const result = await environment.transformRequest(url, {
           allowId(id) {
             return (
               id.startsWith('\0') ||

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -71,12 +71,6 @@ export function transformRequest(
   url: string,
   options: TransformOptions = {},
 ): Promise<TransformResult | null> {
-  // Backward compatibility when only `ssr` is passed
-  if (!options.ssr) {
-    // Backward compatibility
-    options = { ...options, ssr: environment.config.consumer === 'server' }
-  }
-
   if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -53,6 +53,9 @@ export interface TransformOptions {
    * @deprecated inferred from environment
    */
   ssr?: boolean
+}
+
+export interface TransformOptionsInternal {
   /**
    * @internal
    */
@@ -69,7 +72,7 @@ export interface TransformOptions {
 export function transformRequest(
   environment: DevEnvironment,
   url: string,
-  options: TransformOptions = {},
+  options: TransformOptionsInternal = {},
 ): Promise<TransformResult | null> {
   if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
@@ -141,7 +144,7 @@ export function transformRequest(
 async function doTransform(
   environment: DevEnvironment,
   url: string,
-  options: TransformOptions,
+  options: TransformOptionsInternal,
   timestamp: number,
 ) {
   url = removeTimestampQuery(url)
@@ -231,7 +234,7 @@ async function loadAndTransform(
   environment: DevEnvironment,
   id: string,
   url: string,
-  options: TransformOptions,
+  options: TransformOptionsInternal,
   timestamp: number,
   mod?: EnvironmentModuleNode,
   resolved?: PartialResolvedId,


### PR DESCRIPTION
### Description

Made `transformRequest` to be not called from functions other than `environment.transformRequest`.

- 477921b75afee033d037f977edb42b85048eb94d: made `server.warmupRequest` to use `environment.warmupRequest` to remove duplicate code
- 49efc3445bdc9a51f084712e33356530be4e14d7: removed `options.ssr` handling in `transformRequest` as it was not used
- cc0895dcc2e8509b7b65d48cbb8f50afa694ab3d: split `TransformOptionsInternal` type as `ssr` option is only used for `server.transformRequest` and `server.warmupRequest`
- 9d34bac122abb416803a0c2177ee1aadbdc7cc75: made the transform middleware to use `environment.transformRequest` instead of `transformRequest` so that `transformRequest` is only used from `environment.transformRequest`

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
