### PR TITLE
refactor: use `fs.cpSync`

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -644,7 +644,11 @@ async function init() {
       )
       fs.writeFileSync(targetPath, updatedContent)
     } else {
-      copy(path.join(templateDir, file), targetPath)
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is not experimental in Node 22.3+
+      fs.cpSync(path.join(templateDir, file), targetPath, {
+        recursive: true,
+        mode: fs.constants.COPYFILE_FICLONE,
+      })
     }
   }
 
@@ -710,15 +714,6 @@ function formatTargetDir(targetDir: string) {
   return targetDir.trim().replace(/\/+$/g, '')
 }
 
-function copy(src: string, dest: string) {
-  const stat = fs.statSync(src)
-  if (stat.isDirectory()) {
-    copyDir(src, dest)
-  } else {
-    fs.copyFileSync(src, dest)
-  }
-}
-
 function isValidPackageName(projectName: string) {
   return /^(?:@[a-z\d\-*~][a-z\d\-*._~]*\/)?[a-z\d\-~][a-z\d\-._~]*$/.test(
     projectName,
@@ -732,15 +727,6 @@ function toValidPackageName(projectName: string) {
     .replace(/\s+/g, '-')
     .replace(/^[._]/, '')
     .replace(/[^a-z\d\-~]+/g, '-')
-}
-
-function copyDir(srcDir: string, destDir: string) {
-  fs.mkdirSync(destDir, { recursive: true })
-  for (const file of fs.readdirSync(srcDir)) {
-    const srcFile = path.resolve(srcDir, file)
-    const destFile = path.resolve(destDir, file)
-    copy(srcFile, destFile)
-  }
 }
 
 function isEmpty(path: string) {

--- a/packages/vite/src/node/plugins/prepareOutDir.ts
+++ b/packages/vite/src/node/plugins/prepareOutDir.ts
@@ -4,7 +4,7 @@ import colors from 'picocolors'
 import type { Plugin } from '../plugin'
 import { getResolvedOutDirs, resolveEmptyOutDir } from '../watch'
 import type { Environment } from '../environment'
-import { copyDir, emptyDir, normalizePath } from '../utils'
+import { emptyDir, normalizePath } from '../utils'
 import { withTrailingSlash } from '../../shared/utils'
 
 export function prepareOutDirPlugin(): Plugin {
@@ -86,7 +86,11 @@ function prepareOutDir(
           ),
         )
       }
-      copyDir(publicDir, outDir)
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is not experimental in Node 22.3+
+      fs.cpSync(publicDir, outDir, {
+        recursive: true,
+        mode: fs.constants.COPYFILE_FICLONE,
+      })
     }
   }
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -624,23 +624,6 @@ export function emptyDir(dir: string, skip?: string[]): void {
   }
 }
 
-export function copyDir(srcDir: string, destDir: string): void {
-  fs.mkdirSync(destDir, { recursive: true })
-  for (const file of fs.readdirSync(srcDir)) {
-    const srcFile = path.resolve(srcDir, file)
-    if (srcFile === destDir) {
-      continue
-    }
-    const destFile = path.resolve(destDir, file)
-    const stat = fs.statSync(srcFile)
-    if (stat.isDirectory()) {
-      copyDir(srcFile, destFile)
-    } else {
-      fs.copyFileSync(srcFile, destFile)
-    }
-  }
-}
-
 export const ERR_SYMLINK_IN_RECURSIVE_READDIR =
   'ERR_SYMLINK_IN_RECURSIVE_READDIR'
 export async function recursiveReaddir(dir: string): Promise<string[]> {


### PR DESCRIPTION
### Description

`fs.cpSync` is now stable enough, and also supports `mode: fs.constants.COPYFILE_FICLONE,` which may improve perf in some cases.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
