### PR TITLE
feat: add `removeServerPluginContainer` future deprecation

### DIFF
--- a/docs/changes/per-environment-apis.md
+++ b/docs/changes/per-environment-apis.md
@@ -14,6 +14,7 @@ The `Environment` instance was first introduced at `v6.0`. The deprecation of `s
 ```ts
 future: {
   removeServerModuleGraph: 'warn',
+  removeServerPluginContainer: 'warn',
   removeServerTransformRequest: 'warn',
 }
 ```
@@ -29,5 +30,6 @@ In Vite v6, it is now possible to create any number of custom environments (`cli
 ## Migration Guide
 
 - `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-environment-instances#separate-module-graphs)
+- `server.pluginContainer` -> `environment.pluginContainer`
 - `server.transformRequest(url, ssr)` -> `environment.transformRequest(url)`
 - `server.warmupRequest(url, ssr)` -> `environment.warmupRequest(url)`

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -482,6 +482,7 @@ export interface FutureOptions {
   removePluginHookSsrArgument?: 'warn'
 
   removeServerModuleGraph?: 'warn'
+  removeServerPluginContainer?: 'warn'
   removeServerHot?: 'warn'
   removeServerTransformRequest?: 'warn'
 

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -8,6 +8,7 @@ const deprecationCode = {
   removePluginHookHandleHotUpdate: 'changes/hotupdate-hook',
 
   removeServerModuleGraph: 'changes/per-environment-apis',
+  removeServerPluginContainer: 'changes/per-environment-apis',
   removeServerHot: 'changes/per-environment-apis',
   removeServerTransformRequest: 'changes/per-environment-apis',
 
@@ -22,6 +23,8 @@ const deprecationMessages = {
 
   removeServerModuleGraph:
     'The `server.moduleGraph` is replaced with `this.environment.moduleGraph`.',
+  removeServerPluginContainer:
+    'The `server.pluginContainer` is replaced with `this.environment.pluginContainer`.',
   removeServerHot: 'The `server.hot` is replaced with `this.environment.hot`.',
   removeServerTransformRequest:
     'The `server.transformRequest` is replaced with `this.environment.transformRequest`.',

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -531,7 +531,7 @@ export async function _createServer(
     client: () => environments.client.moduleGraph,
     ssr: () => environments.ssr.moduleGraph,
   })
-  const pluginContainer = createPluginContainer(environments)
+  let pluginContainer = createPluginContainer(environments)
 
   const closeHttpServer = createServerCloseFn(httpServer)
 
@@ -568,7 +568,13 @@ export async function _createServer(
     hot: ws,
 
     environments,
-    pluginContainer,
+    get pluginContainer() {
+      warnFutureDeprecation(config, 'removeServerPluginContainer')
+      return pluginContainer
+    },
+    set pluginContainer(p) {
+      pluginContainer = p
+    },
     get moduleGraph() {
       warnFutureDeprecation(config, 'removeServerModuleGraph')
       return moduleGraph

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -383,9 +383,11 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
-      const result = await server!.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.client,
-      })
+      const result =
+        await server!.environments.client.pluginContainer.transform(
+          code,
+          mod.id!,
+        )
       let content = ''
       if (result.map && 'version' in result.map) {
         if (result.map.mappings) {
@@ -408,9 +410,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
-      await server?.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.client,
-      })
+      await server?.environments.client.pluginContainer.transform(code, mod.id!)
 
       const hash = getHash(cleanUrl(mod.id!))
       const result = htmlProxyResult.get(`${hash}_${index}`)

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -17,7 +17,7 @@ async function createDevServer() {
       noDiscovery: true,
     },
   })
-  server.pluginContainer.buildStart({})
+  server.environments.ssr.pluginContainer.buildStart({})
   return server
 }
 
@@ -93,7 +93,7 @@ test('virtual module invalidation simple', async () => {
       },
     ],
   })
-  await server.pluginContainer.buildStart({})
+  server.environments.ssr.pluginContainer.buildStart({})
 
   const mod1 = await server.ssrLoadModule('virtual:test')
   expect(mod1.default).toEqual(1)
@@ -151,7 +151,7 @@ test('virtual module invalidation nested', async () => {
       },
     ],
   })
-  await server.pluginContainer.buildStart({})
+  server.environments.ssr.pluginContainer.buildStart({})
 
   const mod1 = await server.ssrLoadModule('virtual:test')
   expect(mod1.default).toEqual(1)

--- a/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
@@ -13,7 +13,7 @@ async function createDevServer() {
       noDiscovery: true,
     },
   })
-  server.pluginContainer.buildStart({})
+  server.environments.ssr.pluginContainer.buildStart({})
   return server
 }
 


### PR DESCRIPTION
### Description

`server.pluginContainer` mixes multiple module graphs, so this should be future deprecated as same as `server.moduleGraph`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
