### PR TITLE
fix(client): add `[vite]` prefixes to debug logs

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -402,17 +402,17 @@ function pingWorkerContentMain(socketUrl: string) {
     port.addEventListener('message', (event) => {
       const { visibility } = event.data
       visibilityManager.currentState = visibility
-      console.debug('new window visibility', visibility)
+      console.debug('[vite] new window visibility', visibility)
       for (const listener of visibilityManager.listeners) {
         listener(visibility)
       }
     })
     port.start()
 
-    console.debug('connected from window')
+    console.debug('[vite] connected from window')
     waitForSuccessfulPingInternal(socketUrl, visibilityManager).then(
       () => {
-        console.debug('ping successful')
+        console.debug('[vite] ping successful')
         try {
           port.postMessage({ type: 'success' })
         } catch (error) {
@@ -420,7 +420,7 @@ function pingWorkerContentMain(socketUrl: string) {
         }
       },
       (error) => {
-        console.debug('error happened', error)
+        console.debug('[vite] error happened', error)
         try {
           port.postMessage({ type: 'error', error })
         } catch (error) {


### PR DESCRIPTION
### Description

add `[vite]` prefixes to all the client's logs, including the ones related to the websocket connection.

this is partially based in how i got spooked today by seeing "content visibility hidden", failing to identify it (it was only recently introduced in #19057, the blob uuid url confused me, and searching the literal string didn't turn up anything because it was interpolated), and coming to the incorrect conclusion that i had malware on my computer, but also based in consistency: the other half of debug calls uses `[vite]`, so these should too.