### PR TITLE
chore(types): add missing semicolons in HmrContext and HotUpdateOptio…

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -18,11 +18,11 @@ The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to per
 
 ```ts
 interface HmrContext {
-  file: string
-  timestamp: number
-  modules: Array<ModuleNode>
-  read: () => string | Promise<string>
-  server: ViteDevServer
+  file: string;
+  timestamp: number;
+  modules: Array<ModuleNode>;
+  read: () => string | Promise<string>;
+  server: ViteDevServer;
 }
 ```
 
@@ -32,12 +32,12 @@ The new `hotUpdate` hook works in the same way as `handleHotUpdate` but it is ca
 
 ```ts
 interface HotUpdateOptions {
-  type: 'create' | 'update' | 'delete'
-  file: string
-  timestamp: number
-  modules: Array<EnvironmentModuleNode>
-  read: () => string | Promise<string>
-  server: ViteDevServer
+  type: 'create' | 'update' | 'delete';
+  file: string;
+  timestamp: number;
+  modules: Array<EnvironmentModuleNode>;
+  read: () => string | Promise<string>;
+  server: ViteDevServer;
 }
 ```
 


### PR DESCRIPTION
### Description

This PR improves TypeScript interface consistency by adding missing semicolons to the `HmrContext` and `HotUpdateOptions` interfaces.

Although semicolons are optional in TypeScript interfaces, most codebases—including Vite's—use them consistently. This change aligns these interfaces with the prevailing style and improves readability and maintainability.

Changes:

* Add missing semicolons in `HmrContext` and `HotUpdateOptions` definitions in `types/hmr.d.ts`
* Update related example in `docs/hotupdate-hook.md` for consistency

No functional changes are introduced.
