### PR TITLE
- fix: A bug fix

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1896,7 +1896,7 @@ type CssUrlReplacer = (
 ) => string | false | Promise<string | false>
 // https://drafts.csswg.org/css-syntax-3/#identifier-code-point
 export const cssUrlRE =
-  /(?<!@import\s+)(?<=^|[^\w\-\u0080-\uffff])url\((\s*('[^']+'|"[^"]+")\s*|[^'")]+)\)/
+  /(?<!@import\s+)(?<=^|[^\w\-\u0080-\uffff])url\(\s*(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|((?:\\.|[^\s'")\\])+))\s*\)/g
 export const cssDataUriRE =
   /(?<=^|[^\w\-\u0080-\uffff])data-uri\((\s*('[^']+'|"[^"]+")\s*|[^'")]+)\)/
 export const importCssRE =


### PR DESCRIPTION
Issue: Inline <style> url() with escaped \) is incorrectly transformed into invalid CSS #20816

Bug Description:

When an inline <style> contains an unquoted url(...) with an escaped ) (which is valid CSS syntax), Vite’s dev server transforms it into an invalid quoted form.

### Description of how I fixed and what I changed

I updated a const named cssUrlRe to a new and more robust regex.
This change was made on css.ts file.
That is everything!

OBS: I'm new to the contribuitor thing so don't be too harsh on me and test it, just trying to help!
