### PR TITLE
docs: clarify cspNonce limitations for SPA deployments

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -227,6 +227,7 @@ If using JSX with your own framework, custom `jsxFactory` and `jsxFragment` can 
 ```js twoslash [vite.config.js]
 import { defineConfig } from 'vite'
 
+// using Preact instead of React
 export default defineConfig({
   esbuild: {
     jsxFactory: 'h',
@@ -242,6 +243,7 @@ You can inject the JSX helpers using `jsxInject` (which is a Vite-only option) t
 ```js twoslash [vite.config.js]
 import { defineConfig } from 'vite'
 
+// automatically inject React into JSX files
 export default defineConfig({
   esbuild: {
     jsxInject: `import React from 'react'`,

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -777,12 +777,7 @@ Ensure that you replace the placeholder with a unique value for each request. Th
 :::
 
 :::tip Limitations in SPA deployments
-When deploying as a Single Page Application (SPA), be aware that the nonce value is only set in the initial HTML.
-Because navigation in an SPA does not reload the HTML document, the nonce meta tag will not be refreshed on
-subsequent requests. This means that enforcing CSP with nonces in a pure SPA deployment is not fully reliable.
-
-For stronger guarantees, prefer using SSR or serving fresh HTML responses per request so that a new nonce
-can be injected dynamically.
+The CSP specification requires generating a unique nonce for each HTTP response. In a pure SPA, client-side navigations do not reload the HTML document, so the nonce is not rotated automatically after the initial load. This is fine per the spec, but you must propagate the current document’s nonce to any scripts created at runtime, or use `strict-dynamic` from a trusted bootstrap script. If you rely on per-navigation rotation or need policy changes between routes, serve a fresh HTML response (SSR/MPA).
 :::
 
 ### [`data:`](<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#scheme-source:~:text=schemes%20(not%20recommended).-,data%3A,-Allows%20data%3A>)

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -774,6 +774,15 @@ The nonce value of a meta tag with `property="csp-nonce"` will be used by Vite w
 Ensure that you replace the placeholder with a unique value for each request. This is important to prevent bypassing a resource's policy, which can otherwise be easily done.
 :::
 
+:::tip Limitations in SPA deployments
+When deploying as a Single Page Application (SPA), be aware that the nonce value is only set in the initial HTML.
+Because navigation in an SPA does not reload the HTML document, the nonce meta tag will not be refreshed on
+subsequent requests. This means that enforcing CSP with nonces in a pure SPA deployment is not fully reliable.
+
+For stronger guarantees, prefer using SSR or serving fresh HTML responses per request so that a new nonce
+can be injected dynamically.
+:::
+
 ### [`data:`](<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#scheme-source:~:text=schemes%20(not%20recommended).-,data%3A,-Allows%20data%3A>)
 
 By default, during build, Vite inlines small assets as data URIs. Allowing `data:` for related directives (e.g. [`img-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src), [`font-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src)), or, disabling it by setting [`build.assetsInlineLimit: 0`](/config/build-options#build-assetsinlinelimit) is necessary.


### PR DESCRIPTION
The CSP spec only requires generating a unique nonce per HTML response.
In SPAs, client-side navigations do not reload the document, so the
original nonce is not rotated automatically. This is not a spec violation,
but in practice it means that nonce-based CSP requires either propagating
the current nonce to dynamically created scripts or using `strict-dynamic`
from a trusted bootstrap script.

For cases where per-navigation rotation or policy changes are required,
SSR or serving fresh HTML responses per route is recommended.