### PR TITLE
feat(create-vite): add interactive prompts for Tailwind CSS v4 and ESLint setup

### DIFF
--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -37,6 +37,23 @@ deno init --npm vite
 
 Then follow the prompts!
 
+### Interactive Options
+
+When running in interactive mode (TTY), `create-vite` will prompt you with additional setup options after selecting a framework and variant:
+
+- **Add Tailwind CSS?** - Automatically install and configure Tailwind CSS v4 with the `@tailwindcss/vite` plugin
+- **Add a linter?** - Choose between:
+  - None
+  - ESLint
+  - ESLint + Prettier
+
+These options help you quickly set up a production-ready project with common tools and configurations. The tool will:
+
+- Install the necessary dependencies
+- Add the Tailwind CSS Vite plugin to your `vite.config` (if Tailwind is selected)
+- Add `@import "tailwindcss";` to your CSS file (if Tailwind is selected)
+- Create basic ESLint and Prettier configs (if linter is selected)
+
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:
 
 ```bash

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -999,7 +999,8 @@ function setupTailwind(root: string, pkgManager: string, isTs: boolean) {
   if (fs.existsSync(viteConfigPath)) {
     editFile(viteConfigPath, (content) => {
       // Add import for @tailwindcss/vite
-      const importRegex = /import(?:\s+\S.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])|\s{2,})from\s+['"]vite['"]/
+      const importRegex =
+        /import(?:\s+\S.*(?:[\n\r\u2028\u2029]\s*|[\t\v\f \xa0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff])|\s{2,})from\s+['"]vite['"]/
       if (importRegex.test(content)) {
         content = content.replace(
           importRegex,


### PR DESCRIPTION
✨ Summary

This PR enhances the create-vite interactive wizard by introducing optional setup prompts for Tailwind CSS v4 and ESLint/Prettier during project creation.
It enables developers to bootstrap projects with these tools automatically — improving the developer experience and reducing repetitive setup work.

🎯 Motivation

Improved Developer Experience: Simplifies the setup process for Tailwind CSS and linting tools.

Modern Approach: Leverages the latest Tailwind CSS v4 with the @tailwindcss/vite plugin.

Opt-In Only: Prompts are shown only in interactive mode, ensuring non-interactive usage remains unchanged.

Reduced Boilerplate: Eliminates manual configuration steps that developers commonly perform after project creation.

🛠️ Changes
Modified Files
packages/create-vite/src/index.ts

Added new interactive prompts for:

Tailwind CSS v4 setup

Linter selection (ESLint / ESLint + Prettier)

Implemented:

setupTailwind()

Installs tailwindcss and @tailwindcss/vite

Configures Tailwind plugin in vite.config.ts/js

Adds @import "tailwindcss"; to CSS entry file

Creates a new CSS file if none exists

setupESLint()

Supports three options: None, ESLint, ESLint + Prettier

Generates .eslintrc.json with appropriate configuration

Installs required dependencies based on selection

Prompts are displayed only for non-custom templates in interactive mode.

packages/create-vite/README.md

Documented the new interactive options and usage examples.

Added descriptions for Tailwind CSS and ESLint setup features.

🚀 New Features
1. Tailwind CSS v4 Setup (Optional)

Uses modern @tailwindcss/vite plugin.

Automatically updates vite.config with the Tailwind plugin.

Injects @import "tailwindcss" into the main CSS file.

Creates the CSS file if missing.

Installs required dependencies.

2. ESLint / Prettier Setup (Optional)

Three options:

None

ESLint only

ESLint + Prettier

Generates .eslintrc.json based on choice.

Installs necessary npm packages automatically.

🧪 How to Test
1. Clone and build the package
git clone https://github.com/Ramjirv32/vite.git
cd vite
pnpm install
pnpm run build

2. Run create-vite in interactive mode
node packages/create-vite/dist/index.js


Follow the prompts:

Choose a framework (e.g., React, Vue)

Choose a variant (e.g., TypeScript)

Answer “Yes” to “Add Tailwind CSS?” ✅

Select a linter option (e.g., “ESLint + Prettier”) ✅

Then:

cd <your-project-name>

# Verify setup
cat package.json
cat vite.config.ts
cat src/index.css
cat .eslintrc.json

3. Run the project
npm install
npm run dev

🔍 Verification Script

To automate validation, you can use the provided verify-setup.sh script:

chmod +x verify-setup.sh
./verify-setup.sh <your-project-name>

✅ Expected Output
✅ tailwindcss and @tailwindcss/vite found in package.json
✅ Tailwind plugin imported and added to vite.config
✅ @import "tailwindcss" found in CSS file
✅ ESLint configuration found

🧩 Notes

This update maintains backward compatibility — non-interactive usage is unaffected.

The new setup options provide a faster, modern, and opinionated way to start Vite projects with Tailwind and ESLint out of the box.