### PR TITLE
Make SPA fallback try each directory component

### DIFF
--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -63,8 +63,20 @@ export function htmlFallbackMiddleware(
     }
 
     if (spaFallback) {
-      debug?.(`Rewriting ${req.method} ${req.url} to /index.html`)
-      req.url = '/index.html'
+      // remove a path component at a time from pathname and check for
+      // the presence of a corresponding index.html
+      let workingPathname = pathname
+      while (true) {
+        const filePath = path.join(root, workingPathname, 'index.html')
+        if (fs.existsSync(filePath)) {
+          const newUrl = workingPathname + '/index.html'
+          debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`)
+          req.url = newUrl
+          return next()
+        }
+        if (workingPathname === '/') break
+        workingPathname = path.dirname(workingPathname)
+      }
     }
 
     next()


### PR DESCRIPTION
This PR adds logic to make SPA fallback look for a corresponding index.html for each directory component all the way down to root.

In dev mode if the browser requests /foo/bar we will try looking for an index.html like this:
* <root>/foo/bar/index.html
* <root>/foo/index.html
* <root>/index.html

This way if you're developing a suite of single page applications that use SPA routing you should no longer get not found errors when you refresh/go direct as posted about [here](https://stackoverflow.com/questions/79372590/how-to-configure-multi-page-routing-in-vite-to-avoid-not-found-error-on-direct).

This is my first contribution - would be great to get some indication of whether or not a PR like this is likely to be accepted before I go writing tests/updating docs - just let me know what is needed.