### PR TITLE
fix(config): make debugger work with bundle loader

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1938,7 +1938,7 @@ async function bundleConfigFile(
     mainFields: ['main'],
     sourcemap: 'inline',
     // the last slash is needed to make the path correct
-    sourceRoot: path.dirname(fileName) + path.sep,
+    sourceRoot: pathToFileURL(path.dirname(fileName)).href + '/',
     metafile: true,
     define: {
       __dirname: dirnameVarName,


### PR DESCRIPTION
### Description

It seems `sourceRoot: path.dirname(fileName) + path.sep,` now doesn't work with VSCode's debugger. Since not supporting the file URLs are a bugs on the sourcemap consumer side, I switched to use the file URL.

I confirmed that the settings added in #19631 now works and `node --enable-source-maps` still works.
On the other hand, the stacktrace is now broken when used with [`source-map-support`](https://www.npmjs.com/package/source-map-support) or [`@cspotcode/source-map-support`](https://www.npmjs.com/package/@cspotcode/source-map-support). This is a bug on these packages side.

fixes #20177
refs #18833

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
