### PR TITLE
test(cli): use `stripVTControlCharacters` before matching strings

### DIFF
--- a/playground/cli-module/__tests__/serve.ts
+++ b/playground/cli-module/__tests__/serve.ts
@@ -1,6 +1,7 @@
 // this is automatically detected by playground/vitestSetup.ts and will replace
 // the default e2e test serve behavior
 
+import { stripVTControlCharacters } from 'node:util'
 import { execaCommand } from 'execa'
 import kill from 'kill-port'
 import {
@@ -117,14 +118,12 @@ async function startedOnPort(serverProcess, port, timeout) {
   let checkPort
   const startedPromise = new Promise<void>((resolve, reject) => {
     checkPort = (data) => {
-      const str = data.toString()
-      // hack, console output may contain color code gibberish
-      // skip gibberish between localhost: and port number
+      const str = stripVTControlCharacters(data.toString())
       const match = str.match(
-        /(http:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):).*(\d{4})/,
+        /http:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):(\d{4})/,
       )
       if (match) {
-        const startedPort = parseInt(match[2], 10)
+        const startedPort = parseInt(match[1], 10)
         if (startedPort === port) {
           resolve()
         } else {

--- a/playground/cli/__tests__/serve.ts
+++ b/playground/cli/__tests__/serve.ts
@@ -1,6 +1,7 @@
 // this is automatically detected by playground/vitestSetup.ts and will replace
 // the default e2e test serve behavior
 
+import { stripVTControlCharacters } from 'node:util'
 import { execaCommand } from 'execa'
 import kill from 'kill-port'
 import {
@@ -120,14 +121,12 @@ async function startedOnPort(serverProcess, port, timeout) {
   let checkPort
   const startedPromise = new Promise<void>((resolve, reject) => {
     checkPort = (data) => {
-      const str = data.toString()
-      // hack, console output may contain color code gibberish
-      // skip gibberish between localhost: and port number
+      const str = stripVTControlCharacters(data.toString())
       const match = str.match(
-        /(http:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):).*(\d{4})/,
+        /http:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):(\d{4})/,
       )
       if (match) {
-        const startedPort = parseInt(match[2], 10)
+        const startedPort = parseInt(match[1], 10)
         if (startedPort === port) {
           resolve()
         } else {


### PR DESCRIPTION
### Description

Made the test to use `stripVTControlCharacters` to make the test more robost and easier to understand.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
