### PR TITLE
docs(rolldown): update description for enabling native plugins

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -143,7 +143,7 @@ export default {
 
 Thanks to Rolldown and Oxc, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. Native plugins are now enabled by default, with the default value set to `'v1'`.
 
-If you encounter any issues, you can change the `experimental.enableNativePlugin` option in your Vite config to `'resolver'` or `false`.
+If you encounter any issues, you can change the `experimental.enableNativePlugin` option in your Vite config to `'resolver'` or `false` as a workaround. Note that this option will be removed in the future.
 
 ### `@vitejs/plugin-react-oxc`
 

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -141,9 +141,9 @@ export default {
 
 ### Enabling Native Plugins
 
-Thanks to Rolldown and Oxc, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. At the time of writing, using these plugins is not enabled by default, as their behavior may differ from the JavaScript versions.
+Thanks to Rolldown and Oxc, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. Native plugins are now enabled by default, with the default value set to `'v1'`.
 
-To test them, you can set the `experimental.enableNativePlugin` option to `true` in your Vite config.
+If you encounter any issues, you can change the `experimental.enableNativePlugin` option in your Vite config to `'resolver'` or `false`.
 
 ### `@vitejs/plugin-react-oxc`
 


### PR DESCRIPTION
### Description

The document here is not deployed, so you would revert it here and make a PR to vitejs/vite instead?

_Originally posted by @sapphi-red in https://github.com/vitejs/rolldown-vite/pull/168#discussion_r2269216363_
