### PR TITLE
build: remove cjs reference in files field

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -51,8 +51,6 @@
     "dist",
     "misc/**/*.js",
     "client.d.ts",
-    "index.cjs",
-    "index.d.cts",
     "types"
   ],
   "engines": {


### PR DESCRIPTION
### Description


Small thing I noticed since we no longer export CJS.