### PR TITLE
fix(server): drain stdin when not interactive

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1634,12 +1634,17 @@ const parentSigtermCallback: SigtermCallback = async (signal, exitCode) => {
   await Promise.all([...sigtermCallbacks].map((cb) => cb(signal, exitCode)))
 }
 
+const drain = () => {}
+
 export const setupSIGTERMListener = (
   callback: (signal?: 'SIGTERM', exitCode?: number) => Promise<void>,
 ): void => {
   if (sigtermCallbacks.size === 0) {
     process.once('SIGTERM', parentSigtermCallback)
     if (process.env.CI !== 'true') {
+      if (!process.stdin.isTTY) {
+        process.stdin.on('data', drain)
+      }
       process.stdin.on('end', parentSigtermCallback)
     }
   }
@@ -1653,6 +1658,7 @@ export const teardownSIGTERMListener = (
   if (sigtermCallbacks.size === 0) {
     process.off('SIGTERM', parentSigtermCallback)
     if (process.env.CI !== 'true') {
+      process.stdin.off('data', drain)
       process.stdin.off('end', parentSigtermCallback)
     }
   }


### PR DESCRIPTION
### Description

If stdin.on('data') isn't called, 'end' is never emitted. This works in interactive mode (ie. stdin.isTTY) since readline drains stdin.


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
