### PR TITLE
ci: remove git clone from ecosystem-ci-trigger

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -12,7 +12,6 @@ jobs:
       issues: write # to add / delete reactions, post comments
       pull-requests: write # to read PR data, and to add labels
       actions: read # to check workflow status
-      contents: read # to clone the repo
     steps:
       - name: Check User Permissions
         uses: actions/github-script@v8
@@ -229,12 +228,6 @@ jobs:
               })
               console.log('Removed "rocket" reaction.')
             }
-
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ fromJSON(steps.get-pr-data.outputs.result).num }}/head
-          fetch-depth: 0
 
       - name: Trigger Downstream Workflow
         uses: actions/github-script@v8


### PR DESCRIPTION
### Description

Follow up to #20792

This git clone was for the commit hash ambiguity check.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
