### PR TITLE
feat(cli): enhance user prompts with navigation instructions

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -435,9 +435,11 @@ async function init() {
   }
   if (!template) {
     const framework = await prompts.select({
-      message: hasInvalidArgTemplate
-        ? `"${argTemplate}" isn't a valid template. Please choose from below: `
-        : 'Select a framework:',
+      message:
+        (hasInvalidArgTemplate
+          ? `"${argTemplate}" isn't a valid template. Please choose from below:`
+          : 'Select a framework:') +
+        `\n  ${colors.dim('(Use ↑/↓ to move, Enter to select)')}`,
       options: FRAMEWORKS.map((framework) => {
         const frameworkColor = framework.color
         return {
@@ -449,7 +451,9 @@ async function init() {
     if (prompts.isCancel(framework)) return cancel()
 
     const variant = await prompts.select({
-      message: 'Select a variant:',
+      message:
+        'Select a variant:' +
+        `\n  ${colors.dim('(Use ↑/↓ to move, Enter to select)')}`,
       options: framework.variants.map((variant) => {
         const variantColor = variant.color
         const command = variant.customCommand


### PR DESCRIPTION
### Description
Enhancement: adds inline keyboard navigation hints to the two interactive create-vite select prompts (framework + variant). Addresses UX confusion noted in issue [#20328](https://github.com/vitejs/vite/issues/20328).

### Changes:
- Appends dim help line: (Use ↑/↓ to move, Enter to select) to framework and variant selection (including invalid template fallback).
- No logic, API, or workflow changes; scaffolding path unchanged.
- Build, typecheck, and manual interactive tests verified.
