### PR TITLE
fix(optimizer): discover correct jsx runtime during scan

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-jsx.tsx
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-jsx.tsx
@@ -1,5 +1,4 @@
 ;(globalThis as any).__test_scan_jsx_runtime ??= 0
 ;(globalThis as any).__test_scan_jsx_runtime++
 
-// @ts-ignore
-export default <div>test</div>
+export default <div />

--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-jsx.tsx
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-jsx.tsx
@@ -1,0 +1,5 @@
+;(globalThis as any).__test_scan_jsx_runtime ??= 0
+;(globalThis as any).__test_scan_jsx_runtime++
+
+// @ts-ignore
+export default <div>test</div>

--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-no-jsx.js
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-no-jsx.js
@@ -1,0 +1,3 @@
+import * as vue from 'vue'
+
+export default vue

--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/tsconfig.json
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "vue",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+  }
+}

--- a/packages/vite/src/node/__tests__/package.json
+++ b/packages/vite/src/node/__tests__/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@vitejs/parent": "link:./packages/parent",
     "@vitejs/cjs-ssr-dep": "link:./fixtures/cjs-ssr-dep",
-    "@vitejs/test-dep-conditions": "file:./fixtures/test-dep-conditions"
+    "@vitejs/test-dep-conditions": "file:./fixtures/test-dep-conditions",
+    "vue": "^3.5.18"
   }
 }

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -1,6 +1,8 @@
+import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { commentRE, importsRE, scriptRE } from '../optimizer/scan'
 import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
+import { createServer, createServerModuleRunner } from '..'
 
 describe('optimizer-scan:script-test', () => {
   const scriptContent = `import { defineComponent } from 'vue'
@@ -122,4 +124,45 @@ describe('optimizer-scan:script-test', () => {
     ret = `//export default { }`.replace(singlelineCommentsRE, '')
     expect(ret).not.toContain('export default')
   })
+})
+
+test('scan jsx-runtime', async (ctx) => {
+  const server = await createServer({
+    configFile: false,
+    // logLevel: 'error',
+    root: path.join(import.meta.dirname, 'fixtures', 'scan-jsx-runtime'),
+    environments: {
+      client: {
+        // silence client optimizer
+        optimizeDeps: {
+          noDiscovery: true,
+        },
+      },
+      ssr: {
+        resolve: {
+          noExternal: true,
+        },
+        optimizeDeps: {
+          force: true,
+          noDiscovery: false,
+          entries: ['./entry-jsx.tsx', './entry-no-jsx.js'],
+        },
+      },
+    },
+  })
+
+  // TODO: should server listen be needed for optimizer?
+  await server.listen()
+  ctx.onTestFinished(() => server.close())
+
+  const runner = createServerModuleRunner(server.environments.ssr)
+
+  // flush initial optimizer by importing any file
+  await runner.import('./entry-no-jsx.js')
+
+  // verify jsx won't trigger optimizer re-run
+  const mod1 = await runner.import('./entry-jsx.js')
+  const mod2 = await runner.import('./entry-jsx.js')
+  expect((globalThis as any).__test_scan_jsx_runtime).toBe(1)
+  expect(mod1).toBe(mod2)
 })

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -151,7 +151,7 @@ test('scan jsx-runtime', async (ctx) => {
     },
   })
 
-  // TODO: should server listen be needed for optimizer?
+  // start server to ensure optimizer run
   await server.listen()
   ctx.onTestFinished(() => server.close())
 

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -129,7 +129,7 @@ describe('optimizer-scan:script-test', () => {
 test('scan jsx-runtime', async (ctx) => {
   const server = await createServer({
     configFile: false,
-    // logLevel: 'error',
+    logLevel: 'error',
     root: path.join(import.meta.dirname, 'fixtures', 'scan-jsx-runtime'),
     environments: {
       client: {

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -155,7 +155,9 @@ test('scan jsx-runtime', async (ctx) => {
   await server.listen()
   ctx.onTestFinished(() => server.close())
 
-  const runner = createServerModuleRunner(server.environments.ssr)
+  const runner = createServerModuleRunner(server.environments.ssr, {
+    hmr: { logger: false },
+  })
 
   // flush initial optimizer by importing any file
   await runner.import('./entry-no-jsx.js')

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -301,23 +301,24 @@ async function prepareEsbuildScanner(
       tsconfig.compilerOptions?.jsxFragmentFactory ||
       tsconfig.compilerOptions?.jsxImportSource
     ) {
-      const compilerOptions = {
-        experimentalDecorators:
-          tsconfig.compilerOptions?.experimentalDecorators,
-        jsx: tsconfig.compilerOptions?.jsx,
-        jsxFactory: tsconfig.compilerOptions?.jsxFactory,
-        jsxFragmentFactory: tsconfig.compilerOptions?.jsxFragmentFactory,
-        jsxImportSource: tsconfig.compilerOptions?.jsxImportSource,
+      tsconfigRaw = {
+        compilerOptions: {
+          experimentalDecorators:
+            tsconfig.compilerOptions?.experimentalDecorators,
+          // esbuild uses tsconfig fields when both the normal options and tsconfig was set
+          // but we want to prioritize the normal options
+          jsx: esbuildOptions.jsx ? undefined : tsconfig.compilerOptions?.jsx,
+          jsxFactory: esbuildOptions.jsxFactory
+            ? undefined
+            : tsconfig.compilerOptions?.jsxFactory,
+          jsxFragmentFactory: esbuildOptions.jsxFragment
+            ? undefined
+            : tsconfig.compilerOptions?.jsxFragmentFactory,
+          jsxImportSource: esbuildOptions.jsxImportSource
+            ? undefined
+            : tsconfig.compilerOptions?.jsxImportSource,
+        },
       }
-      // esbuild uses tsconfig fields when both the normal options and tsconfig was set
-      // but we want to prioritize the normal options
-      if (esbuildOptions.jsx) compilerOptions.jsx = undefined
-      if (esbuildOptions.jsxFactory) compilerOptions.jsxFactory = undefined
-      if (esbuildOptions.jsxFragment)
-        compilerOptions.jsxFragmentFactory = undefined
-      if (esbuildOptions.jsxImportSource)
-        compilerOptions.jsxImportSource = undefined
-      tsconfigRaw = { compilerOptions }
     }
   }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -301,16 +301,23 @@ async function prepareEsbuildScanner(
       tsconfig.compilerOptions?.jsxFragmentFactory ||
       tsconfig.compilerOptions?.jsxImportSource
     ) {
-      tsconfigRaw = {
-        compilerOptions: {
-          experimentalDecorators:
-            tsconfig.compilerOptions?.experimentalDecorators,
-          jsx: tsconfig.compilerOptions?.jsx,
-          jsxFactory: tsconfig.compilerOptions?.jsxFactory,
-          jsxFragmentFactory: tsconfig.compilerOptions?.jsxFragmentFactory,
-          jsxImportSource: tsconfig.compilerOptions?.jsxImportSource,
-        },
+      const compilerOptions = {
+        experimentalDecorators:
+          tsconfig.compilerOptions?.experimentalDecorators,
+        jsx: tsconfig.compilerOptions?.jsx,
+        jsxFactory: tsconfig.compilerOptions?.jsxFactory,
+        jsxFragmentFactory: tsconfig.compilerOptions?.jsxFragmentFactory,
+        jsxImportSource: tsconfig.compilerOptions?.jsxImportSource,
       }
+      // esbuild uses tsconfig fields when both the normal options and tsconfig was set
+      // but we want to prioritize the normal options
+      if (esbuildOptions.jsx) compilerOptions.jsx = undefined
+      if (esbuildOptions.jsxFactory) compilerOptions.jsxFactory = undefined
+      if (esbuildOptions.jsxFragment)
+        compilerOptions.jsxFragmentFactory = undefined
+      if (esbuildOptions.jsxImportSource)
+        compilerOptions.jsxImportSource = undefined
+      tsconfigRaw = { compilerOptions }
     }
   }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -294,8 +294,23 @@ async function prepareEsbuildScanner(
     const { tsconfig } = await loadTsconfigJsonForFile(
       path.join(environment.config.root, '_dummy.js'),
     )
-    if (tsconfig.compilerOptions?.experimentalDecorators) {
-      tsconfigRaw = { compilerOptions: { experimentalDecorators: true } }
+    if (
+      tsconfig.compilerOptions?.experimentalDecorators ||
+      tsconfig.compilerOptions?.jsx ||
+      tsconfig.compilerOptions?.jsxFactory ||
+      tsconfig.compilerOptions?.jsxFragmentFactory ||
+      tsconfig.compilerOptions?.jsxImportSource
+    ) {
+      tsconfigRaw = {
+        compilerOptions: {
+          experimentalDecorators:
+            tsconfig.compilerOptions?.experimentalDecorators,
+          jsx: tsconfig.compilerOptions?.jsx,
+          jsxFactory: tsconfig.compilerOptions?.jsxFactory,
+          jsxFragmentFactory: tsconfig.compilerOptions?.jsxFragmentFactory,
+          jsxImportSource: tsconfig.compilerOptions?.jsxImportSource,
+        },
+      }
     }
   }
 
@@ -310,6 +325,7 @@ async function prepareEsbuildScanner(
     format: 'esm',
     logLevel: 'silent',
     plugins: [...plugins, plugin],
+    jsxDev: !environment.config.isProduction,
     ...esbuildOptions,
     tsconfigRaw,
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,6 +438,9 @@ importers:
       '@vitejs/test-dep-conditions':
         specifier: file:./fixtures/test-dep-conditions
         version: file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions
+      vue:
+        specifier: ^3.5.18
+        version: 3.5.18(typescript@5.7.3)
 
   packages/vite/src/node/__tests__/fixtures/cjs-ssr-dep: {}
 


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19343
- Closes https://github.com/vitejs/vite-plugin-react/issues/650

The initial reproduction was for the browser, but I used a hmr module runner so that it's easier to unit test.