### PR TITLE
fix(types): add undefined to optional properties for exactOptionalProperties type compatibility

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -136,7 +136,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
         isEntry: boolean
       },
     ) => Promise<ResolveIdResult> | ResolveIdResult,
-    { filter?: { id?: StringFilter<RegExp> | undefined } } | undefined
+    { filter?: { id?: StringFilter<RegExp> } }
   >
   load?: ObjectHook<
     (
@@ -146,7 +146,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
         ssr?: boolean | undefined
       },
     ) => Promise<LoadResult> | LoadResult,
-    { filter?: { id?: StringFilter | undefined } | undefined }
+    { filter?: { id?: StringFilter } }
   >
   transform?: ObjectHook<
     (
@@ -157,14 +157,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
         ssr?: boolean | undefined
       },
     ) => Promise<TransformResult> | TransformResult,
-    {
-      filter?:
-        | {
-            id?: StringFilter | undefined
-            code?: StringFilter | undefined
-          }
-        | undefined
-    }
+    { filter?: { id?: StringFilter; code?: StringFilter } }
   >
   /**
    * Opt-in this plugin into the shared plugins pipeline.

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -136,7 +136,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
         isEntry: boolean
       },
     ) => Promise<ResolveIdResult> | ResolveIdResult,
-    { filter?: { id?: StringFilter<RegExp> | undefined } }
+    { filter?: { id?: StringFilter<RegExp> | undefined } } | undefined
   >
   load?: ObjectHook<
     (
@@ -146,7 +146,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
         ssr?: boolean | undefined
       },
     ) => Promise<LoadResult> | LoadResult,
-    { filter?: { id?: StringFilter | undefined } }
+    { filter?: { id?: StringFilter | undefined } | undefined }
   >
   transform?: ObjectHook<
     (
@@ -158,10 +158,12 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       },
     ) => Promise<TransformResult> | TransformResult,
     {
-      filter?: {
-        id?: StringFilter | undefined
-        code?: StringFilter | undefined
-      }
+      filter?:
+        | {
+            id?: StringFilter | undefined
+            code?: StringFilter | undefined
+          }
+        | undefined
     }
   >
   /**

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -128,25 +128,25 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       options: {
         attributes: Record<string, string>
         custom?: CustomPluginOptions
-        ssr?: boolean
+        ssr?: boolean | undefined
         /**
          * @internal
          */
-        scan?: boolean
+        scan?: boolean | undefined
         isEntry: boolean
       },
     ) => Promise<ResolveIdResult> | ResolveIdResult,
-    { filter?: { id?: StringFilter<RegExp> } }
+    { filter?: { id?: StringFilter<RegExp> | undefined } }
   >
   load?: ObjectHook<
     (
       this: PluginContext,
       id: string,
       options?: {
-        ssr?: boolean
+        ssr?: boolean | undefined
       },
     ) => Promise<LoadResult> | LoadResult,
-    { filter?: { id?: StringFilter } }
+    { filter?: { id?: StringFilter | undefined } }
   >
   transform?: ObjectHook<
     (
@@ -154,10 +154,15 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       code: string,
       id: string,
       options?: {
-        ssr?: boolean
+        ssr?: boolean | undefined
       },
     ) => Promise<TransformResult> | TransformResult,
-    { filter?: { id?: StringFilter; code?: StringFilter } }
+    {
+      filter?: {
+        id?: StringFilter | undefined
+        code?: StringFilter | undefined
+      }
+    }
   >
   /**
    * Opt-in this plugin into the shared plugins pipeline.


### PR DESCRIPTION
Fixes #20948

# Fix Plugin Type Compatibility with `exactOptionalPropertyTypes`

## Problem

When TypeScript's `exactOptionalPropertyTypes` is enabled, users cannot spread Rollup plugins into Vite config:

```typescript
plugins: [
  {
    enforce: "pre",
    ...virtual({ "foo": "" })  // ❌ Type error
  }
]
```

Error: `Type 'Plugin<any>' is not assignable to type 'PluginOption'`

## Root Cause

Rollup v4.43.0 added support for `exactOptionalPropertyTypes` by explicitly marking optional properties with `| undefined`. Vite's Plugin interface didn't match these updated type definitions, causing incompatibility.

## Solution

Add `| undefined` to Vite's optional hook parameters (`ssr`, `scan`) that extend Rollup's plugin hooks. This aligns with Rollup's type definitions while maintaining backward compatibility.

## Changes

- `resolveId` hook: `ssr?: boolean` → `ssr?: boolean | undefined`
- `load` hook: `ssr?: boolean` → `ssr?: boolean | undefined`
- `transform` hook: `ssr?: boolean` → `ssr?: boolean | undefined`
- Internal: `scan?: boolean` → `scan?: boolean | undefined`

## Result

✅ Rollup plugins can be spread into Vite config
✅ Compatible with `exactOptionalPropertyTypes: true`
✅ Full type compatibility with Rollup v4.43.0+
✅ No breaking changes for existing users