### PR TITLE
feat: support `RegExp | RegExp[]` for `external`

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -4,14 +4,14 @@ Unless noted, the options in this section are applied to both dev and build.
 
 ## ssr.external
 
-- **Type:** `string[] | true`
+- **Type:** `string | RegExp | (string | RegExp)[] | true`
 - **Related:** [SSR Externals](/guide/ssr#ssr-externals)
 
 Externalize the given dependencies and their transitive dependencies for SSR. By default, all dependencies are externalized except for linked dependencies (for HMR). If you prefer to externalize the linked dependency, you can pass its name to this option.
 
 If `true`, all dependencies including linked dependencies are externalized.
 
-Note that the explicitly listed dependencies (using `string[]` type) will always take priority if they're also listed in `ssr.noExternal` (using any type).
+Note that explicitly listed dependencies (strings or regular expressions) will always take priority if they're also listed in `ssr.noExternal` (using any type).
 
 ## ssr.noExternal
 
@@ -20,7 +20,7 @@ Note that the explicitly listed dependencies (using `string[]` type) will always
 
 Prevent listed dependencies from being externalized for SSR, which they will get bundled in build. By default, only linked dependencies are not externalized (for HMR). If you prefer to externalize the linked dependency, you can pass its name to the `ssr.external` option.
 
-If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized. If `ssr.target: 'node'` is set, Node.js built-ins will also be externalized by default.
+If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (strings or regular expressions) can take priority and still be externalized. If `ssr.target: 'node'` is set, Node.js built-ins will also be externalized by default.
 
 Note that if both `ssr.noExternal: true` and `ssr.external: true` are configured, `ssr.noExternal` takes priority and no dependencies are externalized.
 

--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -14,14 +14,63 @@ describe('createIsConfiguredAsExternal', () => {
     const isExternal = await createIsExternal(true)
     expect(isExternal('@vitejs/cjs-ssr-dep')).toBe(true)
   })
+
+  test('regex external id match', async () => {
+    const isExternal = await createIsExternal(undefined, [
+      /^@vitejs\/regex-match$/,
+    ])
+    expect(isExternal('@vitejs/regex-match')).toBe(true)
+    expect(isExternal('@vitejs/regex-mismatch')).toBe(false)
+  })
+
+  test('regex external package match', async () => {
+    const isExternal = await createIsExternal(undefined, [
+      /^@vitejs\/regex-package/,
+    ])
+    expect(isExternal('@vitejs/regex-package/foo')).toBe(true)
+    expect(isExternal('@vitejs/regex-package')).toBe(true)
+    expect(isExternal('@vitejs/not-regex-package/foo')).toBe(false)
+  })
+
+  test('regex external takes precedence over noExternal for explicit matches', async () => {
+    const isExternal = await createIsExternal(
+      undefined,
+      [/^@vitejs\/regex-overlap/],
+      ['@vitejs/regex-overlap'],
+    )
+    expect(isExternal('@vitejs/regex-overlap')).toBe(true)
+    expect(isExternal('@vitejs/regex-overlap/sub')).toBe(true)
+  })
+
+  test('noExternal alone keeps dependencies bundled', async () => {
+    const isExternal = await createIsExternal(undefined, undefined, [
+      '@vitejs/no-external',
+    ])
+    expect(isExternal('@vitejs/no-external')).toBe(false)
+    expect(isExternal('@vitejs/no-external/sub')).toBe(false)
+  })
 })
 
-async function createIsExternal(external?: true) {
+async function createIsExternal(
+  external?: true,
+  resolveExternal?: (string | RegExp)[],
+  noExternal?: (string | RegExp)[] | true,
+) {
   const resolvedConfig = await resolveConfig(
     {
       configFile: false,
       root: fileURLToPath(new URL('./', import.meta.url)),
-      resolve: { external },
+      resolve: {
+        external,
+      },
+      environments: {
+        ssr: {
+          resolve: {
+            external: resolveExternal,
+            noExternal,
+          },
+        },
+      },
     },
     'serve',
   )

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -2,8 +2,10 @@ import { join } from 'node:path'
 import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../server'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
+import { configDefaults } from '../config'
 import type { EnvironmentOptions, InlineConfig } from '../config'
 import { build } from '../build'
+import { normalizeExternalOption } from '../plugins/resolve'
 
 describe('import and resolveId', () => {
   async function createTestServer() {
@@ -52,6 +54,34 @@ describe('import and resolveId', () => {
       'dir/index.default.js',
       expect.stringContaining('dir/index.module.js'),
     ])
+  })
+})
+
+describe('normalizeExternalOption', () => {
+  test('string to array', () => {
+    expect(normalizeExternalOption('pkg')).toEqual(['pkg'])
+  })
+
+  test('regex to array', () => {
+    const regexp = /^pkg$/
+    expect(normalizeExternalOption(regexp)).toEqual([regexp])
+  })
+
+  test('array untouched', () => {
+    const value = ['pkg', /^pkg$/]
+    expect(normalizeExternalOption(value)).toBe(value)
+  })
+
+  test('true passthrough', () => {
+    expect(normalizeExternalOption(true)).toBe(true)
+  })
+
+  test('undefined becomes empty array', () => {
+    expect(normalizeExternalOption(undefined)).toEqual([])
+  })
+
+  test('config default external normalized', () => {
+    expect(normalizeExternalOption(configDefaults.resolve.external)).toEqual([])
   })
 })
 

--- a/packages/vite/src/node/ssr/index.ts
+++ b/packages/vite/src/node/ssr/index.ts
@@ -7,7 +7,7 @@ export type SsrDepOptimizationConfig = DepOptimizationConfig
 
 export interface SSROptions {
   noExternal?: string | RegExp | (string | RegExp)[] | true
-  external?: string[] | true
+  external?: string | RegExp | (string | RegExp)[] | true
 
   /**
    * Define the target for the ssr build. The browser field in package.json

--- a/playground/ssr-external-regex/__tests__/ssr-external-regex.spec.ts
+++ b/playground/ssr-external-regex/__tests__/ssr-external-regex.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest'
+import { isBuild, readFile } from '~utils'
+
+describe.runIf(isBuild)('build', () => {
+  test('ssr external regex keeps npm specifier externalized', async () => {
+    const contents = readFile('dist/entry-ssr.js')
+    expect(contents).toContain('npm:react@19.2.0')
+  })
+})

--- a/playground/ssr-external-regex/package.json
+++ b/playground/ssr-external-regex/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-ssr-external-regex",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build"
+  }
+}

--- a/playground/ssr-external-regex/src/entry-ssr.ts
+++ b/playground/ssr-external-regex/src/entry-ssr.ts
@@ -1,0 +1,3 @@
+import 'npm:react@19.2.0'
+
+export default 'regex-external-ok'

--- a/playground/ssr-external-regex/vite.config.ts
+++ b/playground/ssr-external-regex/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    ssr: './src/entry-ssr.ts',
+    minify: false,
+  },
+  environments: {
+    ssr: {
+      resolve: {
+        external: [/^npm:/],
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1592,6 +1592,8 @@ importers:
 
   playground/ssr-deps/ts-transpiled-exports: {}
 
+  playground/ssr-external-regex: {}
+
   playground/ssr-html:
     devDependencies:
       express:


### PR DESCRIPTION
### Description

## Changes

- Extended resolve.external type from `string[] | true` to `string | RegExp | (string | RegExp)[] | true`.
- Try to ensure that existing inputs are not affected in any way

## Documentation

- Updated `docs/config/ssr-options.md`

## Issues

Fixes #20843 