### PR TITLE
chore: remove unused constants entry from rolldown.config.ts

### DIFF
--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -75,7 +75,6 @@ const nodeConfig = defineConfig({
   input: {
     index: path.resolve(__dirname, 'src/node/index.ts'),
     cli: path.resolve(__dirname, 'src/node/cli.ts'),
-    constants: path.resolve(__dirname, 'src/node/constants.ts'),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Description

There's no exports for constants defined in package.json and all exports from constants were already exported by `node/index.ts` so I think it's safe to remove it.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
