### PR TITLE
docs: rework scaffolding your first vite project

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -43,10 +43,6 @@ The supported template presets are:
 
 ## Scaffolding Your First Vite Project
 
-::: tip Compatibility Note
-Vite requires [Node.js](https://nodejs.org/en/) version 20.19+, 22.12+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
-:::
-
 ::: code-group
 
 ```bash [npm]
@@ -72,6 +68,12 @@ $ deno init --npm vite
 :::
 
 Then follow the prompts!
+
+::: tip Compatibility Note
+Vite requires [Node.js](https://nodejs.org/en/) version 20.19+, 22.12+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+:::
+
+:::: details Using create vite with command line options
 
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:
 
@@ -103,6 +105,8 @@ $ deno init --npm vite my-vue-app --template vue
 See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
 
 You can use `.` for the project name to scaffold in the current directory.
+
+::::
 
 ## Community Templates
 


### PR DESCRIPTION
fixes #20452
close #20453

### Description

Reworks the scaffolding your first vite project section so the main command is more clearly visible.

From @sapphi-red's idea, but instead of removing the command line arguments section, it is collapsed by default. Also move the compatibility note after the command so it doesn't take the attention out of it after the title.

<img width="757" height="467" alt="image" src="https://github.com/user-attachments/assets/d8d045f1-b2c5-4ea1-9703-fb6c45e18c78" />
