### PR TITLE
fix(dev): trim trailing slash before `server.fs.deny` check

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -297,7 +297,12 @@ export function isFileLoadingAllowed(
 
   if (!fs.strict) return true
 
-  if (config.fsDenyGlob(filePath)) return false
+  // NOTE: `fs.readFile('/foo.png/')` tries to load `'/foo.png'`
+  // so we should check the path without trailing slash
+  const filePathWithoutTrailingSlash = filePath.endsWith('/')
+    ? filePath.slice(0, -1)
+    : filePath
+  if (config.fsDenyGlob(filePathWithoutTrailingSlash)) return false
 
   if (config.safeModulePaths.has(filePath)) return true
 

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -13,7 +13,14 @@ import {
 import type { Page } from 'playwright-chromium'
 import WebSocket from 'ws'
 import testJSON from '../safe.json'
-import { browser, isServe, page, viteServer, viteTestUrl } from '~utils'
+import {
+  browser,
+  isServe,
+  isWindows,
+  page,
+  viteServer,
+  viteTestUrl,
+} from '~utils'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -540,7 +547,9 @@ describe.runIf(isServe)('invalid request', () => {
 
   test('should deny request to denied file when a request ends with \\', async () => {
     const response = await sendRawRequest(viteTestUrl, '/src/.env\\')
-    expect(response).toContain('HTTP/1.1 403 Forbidden')
+    expect(response).toContain(
+      isWindows ? 'HTTP/1.1 403 Forbidden' : 'HTTP/1.1 404 Not Found',
+    )
   })
 
   test('should deny request to denied file when a request ends with \\ with /@fs/', async () => {
@@ -548,7 +557,9 @@ describe.runIf(isServe)('invalid request', () => {
       viteTestUrl,
       path.posix.join('/@fs/', root, 'root/src/.env') + '\\',
     )
-    expect(response).toContain('HTTP/1.1 403 Forbidden')
+    expect(response).toContain(
+      isWindows ? 'HTTP/1.1 403 Forbidden' : 'HTTP/1.1 404 Not Found',
+    )
   })
 
   test('should deny request with /@fs/ to denied file when a request has /.', async () => {

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -538,6 +538,19 @@ describe.runIf(isServe)('invalid request', () => {
     expect(response).toContain('HTTP/1.1 403 Forbidden')
   })
 
+  test('should deny request to denied file when a request ends with \\', async () => {
+    const response = await sendRawRequest(viteTestUrl, '/src/.env\\')
+    expect(response).toContain('HTTP/1.1 403 Forbidden')
+  })
+
+  test('should deny request to denied file when a request ends with \\ with /@fs/', async () => {
+    const response = await sendRawRequest(
+      viteTestUrl,
+      path.posix.join('/@fs/', root, 'root/src/.env') + '\\',
+    )
+    expect(response).toContain('HTTP/1.1 403 Forbidden')
+  })
+
   test('should deny request with /@fs/ to denied file when a request has /.', async () => {
     const response = await sendRawRequest(
       viteTestUrl,


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/security/advisories/GHSA-93m4-6634-74q7

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
