### PR TITLE
docs(cli): document `vite preview` with more information

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -106,6 +106,8 @@ vite optimize [root]
 
 Locally preview the production build. Do not use this as a production server as it's not designed for it.
 
+This command starts a server in the build directory (by default `dist`). Run `vite build` beforehand to ensure that the build directory is up-to-date. Depending on the project's configured [`appType`](/config/shared-options.html#apptype), it makes use of certain middleware.
+
 #### Usage
 
 ```bash


### PR DESCRIPTION
This additional documentation would help a beginner avoid some misunderstandings when using `vite preview`:

- The files served are from the build directory, so the build command needs to be run first. The build command is not run automatically.
- `vite preview` does not behave like a typical static server by default, as it includes middleware that redirects some requests to `index.html`, among other things. This depends on an option that isn't listed under preview's options, but under the list of shared options.

The additional documentation clarifies these points briefly.