### PR TITLE
feat(dev): support HTTP2 even if proxy feature is used

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -92,8 +92,6 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 
 Enable TLS + HTTP/2. The value is an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
 
-Note that this downgrades to TLS only when the [`server.proxy` option](#server-proxy) is also used.
-
 A valid certificate is needed. For a basic setup, you can add [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) to the project plugins, which will automatically create and cache a self-signed certificate. But we recommend creating your own certificates.
 
 ## server.open

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -124,24 +124,18 @@ export async function resolveHttpServer(
     return createServer(app)
   }
 
-  // #484 fallback to http1 when proxy is needed.
-  if (proxy) {
-    const { createServer } = await import('node:https')
-    return createServer(httpsOptions, app)
-  } else {
-    const { createSecureServer } = await import('node:http2')
-    return createSecureServer(
-      {
-        // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM
-        // errors on large numbers of requests
-        maxSessionMemory: 1000,
-        ...httpsOptions,
-        allowHTTP1: true,
-      },
-      // @ts-expect-error TODO: is this correct?
-      app,
-    )
-  }
+  const { createSecureServer } = await import('node:http2')
+  return createSecureServer(
+    {
+      // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM
+      // errors on large numbers of requests
+      maxSessionMemory: 1000,
+      ...httpsOptions,
+      allowHTTP1: true,
+    },
+    // @ts-expect-error TODO: is this correct?
+    app,
+  )
 }
 
 export async function resolveHttpsConfig(

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -115,7 +115,6 @@ export interface CorsOptions {
 export type CorsOrigin = boolean | string | RegExp | (string | RegExp)[]
 
 export async function resolveHttpServer(
-  { proxy }: CommonServerOptions,
   app: Connect.Server,
   httpsOptions?: HttpsServerOptions,
 ): Promise<HttpServer> {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -146,7 +146,7 @@ export async function preview(
 
   const httpsOptions = await resolveHttpsConfig(config.preview.https)
   const app = connect() as Connect.Server
-  const httpServer = await resolveHttpServer(config.preview, app, httpsOptions)
+  const httpServer = await resolveHttpServer(app, httpsOptions)
   setClientErrorHandler(httpServer, config.logger)
 
   const options = config.preview

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -478,7 +478,7 @@ export async function _createServer(
   const middlewares = connect() as Connect.Server
   const httpServer = middlewareMode
     ? null
-    : await resolveHttpServer(serverConfig, middlewares, httpsOptions)
+    : await resolveHttpServer(middlewares, httpsOptions)
 
   const ws = createWebSocketServer(httpServer, config, httpsOptions)
 


### PR DESCRIPTION
### Description

Fixes #4184. Previously using https and proxy server options did not work, since http-proxy didn't support https servers. With the recent [switch to http-proxy3](https://github.com/vitejs/vite/pull/20402) this is no longer necessary and vite can support both options simultaneously, allowing to serve with http2. 
