### PR TITLE
ci: use `actions-cool/issues-helper` for locking old closed issues

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -12,13 +12,13 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5
+      - uses: actions-cool/issues-helper@50068f49b7b2b3857270ead65e2d02e4459b022c # v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-inactive-days: "14"
-          #issue-comment: |
+          actions: "lock-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          #body: |
           #  This issue has been locked since it has been closed for more than 14 days.
           #
           #  If you have found a concrete bug or regression related to it, please open a new [bug report](https://github.com/vitejs/vite/issues/new/choose) with a reproduction against the latest Vite version. If you have any other comments you should join the chat at [Vite Land](https://chat.vite.dev) or create a new [discussion](https://github.com/vitejs/vite/discussions).
-          issue-lock-reason: ""
-          process-only: "issues"
+          issue-state: closed
+          inactive-day: 14


### PR DESCRIPTION
### Description

Migrated from `dessant/lock-threads` to `actions-cool/issues-helper` as `dessant/lock-threads` was using a deprecated API and was not maintained.
https://github.com/vitejs/vite/actions/runs/17027950833/job/48265889554#step:2:11
Probably the API would still work after the date though.

I chose `actions-cool/issues-helper` because it was used in other workflows.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
