### PR TITLE
feat(preview): allow setting compression options

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -96,3 +96,10 @@ See [`server.cors`](./server-options#server-cors) for more details.
 - **Type:** `OutgoingHttpHeaders`
 
 Specify server response headers.
+
+## preview.compression
+
+- **Type:** `CompressionOptions`
+- Default: `{ threshold: 1024, level: -1, brotli: false, gzip: true, mimes: /text|javascript|\/json|xml/i }`
+
+Configure compression for files served by the preview server. See [`@polka/compression`](https://www.npmjs.com/package/@polka/compression#options) for more details.

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import sirv from 'sirv'
-import compression from '@polka/compression'
+import compression, {
+  type Options as CompressionOptions,
+} from '@polka/compression'
 import connect from 'connect'
 import type { Connect } from 'dep-types/connect'
 import corsMiddleware from 'cors'
@@ -46,10 +48,17 @@ import {
 } from './server/pluginContainer'
 import type { MinimalPluginContextWithoutEnvironment } from './plugin'
 
-export interface PreviewOptions extends CommonServerOptions {}
+export { type Options as CompressionOptions } from '@polka/compression'
+
+export interface PreviewOptions extends CommonServerOptions {
+  compression?: CompressionOptions
+}
 
 export interface ResolvedPreviewOptions
-  extends RequiredExceptFor<PreviewOptions, 'host' | 'https' | 'proxy'> {}
+  extends RequiredExceptFor<
+    PreviewOptions,
+    'host' | 'https' | 'proxy' | 'compression'
+  > {}
 
 export function resolvePreviewOptions(
   preview: PreviewOptions | undefined,
@@ -68,6 +77,7 @@ export function resolvePreviewOptions(
     proxy: preview?.proxy ?? server.proxy,
     cors: preview?.cors ?? server.cors,
     headers: preview?.headers ?? server.headers,
+    compression: preview?.compression,
   }
 }
 
@@ -224,7 +234,7 @@ export async function preview(
     app.use(proxyMiddleware(httpServer, proxy, config))
   }
 
-  app.use(compression())
+  app.use(compression(config.preview.compression))
 
   // base
   if (config.base !== '/') {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

I noticed that the `@polka/compression` middleware doesn't compress WebAssembly files. While I intend to fix this upstream in `@polka/compression` itself, I think it's worth exposing the compression middleware options in Vite itself. I find the preview server useful for (roughly) profiling how long my application will take to load on slow connections, and hosts like GitHub Pages *do* compress WebAssembly.

I hope re-exporting the interface directly from `@polka/compression` isn't an issue--it seems to be done with the HTTP proxy options as well.

I can't seem to find the tests for the preview server--let me know what I should base the tests off of.