### PR TITLE
fix: pass rollup watch options when building in watch mode

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -726,7 +726,10 @@ async function buildEnvironment(
         logger,
       )
       const resolvedChokidarOptions = resolveChokidarOptions(
-        options.watch.chokidar,
+        {
+          ...(rollupOptions.watch || {}).chokidar,
+          ...options.watch.chokidar,
+        },
         resolvedOutDirs,
         emptyOutDir,
         environment.config.cacheDir,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -736,6 +736,7 @@ async function buildEnvironment(
       const watcher = watch({
         ...rollupOptions,
         watch: {
+          ...rollupOptions.watch,
           ...options.watch,
           chokidar: resolvedChokidarOptions,
         },


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

* fixed #20673 

When building in watch mode the rollup options passed in `build.rollupOptions.watch` were not forwarded.
This is sometimes needed because directly passing them using `build.watch` will enforce building in watch mode (see #20657 ) meaning you can no longer build in non-watch mode.

My use case to do this is settings `allowInputInsideOutputPath` while still allow warch and non-watch builds.
    },

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
