### PR TITLE
fix: update build log to include environment name

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -711,12 +711,11 @@ async function buildEnvironment(
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
   const { logger, config } = environment
   const { root, build: options } = config
-  const ssr = config.consumer === 'server'
 
   logger.info(
     colors.cyan(
       `vite v${VERSION} ${colors.green(
-        `building ${ssr ? `SSR bundle ` : ``}for ${environment.config.mode}...`,
+        `building ${environment.name} environment for ${environment.config.mode}...`,
       )}`,
     ),
   )


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

This PR changes build logs:
- "building for ..." -> "build client environment for ..."
- "building SSR bundle for ..." -> "build ssr environment for ..."

For `@vitejs/plugin-rsc`, I've already added extra logs like https://github.com/vitejs/vite-plugin-react/pull/936, but I think it makes sense to change here directly:

_example_

<img width="1163" height="891" alt="image" src="https://github.com/user-attachments/assets/f5eeca00-f828-4b7a-994e-f01c1a2e84c3" />
