### PR TITLE
fix: keep ids for virtual modules as-is

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -463,7 +463,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
 
     if (id) {
       partial.id =
-        isExternalUrl(id) || id.startsWith('\0') ? id : normalizePath(id)
+        isExternalUrl(id) || id[0] === '\0' ? id : normalizePath(id)
       return partial as PartialResolvedId
     } else {
       return null

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -462,8 +462,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
     }
 
     if (id) {
-      partial.id =
-        isExternalUrl(id) || id[0] === '\0' ? id : normalizePath(id)
+      partial.id = isExternalUrl(id) || id[0] === '\0' ? id : normalizePath(id)
       return partial as PartialResolvedId
     } else {
       return null

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -462,7 +462,8 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
     }
 
     if (id) {
-      partial.id = isExternalUrl(id) ? id : normalizePath(id)
+      partial.id =
+        isExternalUrl(id) || id.startsWith('\0') ? id : normalizePath(id)
       return partial as PartialResolvedId
     } else {
       return null

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -163,6 +163,10 @@ test('plugin resolved custom virtual file', async () => {
   expect(await page.textContent('.custom-virtual')).toMatch('[success]')
 })
 
+test('virtual file with URL scheme should not be rewritten (#20803)', async () => {
+  expect(await page.textContent('.virtual-url-scheme')).toMatch('[success]')
+})
+
 test('resolve inline package', async () => {
   expect(await page.textContent('.inline-pkg')).toMatch('[success]')
 })

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -158,6 +158,9 @@
 <h2>Plugin resolved custom virtual file</h2>
 <p class="custom-virtual"></p>
 
+<h2>Virtual file with URL scheme</h2>
+<p class="virtual-url-scheme"></p>
+
 <h2>Inline package</h2>
 <p class="inline-pkg"></p>
 
@@ -393,6 +396,9 @@
 
   import { msg as customVirtualMsg } from '@custom-virtual-file'
   text('.custom-virtual', customVirtualMsg)
+
+  import { msg as virtualUrlSchemeMsg } from 'virtual-with-scheme'
+  text('.virtual-url-scheme', virtualUrlSchemeMsg)
 
   import { msg as inlineMsg } from './inline-package'
   text('.inline-pkg', inlineMsg)

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -10,6 +10,9 @@ const virtualId9036 = '\0' + virtualFile9036
 
 const customVirtualFile = '@custom-virtual-file'
 
+const virtualFileWithScheme = 'virtual-with-scheme'
+const virtualIdWithScheme = '\0https://example.com/virtual.js'
+
 const generatedContentVirtualFile = '@generated-content-virtual-file'
 const generatedContentImports = [
   {
@@ -74,6 +77,19 @@ export default defineConfig({
       load(id) {
         if (id === customVirtualFile) {
           return `export const msg = "[success] from custom virtual file"`
+        }
+      },
+    },
+    {
+      name: 'virtual-url-scheme-test',
+      resolveId(id) {
+        if (id === virtualFileWithScheme) {
+          return virtualIdWithScheme
+        }
+      },
+      load(id) {
+        if (id === virtualIdWithScheme) {
+          return `export const msg = "[success] from virtual file with URL scheme"`
         }
       },
     },


### PR DESCRIPTION
### Description

Vite applies the `normalizePath` function for ids that doesn't look like an external url. But that means the normalization is applied to ids that follows the virtual module convention as well. In that case, it is more intuitive to keep the path as-is.
Because this behavior existed since the initial 2.0.0 release, there may be plugins that relies on this behavior. We need to decide whether this change is acceptable. Note that this is a dev-only behavior because the logic only exists in the plugin container...

fixes #20803
refs https://github.com/vitejs/vite/commit/abf784403e1d9e36653ee4fd167c4cf341fd343f
refs https://vite.dev/guide/api-plugin.html#path-normalization

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
