### PR TITLE
chore: clarify HTTP/2 server compatibility with Connect app

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -138,8 +138,9 @@ export async function resolveHttpServer(
         ...httpsOptions,
         allowHTTP1: true,
       },
-      // @ts-expect-error TODO: is this correct?
-      app,
+      // When allowHTTP1 is true, the HTTP/2 server can handle HTTP/1.1 requests,
+      // making the Connect app compatible as a request listener
+      app as unknown as Parameters<typeof createSecureServer>[1],
     )
   }
 }


### PR DESCRIPTION
Resolves the TODO comment in resolveHttpServer by replacing @ts-expect-error with a proper type cast and explanatory comment.

When allowHTTP1: true is set, the HTTP/2 server can handle HTTP/1.1 requests, making the Connect app compatible as a request listener since:
- Http2ServerRequest extends IncomingMessage
- Http2ServerResponse extends ServerResponse
- The server operates in HTTP/1.1 compatibility mode

This change improves code clarity and maintainability by removing the ambiguous TODO and explaining the type compatibility.

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
