### PR TITLE
docs: fix `buildApp` type mismatch in code example

### DIFF
--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -315,7 +315,7 @@ export default {
   builder: {
     buildApp: async (builder) => {
       const environments = Object.values(builder.environments)
-      return Promise.all(
+      await Promise.all(
         environments.map((environment) => builder.build(environment)),
       )
     },


### PR DESCRIPTION
### Description

`buildApp` returns `Promise<void> | undefined`, so using this example as is results in a type error