### PR TITLE
fix: preserve original sourcemap file field when combining sourcemaps

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -711,11 +711,15 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 source: chunk.fileName,
                 hires: 'boundary',
               })
+              const originalFile = chunk.map.file
               const map = combineSourcemaps(chunk.fileName, [
                 nextMap as RawSourceMap,
                 chunk.map as RawSourceMap,
               ]) as SourceMap
               map.toUrl = () => genSourceMapUrl(map)
+              if (originalFile) {
+                map.file = originalFile
+              }
 
               const originalDebugId = chunk.map.debugId
               chunk.map = map

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -193,10 +193,6 @@ describe.runIf(isBuild)('build tests', () => {
       if (mapObj.file) {
         expect(
           mapObj.file,
-          `Sourcemap file field for ${mapAsset} should not include directory prefix`,
-        ).not.toMatch(/^assets\//)
-        expect(
-          mapObj.file,
           `Sourcemap file field for ${mapAsset} should be just the filename`,
         ).toMatch(/^[^/]+\.js$/)
       }

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -182,6 +182,27 @@ describe.runIf(isBuild)('build tests', () => {
     )
   })
 
+  test('sourcemap file field is consistent (#20853)', async () => {
+    const assets = listAssets()
+    const mapAssets = assets.filter((asset) => asset.endsWith('.js.map'))
+
+    for (const mapAsset of mapAssets) {
+      const mapContent = readFile(`dist/assets/${mapAsset}`)
+      const mapObj = JSON.parse(mapContent)
+
+      if (mapObj.file) {
+        expect(
+          mapObj.file,
+          `Sourcemap file field for ${mapAsset} should not include directory prefix`,
+        ).not.toMatch(/^assets\//)
+        expect(
+          mapObj.file,
+          `Sourcemap file field for ${mapAsset} should be just the filename`,
+        ).toMatch(/^[^/]+\.js$/)
+      }
+    }
+  })
+
   test('__vite__mapDeps injected after banner', async () => {
     const js = findAssetFile(/after-preload-dynamic-hashbang-[-\w]{8}\.js$/)
     expect(js.split('\n').slice(0, 2)).toEqual([


### PR DESCRIPTION
### Description

#20853 

Fixes inconsistent `file` field in sourcemaps when preload code is injected.

This happened because [combineSourcemaps()](cci:1://file:///Users/leejihoon/Documents/open-source/vite/packages/vite/src/node/utils.ts:863:0-921:1) overwrites the `file` field with `chunk.fileName`, which includes the `assets/` directory.

### Solution
Preserve the original `chunk.map.file` value after combining sourcemaps to maintain consistency with Rollup/Rolldown behavior.
