### PR TITLE
fix: fallback terser to main thread when nameCache is provided

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/terser.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/terser.spec.ts
@@ -27,7 +27,12 @@ describe('terser', () => {
           },
           load(id) {
             if (id === '\0entry.js') {
-              return `const foo = 1;console.log(foo)`
+              return `
+                const foo = 1;
+                console.log(foo);
+                const bar = { hello: 1, ["world"]: 2 };
+                console.log(bar.hello + bar["world"]);
+              `
             }
           },
         },
@@ -51,5 +56,22 @@ describe('terser', () => {
       },
     })
     expect(resultCode).toContain('prefix_')
+  })
+
+  test('nameCache', async () => {
+    const nameCache = {}
+
+    await run({
+      compress: false,
+      mangle: {
+        properties: {
+          keep_quoted: true,
+        },
+      },
+      nameCache,
+    })
+
+    expect(nameCache).toHaveProperty('props.props.$hello')
+    expect(nameCache).not.toHaveProperty('props.props.$world')
   })
 })

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -66,7 +66,8 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
                 (typeof options.mangle.properties === 'object' &&
                   options.mangle.properties.nth_identifier?.get))) ||
             typeof options.format?.comments === 'function' ||
-            typeof options.output?.comments === 'function'
+            typeof options.output?.comments === 'function' ||
+            options.nameCache
           )
         },
         max: maxWorkers,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR fixes #20751 
When nameCache is provided, it gets cloned for each worker thread, resulting in isolated caches that are not synchronized back to the main thread. This causes the nameCache to be ineffective.

Fix: Fallback to running Terser in the main thread when a nameCache is provided, ensuring the cache is shared and updated correctly.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
