### PR TITLE
feat(create-vite): bump TS to 5.9

### DIFF
--- a/packages/create-vite/template-lit-ts/package.json
+++ b/packages/create-vite/template-lit-ts/package.json
@@ -12,7 +12,7 @@
     "lit": "^3.3.1"
   },
   "devDependencies": {
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7"
   }
 }

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",
     "@types/node": "^24.6.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7"
   }
 }

--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "serve": "^14.2.5",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7"
   },
   "dependencies": {

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
     "globals": "^16.4.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
     "vite": "^7.1.7"
   }

--- a/packages/create-vite/template-solid-ts/package.json
+++ b/packages/create-vite/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7",
     "vite-plugin-solid": "^2.11.8"
   }

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^24.6.0",
     "svelte": "^5.39.6",
     "svelte-check": "^4.3.2",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7"
   }
 }

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7"
   }
 }

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^24.6.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.8.1",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.7",
     "vue-tsc": "^3.1.0"
   }


### PR DESCRIPTION
Nothing special to update, support from typescript-eslint for the React template was added a long time ago!