### PR TITLE
fix(css): fallback to sass when sass-embedded platform binary is missing

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2520,17 +2520,18 @@ const scssProcessor = (
   maxWorkers: number | undefined,
 ): StylePreprocessor<SassStylePreprocessorInternalOptions> => {
   let worker: ReturnType<typeof makeScssWorker> | undefined
+  let failedSassEmbedded: boolean | undefined
 
   return {
     close() {
       worker?.stop()
     },
     async process(environment, source, root, options, resolvers) {
-      let failedSassEmbedded: boolean | undefined
       let sassPackage = loadSassPackage(root, failedSassEmbedded ?? false)
 
       if (failedSassEmbedded === undefined) {
-        // failedSassEmbedded is undefined for the first time
+        failedSassEmbedded = false
+
         try {
           await import(sassPackage.path)
         } catch (e) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2528,10 +2528,8 @@ const scssProcessor = (
     },
     async process(environment, source, root, options, resolvers) {
       let sassPackage = loadSassPackage(root, failedSassEmbedded ?? false)
-
       if (failedSassEmbedded === undefined) {
         failedSassEmbedded = false
-
         try {
           await import(sassPackage.path)
         } catch (e) {


### PR DESCRIPTION
Fixes #19518 

### Description

When sass-embedded is installed but the platform-specific binary is unavailable (e.g., sass-embedded-freebsd-x64), Vite now automatically falls back to the sass package with a warning instead of failing the build.

I tested this locally using a Docker container to emulate the freebsd-x64 platform that was unable to install sass-embedded and was able to verify that it fails without my changes, and that it falls back to sass with my changes.
