### PR TITLE
fix: don't consider ids with `npm:` prefix as a built-in module

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1996,7 +1996,7 @@ async function bundleConfigFile(
               // With the `isNodeBuiltin` check above, this check captures if the builtin is a
               // non-node built-in, which esbuild doesn't know how to handle. In that case, we
               // externalize it so the non-node runtime handles it instead.
-              if (isNodeLikeBuiltin(id)) {
+              if (isNodeLikeBuiltin(id) || id.startsWith('npm:')) {
                 return { external: true }
               }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -98,8 +98,6 @@ export const normalizeId = (id: string): string =>
 
 // Supported by Node, Deno, Bun
 const NODE_BUILTIN_NAMESPACE = 'node:'
-// Supported by Deno
-const NPM_BUILTIN_NAMESPACE = 'npm:'
 // Supported by Bun
 const BUN_BUILTIN_NAMESPACE = 'bun:'
 // Some runtimes like Bun injects namespaced modules here, which is not a node builtin
@@ -136,7 +134,6 @@ export function createIsBuiltin(
 export const nodeLikeBuiltins = [
   ...nodeBuiltins,
   new RegExp(`^${NODE_BUILTIN_NAMESPACE}`),
-  new RegExp(`^${NPM_BUILTIN_NAMESPACE}`),
   new RegExp(`^${BUN_BUILTIN_NAMESPACE}`),
 ]
 


### PR DESCRIPTION
### Description

We're working on revamping our Deno vite plugin and noticed that any specifier starting with `npm:` is not being passed through the plugin system. Those kind of specifiers are frequently used when using packages from [JSR](https://jsr.io/) in Deno, without going through the jsr npm registry adapter.

After a bit of debugging it turns out that this code here makes it so that every `npm:` specifier is treated as a built-in module:

https://github.com/vitejs/vite/blob/3f7598c14fae6824a308ab74b68ff6086770990f/packages/vite/src/node/utils.ts#L101-L102

https://github.com/vitejs/vite/blob/3f7598c14fae6824a308ab74b68ff6086770990f/packages/vite/src/node/utils.ts#L136-L145

This is not correct as Deno doesn't ship with `npm:` modules built-in. It supports loading these specifiers from the npm registry instead. Consequently, the fix is pretty simple: Don't treat `npm:` specifiers as built-in modules. With that change `npm:` specifiers are passed through the plugin system again.