### PR TITLE
fix(create-vite): node@24.xxx fm.rmSync can‘t remove chinese file or folder #20724

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -604,7 +604,7 @@ function emptyDir(dir: string) {
     if (file === '.git') {
       continue
     }
-    fs.rmSync(path.resolve(dir, file), { recursive: true, force: true })
+    fs.promises.rm(path.resolve(dir, file), { recursive: true, force: true })
   }
 }
 

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -596,7 +596,7 @@ function isEmpty(path: string) {
   return files.length === 0 || (files.length === 1 && files[0] === '.git')
 }
 
-function emptyDir(dir: string) {
+assync function emptyDir(dir: string) {
   if (!fs.existsSync(dir)) {
     return
   }
@@ -604,7 +604,7 @@ function emptyDir(dir: string) {
     if (file === '.git') {
       continue
     }
-    fs.rmSync(path.resolve(dir, file), { recursive: true, force: true })
+    await fs.promises.rm(path.resolve(dir, file), { recursive: true, force: true })
   }
 }
 


### PR DESCRIPTION
## Description
Fix issue where `rmSync` fails to remove files and folders with Chinese names when using create-vite on Node.js 24.

## Changes
- Replace `fs.rmSync()` with `fs.rm()` promise variant
- Ensure proper handling of Unicode file names

Fixes #20724