### PR TITLE
fix(create-vite): support deno create command

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -658,6 +658,10 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
         if (pkgManager === 'bun') {
           return 'bun x create-'
         }
+        // Deno uses `init --npm` instead of `create`
+        if (pkgManager === 'deno') {
+          return 'deno init --npm '
+        }
         // pnpm doesn't support the -- syntax
         if (pkgManager === 'pnpm') {
           return 'pnpm create '

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -658,9 +658,9 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
         if (pkgManager === 'bun') {
           return 'bun x create-'
         }
-        // Deno uses `init --npm` instead of `create`
+        // Deno uses `run -A npm:create-` instead of `create` or `init` to also provide needed perms
         if (pkgManager === 'deno') {
-          return 'deno init --npm '
+          return 'deno run -A npm:create-'
         }
         // pnpm doesn't support the -- syntax
         if (pkgManager === 'pnpm') {
@@ -673,20 +673,23 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
       })
       // Only Yarn 1.x doesn't support `@version` in the `create` command
       .replace('@latest', () => (isYarn1 ? '' : '@latest'))
-      .replace(/^npm exec/, () => {
+      .replace(/^npm exec /, () => {
         // Prefer `pnpm dlx`, `yarn dlx`, or `bun x`
         if (pkgManager === 'pnpm') {
-          return 'pnpm dlx'
+          return 'pnpm dlx '
         }
         if (pkgManager === 'yarn' && !isYarn1) {
-          return 'yarn dlx'
+          return 'yarn dlx '
         }
         if (pkgManager === 'bun') {
-          return 'bun x'
+          return 'bun x '
+        }
+        if (pkgManager === 'deno') {
+          return 'deno run -A npm:'
         }
         // Use `npm exec` in all other cases,
         // including Yarn 1.x and other custom npm clients.
-        return 'npm exec'
+        return 'npm exec '
       })
   )
 }


### PR DESCRIPTION
### Description

fixes #20804

Finally got around to fixing the issue I reported in #20804

some caveats:
- some option from tsrouter will not work, but this more of a tsrouter problem, not vite. Overall not an issue

```bash
◇  Installed dependencies
│
◇  Solid-UI commands complete
│
└  Your TanStack app is ready in 'TARGET_DIR'.

Use the following commands to start your app:
% cd TARGET_DIR
% deno task dev

Please check the README.md for information on testing, styling, adding routes, etc.

Errors were encountered during the creation of your app:

Command "npx solidui-cli@latest add button input" did not run successfully. Please run this manually in your project.
```