### PR TITLE
fix(config): delete dir simultaneously when deleting temporary files

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2111,7 +2111,15 @@ async function loadConfigFromBundledFile(
     try {
       return (await import(pathToFileURL(tempFileName).href)).default
     } finally {
-      fs.unlink(tempFileName, () => {}) // Ignore errors
+      if (nodeModulesDir) {
+        fs.rm(
+          path.resolve(nodeModulesDir, '.vite-temp'),
+          { recursive: true },
+          () => {},
+        ) // Ignore errors
+      } else {
+        fs.unlink(tempFileName, () => {}) // Ignore errors
+      }
     }
   }
   // for cjs, we can register a custom loader via `_require.extensions`


### PR DESCRIPTION
### Description
When deleting temporary files, the corresponding temporary folders are not deleted. I think it would be better to delete them synchronously.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
