### PR TITLE
fix: disable optional peer dep handling for `nodeResolveWithVite`

### DIFF
--- a/packages/vite/src/node/nodeResolve.ts
+++ b/packages/vite/src/node/nodeResolve.ts
@@ -37,5 +37,6 @@ export function nodeResolveWithVite(
     packageCache: undefined,
     isRequire: options.isRequire,
     builtins: nodeLikeBuiltins,
+    disableOptionalPeerDepHandling: true,
   })?.id
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -147,6 +147,12 @@ interface ResolvePluginOptions {
    * @internal
    */
   idOnly?: boolean
+
+  /**
+   * Set by `nodeResolveWithVite`, disables optional peer dependency handling.
+   * @internal
+   */
+  disableOptionalPeerDepHandling?: boolean
 }
 
 export interface InternalResolveOptions
@@ -741,6 +747,7 @@ export function tryNodeResolve(
     // if import can't be found, check if it's an optional peer dep.
     // if so, we can resolve to a special id that errors only when imported.
     if (
+      !options.disableOptionalPeerDepHandling &&
       basedir !== root && // root has no peer dep
       !isModuleBuiltin(id) &&
       !id.includes('\0') &&


### PR DESCRIPTION
### Description

Trying to fix this error in ecosystem-ci:
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/18737739165/job/53447778542#step:7:857

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
