### PR TITLE
feat(css): support css module other files

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -183,6 +183,7 @@ A nonce value placeholder that will be used when generating script / style tags.
     ) => void
     scopeBehaviour?: 'global' | 'local'
     globalModulePaths?: RegExp[]
+    auto?: boolean | RegExp | ((path: string) => boolean)
     exportGlobals?: boolean
     generateScopedName?:
       | string

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -274,7 +274,8 @@ Note that CSS minification will run after PostCSS and will use [`build.cssTarget
 
 ### CSS Modules
 
-Any CSS file ending with `.module.css` is considered a [CSS modules file](https://github.com/css-modules/css-modules). Importing such a file will return the corresponding module object:
+By default, Vite treats all CSS files ending with **`.module.css`** as [CSS Modules](https://github.com/css-modules/css-modules).
+Importing these files returns a corresponding module object.
 
 ```css [example.module.css]
 .red {
@@ -282,14 +283,48 @@ Any CSS file ending with `.module.css` is considered a [CSS modules file](https:
 }
 ```
 
-```js twoslash
-import 'vite/client'
-// ---cut---
+```js
 import classes from './example.module.css'
 document.getElementById('foo').className = classes.red
 ```
 
 CSS modules behavior can be configured via the [`css.modules` option](/config/shared-options.md#css-modules).
+
+#### CSS Module Matching Configuration Options
+
+All options are configured in the `css.modules` object.
+Vite's internal CSS plugin matches files according to the priority order: `globalModulePaths`, `auto`, and `scopeBehaviour`, and stops at the first matching rule.
+
+| Option                  | Type                            | Description                                                                                                                                                                                                           |
+| :---------------------- | :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`globalModulePaths`** | `RegExp[]`                      | Highest priority. Files matching any regex in this array will never be treated as modules.                                                                                                                            |
+| **`auto`**              | `boolean \| RegExp \| Function` | If set, determines module matching completely, overriding `scopeBehaviour`. Can be a boolean, a regular expression, or a custom function, e.g., `auto: /\.m\.css$/` or `auto: path => path.includes('/components/')`. |
+| **`scopeBehaviour`**    | `'local' \| 'global'`           | Used if `auto` is not defined. `'local'` treats all unmatched files as modules; `'global'` falls back to the default `.module.css` file naming convention.                                                            |
+
+#### Example Configuration
+
+```js
+// vite.config.js
+export default {
+  css: {
+    modules: {
+      globalModulePaths: [/global\.css$/],
+      auto: /\.m\.css$/,
+      scopeBehaviour: 'local',
+    },
+  },
+}
+```
+
+### Usage Notes
+
+- **Priority Exclusion**: Files matching `globalModulePaths` are never treated as modules
+
+- **Custom Rules**: If `auto` is defined, it fully controls module matching behavior
+
+- **Default Behavior**: If `auto` is not used, `scopeBehaviour` determines module matching
+
+- **Fallback Rule**: If none of the above match, the system falls back to checking whether the file name contains `.module.`
 
 If `css.modules.localsConvention` is set to enable camelCase locals (e.g. `localsConvention: 'camelCaseOnly'`), you can also use named imports:
 


### PR DESCRIPTION
### Description
Fixes #20929
Enhance Vite CSS Plugin to improve matching of CSS Module files.

## What this PR does

The logic to determine whether a file is treated as a module executes in order and stops at the first matching rule:

* **Priority exclusion**: If a file path matches any of the exclusion patterns, it is never treated as a module. This has the highest priority
* **Custom logic**: If a custom rule is defined, whether the file is treated as a module is determined entirely by that rule (function, regex, or boolean)
* **Global default**: If no custom rule is used, the system checks the global default setting, and treats the file as a module if appropriate
* **File name convention**: If none of the above rules match, the system falls back to the default behavior, checking if the file name contains `.module.`

## Test

* Unit tests and full test suite pass: `pnpm run test-unit`, `pnpm run test`
* Code linting passes without errors: `pnpm run lint`
* Created `playground/css-module` to test various combinations of custom logic and global default; build and module matching behavior meet expectations

### Note
Do I need to submit playground/css-module?

