### PR TITLE
test: fix unimportant errors in test-unit

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -20,6 +20,8 @@ describe('custom environment conditions', () => {
         middlewareMode: true,
         ws: false,
       },
+      // disable scanner for client env to suppress scanner warnings
+      optimizeDeps: { entries: [] },
       environments: {
         // default
         ssr: {

--- a/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
@@ -41,6 +41,7 @@ const createServerWithPlugin = async (plugin: Plugin) => {
     logLevel: 'error',
     server: {
       middlewareMode: true,
+      ws: false,
     },
   })
   onTestFinished(() => server.close())

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -13,6 +13,7 @@ describe('import and resolveId', () => {
       logLevel: 'error',
       server: {
         middlewareMode: true,
+        ws: false,
       },
     })
     onTestFinished(() => server.close())

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -330,7 +330,7 @@ describe('module runner initialization', async () => {
     runner,
     onTestFinished,
   }) => {
-    const spy = vi.spyOn(console, 'log')
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
     onTestFinished(() => spy.mockRestore())
 
     await runner.import('/fixtures/execution-order-re-export/index.js')


### PR DESCRIPTION
### Description

Fixed the following errors / outputs in test-unit:

> WebSocket server error: Port 24678 is already in use

> (!) Failed to run dependency scan. Skipping dependency pre-bundling. Error: The following dependencies are imported but could not be resolved:
> 
>   entry.js (imported by D:/documents/GitHub/vite/packages/vite/src/node/__tests__/packages/build-project/index.html)
> 
> Are they installed?

> stdout | packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts > module runner initialization > execution order with mixed import and re-export
> dep1

> stdout | packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts > module runner initialization > execution order with mixed import and re-export
> dep2

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
