### PR TITLE
test: detect ts support via `process.features`

### DIFF
--- a/packages/vite/src/node/__tests__/runnerImport.spec.ts
+++ b/packages/vite/src/node/__tests__/runnerImport.spec.ts
@@ -4,9 +4,8 @@ import { loadConfigFromFile } from 'vite'
 import { runnerImport } from '../ssr/runnerImport'
 import { slash } from '../../shared/utils'
 
-const [nvMajor, nvMinor] = process.versions.node.split('.').map(Number)
-const isTypeStrippingSupported =
-  (nvMajor === 23 && nvMinor >= 6) || nvMajor >= 24
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
+const isTypeStrippingSupported = !!process.features.typescript
 
 describe('importing files using inlined environment', () => {
   const fixture = (name: string) =>


### PR DESCRIPTION
### Description

Node 22.18.0 enables TS support by default. I changed this detection to use `process.features.typescript` instead of the version check as that would take `--no-experimental-strip-types` into account.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
