### PR TITLE
fix(dev): trim trailing slash before `server.fs.deny` check (#20968)

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -259,7 +259,12 @@ export function isFileLoadingAllowed(
 
   if (!fs.strict) return true
 
-  if (server._fsDenyGlob(filePath)) return false
+  // NOTE: `fs.readFile('/foo.png/')` tries to load `'/foo.png'`
+  // so we should check the path without trailing slash
+  const filePathWithoutTrailingSlash = filePath.endsWith('/')
+    ? filePath.slice(0, -1)
+    : filePath
+  if (server._fsDenyGlob(filePathWithoutTrailingSlash)) return false
 
   if (server.moduleGraph.safeModulesPath.has(filePath)) return true
 

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -13,7 +13,14 @@ import {
 import type { Page } from 'playwright-chromium'
 import WebSocket from 'ws'
 import testJSON from '../safe.json'
-import { browser, isServe, page, viteServer, viteTestUrl } from '~utils'
+import {
+  browser,
+  isServe,
+  isWindows,
+  page,
+  viteServer,
+  viteTestUrl,
+} from '~utils'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -478,6 +485,23 @@ describe.runIf(isServe)('invalid request', () => {
   test('should deny request to denied file when a request has /.', async () => {
     const response = await sendRawRequest(viteTestUrl, '/src/dummy.crt/.')
     expect(response).toContain('HTTP/1.1 403 Forbidden')
+  })
+
+  test('should deny request to denied file when a request ends with \\', async () => {
+    const response = await sendRawRequest(viteTestUrl, '/src/.env\\')
+    expect(response).toContain(
+      isWindows ? 'HTTP/1.1 403 Forbidden' : 'HTTP/1.1 404 Not Found',
+    )
+  })
+
+  test('should deny request to denied file when a request ends with \\ with /@fs/', async () => {
+    const response = await sendRawRequest(
+      viteTestUrl,
+      path.posix.join('/@fs/', root, 'root/src/.env') + '\\',
+    )
+    expect(response).toContain(
+      isWindows ? 'HTTP/1.1 403 Forbidden' : 'HTTP/1.1 404 Not Found',
+    )
   })
 
   test('should deny request with /@fs/ to denied file when a request has /.', async () => {


### PR DESCRIPTION
### Description

Backport of https://github.com/vitejs/vite/pull/20968 to v5

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
