### PR TITLE
fix(manifest): initialize `entryCssAssetFileNames` as an empty Set

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -136,7 +136,7 @@ export function manifestPlugin(): Plugin {
       }
 
       const entryCssReferenceIds = cssEntriesMap.get(this.environment)!
-      const entryCssAssetFileNames = new Set(entryCssReferenceIds)
+      const entryCssAssetFileNames = new Set()
       for (const id of entryCssReferenceIds) {
         try {
           const fileName = this.getFileName(id)


### PR DESCRIPTION
### Description

Fixed an unintended erroneous behavior.

`entryCssAssetFileNames` variable contains file names, but `new Set(entryCssReferenceIds)` was putting reference ids in it.