### PR TITLE
fix: skip prepareOutDirPlugin in workers

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -467,7 +467,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
   return {
     pre: [
       completeSystemWrapPlugin(),
-      prepareOutDirPlugin(),
+      ...(!config.worker ? [prepareOutDirPlugin()] : []),
       perEnvironmentPlugin('commonjs', (environment) => {
         const { commonjsOptions } = environment.config.build
         const usePluginCommonjs =

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -467,7 +467,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
   return {
     pre: [
       completeSystemWrapPlugin(),
-      ...(!config.worker ? [prepareOutDirPlugin()] : []),
+      ...(!config.isWorker ? [prepareOutDirPlugin()] : []),
       perEnvironmentPlugin('commonjs', (environment) => {
         const { commonjsOptions } = environment.config.build
         const usePluginCommonjs =


### PR DESCRIPTION
### Description

`prepareOutDirPlugin` removed the directory when bundling workers and caused some files missing.

refs #20373

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
