### PR TITLE
fix path typo.

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -59,7 +59,7 @@ function start() {
       } catch {}
     }, 10 * 1000).unref()
   } catch {}
-  return import('../dist/node/cli.js')
+  return import('../vite/dist/node/cli.js')
 }
 
 if (profileIndex > 0) {


### PR DESCRIPTION
### Description

`node_modules/.bin/vite`  current error, this pr works for me after local manual repair
`node_modules/vite/bin/vite` but may bad for this

correct approach might be to use the absolute path, But I'm not sure





<img width="861" height="476" alt="1754549621382" src="https://github.com/user-attachments/assets/5a6941a6-a4ab-471f-bbee-13a27e56e387" />

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
