### PR TITLE
fix(client): use CSP nonce when rendering error overlay

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -6,7 +6,7 @@ import {
   normalizeModuleRunnerTransport,
 } from '../shared/moduleRunnerTransport'
 import { createHMRHandler } from '../shared/hmrHandler'
-import { ErrorOverlay, overlayId } from './overlay'
+import { ErrorOverlay, cspNonce, overlayId } from './overlay'
 import '@vite/env'
 
 // injected by the hmr plugin when served
@@ -505,11 +505,6 @@ if ('document' in globalThis) {
       sheetsMap.set(el.getAttribute('data-vite-dev-id')!, el)
     })
 }
-
-const cspNonce =
-  'document' in globalThis
-    ? document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')?.nonce
-    : undefined
 
 // all css imports should be inserted at the same position
 // because after build it will be a single css file

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -7,15 +7,22 @@ declare const __HMR_CONFIG_NAME__: string
 const hmrConfigName = __HMR_CONFIG_NAME__
 const base = __BASE__ || '/'
 
+export const cspNonce =
+  'document' in globalThis
+    ? document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')?.nonce
+    : undefined
+
 // Create an element with provided attributes and optional children
 function h(
   e: string,
-  attrs: Record<string, string> = {},
+  attrs: Record<string, string | undefined> = {},
   ...children: (string | Node)[]
 ) {
   const elem = document.createElement(e)
   for (const [k, v] of Object.entries(attrs)) {
-    elem.setAttribute(k, v)
+    if (v !== undefined) {
+      elem.setAttribute(k, v)
+    }
   }
   elem.append(...children)
   return elem
@@ -197,7 +204,7 @@ const createTemplate = () =>
         '.',
       ),
     ),
-    h('style', {}, templateStyle),
+    h('style', { nonce: cspNonce }, templateStyle),
   )
 
 const fileRE = /(?:file:\/\/)?(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g


### PR DESCRIPTION
### Description

The [error overlay](https://github.com/vitejs/vite/blob/91e68a3015bdf30667ba9365f8fc51d3571f10d0/packages/vite/src/client/overlay.ts#L200) currently doesn't use the `cspNonce` from [client](https://github.com/vitejs/vite/blob/91e68a3015bdf30667ba9365f8fc51d3571f10d0/packages/vite/src/client/client.ts#L509), so when a strict CSP is enabled, the error overlay looks broken.



<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
