### PR TITLE
fix(dev): allow aliases starting with `//`

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -512,8 +512,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           if (specifier !== undefined) {
             // skip external / data uri
             if (
-              (isExternalUrl(specifier) && !specifier.startsWith('file://')) ||
-              isDataUrl(specifier)
+              ((isExternalUrl(specifier) && !specifier.startsWith('file://')) ||
+                isDataUrl(specifier)) &&
+              !matchAlias(specifier)
             ) {
               return
             }

--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -46,6 +46,12 @@ test('aliased module', async () => {
   )
 })
 
+test('url conflict alias', async () => {
+  expect(await page.textContent('.url-conflict')).toMatch(
+    '[success] url conflict alias',
+  )
+})
+
 test('custom resolver', async () => {
   expect(await page.textContent('.custom-resolver')).toMatch(
     '[success] alias to custom-resolver path',

--- a/playground/alias/dir/url_conflict.js
+++ b/playground/alias/dir/url_conflict.js
@@ -1,0 +1,1 @@
+export const msg = `[success] url conflict alias`

--- a/playground/alias/index.html
+++ b/playground/alias/index.html
@@ -5,6 +5,7 @@
 <p class="regex"></p>
 <p class="dep"></p>
 <p class="from-script-src"></p>
+<p class="url-conflict"></p>
 <p class="aliased-module"></p>
 <p class="custom-resolver"></p>
 
@@ -17,6 +18,7 @@
   import { msg as regexMsg } from 'regex/test'
   import { msg as depMsg } from 'dep'
   import { msg as moduleMsg } from 'aliased-module/index.js'
+  import { msg as urlConflictMsg } from '//url_conflict.js'
   import { msg as customResolverMsg } from 'custom-resolver'
 
   function text(el, text) {
@@ -28,6 +30,7 @@
   text('.regex', regexMsg + ' via regex')
   text('.dep', depMsg)
   text('.aliased-module', moduleMsg)
+  text('.url-conflict', urlConflictMsg)
   text('.custom-resolver', customResolverMsg)
 
   import { createApp } from 'vue'

--- a/playground/alias/vite.config.js
+++ b/playground/alias/vite.config.js
@@ -15,6 +15,8 @@ export default defineConfig({
         replacement: `${path.resolve(__dirname, 'dir')}/$1`,
       },
       { find: '/@', replacement: path.resolve(__dirname, 'dir') },
+      // aliasing a pattern that conflicts with url schemes
+      { find: /^\/\//, replacement: path.join(__dirname, 'dir/') },
       // aliasing an optimized dep
       { find: 'vue', replacement: 'vue/dist/vue.esm-bundler.js' },
       // aliasing an optimized dep to absolute URL


### PR DESCRIPTION
### Description

Fix alias resolution being incorrectly skipped for URL-like patterns in dev server.

**Problem**

When an alias pattern resembles a URL (e.g., `{ find: '//', replace: '...' }`), the dev server's import analysis plugin incorrectly treats imports like `//foo` as external URLs and skips alias resolution ([codepointer](https://github.com/vitejs/vite/blob/a679a64/packages/vite/src/node/plugins/importAnalysis.ts#L515)). This causes:

1. **Inconsistency with build:** `vite build` correctly applies these aliases while dev server doesn't
2. **Broken aliases:** Any alias matching URL patterns (scheme-relative, file://, etc.) fails in dev mode

**Solution**

Check if an import matches an alias before skipping it as an external URL.

### Testing

Added test case in `playground/alias/` that:
- Defines an alias with URL-like pattern (`//` prefix)
- Verifies it resolves correctly in dev server
- Test passes with fix, fails without it

### Risks

None. Projects with URL-pattern aliases are already broken in dev mode, this fixes them without impacting other flows.
