### PR TITLE
docs: fix redundant "yet" and add missing punctuation

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -9,12 +9,12 @@ We're planning to deprecate the `handleHotUpdate` plugin hook in favor of [`hotU
 Affected scope: `Vite Plugin Authors`
 
 ::: warning Future Deprecation
-`hotUpdate` was first introduced in `v6.0`. The deprecation of `handleHotUpdate` is planned for a future major. We don't yet recommend moving away from `handleHotUpdate` yet. If you want to experiment and give us feedback, you can use the `future.removePluginHookHandleHotUpdate` to `"warn"` in your vite config.
+`hotUpdate` was first introduced in `v6.0`. The deprecation of `handleHotUpdate` is planned for a future major. We don't recommend moving away from `handleHotUpdate` yet. If you want to experiment and give us feedback, you can use the `future.removePluginHookHandleHotUpdate` to `"warn"` in your vite config.
 :::
 
 ## Motivation
 
-The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`
+The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
 
 ```ts
 interface HmrContext {


### PR DESCRIPTION
### Description

This PR fixes two minor documentation issues:

1.  Removes redundant usage of "yet" in the sentence about `handleHotUpdate`:
- Original: `We don’t yet recommend moving away from handleHotUpdate yet.`
- Updated: `We don’t recommend moving away from handleHotUpdate yet.`
- Fixes the duplicate use of "yet" in the same sentence.

2.  Adds missing punctuation to a sentence about HmrContext:
- Original: `A list of modules to be updated is passed in the HmrContext`
- Updated: `A list of modules to be updated is passed in the HmrContext.`
- Corrects the missing period at the end of the sentence.

These changes improve the clarity and correctness of the documentation without affecting any functionality.  No tests are needed as these are purely documentation fixes.

<! ----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way.  If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

The changes are straightforward and don't require special attention from reviewers.  I've verified there are no existing PRs addressing these documentation issues.  The updates align with Vite's contribution guidelines for minor documentation improvements.
