### PR TITLE
Replaced hard coded port number

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -97,7 +97,7 @@ async function createServer() {
     // serve index.html - we will tackle this next
   })
 
-  app.listen(5173)
+  app.listen(vite.config.server.port)
 }
 
 createServer()


### PR DESCRIPTION
### Description

Replaced the hard coded port number in the [SSR page of the docs](https://vite.dev/guide/ssr) with the `vite.config.server.port` variable. This is more generic and avoids hard coding ports