### PR TITLE
fix(create-vite): stop process when Ctrl+C is pressed

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -347,7 +347,7 @@ const renameFiles: Record<string, string | undefined> = {
 const defaultTargetDir = 'vite-project'
 
 function run(...params: Parameters<typeof spawn.sync>) {
-  const { status, error } = spawn.sync(...params)
+  const { status, error, signal } = spawn.sync(...params)
   if (status != null && status > 0) {
     process.exit(status)
   }
@@ -356,6 +356,10 @@ function run(...params: Parameters<typeof spawn.sync>) {
     console.error(`\n${params.slice(0, -1).join(' ')} error!`)
     console.error(error)
     process.exit(1)
+  }
+
+  if (signal) {
+    process.emit(signal)
   }
 }
 


### PR DESCRIPTION
### Description

After the dev server is started with the auto start feature, pressing Ctrl+C did not exit the whole command (it had to be pressed twice).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
