### PR TITLE
chore: update url of `create-react-app` license

### DIFF
--- a/packages/vite/bin/openChrome.js
+++ b/packages/vite/bin/openChrome.js
@@ -3,7 +3,7 @@ Copyright (c) 2015-present, Facebook, Inc.
 
 This source code is licensed under the MIT license found in the
 LICENSE file at
-https://github.com/facebookincubator/create-react-app/blob/master/LICENSE
+https://github.com/facebook/create-react-app/blob/main/LICENSE
 */
 
 /* global Application */

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -4,7 +4,7 @@
  *
  * MIT Licensed
  * Copyright (c) 2015-present, Facebook, Inc.
- * https://github.com/facebook/create-react-app/blob/master/LICENSE
+ * https://github.com/facebook/create-react-app/blob/main/LICENSE
  *
  */
 


### PR DESCRIPTION
the url is changed. this is the correct url now (https://github.com/facebook/create-react-app/blob/main/LICENSE)