### PR TITLE
fix(create-vite): use shorter command name for `run dev` for each package manager

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -379,7 +379,7 @@ function start(root: string, agent: string) {
     return
   }
   prompts.log.step('Starting dev server...')
-  run(agent, agent === 'npm' ? ['run', 'dev'] : ['dev'], {
+  run(agent, agent === 'yarn' ? ['dev'] : ['run', 'dev'], {
     stdio: 'inherit',
     cwd: root,
   })

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -367,7 +367,7 @@ function install(root: string, agent: string) {
     return
   }
   prompts.log.step(`Installing dependencies with ${agent}...`)
-  run(agent, agent === 'yarn' ? [] : ['install'], {
+  run(agent, getInstallCommand(agent), {
     stdio: 'inherit',
     cwd: root,
   })
@@ -379,7 +379,7 @@ function start(root: string, agent: string) {
     return
   }
   prompts.log.step('Starting dev server...')
-  run(agent, agent === 'yarn' ? ['dev'] : ['run', 'dev'], {
+  run(agent, getRunCommand(agent, 'dev'), {
     stdio: 'inherit',
     cwd: root,
   })
@@ -681,16 +681,8 @@ async function init() {
         cdProjectName.includes(' ') ? `"${cdProjectName}"` : cdProjectName
       }`
     }
-    switch (pkgManager) {
-      case 'yarn':
-        doneMessage += '\n  yarn'
-        doneMessage += '\n  yarn dev'
-        break
-      default:
-        doneMessage += `\n  ${pkgManager} install`
-        doneMessage += `\n  ${pkgManager} run dev`
-        break
-    }
+    doneMessage += `\n  ${getInstallCommand(pkgManager).join(' ')}`
+    doneMessage += `\n  ${getRunCommand(pkgManager, 'dev').join(' ')}`
     prompts.outro(doneMessage)
   }
 }
@@ -833,6 +825,26 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
         return 'npm exec '
       })
   )
+}
+
+function getInstallCommand(agent: string) {
+  if (agent === 'yarn') {
+    return [agent]
+  }
+  return [agent, 'install']
+}
+
+function getRunCommand(agent: string, script: string) {
+  switch (agent) {
+    case 'yarn':
+    case 'pnpm':
+    case 'bun':
+      return [agent, script]
+    case 'deno':
+      return [agent, 'task', script]
+    default:
+      return [agent, 'run', script]
+  }
 }
 
 init().catch((e) => {


### PR DESCRIPTION
### Description

To align with
https://github.com/vitejs/vite/blob/d7d634c0415812dc1ca4f343368906e6f8253158/packages/create-vite/src/index.ts#L702-L711

Also `deno dev` doesn't work.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
