### PR TITLE
docs(server): add reference link for 'server.watcher' null behavior

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -256,7 +256,7 @@ File system watcher options to pass on to [chokidar](https://github.com/paulmill
 
 The Vite server watcher watches the `root` and skips the `.git/`, `node_modules/`, `test-results/`, and Vite's `cacheDir` and `build.outDir` directories by default. When updating a watched file, Vite will apply HMR and update the page only if needed.
 
-If set to `null`, no files will be watched. `server.watch` will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
+If set to `null`, no files will be watched. [`server.watcher`](/guide/api-javascript.html#vitedevserver) will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
 
 ::: warning Watching files in `node_modules`
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -256,7 +256,7 @@ File system watcher options to pass on to [chokidar](https://github.com/paulmill
 
 The Vite server watcher watches the `root` and skips the `.git/`, `node_modules/`, `test-results/`, and Vite's `cacheDir` and `build.outDir` directories by default. When updating a watched file, Vite will apply HMR and update the page only if needed.
 
-If set to `null`, no files will be watched. `server.watcher` will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
+If set to `null`, no files will be watched. `server.watch` will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
 
 ::: warning Watching files in `node_modules`
 


### PR DESCRIPTION
### Description
This PR adds a reference link in the documentation for the `server.watcher` option regarding its behavior when set to `null`.  
The documentation states:  
If set to `null`, no files will be watched. `server.watcher` will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.  
This PR adds a link to the [`server.watcher` API](https://vite.dev/guide/api-javascript.html#vitedevserver) for further details.

### What was changed
- Added a link to the `server.watcher` API documentation in the relevant sentence about its behavior when set to `null`.

### Why this change is necessary
- Improves usability and clarity by providing direct access to the detailed API documentation.
- Helps users understand the behavior and use of `server.watcher` more effectively.