### PR TITLE
feat(vite): expose injectEnvironmentToHooks

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1083,6 +1083,9 @@ function isExternal(id: string, test: string | RegExp) {
   }
 }
 
+/**
+ * Inject an environment into the hooks of a plugin.
+ */
 export function injectEnvironmentToHooks(
   environment: Environment,
   plugin: Plugin,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -12,7 +12,7 @@ export { perEnvironmentPlugin } from './plugin'
 export { perEnvironmentState } from './environment'
 export { createServer } from './server'
 export { preview } from './preview'
-export { build, createBuilder } from './build'
+export { build, createBuilder, injectEnvironmentToHooks } from './build'
 
 export { optimizeDeps } from './optimizer'
 export { createIdResolver } from './idResolver'


### PR DESCRIPTION
### Description

- Implements #20720 
- Exposing this function allows for more flexibility when working with rollup directly, especially in worker contexts. To that end, using `injectEnvironmentToHooks` allows to pass vite plugins directly to rollup.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
