### PR TITLE
docs(static-deploy): clarify GitHub Pages instructions (enable + workflow)

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -65,14 +65,13 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 
 2. **Enable GitHub Pages**
 
-   In your repository, go to **Settings → Pages**.
-   Under **Build and deployment**, open the **Source** dropdown, and select **GitHub Actions**.
+   In your repository, go to **Settings → Pages**. Under **Build and deployment**, open the **Source** dropdown, and select **GitHub Actions**.
 
    GitHub will now deploy your site using a GitHub Actions [workflow](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflows), which is necessary since Vite requires a build step for deployment.
 
 3. **Create a Workflow**
 
-   Open a new file in your repository at `.github/workflows/deploy.yml`. You can also click on **“create your own”**, which will generate a starter workflow file for you.
+   Create a new file in your repository at `.github/workflows/deploy.yml`. You can also click on **“create your own”** from the previous step, which will generate a starter workflow file for you.
 
    Here’s a sample workflow that installs dependencies with npm, builds the site, and deploys it whenever you push changes to the `main` branch:
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -55,13 +55,26 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 
 ## GitHub Pages
 
-1. Set the correct `base` in `vite.config.js`.
+1. **Update Vite Config**
+
+   Set the correct `base` in `vite.config.js`.
 
    If you are deploying to `https://<USERNAME>.github.io/`, or to a custom domain through GitHub Pages (eg. `www.example.com`), set `base` to `'/'`. Alternatively, you can remove `base` from the configuration, as it defaults to `'/'`.
 
    If you are deploying to `https://<USERNAME>.github.io/<REPO>/` (eg. your repository is at `https://github.com/<USERNAME>/<REPO>`), then set `base` to `'/<REPO>/'`.
 
-2. Go to your GitHub Pages configuration in the repository settings page and choose the source of deployment as "GitHub Actions", this will lead you to create a workflow that builds and deploys your project, a sample workflow that installs dependencies and builds using npm is provided:
+2. **Enable GitHub Pages**
+
+   In your repository, go to **Settings → Pages**.
+   Under **Build and deployment**, open the **Source** dropdown, and select **GitHub Actions**.
+
+   GitHub will now deploy your site using a GitHub Actions [workflow](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflows), which is necessary since Vite requires a build step for deployment.
+
+3. **Create a Workflow**
+
+   Open a new file in your repository at `.github/workflows/deploy.yml`. You can also click on **“create your own”**, which will generate a starter workflow file for you.
+
+   Here’s a sample workflow that installs dependencies with npm, builds the site, and deploys it whenever you push changes to the `main` branch:
 
    <<< ./static-deploy-github-pages.yaml#content [.github/workflows/deploy.yml]
 


### PR DESCRIPTION
### Description

Clarifies the GitHub Pages deployment instructions in the documentation.  

- Splits the steps into "Enable GitHub Pages" and "Create a Workflow" for easier readability
- Adds explicit instructions on how and where to create a workflow file
- Explains why a workflow is required  
- Improves beginner-friendliness by simplifying explanations