### PR TITLE
perf(worker): rebuild only when affected

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -45,16 +45,7 @@ class WorkerOutputCache {
    * worker bundle information for each input id
    * used to bundle the same worker file only once
    */
-  private bundles = new Map<
-    /* inputId */ string,
-    {
-      entryFilename: string
-      entryCode: string
-      entryUrlPlaceholder: string
-      referencedAssets: Set<string>
-      watchedFiles: string[]
-    }
-  >()
+  private bundles = new Map</* inputId */ string, WorkerBundle>()
   /** list of assets emitted for the worker bundles */
   private assets = new Map<string, WorkerBundleAsset>()
   private fileNameHash = new Map<

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -64,7 +64,7 @@ class WorkerOutputCache {
   private invalidatedBundles = new Set</* inputId */ string>()
 
   saveWorkerBundle(
-    id: string,
+    file: string,
     watchedFiles: string[],
     outputEntryFilename: string,
     outputEntryCode: string,
@@ -82,7 +82,7 @@ class WorkerOutputCache {
       referencedAssets: new Set(outputAssets.map((asset) => asset.fileName)),
       watchedFiles,
     }
-    this.bundles.set(id, bundle)
+    this.bundles.set(file, bundle)
     return bundle
   }
 
@@ -102,25 +102,25 @@ class WorkerOutputCache {
   }
 
   invalidateAffectedBundles(file: string) {
-    for (const [inputId, bundle] of this.bundles.entries()) {
+    for (const [bundleInputFile, bundle] of this.bundles.entries()) {
       if (bundle.watchedFiles.includes(file)) {
-        this.invalidatedBundles.add(inputId)
+        this.invalidatedBundles.add(bundleInputFile)
       }
     }
   }
 
-  removeBundleIfInvalidated(inputId: string) {
-    if (this.invalidatedBundles.has(inputId)) {
-      this.invalidatedBundles.delete(inputId)
-      this.removeBundle(inputId)
+  removeBundleIfInvalidated(file: string) {
+    if (this.invalidatedBundles.has(file)) {
+      this.invalidatedBundles.delete(file)
+      this.removeBundle(file)
     }
   }
 
-  private removeBundle(inputId: string) {
-    const bundle = this.bundles.get(inputId)
+  private removeBundle(file: string) {
+    const bundle = this.bundles.get(file)
     if (!bundle) return
 
-    this.bundles.delete(inputId)
+    this.bundles.delete(file)
     this.fileNameHash.delete(getHash(bundle.entryFilename))
 
     this.assets.delete(bundle.entryFilename)
@@ -134,8 +134,8 @@ class WorkerOutputCache {
     }
   }
 
-  getWorkerBundle(id: string) {
-    return this.bundles.get(id)
+  getWorkerBundle(file: string) {
+    return this.bundles.get(file)
   }
 
   getAssets() {
@@ -274,7 +274,7 @@ async function bundleWorkerEntry(
   const newBundleInfo = workerOutputCaches
     .get(config.mainConfig || config)!
     .saveWorkerBundle(
-      id,
+      input,
       watchedFiles,
       outputChunk.fileName,
       outputChunk.code,

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -204,12 +204,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       return environment.config.consumer === 'client'
     },
 
-    shouldTransformCachedModule({ code }) {
-      if (isBuild && config.build.watch && workerImportMetaUrlRE.test(code)) {
-        return true
-      }
-    },
-
     transform: {
       filter: { code: workerImportMetaUrlRE },
       async handler(code, id) {
@@ -262,7 +256,11 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           } else {
             let builtUrl: string
             if (isBuild) {
-              builtUrl = await workerFileToUrl(config, file)
+              const result = await workerFileToUrl(config, file)
+              builtUrl = result.entryUrlPlaceholder
+              for (const file of result.watchedFiles) {
+                this.addWatchFile(file)
+              }
             } else {
               builtUrl = await fileToUrl(this, cleanUrl(file))
               builtUrl = injectQuery(


### PR DESCRIPTION
### Description

Instead of building the worker every time any file is changed (before this PR `shouldTransformCachedModule` returns true), this PR makes the worker plugin to track the watched files so that the worker is re-built only when the content is changed.

This PR was initiated by the fact that the usage of `shouldTransformCachedModule` makes it difficult to make the plugins performant (https://github.com/rolldown/rolldown/issues/4389).

refs #11919, #14712

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
