### PR TITLE
fix: normalize path before calling `fileToBuiltUrl`

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -449,10 +449,11 @@ export async function urlToBuiltUrl(
   if (checkPublicFile(url, topLevelConfig)) {
     return publicFileToBuiltUrl(url, topLevelConfig)
   }
-  const file =
+  const file = normalizePath(
     url[0] === '/'
       ? path.join(topLevelConfig.root, url)
-      : path.join(path.dirname(importer), url)
+      : path.join(path.dirname(importer), url),
+  )
   return fileToBuiltUrl(
     pluginContext,
     file,


### PR DESCRIPTION
### Description

`id` passed here is normalized, except for the line I changed in this PR.
https://github.com/vitejs/vite/blob/9f4eef7c47e0795d4d21395460d8510fe0059abd/packages/vite/src/node/plugins/asset.ts#L405
This PR fixes that and reduces duplicate work to be done.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
