### PR TITLE
perf(cli): dynamically import `resolveConfig`

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -9,7 +9,6 @@ import type { ServerOptions } from './server'
 import type { CLIShortcut } from './shortcuts'
 import type { LogLevel } from './logger'
 import { createLogger } from './logger'
-import { resolveConfig } from './config'
 import type { InlineConfig } from './config'
 
 const cli = cac('vite')
@@ -352,6 +351,7 @@ cli
   .action(
     async (root: string, options: { force?: boolean } & GlobalCLIOptions) => {
       filterDuplicateOptions(options)
+      const { resolveConfig } = await import('./config')
       const { optimizeDeps } = await import('./optimizer')
       try {
         const config = await resolveConfig(


### PR DESCRIPTION
### Description

I noticed that `resolveConfig` was top-level imported but only used in `vite optimize` in the CLI entrypoint. Making it a dynamic import doesn't change much for normal `vite dev` or `vite build` calls, but should help with `vite --version` or `vite --help`.

With `time vite --help`, before:

```
0.12s user 0.02s system 133% cpu 0.108 total
```

after:

```
0.04s user 0.01s system 91% cpu 0.049 total
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
