### PR TITLE
feat: remove unused assets css in dist

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -230,6 +230,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     generateBundle(_, bundle) {
       // Remove empty entry point file
       let importedFiles: Set<string> | undefined
+      const importedCssAssets = new Set<string>()
       for (const file in bundle) {
         const chunk = bundle[file]
         if (
@@ -254,6 +255,24 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
             }
           }
           if (!importedFiles.has(file)) {
+            delete bundle[file]
+          }
+        }
+        if (chunk.type === 'chunk' && chunk.viteMetadata) {
+          for (const importedAsset of chunk.viteMetadata.importedAssets) {
+            importedCssAssets.add(importedAsset)
+          }
+          for (const importedCss of chunk.viteMetadata.importedCss) {
+            importedCssAssets.add(importedCss)
+          }
+        }
+      }
+
+      // Remove CSS and assets that were not imported by any chunk
+      for (const file in bundle) {
+        const chunk = bundle[file]
+        if (chunk.type === 'asset' && importedCssAssets) {
+          if (!importedCssAssets.has(cleanUrl(chunk.fileName))) {
             delete bundle[file]
           }
         }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -271,7 +271,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       // Remove CSS and assets that were not imported by any chunk
       for (const file in bundle) {
         const chunk = bundle[file]
-        if (chunk.type === 'asset' && importedCssAssets) {
+        if (chunk.type === 'asset' && importedCssAssets.size > 0) {
           if (!importedCssAssets.has(cleanUrl(chunk.fileName))) {
             delete bundle[file]
           }


### PR DESCRIPTION
### Description

When one imports an asset (let's say .svg) using import.meta.glob(..., { eager: true, import: 'default' }) new path will be inlined in a const and then this const get's tree-shaked/optimized, corresponding asset is not excluded from the final build.

It's expected that no unused assets, especially heavy ones like fonts and images, are not included in final build.

Fix: https://github.com/vitejs/vite/issues/19949
Ref: https://github.com/BerkliumBirb/vite-broken-tree-shaking

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
