### PR TITLE
chore: replace `tseslint.config` with `defineConfig`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import pluginN from 'eslint-plugin-n'
 import pluginImportX from 'eslint-plugin-import-x'
 import pluginRegExp from 'eslint-plugin-regexp'
 import tseslint from 'typescript-eslint'
+import { defineConfig } from 'eslint/config'
 import globals from 'globals'
 
 const require = createRequire(import.meta.url)
@@ -15,7 +16,7 @@ const pkgVite = require('./packages/vite/package.json')
 // explicitly, set this to `true` manually.
 const shouldTypeCheck = typeof process.env.VSCODE_PID === 'string'
 
-export default tseslint.config(
+export default defineConfig(
   {
     ignores: [
       'packages/create-vite/template-*',


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

`tseslint.config` was deprecated in [typescript-eslint@8.42.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.42.0).
