### PR TITLE
build(legacy): remove duplicated rolldown-vite file

### DIFF
--- a/packages/plugin-legacy/tsdown.config.ts
+++ b/packages/plugin-legacy/tsdown.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       validateAllDepsForRolldownViteIsIncluded()
 
       const files = new fdir()
-        .glob('!**/*.d.ts')
+        .glob('!**/{*.d.ts,vendor/rolldown-vite/**/*}')
         .withRelativePaths()
         .crawl(path.join(pluginLegacyForRolldownVitePackagePath, 'dist'))
         .sync()


### PR DESCRIPTION
### Description

Follow up to #20417

`dist/vendor/rolldown-vite/vendor/rolldown-vite/index.js` was copied because `@vitejs/plugin-legacy-for-rolldown-vite` has `dist/vendor/rolldown-vite/index.js` as well.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
