### PR TITLE
fix(module-runner): make `getBuiltins` response JSON serializable

### DIFF
--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -134,7 +134,11 @@ export class DevEnvironment extends BaseEnvironment {
         return this.fetchModule(id, importer, options)
       },
       getBuiltins: async () => {
-        return this.config.resolve.builtins
+        return this.config.resolve.builtins.map((builtin) =>
+          typeof builtin === 'string'
+            ? { type: 'string', value: builtin }
+            : { type: 'RegExp', source: builtin.source, flags: builtin.flags },
+        )
       },
     })
 

--- a/packages/vite/src/shared/invokeMethods.ts
+++ b/packages/vite/src/shared/invokeMethods.ts
@@ -83,5 +83,10 @@ export type InvokeMethods = {
     options?: FetchFunctionOptions,
   ) => Promise<FetchResult>
 
-  getBuiltins: () => Promise<(string | RegExp)[]>
+  getBuiltins: () => Promise<
+    Array<
+      | { type: 'string'; value: string }
+      | { type: 'RegExp'; source: string; flags: string }
+    >
+  >
 }


### PR DESCRIPTION
### Description

fixes this ecosystem-ci error: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/18897620961/job/53938322239#step:7:1406

#20924 broke it because the regex was not serialized properly with JSON.stringify. 

refs #20924

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
