### PR TITLE
docs(config): fix type of preview.allowedHosts to 'string[] | true'

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -21,7 +21,7 @@ See [`server.host`](./server-options#server-host) for more details.
 
 ## preview.allowedHosts
 
-- **Type:** `string | true`
+- **Type:** `string[] | true`
 - **Default:** [`server.allowedHosts`](./server-options#server-allowedhosts)
 
 The hostnames that Vite is allowed to respond to.


### PR DESCRIPTION
### Description
This PR fixes the type definition of `preview.allowedHosts` in the Vite documentation.  
The type was incorrectly specified as `string | true`, but it should be `string[] | true` to align with the actual implementation and `server.allowedHosts` type.
```ts
interface CommonServerOptions {
  /**
   * The hostnames that Vite is allowed to respond to.
   * `localhost` and subdomains under `.localhost` and all IP addresses are allowed by default.
   * When using HTTPS, this check is skipped.
   *
   * If a string starts with `.`, it will allow that hostname without the `.` and all subdomains under the hostname.
   * For example, `.example.com` will allow `example.com`, `foo.example.com`, and `foo.bar.example.com`.
   *
   * If set to `true`, the server is allowed to respond to requests for any hosts.
   * This is not recommended as it will be vulnerable to DNS rebinding attacks.
   */
  allowedHosts?: string[] | true;
}
```
<img width="219" height="255" alt="스크린샷 2025-08-27 오전 10 38 35" src="https://github.com/user-attachments/assets/c07fff76-e2e6-4427-b790-670d3874e94b" />

### What was changed
- Corrected the type of `preview.allowedHosts` from `string | true` to `string[] | true`.
- Kept the rest of the description and default value as is, linking to `server.allowedHosts` for details.

### Why this change is necessary
- Provides accurate and consistent documentation.
- Helps users understand the correct expected configuration type for `preview.allowedHosts`.
