### PR TITLE
docs(static-deploy): add workflow file location for GitHub Pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -486,7 +486,11 @@ export default defineConfig({
     languages: ['ts', 'js', 'json'],
     codeTransformers: [transformerTwoslash()],
     config(md) {
-      md.use(groupIconMdPlugin)
+      md.use(groupIconMdPlugin, {
+        titleBar: {
+          includeSnippet: true,
+        },
+      })
       md.use(markdownItImageSize, {
         publicDir: path.resolve(import.meta.dirname, '../public'),
       })

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -63,7 +63,7 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 
 2. Go to your GitHub Pages configuration in the repository settings page and choose the source of deployment as "GitHub Actions", this will lead you to create a workflow that builds and deploys your project, a sample workflow that installs dependencies and builds using npm is provided:
 
-   <<< ./static-deploy-github-pages.yaml#content
+   <<< ./static-deploy-github-pages.yaml#content [.github/workflows/deploy.yml]
 
 ## GitLab Pages and GitLab CI
 


### PR DESCRIPTION
Added instruction for workflow file location.

### Description

As a beginner to GitHub Pages, I didn’t realize the workflow file must be placed under `.github/workflows/` in the repository root.  
The existing docs provide a sample workflow but don’t explicitly say where it should live, which can cause confusion for new users.  

This PR adds a clear instruction about the file location, making the deployment guide more beginner-friendly.