### PR TITLE
fix(create-vite): unique name for tanstack router options

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -144,7 +144,7 @@ const FRAMEWORKS: Framework[] = [
         customCommand: 'npm create react-router@latest TARGET_DIR',
       },
       {
-        name: 'custom-tanstack-router',
+        name: 'custom-tanstack-router-react',
         display: 'TanStack Router ↗',
         color: cyan,
         customCommand:
@@ -245,7 +245,7 @@ const FRAMEWORKS: Framework[] = [
         color: yellow,
       },
       {
-        name: 'custom-tanstack-router',
+        name: 'custom-tanstack-router-solid',
         display: 'TanStack Router ↗',
         color: cyan,
         customCommand:


### PR DESCRIPTION
### Description

Resolves https://github.com/vitejs/vite/issues/20782

Due to the duplicate name, selecting the TanStack Router Solid template always uses the react command accidentally
