### PR TITLE
docs: replace legacy docker compose command

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -109,7 +109,7 @@ VITE_FOO=foo${VITE_BAR}
 VITE_BAR=bar
 ```
 
-This does not work in shell scripts and other tools like `docker-compose`.
+This does not work in shell scripts and other tools like `docker compose`.
 That said, Vite supports this behavior as this has been supported by `dotenv-expand` for a long time and other tools in JavaScript ecosystem uses older versions that supports this behavior.
 
 To avoid interop issues, it is recommended to avoid relying on this behavior. Vite may start emitting warnings for this behavior in the future.


### PR DESCRIPTION
`docker-compose` command is from docker v1 which has stopped receiving updates from July 2023. It’s also no longer available in new releases of Docker Desktop.

https://docs.docker.com/compose/releases/migrate/#how-do-i-switch-to-compose-v2