### PR TITLE
chore: remove codeflow

### DIFF
--- a/.stackblitz/codeflow.json
+++ b/.stackblitz/codeflow.json
@@ -1,8 +1,0 @@
-{
-  "pnpm": {
-    "overrides": {
-      "vite": "./packages/vite",
-      "@vitejs/plugin-legacy": "./packages/plugin-legacy"
-    }
-  }
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,6 @@
 
 Hi! We're really excited that you're interested in contributing to Vite! Before submitting your contribution, please read through the following guide. We also suggest you read the [Project Philosophy](https://vite.dev/guide/philosophy) in our documentation.
 
-You can use [StackBlitz Codeflow](https://stackblitz.com/codeflow) to fix bugs or implement features. You'll see a Codeflow button on issues to start a PR to fix them. A button will also appear on PRs to review them without needing to check out the branch locally. When using Codeflow, the Vite repository will be cloned for you in an online editor, with the Vite package built in watch mode ready to test your changes. If you'd like to learn more, check out the [Codeflow docs](https://developer.stackblitz.com/codeflow/what-is-codeflow).
-
-[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/vitejs/vite)
-
 ## Repo Setup
 
 To develop locally, fork the Vite repository and clone it in your local machine. The Vite repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). You can find the required pnpm version in `package.json` under the `packageManager` key.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://npmjs.com/package/vite"><img src="https://img.shields.io/npm/v/vite.svg" alt="npm package"></a>
   <a href="https://nodejs.org/en/about/previous-releases"><img src="https://img.shields.io/node/v/vite.svg" alt="node compatibility"></a>
   <a href="https://github.com/vitejs/vite/actions/workflows/ci.yml"><img src="https://github.com/vitejs/vite/actions/workflows/ci.yml/badge.svg?branch=main" alt="build status"></a>
-  <a href="https://pr.new/vitejs/vite"><img src="https://developer.stackblitz.com/img/start_pr_dark_small.svg" alt="Start new PR in StackBlitz Codeflow"></a>
   <a href="https://chat.vite.dev"><img src="https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord" alt="discord chat"></a>
 </p>
 <br/>


### PR DESCRIPTION
### Description

closes #20838

Codeflow hasn't been working ootb properly for a while now. This PR removes its integration.

We should also remove [the bot](https://github.com/apps/bolt-new-by-stackblitz) from the repo/org: [example comment](https://github.com/vitejs/vite/issues/16262#issuecomment-2017421913). Looks like it has been repurposed for bolt.new.

cc @patak-dev I know you've not been involved much recently, but wanted to let you know since you added this initially.