### PR TITLE
refactor(build): rename `indexOfMatchInSlice` to `findPreloadMarker`

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -48,13 +48,9 @@ function toRelativePath(filename: string, importer: string) {
   return relPath[0] === '.' ? relPath : `./${relPath}`
 }
 
-function indexOfMatchInSlice(
-  str: string,
-  reg: RegExp,
-  pos: number = 0,
-): number {
-  reg.lastIndex = pos
-  const result = reg.exec(str)
+function findPreloadMarker(str: string, pos: number = 0): number {
+  preloadMarkerRE.lastIndex = pos
+  const result = preloadMarkerRE.exec(str)
   return result?.index ?? -1
 }
 
@@ -586,14 +582,10 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 addDeps(normalizedFile)
               }
 
-              let markerStartPos = indexOfMatchInSlice(
-                code,
-                preloadMarkerRE,
-                end,
-              )
+              let markerStartPos = findPreloadMarker(code, end)
               // fix issue #3051
               if (markerStartPos === -1 && imports.length === 1) {
-                markerStartPos = indexOfMatchInSlice(code, preloadMarkerRE)
+                markerStartPos = findPreloadMarker(code)
               }
 
               if (markerStartPos > 0) {
@@ -688,7 +680,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // there may still be markers due to inlined dynamic imports, remove
           // all the markers regardless
-          let markerStartPos = indexOfMatchInSlice(code, preloadMarkerRE)
+          let markerStartPos = findPreloadMarker(code)
           while (markerStartPos >= 0) {
             if (!rewroteMarkerStartPos.has(markerStartPos)) {
               s.update(
@@ -697,9 +689,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 'void 0',
               )
             }
-            markerStartPos = indexOfMatchInSlice(
+            markerStartPos = findPreloadMarker(
               code,
-              preloadMarkerRE,
               markerStartPos + preloadMarker.length,
             )
           }


### PR DESCRIPTION
### Description

Since `indexOfMatchInSlice` is only used to find `preloadMarker`, rename it to be more descriptive and use `preloadMarkerRE` directly.
