### PR TITLE
feat: add `server.warmupRequest` to future deprecation

### DIFF
--- a/docs/changes/per-environment-apis.md
+++ b/docs/changes/per-environment-apis.md
@@ -15,6 +15,7 @@ The `Environment` instance was first introduced at `v6.0`. The deprecation of `s
 future: {
   removeServerModuleGraph: 'warn',
   removeServerTransformRequest: 'warn',
+  removeServerWarmupRequest: 'warn',
 }
 ```
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -484,6 +484,7 @@ export interface FutureOptions {
   removeServerModuleGraph?: 'warn'
   removeServerHot?: 'warn'
   removeServerTransformRequest?: 'warn'
+  removeServerWarmupRequest?: 'warn'
 
   removeSsrLoadModule?: 'warn'
 }
@@ -702,6 +703,7 @@ export const configDefaults = Object.freeze({
     removeServerModuleGraph: undefined,
     removeServerHot: undefined,
     removeServerTransformRequest: undefined,
+    removeServerWarmupRequest: undefined,
     removeSsrLoadModule: undefined,
   },
   legacy: {

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -24,7 +24,7 @@ const deprecationMessages = {
     'The `server.moduleGraph` is replaced with `this.environment.moduleGraph`.',
   removeServerHot: 'The `server.hot` is replaced with `this.environment.hot`.',
   removeServerTransformRequest:
-    'The `server.transformRequest` is replaced with `this.environment.transformRequest`.',
+    'The `server.transformRequest` related APIs are replaced with methods in `this.environment`.',
 
   removeSsrLoadModule:
     'The `server.ssrLoadModule` is replaced with Environment Runner.',

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -10,6 +10,7 @@ const deprecationCode = {
   removeServerModuleGraph: 'changes/per-environment-apis',
   removeServerHot: 'changes/per-environment-apis',
   removeServerTransformRequest: 'changes/per-environment-apis',
+  removeServerWarmupRequest: 'changes/per-environment-apis',
 
   removeSsrLoadModule: 'changes/ssr-using-modulerunner',
 } satisfies Record<keyof FutureOptions, string>
@@ -24,7 +25,9 @@ const deprecationMessages = {
     'The `server.moduleGraph` is replaced with `this.environment.moduleGraph`.',
   removeServerHot: 'The `server.hot` is replaced with `this.environment.hot`.',
   removeServerTransformRequest:
-    'The `server.transformRequest` related APIs are replaced with methods in `this.environment`.',
+    'The `server.transformRequest` is replaced with `this.environment.transformRequest`.',
+  removeServerWarmupRequest:
+    'The `server.warmupRequest` is replaced with `this.environment.warmupRequest`.',
 
   removeSsrLoadModule:
     'The `server.ssrLoadModule` is replaced with Environment Runner.',

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -601,6 +601,11 @@ export async function _createServer(
       return environment.transformRequest(url)
     },
     warmupRequest(url, options) {
+      warnFutureDeprecation(
+        config,
+        'removeServerTransformRequest',
+        'server.warmupRequest() is deprecated. Use environment.warmupRequest() instead.',
+      )
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
       return environment.warmupRequest(url)
     },

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -592,20 +592,12 @@ export async function _createServer(
       })
     },
     transformRequest(url, options) {
-      warnFutureDeprecation(
-        config,
-        'removeServerTransformRequest',
-        'server.transformRequest() is deprecated. Use environment.transformRequest() instead.',
-      )
+      warnFutureDeprecation(config, 'removeServerTransformRequest')
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
       return environment.transformRequest(url)
     },
     warmupRequest(url, options) {
-      warnFutureDeprecation(
-        config,
-        'removeServerTransformRequest',
-        'server.warmupRequest() is deprecated. Use environment.warmupRequest() instead.',
-      )
+      warnFutureDeprecation(config, 'removeServerWarmupRequest')
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
       return environment.warmupRequest(url)
     },


### PR DESCRIPTION
### Description

~~_Built on top of #20430_~~

`server.warmupRequest` was mentioned in https://vite.dev/changes/per-environment-apis.html#migration-guide but did not have `warnFutureDeprecation` call.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
