### PR TITLE
feat: add `future: 'warn'`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -391,7 +391,7 @@ export interface UserConfig extends DefaultEnvironmentOptions {
   /**
    * Options to opt-in to future behavior
    */
-  future?: FutureOptions
+  future?: FutureOptions | 'warn'
   /**
    * Legacy options
    *
@@ -559,6 +559,7 @@ export interface ResolvedConfig
       | 'dev'
       | 'environments'
       | 'experimental'
+      | 'future'
       | 'server'
       | 'preview'
     > & {
@@ -617,6 +618,7 @@ export interface ResolvedConfig
       worker: ResolvedWorkerOptions
       appType: AppType
       experimental: RequiredExceptFor<ExperimentalOptions, 'renderBuiltUrl'>
+      future: FutureOptions | undefined
       environments: Record<string, ResolvedEnvironmentOptions>
       /**
        * The token to connect to the WebSocket server from browsers.
@@ -1534,7 +1536,20 @@ export async function resolveConfig(
       configDefaults.experimental,
       config.experimental ?? {},
     ),
-    future: config.future,
+    future:
+      config.future === 'warn'
+        ? ({
+            removePluginHookHandleHotUpdate: 'warn',
+            removePluginHookSsrArgument: 'warn',
+            removeServerModuleGraph: 'warn',
+            removeServerReloadModule: 'warn',
+            removeServerPluginContainer: 'warn',
+            removeServerHot: 'warn',
+            removeServerTransformRequest: 'warn',
+            removeServerWarmupRequest: 'warn',
+            removeSsrLoadModule: 'warn',
+          } satisfies Required<FutureOptions>)
+        : config.future,
 
     ssr,
 


### PR DESCRIPTION
### Description

This PR adds `future: 'warn'` so that it is easier to turn on all future options.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
