### PR TITLE
test: fix `resolve.mainFields.custom-first` test flaky fail

### DIFF
--- a/playground/resolve/vite.config-mainfields-custom-first.js
+++ b/playground/resolve/vite.config-mainfields-custom-first.js
@@ -3,4 +3,5 @@ config.resolve.mainFields = [
   'custom',
   ...config.resolve.mainFields.filter((f) => f !== 'custom'),
 ]
+config.build.outDir = 'dist-mainfields-custom-first'
 export default config


### PR DESCRIPTION
### Description

This PR fixes this flaky fail:
https://github.com/vitejs/vite/actions/runs/16371335029/job/46260197438?pr=20424#step:13:25

Both `playground/resolve/__tests__/resolve.spec.ts` and `playground/resolve/__tests__/mainfields-custom-first/resolve-mainfields-custom-first.spec.ts` was writing to the same dist directory and overwriting each other.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
