### PR TITLE
fix(types): strict env typings fail when `skipLibCheck` is `false`

### DIFF
--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -11,8 +11,7 @@ interface ViteTypeOptions {
 type ImportMetaEnvFallbackKey =
   'strictImportMetaEnv' extends keyof ViteTypeOptions ? never : string
 
-interface ImportMetaEnv {
-  [key: ImportMetaEnvFallbackKey]: any
+interface ImportMetaEnv extends Record<ImportMetaEnvFallbackKey, any> {
   BASE_URL: string
   MODE: string
   DEV: boolean


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

The issue is that when setting `ViteTypeOptions.strictImportMetaEnv`, like in the [docs](https://vite.dev/guide/env-and-mode.html#intellisense-for-typescript):

```ts
// vite-env.d.ts

/// <reference types="vite/client" />

interface ViteTypeOptions {
  strictImportMetaEnv: unknown;
}
```

It causes `tsc` to fail if `compilerOptions.skipLibCheck` is set to `false`:

```sh
node_modules/vite/types/importMeta.d.ts:15:4 - error TS1268: An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type.

15   [key: ImportMetaEnvFallbackKey]: any
      ~~~


Found 1 error in node_modules/vite/types/importMeta.d.ts:15
```

Im sorry if this has been brought up before, I couldn't find any reference to it 🙂 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
