### PR TITLE
fix(css): respect emitAssets when cssCodeSplit=false

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -953,8 +953,18 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         return
       }
 
+      // vite:asset cleans up earlier assets of 'renderChunk',
+      // but with cssCodeSplit=false we may still emit CSS here.
+      // So is our responsibility to respect emitAssets
+      const canEmitAssets =
+        config.command !== 'build' || this.environment.config.build.emitAssets
+
       // extract as single css bundle if no codesplit
-      if (!this.environment.config.build.cssCodeSplit && !hasEmitted) {
+      if (
+        canEmitAssets &&
+        !this.environment.config.build.cssCodeSplit &&
+        !hasEmitted
+      ) {
         let extractedCss = ''
         const collected = new Set<OutputChunk>()
         // will be populated in order they are used by entry points


### PR DESCRIPTION
Fixes vitejs/vite#15196

### Description

`vite:css-post` is placed after `vite:asset` which cleans up assets in the `generateBundle` phase.

`vite:css-post` emits assets inside `renderChunk` but also in the `generateBundle` phase for `cssCodeSplit=false`, which is AFTER `vite:asset` execution.

So it's `vite:css-post` responsibility to respect the `emitAssets` config.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
