### PR TITLE
fix(module-runner): normalize file:// on windows

### DIFF
--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -135,10 +135,9 @@ const prefixedBuiltins = new Set([
 // transform file url to id
 // virtual:custom -> virtual:custom
 // \0custom -> \0custom
-// /root/id -> /id
-// /root/id.js -> /id.js
-// C:/root/id.js -> /id.js
-// C:\root\id.js -> /id.js
+// node:fs -> fs
+// /@fs/C:/root/id.js => C:/root/id.js
+// file:///C:/root/id.js -> C:/root/id.js
 export function normalizeModuleId(file: string): string {
   if (prefixedBuiltins.has(file)) return file
 
@@ -149,5 +148,5 @@ export function normalizeModuleId(file: string): string {
     .replace(/^\/+/, '/')
 
   // if it's not in the root, keep it as a path, not a URL
-  return unixFile.replace(/^file:\//, '/')
+  return unixFile.replace(/^file:\/+/, isWindows ? '' : '/')
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/import-external.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/import-external.ts
@@ -1,0 +1,1 @@
+import 'tinyglobby'

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -503,16 +503,15 @@ describe('virtual module hmr', async () => {
       posix.join(server.config.root, 'fixtures/import-external.ts'),
     )
     const moduleNode = runner.evaluatedModules.getModuleByUrl('tinyglobby')!
-    console.log(moduleNode)
     const meta = moduleNode.meta as ExternalFetchResult
     if (process.platform === 'win32') {
-      expect(meta.externalize).toMatch(/file:\/\/\/\w:\//) // file:///C:/
-      expect(moduleNode.id).toMatch(/\w:\//) // C:/
-      expect(moduleNode.file).toMatch(/\w:\//) // C:/
+      expect(meta.externalize).toMatch(/^file:\/\/\/\w:\//) // file:///C:/
+      expect(moduleNode.id).toMatch(/^\w:\//) // C:/
+      expect(moduleNode.file).toMatch(/^\w:\//) // C:/
     } else {
-      expect(meta.externalize).toMatch(/file:\/\/\//) // file:///
-      expect(moduleNode.id).toMatch(/\//) // /
-      expect(moduleNode.file).toMatch(/\//) // /
+      expect(meta.externalize).toMatch(/^file:\/\/\//) // file:///
+      expect(moduleNode.id).toMatch(/^\//) // /
+      expect(moduleNode.file).toMatch(/^\//) // /
     }
   })
 })

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -3,12 +3,17 @@ import { posix, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, vi } from 'vitest'
 import { isWindows } from '../../../../shared/utils'
+import type { ExternalFetchResult } from '../../../../shared/invokeMethods'
 import { createModuleRunnerTester } from './utils'
 
 const _URL = URL
 
 describe('module runner initialization', async () => {
-  const it = await createModuleRunnerTester()
+  const it = await createModuleRunnerTester({
+    resolve: {
+      external: ['tinyglobby'],
+    },
+  })
 
   it('correctly runs ssr code', async ({ runner }) => {
     const mod = await runner.import('/fixtures/simple.js')
@@ -488,5 +493,26 @@ describe('virtual module hmr', async () => {
       const mod = runner.evaluatedModules.getModuleById('\0virtual:test')
       expect(mod?.exports.default).toBe('reloaded')
     })
+  })
+
+  it("the external module's ID and file are resolved correctly", async ({
+    server,
+    runner,
+  }) => {
+    await runner.import(
+      posix.join(server.config.root, 'fixtures/import-external.ts'),
+    )
+    const moduleNode = runner.evaluatedModules.getModuleByUrl('tinyglobby')!
+    console.log(moduleNode)
+    const meta = moduleNode.meta as ExternalFetchResult
+    if (process.platform === 'win32') {
+      expect(meta.externalize).toMatch(/file:\/\/\/\w:\//) // file:///C:/
+      expect(moduleNode.id).toMatch(/\w:\//) // C:/
+      expect(moduleNode.file).toMatch(/\w:\//) // C:/
+    } else {
+      expect(meta.externalize).toMatch(/file:\/\/\//) // file:///
+      expect(moduleNode.id).toMatch(/\//) // /
+      expect(moduleNode.file).toMatch(/\//) // /
+    }
   })
 })


### PR DESCRIPTION
### Description

Previously, it would store `file` and `id` as:

- `///C:/root/id.js`

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
