### PR TITLE
fix(resolve): match resolved subpath import path's relative prefix with regex (fix #20972)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -520,7 +520,7 @@ function resolveSubpathImports(
   if (importsPath?.[0] === '.') {
     importsPath = path.relative(basedir, path.join(pkgData.dir, importsPath))
 
-    if (importsPath[0] !== '.') {
+    if (!relativePrefixRE.test(importsPath)) {
       importsPath = `./${importsPath}`
     }
   }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixes #20972.

In [resolveSubpathImports](https://github.com/vitejs/vite/blob/v7.1.11/packages/vite/src/node/plugins/resolve.ts#L500), use a regular expression to match resolved relative paths' relative prefix since only checking a path starts with `"."` does not consider dot-prefixed directories.

The regex used was already [defined in the same file](https://github.com/vitejs/vite/blob/v7.1.11/packages/vite/src/node/plugins/resolve.ts#L68):

```js
const relativePrefixRE = /^\.\.?(?:[/\\]|$)/
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
