### PR TITLE
refactor(create-vite): migrate `tseslint.config` to ESLint core's `defineConfig`

### DIFF
--- a/packages/create-vite/template-react-ts/README.md
+++ b/packages/create-vite/template-react-ts/README.md
@@ -12,7 +12,7 @@ Currently, two official plugins are available:
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
 
 ```js
-export default tseslint.config([
+export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{ts,tsx}'],
@@ -20,11 +20,11 @@ export default tseslint.config([
       // Other configs...
 
       // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
+      tseslint.configs.recommendedTypeChecked,
       // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
+      tseslint.configs.strictTypeChecked,
       // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
 
       // Other configs...
     ],
@@ -46,7 +46,7 @@ You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-re
 import reactX from 'eslint-plugin-react-x'
 import reactDom from 'eslint-plugin-react-dom'
 
-export default tseslint.config([
+export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{ts,tsx}'],

--- a/packages/create-vite/template-react-ts/eslint.config.js
+++ b/packages/create-vite/template-react-ts/eslint.config.js
@@ -3,9 +3,9 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import { defineConfig, globalIgnores } from 'eslint/config'
 
-export default tseslint.config([
+export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{ts,tsx}'],


### PR DESCRIPTION
This PR updates the ESLint configuration for the React + TypeScript template, aligning it with the latest [typescript-eslint v8.42.0 release](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.42.0), where `tseslint.config(...)` was deprecated.

### Changes

- Migrated the ESLint config from `tseslint.config(...)` to ESLint core’s [`defineConfig(...)`](https://eslint.org/docs/latest/use/configure/configuration-files#using-defineconfig).  
- Updated the README to replace usage examples with `defineConfig`.  
- Removed unnecessary spread operator (`...`) inside `extends`, since `extends` can directly accept an array of configurations without spread syntax.

### References

- Deprecation of `tseslint.config(...)`: [typescript-eslint v8.42.0 release notes](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.42.0)  
- Migration discussion: [typescript-eslint/typescript-eslint#10935](https://github.com/typescript-eslint/typescript-eslint/issues/10935)
- Migration guide: [Migrating to `defineConfig`](https://typescript-eslint.io/packages/typescript-eslint/#migrating-to-defineconfig)
- ESLint docs on `extends` supporting arrays: [Extending Configurations](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configurations)