### PR TITLE
fix: increase stream reset rate limit for HTTP2

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -129,6 +129,10 @@ export async function resolveHttpServer(
       // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM
       // errors on large numbers of requests
       maxSessionMemory: 1000,
+      // Increase the stream reset rate limit to prevent net::ERR_HTTP2_PROTOCOL_ERROR
+      // errors on large numbers of requests
+      streamResetBurst: 100000,
+      streamResetRate: 33,
       ...httpsOptions,
       allowHTTP1: true,
     },


### PR DESCRIPTION
### Description

This change fixes `net::ERR_HTTP2_PROTOCOL_ERROR` errors that happens when there're many modules.
These options were introduced by https://github.com/nodejs/node/pull/54875 for this purpose.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
