### PR TITLE
feat: generate code frame for parse errors thrown by terser

### DIFF
--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -55,7 +55,7 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           } catch (e) {
             // convert to a plain object as additional properties of Error instances are not
             // sent back to the main thread
-            throw { ...e }
+            throw { stack: e.stack /* stack is non-enumerable */, ...e }
           }
         },
       {
@@ -124,7 +124,8 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           line: e.line,
           column: e.col,
         }
-        e.frame = generateCodeFrame(code, e.pos)
+        e.frame =
+          e.pos !== undefined ? generateCodeFrame(code, e.pos) : undefined
         throw e
       }
     },

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -124,7 +124,16 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           line: e.line,
           column: e.col,
         }
-        e.frame =
+        if (e.line !== undefined && e.col !== undefined) {
+          e.loc = {
+            file: chunk.fileName,
+            line: e.line,
+            column: e.col,
+          }
+        }
+        if (e.pos !== undefined) {
+          e.frame = generateCodeFrame(code, e.pos)
+        }
           e.pos !== undefined ? generateCodeFrame(code, e.pos) : undefined
         throw e
       }

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -5,7 +5,7 @@ import type {
 import { WorkerWithFallback } from 'artichokie'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '..'
-import { requireResolveFromRootWithFallback } from '../utils'
+import { generateCodeFrame, requireResolveFromRootWithFallback } from '../utils'
 
 export interface TerserOptions extends TerserMinifyOptions {
   /**
@@ -47,10 +47,16 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           code: string,
           options: TerserMinifyOptions,
         ) => {
-          // test fails when using `import`. maybe related: https://github.com/nodejs/node/issues/43205
-          // eslint-disable-next-line no-restricted-globals -- this function runs inside cjs
-          const terser = require(terserPath)
-          return terser.minify(code, options) as TerserMinifyOutput
+          try {
+            // test fails when using `import`. maybe related: https://github.com/nodejs/node/issues/43205
+            // eslint-disable-next-line no-restricted-globals -- this function runs inside cjs
+            const terser = require(terserPath)
+            return (await terser.minify(code, options)) as TerserMinifyOutput
+          } catch (e) {
+            // convert to a plain object as additional properties of Error instances are not
+            // sent back to the main thread
+            throw { ...e }
+          }
         },
       {
         shouldUseFake(_terserPath, _code, options) {
@@ -78,7 +84,7 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
       return !!environment.config.build.minify
     },
 
-    async renderChunk(code, _chunk, outputOptions) {
+    async renderChunk(code, chunk, outputOptions) {
       // This plugin is included for any non-false value of config.build.minify,
       // so that normal chunks can use the preferred minifier, and legacy chunks
       // can use terser.
@@ -100,16 +106,26 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
       worker ||= makeWorker()
 
       const terserPath = loadTerserPath(config.root)
-      const res = await worker.run(terserPath, code, {
-        safari10: true,
-        ...terserOptions,
-        sourceMap: !!outputOptions.sourcemap,
-        module: outputOptions.format.startsWith('es'),
-        toplevel: outputOptions.format === 'cjs',
-      })
-      return {
-        code: res.code!,
-        map: res.map as any,
+      try {
+        const res = await worker.run(terserPath, code, {
+          safari10: true,
+          ...terserOptions,
+          sourceMap: !!outputOptions.sourcemap,
+          module: outputOptions.format.startsWith('es'),
+          toplevel: outputOptions.format === 'cjs',
+        })
+        return {
+          code: res.code!,
+          map: res.map as any,
+        }
+      } catch (e) {
+        e.loc = {
+          file: chunk.fileName,
+          line: e.line,
+          column: e.col,
+        }
+        e.frame = generateCodeFrame(code, e.pos)
+        throw e
       }
     },
 

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -119,11 +119,6 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           map: res.map as any,
         }
       } catch (e) {
-        e.loc = {
-          file: chunk.fileName,
-          line: e.line,
-          column: e.col,
-        }
         if (e.line !== undefined && e.col !== undefined) {
           e.loc = {
             file: chunk.fileName,
@@ -134,7 +129,6 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
         if (e.pos !== undefined) {
           e.frame = generateCodeFrame(code, e.pos)
         }
-          e.pos !== undefined ? generateCodeFrame(code, e.pos) : undefined
         throw e
       }
     },

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -48,9 +48,9 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
           code: string,
           options: TerserMinifyOptions,
         ) => {
+          const terser: typeof import('terser') = (await import(terserPath))
+            .default
           try {
-            const terser: typeof import('terser') = (await import(terserPath))
-              .default
             return (await terser.minify(code, options)) as TerserMinifyOutput
           } catch (e) {
             // convert to a plain object as additional properties of Error instances are not


### PR DESCRIPTION
### Description

Made errors thrown by terser to contain code frame so that it's easier to understand the error.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
