### PR TITLE
fix(client): keep ping on WS constructor error

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -441,24 +441,28 @@ async function waitForSuccessfulPingInternal(
   }
 
   async function ping() {
-    const socket = new WebSocket(socketUrl, 'vite-ping')
-    return new Promise<boolean>((resolve) => {
-      function onOpen() {
-        resolve(true)
-        close()
-      }
-      function onError() {
-        resolve(false)
-        close()
-      }
-      function close() {
-        socket.removeEventListener('open', onOpen)
-        socket.removeEventListener('error', onError)
-        socket.close()
-      }
-      socket.addEventListener('open', onOpen)
-      socket.addEventListener('error', onError)
-    })
+    try {
+      const socket = new WebSocket(socketUrl, 'vite-ping')
+      return new Promise<boolean>((resolve) => {
+        function onOpen() {
+          resolve(true)
+          close()
+        }
+        function onError() {
+          resolve(false)
+          close()
+        }
+        function close() {
+          socket.removeEventListener('open', onOpen)
+          socket.removeEventListener('error', onError)
+          socket.close()
+        }
+        socket.addEventListener('open', onOpen)
+        socket.addEventListener('error', onError)
+      })
+    } catch {
+      return false
+    }
   }
 
   function waitForWindowShow(visibilityManager: VisibilityManager) {


### PR DESCRIPTION
### Description

I'm not sure why but it seems `new WebSocket(socketUrl, 'vite-ping')` throws an error instead of the `error` event when pinging from the SharedWorker. That caused the pinging to stop.

refs https://github.com/vitejs/vite/pull/19057

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
