### PR TITLE
test: run assets variant tests in dedicated directory

### DIFF
--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -43,6 +43,7 @@ export async function setup({ provide }: TestProject): Promise<void> {
     })
   // also setup dedicated copy for "variant" tests
   for (const [original, variants] of [
+    ['assets', ['encoded-base', 'relative-base', 'runtime-base', 'url-base']],
     ['css', ['lightningcss']],
     ['transform-plugin', ['base']],
   ] as const) {


### PR DESCRIPTION
### Description

This PR fixes the following flaky failure:
```
FAIL  playground/assets/__tests__/relative-base/assets-relative-base.spec.ts > raw references from /public > load raw css from /public       
Error: elementHandle.evaluate: Execution context was destroyed, most likely because of a navigation
 ❯ getColor playground/test-utils.ts:111:24
```

This was probably happening because these tests modifies the files and triggers reload for other variant tests.
https://github.com/vitejs/vite/blob/1f235545b14a51d41b19a49da4a7e3a8e8eb5d10/playground/assets/__tests__/assets.spec.ts#L681-L705

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
