### PR TITLE
feat(hmr): add `import.meta.hot.getExports`

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -22,6 +22,7 @@ interface ImportMeta {
 
 interface ViteHotContext {
   readonly data: any
+  getExports(): Promise<ModuleNamespace | undefined>
 
   accept(): void
   accept(cb: (mod: ModuleNamespace | undefined) => void): void
@@ -198,6 +199,10 @@ import.meta.hot.accept((module) => {
   }
 })
 ```
+
+## `hot.getExports()`
+
+This function returns the exports of the current module. It is similar to `import(import.meta.url)`.
 
 ## `hot.on(event, cb)`
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -552,8 +552,11 @@ export function removeStyle(id: string): void {
   }
 }
 
-export function createHotContext(ownerPath: string): ViteHotContext {
-  return new HMRContext(hmrClient, ownerPath)
+export function createHotContext(
+  ownerPath: string,
+  importMetaUrl: string,
+): ViteHotContext {
+  return new HMRContext(hmrClient, ownerPath, () => import(importMetaUrl))
 }
 
 /**

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -364,7 +364,11 @@ export class ModuleRunner {
             throw new Error(`[module runner] HMR client was closed.`)
           }
           this.debug?.('[module runner] creating hmr context for', mod.url)
-          hotContext ||= new HMRContext(this.hmrClient, mod.url)
+          hotContext ||= new HMRContext(
+            this.hmrClient,
+            mod.url,
+            () => mod.exports,
+          )
           return hotContext
         },
         set: (value) => {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -740,7 +740,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           `import { createHotContext as __vite__createHotContext } from "${clientPublicPath}";` +
             `import.meta.hot = __vite__createHotContext(${JSON.stringify(
               normalizeHmrUrl(importerModule.url),
-            )});`,
+            )}, import.meta.url);`,
         )
       }
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -2,6 +2,7 @@ import type { HotPayload, Update } from 'types/hmrPayload'
 import type { ModuleNamespace, ViteHotContext } from 'types/hot'
 import type { InferCustomEventPayload } from 'types/customEvent'
 import type { NormalizedModuleRunnerTransport } from './moduleRunnerTransport'
+import type { MaybePromise } from './utils'
 
 type CustomListenersMap = Map<string, ((data: any) => void)[]>
 
@@ -27,6 +28,7 @@ export class HMRContext implements ViteHotContext {
   constructor(
     private hmrClient: HMRClient,
     private ownerPath: string,
+    private getCurrentExports: () => MaybePromise<ModuleNamespace | undefined>,
   ) {
     if (!hmrClient.dataMap.has(ownerPath)) {
       hmrClient.dataMap.set(ownerPath, {})
@@ -59,6 +61,10 @@ export class HMRContext implements ViteHotContext {
 
   get data(): any {
     return this.hmrClient.dataMap.get(this.ownerPath)
+  }
+
+  async getExports(): Promise<ModuleNamespace | undefined> {
+    return this.getCurrentExports()
   }
 
   accept(deps?: any, callback?: any): void {

--- a/packages/vite/src/shared/utils.ts
+++ b/packages/vite/src/shared/utils.ts
@@ -1,5 +1,7 @@
 import { NULL_BYTE_PLACEHOLDER, VALID_ID_PREFIX } from './constants'
 
+export type MaybePromise<T> = T | Promise<T>
+
 export const isWindows =
   typeof process !== 'undefined' && process.platform === 'win32'
 

--- a/packages/vite/types/hot.d.ts
+++ b/packages/vite/types/hot.d.ts
@@ -6,6 +6,7 @@ export type ModuleNamespace = Record<string, any> & {
 
 export interface ViteHotContext {
   readonly data: any
+  getExports(): Promise<ModuleNamespace | undefined>
 
   accept(): void
   accept(cb: (mod: ModuleNamespace | undefined) => void): void

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -55,6 +55,10 @@ if (!isBuild) {
       expect(clientLogs).toContain('[vite] connected.')
     })
 
+    test('supports import.meta.hot.getExports', async () => {
+      expect(hmr('.exports')).toBe('{"foo":1}')
+    })
+
     test('self accept', async () => {
       const el = () => hmr('.app')
       await untilConsoleLogAfter(

--- a/playground/hmr-ssr/hmr.ts
+++ b/playground/hmr-ssr/hmr.ts
@@ -28,6 +28,10 @@ globalThis.__HMR__['virtual:increment'] = () => {
 }
 
 if (import.meta.hot) {
+  import.meta.hot.getExports().then((exports) => {
+    globalThis.__HMR__['.exports'] = JSON.stringify(exports)
+  })
+
   import.meta.hot.accept(({ foo }) => {
     log('(self-accepting 1) foo is now:', foo)
   })

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -29,6 +29,10 @@ if (!isBuild) {
     browserLogs.length = 0
   })
 
+  test('supports import.meta.hot.getExports', async () => {
+    expect(await page.textContent('.exports')).toBe('{"foo":1}')
+  })
+
   test('self accept', async () => {
     const el = await page.$('.app')
     await untilBrowserLogAfter(

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -40,6 +40,10 @@ btnDep.onclick = () => {
 }
 
 if (import.meta.hot) {
+  import.meta.hot.getExports().then((exports) => {
+    text('.exports', JSON.stringify(exports))
+  })
+
   import.meta.hot.accept(({ foo }) => {
     console.log('(self-accepting 1) foo is now:', foo)
   })

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -27,6 +27,7 @@
 <div class="virtual"></div>
 <div class="virtual-dep"></div>
 <div class="soft-invalidation"></div>
+<div class="exports"></div>
 <div class="invalidation-parent"></div>
 <div class="invalidation-root"></div>
 <div class="invalidation-circular-deps"></div>


### PR DESCRIPTION
### Description

The react plugin uses `import(import.meta.url)` to get the exports of the current module.
https://github.com/vitejs/vite-plugin-react/blob/e1d1eeaa5ceed5c8c8f8096f29e561f1f6a1f8d5/packages/common/refresh-utils.ts#L84
This does not work in full-bundle mode, because `import.meta.url` will point to the bundled file rather than the original module.

This PR adds `import.meta.hot.getExports` which returns the exports of the current module.

Alternative way to achieve this is to replace `import(import.meta.url)` in transform hook. The downside of that is that `import(` will appear in all react modules and would make dynamic import plugin to run on all of those modules.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
