### PR TITLE
fix(dev): denied request stalled when requested concurrently

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -248,6 +248,7 @@ async function loadAndTransform(
   if (options.allowId && !options.allowId(id)) {
     const err: any = new Error(`Denied ID ${id}`)
     err.code = ERR_DENIED_ID
+    err.id = id
     throw err
   }
 


### PR DESCRIPTION
### Description

When multiple requests with the same URL is sent to the transform middleware, the transform process is deduped by `_pendingRequests`. This caused `allowId` to be called only once for multiple requests.
https://github.com/vitejs/vite/blob/946831f986cb797009b8178659d2b31f570c44ff/packages/vite/src/node/server/middlewares/transform.ts#L243-L248
This is a problem because we call `next()` / `res.send()` in `allowId`.
The requests that was deduped never send the response.

This PR fixes that issue by moving the `next()` / `res.send()` calls outside.

The tests in rolldown-vite started to fail due this issue.
https://github.com/vitejs/rolldown-vite/actions/runs/16614739032/job/47004903302#step:12:27
#20410 revealed this issue as the requests in `fs-serve` playground was previously rejected before the transform process.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
