### PR TITLE
fix(optimizer): ensure consistent browserHash between in-memory and persisted metadata

### DIFF
--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -7,12 +7,12 @@ import { PartialEnvironment } from '../baseEnvironment'
 describe('createIsConfiguredAsExternal', () => {
   test('default', async () => {
     const isExternal = await createIsExternal()
-    expect(isExternal('@vitejs/cjs-ssr-dep')).toBe(false)
+    expect(await isExternal('@vitejs/cjs-ssr-dep')).toBe(false)
   })
 
   test('force external', async () => {
     const isExternal = await createIsExternal(true)
-    expect(isExternal('@vitejs/cjs-ssr-dep')).toBe(true)
+    expect(await isExternal('@vitejs/cjs-ssr-dep')).toBe(true)
   })
 })
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1953,32 +1953,34 @@ async function bundleConfigFile(
         name: 'externalize-deps',
         setup(build) {
           const packageCache = new Map()
-          const resolveByViteResolver = (
+          const resolveByViteResolver = async (
             id: string,
             importer: string,
             isRequire: boolean,
           ) => {
-            return tryNodeResolve(id, importer, {
-              root: path.dirname(fileName),
-              isBuild: true,
-              isProduction: true,
-              preferRelative: false,
-              tryIndex: true,
-              mainFields: [],
-              conditions: [
-                'node',
-                ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
-              ],
-              externalConditions: [],
-              external: [],
-              noExternal: [],
-              dedupe: [],
-              extensions: configDefaults.resolve.extensions,
-              preserveSymlinks: false,
-              packageCache,
-              isRequire,
-              builtins: nodeLikeBuiltins,
-            })?.id
+            return (
+              await tryNodeResolve(id, importer, {
+                root: path.dirname(fileName),
+                isBuild: true,
+                isProduction: true,
+                preferRelative: false,
+                tryIndex: true,
+                mainFields: [],
+                conditions: [
+                  'node',
+                  ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+                ],
+                externalConditions: [],
+                external: [],
+                noExternal: [],
+                dedupe: [],
+                extensions: configDefaults.resolve.extensions,
+                preserveSymlinks: false,
+                packageCache,
+                isRequire,
+                builtins: nodeLikeBuiltins,
+              })
+            )?.id
           }
 
           // externalize bare imports
@@ -2003,16 +2005,16 @@ async function bundleConfigFile(
               const isImport = isESM || kind === 'dynamic-import'
               let idFsPath: string | undefined
               try {
-                idFsPath = resolveByViteResolver(id, importer, !isImport)
+                idFsPath = await resolveByViteResolver(id, importer, !isImport)
               } catch (e) {
                 if (!isImport) {
                   let canResolveWithImport = false
                   try {
-                    canResolveWithImport = !!resolveByViteResolver(
+                    canResolveWithImport = !!(await resolveByViteResolver(
                       id,
                       importer,
                       false,
-                    )
+                    ))
                   } catch {}
                   if (canResolveWithImport) {
                     throw new Error(

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1330,11 +1330,11 @@ function getDepHash(environment: Environment): {
   }
 }
 
-function getOptimizedBrowserHash(
+export function getOptimizedBrowserHash(
   hash: string,
   deps: Record<string, string>,
   timestamp = '',
-) {
+): string {
   return getHash(hash + JSON.stringify(deps) + timestamp)
 }
 

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -331,6 +331,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           depsOptimizer &&
           moduleListContains(depsOptimizer.options.exclude, url)
         ) {
+          // Wait for scanning to complete to ensure stable browserHash and metadata
+          // This prevents inconsistent hashes between in-memory and persisted metadata
           await depsOptimizer.scanProcessing
 
           // if the dependency encountered in the optimized file was excluded from the optimization
@@ -520,7 +522,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             // skip ssr externals and builtins
             if (ssr && !matchAlias(specifier)) {
-              if (shouldExternalize(environment, specifier, importer)) {
+              if (await shouldExternalize(environment, specifier, importer)) {
                 return
               }
               if (isBuiltin(environment.config.resolve.builtins, specifier)) {

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -48,7 +48,7 @@ export async function fetchModule(
     const { externalConditions, dedupe, preserveSymlinks } =
       environment.config.resolve
 
-    const resolved = tryNodeResolve(url, importer, {
+    const resolved = await tryNodeResolve(url, importer, {
       mainFields: ['main'],
       conditions: externalConditions,
       externalConditions,


### PR DESCRIPTION
### Description

This PR fixes an inconsistency in how `browserHash` values are set in `depsOptimizer.metadata` during the initial dependency scan, which can cause duplicate module instances to be loaded in the browser when the Vite dev server restarts mid–asset waterfall.

#### Background

At [Gadget](https://gadget.dev), we use Vite both for development (serving a React frontend) and for production builds. In development, each user works in an ephemeral environment (“sandbox”), which runs both:

- A **Vite dev server** serving the frontend.
- A **Fastify backend server** (also hosting the Vite dev server).

For frontend-only changes, the Vite server stays running and uses HMR to push updates to the browser.  
For backend changes, however, we restart the entire Fastify process — which also restarts the Vite dev server.

These backend restarts are cheap and frequent, so developers often trigger them while the frontend is still loading in the browser.

#### The Problem

When a restart happens during the initial page load, we can hit the following sequence:

1. **Cold boot**: a new sandbox starts, and Vite builds dependency metadata (`depsOptimizer._metadata.json`) from scratch.
2. The first app request is served using this fresh metadata, and the browser begins fetching the asset waterfall (JS chunks, CSS, etc.).
3. **Mid-load restart**: the sandbox restarts while the browser is still fetching assets.
4. A new Vite server starts and **loads the existing** `_metadata.json` from disk (written in step 1).
5. Remaining asset requests in the waterfall are served from this second server.

Because `browserHash` in the in-memory metadata for the first server was not the same value eventually persisted to `_metadata.json`, the same dependency can be served with **two different browser hashes** across the restart.  

If the dependency is React (or any library that maintains singleton state), this results in the browser having **duplicate copies** of the module, causing broken HMR, hydration errors, and subtle runtime issues.

#### Solution

This patch ensures that before resolving `scanProcessing` in the optimizer, we **eagerly set the `browserHash`** on the in-memory `metadata` to the value that will later be written to disk.

By doing this, both:

- The first server (before writing to disk)
- Any subsequent server (loading from `_metadata.json`)

will use **identical** browser hashes for the same dependency, as long as we wait for the initial scan to complete before resolving dependencies.

#### Why This Matters

- Fixes a correctness issue that can manifest in real-world setups where Vite dev servers restart mid-load.
- Ensures consistency between the in-memory and persisted metadata for dependencies.
- Prevents hard-to-debug runtime errors caused by multiple versions of a singleton dependency being loaded into the same page.
