### PR TITLE
feat: use 'native' config loader in Deno by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -25,7 +25,7 @@ vite --config my-config.js
 ::: tip CONFIG LOADING
 By default, Vite uses `esbuild` to bundle the config into a temporary file and load it. This may cause issues when importing TypeScript files in a monorepo. If you encounter any issues with this approach, you can specify `--configLoader runner` to use the [module runner](/guide/api-environment-runtimes.html#modulerunner) instead, which will not create a temporary config and will transform any files on the fly. Note that module runner doesn't support CJS in config files, but external CJS packages should work as usual.
 
-Alternatively, if you're using an environment that supports TypeScript (e.g. `node --experimental-strip-types`), or if you're only writing plain JavaScript, you can specify `--configLoader native` to use the environment's native runtime to load the config file. Note that updates to modules imported by the config file are not detected and hence would not auto-restart the Vite server.
+Alternatively, if you're using an environment that supports TypeScript (e.g. `node --experimental-strip-types`), or if you're only writing plain JavaScript, you can specify `--configLoader native` to use the environment's native runtime to load the config file. When using Deno, vite will pick the `native` loader by default. Note that updates to modules imported by the config file are not detected and hence would not auto-restart the Vite server.
 :::
 
 ## Config Intellisense

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1801,13 +1801,22 @@ export function sortUserPlugins(
   return [prePlugins, normalPlugins, postPlugins]
 }
 
+function getDefaultConfigLoader(): 'bundle' | 'runner' | 'native' {
+  // Deno supports running TS/TSX files natively
+  if (typeof process.versions.deno === 'string') {
+    return 'native'
+  }
+
+  return 'bundle'
+}
+
 export async function loadConfigFromFile(
   configEnv: ConfigEnv,
   configFile?: string,
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
-  configLoader: 'bundle' | 'runner' | 'native' = 'bundle',
+  configLoader: 'bundle' | 'runner' | 'native' = getDefaultConfigLoader(),
 ): Promise<{
   path: string
   config: UserConfig


### PR DESCRIPTION
### Description

Deno supports loading TS/TSX files natively out of the box, so there is no need to transpile the config file.
