### PR TITLE
perf(module-runner): use `module.registerHooks` when available

### DIFF
--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -1,3 +1,5 @@
+import type { ResolveFnOutput, ResolveHookContext } from 'node:module'
+
 export type ImportMetaResolver = (specifier: string, importer: string) => string
 
 const customizationHookNamespace = 'vite-module-runner:import-meta-resolve/v1/'
@@ -10,11 +12,26 @@ export async function resolve(specifier, context, nextResolve) {
     specifier = parsedSpecifier
     context.parentURL = parsedImporter
   }
-
   return nextResolve(specifier, context)
 }
 
 `
+function customizationHookResolve(
+  specifier: string,
+  context: ResolveHookContext,
+  nextResolve: (
+    specifier: string,
+    context: ResolveHookContext,
+  ) => ResolveFnOutput,
+): ResolveFnOutput {
+  if (specifier.startsWith(customizationHookNamespace)) {
+    const data = specifier.slice(customizationHookNamespace.length)
+    const [parsedSpecifier, parsedImporter] = JSON.parse(data)
+    specifier = parsedSpecifier
+    context.parentURL = parsedImporter
+  }
+  return nextResolve(specifier, context)
+}
 
 export async function createImportMetaResolver(): Promise<
   ImportMetaResolver | undefined
@@ -26,7 +43,17 @@ export async function createImportMetaResolver(): Promise<
     return
   }
   // `module.Module` may be `undefined` when `node:module` is mocked
-  if (!module?.register) {
+  if (!module) {
+    return
+  }
+
+  // Use registerHooks if available as it's more performant
+  if (module.registerHooks) {
+    module.registerHooks({ resolve: customizationHookResolve })
+    return importMetaResolveWithCustomHook
+  }
+
+  if (!module.register) {
     return
   }
 
@@ -41,8 +68,14 @@ export async function createImportMetaResolver(): Promise<
     throw e
   }
 
-  return (specifier: string, importer: string) =>
-    import.meta.resolve(
-      `${customizationHookNamespace}${JSON.stringify([specifier, importer])}`,
-    )
+  return importMetaResolveWithCustomHook
+}
+
+function importMetaResolveWithCustomHook(
+  specifier: string,
+  importer: string,
+): string {
+  return import.meta.resolve(
+    `${customizationHookNamespace}${JSON.stringify([specifier, importer])}`,
+  )
 }


### PR DESCRIPTION
### Description

I haven't actually tested whether this is more performant (I assume it is because a worker doesn't have to be spawned).

https://github.com/vitejs/vite/pull/20962#issuecomment-3419786556

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
