### PR TITLE
feat: add `server.hmr.update` to allow configuring ws settings while disabling HMR

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { CLIENT_ENTRY, ENV_ENTRY } from '../constants'
-import { isObject, normalizePath, resolveHostname } from '../utils'
+import { normalizePath, resolveHostname } from '../utils'
 import { perEnvironmentState } from '../environment'
 import { replaceDefine, serializeDefine } from './define'
 
@@ -40,13 +40,12 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
 
       const serverHost = `${resolvedServerHostname}:${resolvedServerPort}${devBase}`
 
-      let hmrConfig = config.server.hmr
-      hmrConfig = isObject(hmrConfig) ? hmrConfig : undefined
-      const host = hmrConfig?.host || null
-      const protocol = hmrConfig?.protocol || null
-      const timeout = hmrConfig?.timeout || 30000
-      const overlay = hmrConfig?.overlay !== false
-      const isHmrServerSpecified = !!hmrConfig?.server
+      const hmrConfig = config.server.hmr
+      const host = hmrConfig.host || null
+      const protocol = hmrConfig.protocol || null
+      const timeout = hmrConfig.timeout || 30000
+      const overlay = hmrConfig.overlay !== false
+      const isHmrServerSpecified = !!hmrConfig.server
       const hmrConfigName = path.basename(config.configFile || 'vite.config.js')
 
       // hmr.clientPort -> hmr.port

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -204,7 +204,7 @@ export class DevEnvironment extends BaseEnvironment {
   }
 
   async reloadModule(module: EnvironmentModuleNode): Promise<void> {
-    if (this.config.server.hmr !== false && module.file) {
+    if (this.config.server.hmr.update && module.file) {
       updateModules(this, module.file, [module], monotonicDateNow())
     }
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -46,6 +46,10 @@ export interface HmrOptions {
   clientPort?: number
   path?: string
   timeout?: number
+  /**
+   * @default true
+   */
+  update?: boolean
   overlay?: boolean
   server?: HttpServer
 }

--- a/packages/vite/src/node/server/middlewares/__tests__/hostCheck.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/hostCheck.spec.ts
@@ -7,6 +7,7 @@ test('getAdditionalAllowedHosts', async () => {
       host: 'vite.host.example.com',
       hmr: {
         host: 'vite.hmr-host.example.com',
+        update: true,
       },
       origin: 'http://vite.origin.example.com:5173',
     },

--- a/packages/vite/src/node/server/middlewares/hostCheck.ts
+++ b/packages/vite/src/node/server/middlewares/hostCheck.ts
@@ -16,10 +16,7 @@ export function getAdditionalAllowedHosts(
   ) {
     list.push(resolvedServerOptions.host)
   }
-  if (
-    typeof resolvedServerOptions.hmr === 'object' &&
-    resolvedServerOptions.hmr.host
-  ) {
+  if (resolvedServerOptions.hmr.host) {
     list.push(resolvedServerOptions.hmr.host)
   }
   if (

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -14,7 +14,6 @@ import type { WebSocket as WebSocketTypes } from '#dep-types/ws'
 import type { ErrorPayload, HotPayload } from '#types/hmrPayload'
 import type { InferCustomEventPayload } from '#types/customEvent'
 import type { ResolvedConfig } from '..'
-import { isObject } from '../utils'
 import type { NormalizedHotChannel, NormalizedHotChannelClient } from './hmr'
 import { normalizeHotChannel } from './hmr'
 import type { HttpServer } from '.'
@@ -143,12 +142,11 @@ export function createWebSocketServer(
 
   let wsHttpServer: Server | undefined = undefined
 
-  const hmr = isObject(config.server.hmr) && config.server.hmr
-  const hmrServer = hmr && hmr.server
-  const hmrPort = hmr && hmr.port
+  const hmr = config.server.hmr
+  const hmrPort = hmr.port
   // TODO: the main server port may not have been chosen yet as it may use the next available
   const portsAreCompatible = !hmrPort || hmrPort === config.server.port
-  const wsServer = hmrServer || (portsAreCompatible && server)
+  const wsServer = hmr.server || (portsAreCompatible && server)
   let hmrServerWsListener: (
     req: InstanceType<typeof IncomingMessage>,
     socket: Duplex,
@@ -411,7 +409,7 @@ export function createWebSocketServer(
         })
       },
     },
-    config.server.hmr !== false,
+    config.server.hmr.update,
     // Don't normalize client as we already handles the send, and to keep `.socket`
     false,
   )

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -39,7 +39,7 @@ function createHMROptions(
   environment: DevEnvironment,
   options: ServerModuleRunnerOptions,
 ) {
-  if (environment.config.server.hmr === false || options.hmr === false) {
+  if (!environment.config.server.hmr.update || options.hmr === false) {
     return false
   }
   if (!('api' in environment.hot)) return false

--- a/playground/js-sourcemap/test-ssr-dev.js
+++ b/playground/js-sourcemap/test-ssr-dev.js
@@ -11,7 +11,7 @@ async function runTest() {
     },
     server: {
       middlewareMode: true,
-      hmr: false,
+      hmr: { update: false },
       ws: false,
     },
     define: {


### PR DESCRIPTION
### Description

I noticed that it's not possible to configure the ws settings when the HMR is disabled by `server.hmr: false`. This PR adds `server.hmr.update: false` option which works similarly to `server.hmr: false`.

The alternative way is to move all ws related options under `server.ws`. This feels more correct, but I'm not sure if the required migration effort for the users is worth.

fixes https://github.com/vitejs/vite/issues/18489
refs https://github.com/vitejs/vite/issues/18489#issuecomment-2440919752, https://github.com/vitejs/vite/issues/18489#issuecomment-3417066808, 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
