### PR TITLE
docs: dark mode not applied properly in landing page

### DIFF
--- a/docs/.vitepress/theme/styles/landing.css
+++ b/docs/.vitepress/theme/styles/landing.css
@@ -4,17 +4,11 @@
 
 html:has(.landing) {
   --vp-c-bg: #101010;
-
   background-color: #101010;
-
-  body {
-    background-color: #101010;
-  }
 }
 
 .landing {
   overflow-x: hidden;
-  background-color: #101010;
 
   * {
     -webkit-font-smoothing: antialiased !important;

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ markdownStyles: false
 ---
 
 <script setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
 import Hero from '.vitepress/theme/components/landing/1. hero-section/HeroSection.vue'
 import FeatureSection from './.vitepress/theme/components/landing/2. feature-section/FeatureSection.vue'
 import FrameworksSection from './.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue'
@@ -24,6 +26,17 @@ import FeatureFlexiblePlugins from './.vitepress/theme/components/landing/2. fea
 import FeatureTypedAPI from './.vitepress/theme/components/landing/2. feature-section/FeatureTypedAPI.vue'
 import FeatureSSRSupport from './.vitepress/theme/components/landing/2. feature-section/FeatureSSRSupport.vue'
 import FeatureCI from './.vitepress/theme/components/landing/2. feature-section/FeatureCI.vue'
+
+const darkMode = ref(false)
+
+onMounted(() => {
+  darkMode.value = document.documentElement.classList.contains('dark')
+  document.documentElement.classList.add('dark')
+})
+
+onBeforeUnmount(() => {
+  document.documentElement.classList.toggle('dark', darkMode.value)
+})
 </script>
 
 <div class="VPHome">

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ markdownStyles: false
 ---
 
 <script setup>
+import { useData } from 'vitepress'
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 import Hero from '.vitepress/theme/components/landing/1. hero-section/HeroSection.vue'
@@ -27,15 +28,14 @@ import FeatureTypedAPI from './.vitepress/theme/components/landing/2. feature-se
 import FeatureSSRSupport from './.vitepress/theme/components/landing/2. feature-section/FeatureSSRSupport.vue'
 import FeatureCI from './.vitepress/theme/components/landing/2. feature-section/FeatureCI.vue'
 
-const darkMode = ref(false)
+const { isDark } = useData()
 
 onMounted(() => {
-  darkMode.value = document.documentElement.classList.contains('dark')
   document.documentElement.classList.add('dark')
 })
 
 onBeforeUnmount(() => {
-  document.documentElement.classList.toggle('dark', darkMode.value)
+  document.documentElement.classList.toggle('dark', isDark.value)
 })
 </script>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 title: Vite
 titleTemplate: Next Generation Frontend Tooling
+# add `dark` here to apply dark mode on initial load,
+# since `onMounted` doesn't run during SSR
 pageClass: landing dark
 
 layout: home

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,10 +20,6 @@ patchedDependencies:
 peerDependencyRules:
   allowedVersions:
     vite: "*"
-  ignoreMissing:
-    - "@algolia/client-search"
-    - "postcss"
-    - "search-insights"
 packageExtensions:
   sass-embedded:
     peerDependencies:


### PR DESCRIPTION
### Description

`pageClass` is only applied to layout not the root. This breaks styling on things that are teleported, like the search modal. Adding dark mode to root programmatically while preserving user preferences.

Before (if you're on light mode and open the landing page):

<img width="887" height="302" alt="image" src="https://github.com/user-attachments/assets/520828bd-a0dd-466f-a968-78764d0e158e" />

\
After (forced dark on landing page):

<img width="839" height="630" alt="image" src="https://github.com/user-attachments/assets/1e33c6d4-b115-4009-9acd-fb565986b786" />

\
`pageClass` is still kept to prevent flash of light mode, because onMounted isn't run on SSR.

peer dep issues were fixed in docsearch (bumped along with vp in #20489), and not sure why postcss was there. Removed those in this PR too, only this is logged, which is unrelated to changes:

```
 WARN  Issues with peer dependencies found
playground/external
└─┬ vue 3.4.38
  └─┬ @vue/server-renderer 3.4.38
    └── ✕ unmet peer vue@3.4.38: found 3.5.18
```