### PR TITLE
fix: preloading module before usage

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -926,7 +926,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             )
           } else {
             const { modulePreload } = this.environment.config.build
-            assetTags = [toScriptTag(chunk, toOutputAssetFilePath, isAsync)]
+            const scriptTag = toScriptTag(chunk, toOutputAssetFilePath, isAsync)
+            assetTags = []
             if (modulePreload !== false) {
               const resolveDependencies =
                 typeof modulePreload === 'object' &&
@@ -946,6 +947,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 ),
               )
             }
+            assetTags.push(scriptTag)
           }
           assetTags.push(...getCssTagsForChunk(chunk, toOutputAssetFilePath))
 


### PR DESCRIPTION
### Description

Currently vite generates modulepreload `<link>` elements in html element after `<script>`. This is reported by lighthouse as too long critical path. Changing order of the elements is considered a correct approach by Lighthouse. Not sure whether browsers are that strict with this, but it feels natural to preload module before its first use.