### PR TITLE
docs: use comma instead of colon in backend integration page

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -62,7 +62,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    </script>
    ```
 
-3. For production: after running `vite build`, a `.vite/manifest.json` file will be generated alongside other asset files. An example manifest file looks like this:
+3. For production, after running `vite build`, a `.vite/manifest.json` file will be generated alongside other asset files. An example manifest file looks like this:
 
    ```json [.vite/manifest.json]
    {


### PR DESCRIPTION
On the backend integration page, there are four topics that begin with:
1. In your Vite config,
2. For development,
3. For production:

I've noticed that the third point has colon (:). But I think it would be `For production,`. 