### PR TITLE
docs(release): update supported versions wording

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -529,6 +529,9 @@ In addition, Vite is highly extensible via its [Plugin API](https://vite.dev/gui
         'gsap/dist/MotionPathPlugin',
       ],
     },
+    define: {
+      __VITE_VERSION__: JSON.stringify(viteVersion),
+    },
   },
   buildEnd,
 })

--- a/docs/.vitepress/theme/components/ReleaseCalculator.vue
+++ b/docs/.vitepress/theme/components/ReleaseCalculator.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+declare const __VITE_VERSION__: string
+
+const previousMajorLatestMinors: Record<string, string> = {
+  '2': '2.9',
+  '3': '3.2',
+  '4': '4.5',
+  '5': '5.4',
+  '6': '6.4',
+}
+
+const viteVersion = ref(__VITE_VERSION__)
+
+const parsedVersion = computed(() => {
+  if (!isValidViteVersion(viteVersion.value)) return null
+
+  let [major, minor, patch] = viteVersion.value.split('.').map((v) => {
+    const num = /^\d+$/.exec(v)?.[0]
+    return num ? parseInt(num) : null
+  })
+  if (!major) return null
+  minor ??= 0
+  patch ??= 0
+
+  return { major, minor, patch }
+})
+
+const supportInfo = computed(() => {
+  if (!parsedVersion.value) return null
+
+  const { major, minor } = parsedVersion.value
+  const f = (versions: string[]) => {
+    return versions
+      .map((v) => previousMajorLatestMinors[v] ?? v)
+      .filter((version) => {
+        if (!isValidViteVersion(version)) return false
+        // Negative versions are invalid
+        if (/-\d/.test(version)) return false
+        return true
+      })
+  }
+
+  return {
+    regularPatches: f([`${major}.${minor}`]),
+    importantFixes: f([`${major - 1}`, `${major}.${minor - 1}`]),
+    securityPatches: f([`${major - 2}`, `${major}.${minor - 2}`]),
+    unsupported: f([`${major - 3}`, `${major}.${minor - 3}`]),
+  }
+})
+
+function versionsToText(versions: string[]) {
+  versions = versions.map((v) => (/^\d/.test(v) ? `<code>vite@${v}</code>` : v))
+  if (versions.length === 0) return ''
+  if (versions.length === 1) return versions[0]
+  return (
+    versions.slice(0, -1).join(', ') + ' and ' + versions[versions.length - 1]
+  )
+}
+
+function isValidViteVersion(version: string) {
+  if (version.length === 1) version += '.'
+  // Vite 0.x shouldn't be mentioned, and Vite 1.x was never released
+  if (version.startsWith('0.') || version.startsWith('1.')) return false
+  return true
+}
+
+function invalidReason(version: string) {
+  let str = `"${version}" is not a valid version.`
+  if (!isValidViteVersion(version)) {
+    str += ' Vite version should be 2.x or higher.'
+  }
+  return str
+}
+</script>
+
+<template>
+  <div>
+    <p class="version-text">
+      <label for="version-input">If the latest Vite version is</label>
+      <input
+        id="version-input"
+        type="text"
+        v-model="viteVersion"
+        :placeholder="viteVersion"
+      />
+    </p>
+
+    <ul v-if="supportInfo" class="support-info">
+      <li v-if="supportInfo.regularPatches.length">
+        Regular patches are released for
+        <span v-html="versionsToText(supportInfo.regularPatches)"></span>.
+      </li>
+      <li v-if="supportInfo.importantFixes.length">
+        Important fixes and security patches are backported to
+        <span v-html="versionsToText(supportInfo.importantFixes)"></span>.
+      </li>
+      <li v-if="supportInfo.securityPatches.length">
+        Security patches are also backported to
+        <span v-html="versionsToText(supportInfo.securityPatches)"></span>.
+      </li>
+      <li v-if="supportInfo.unsupported.length">
+        No longer supported versions include
+        <span
+          v-html="versionsToText(supportInfo.unsupported.concat('below'))"
+        ></span
+        >. Users should upgrade to receive updates.
+      </li>
+    </ul>
+    <p v-else class="invalid">{{ invalidReason(viteVersion) }}</p>
+  </div>
+</template>
+
+<style scoped>
+.version-text {
+  margin-bottom: -16px;
+}
+
+#version-input {
+  padding: 2px 8px;
+  margin: 2px 0 2px 6px;
+  font-size: inherit;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  font-family: var(--vp-font-family-mono);
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  transition: border-color 0.1s;
+}
+
+#version-input:focus,
+#version-input:hover {
+  border-color: var(--vp-c-brand);
+}
+
+.invalid {
+  color: var(--vp-c-danger-1);
+}
+
+.support-info {
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+</style>

--- a/docs/.vitepress/theme/components/SupportedVersions.vue
+++ b/docs/.vitepress/theme/components/SupportedVersions.vue
@@ -40,13 +40,13 @@ const checkedResult = computed(() => {
       parsedVersion.minor >= compared.minor
     )
   }
-  const satisifiesOneSupportedVersion =
+  const satisfiesOneSupportedVersion =
     parsedVersion.major >= parsedViteVersion.major || // Treat future major versions as supported
     supportInfo.regularPatches.some(satisfies) ||
     supportInfo.importantFixes.some(satisfies) ||
     supportInfo.securityPatches.some(satisfies)
 
-  return satisifiesOneSupportedVersion
+  return satisfiesOneSupportedVersion
     ? supportedVersionMessage
     : notSupportedVersionMessage
 })

--- a/docs/.vitepress/theme/components/SupportedVersions.vue
+++ b/docs/.vitepress/theme/components/SupportedVersions.vue
@@ -86,7 +86,7 @@ function computeSupportInfo(
 }
 
 function versionsToText(versions: string[]) {
-  versions = versions.map((v) => (/^\d/.test(v) ? `<code>vite@${v}</code>` : v))
+  versions = versions.map((v) => `<code>vite@${v}</code>`)
   if (versions.length === 0) return ''
   if (versions.length === 1) return versions[0]
   return (

--- a/docs/.vitepress/theme/components/SupportedVersions.vue
+++ b/docs/.vitepress/theme/components/SupportedVersions.vue
@@ -86,7 +86,6 @@ function computeSupportInfo(
     regularPatches: f([`${major}.${minor}`]),
     importantFixes: f([`${major - 1}`, `${major}.${minor - 1}`]),
     securityPatches: f([`${major - 2}`, `${major}.${minor - 2}`]),
-    unsupported: f([`${major - 3}`, `${major}.${minor - 3}`]),
   }
 }
 
@@ -122,12 +121,9 @@ function isValidViteVersion(version: string) {
         Security patches are also backported to
         <span v-html="versionsToText(supportInfo.securityPatches)"></span>.
       </li>
-      <li v-if="supportInfo.unsupported.length">
-        No longer supported versions include
-        <span
-          v-html="versionsToText(supportInfo.unsupported.concat('below'))"
-        ></span
-        >. Users should upgrade to receive updates.
+      <li>
+        All versions before these are no longer supported. Users should upgrade
+        to receive updates.
       </li>
     </ul>
     <p>

--- a/docs/.vitepress/theme/components/SupportedVersions.vue
+++ b/docs/.vitepress/theme/components/SupportedVersions.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 
 declare const __VITE_VERSION__: string
 
+// Constants
 const supportedVersionMessage = {
   color: 'var(--vp-c-brand-1)',
   text: 'supported',
@@ -19,33 +20,28 @@ const previousMajorLatestMinors: Record<string, string> = {
   '6': '6.4',
 }
 
-const parsedViteVersion = parseVersion(__VITE_VERSION__)
-if (!parsedViteVersion) {
-  throw new Error(`Invalid Vite version: ${__VITE_VERSION__}`)
-}
+// Current latest Vite version and support info
+const parsedViteVersion = parseVersion(__VITE_VERSION__)!
 const supportInfo = computeSupportInfo(parsedViteVersion)
 
+// Check supported version input
 const checkedVersion = ref(`${Math.max(parsedViteVersion.major - 3, 2)}.0.0`)
 const checkedResult = computed(() => {
-  const v = parseVersion(checkedVersion.value)
-  if (!v) return notSupportedVersionMessage
+  const version = checkedVersion.value
+  if (!isValidViteVersion(version)) return notSupportedVersionMessage
+
+  const parsedVersion = parseVersion(checkedVersion.value)
+  if (!parsedVersion) return notSupportedVersionMessage
 
   const satisfies = (targetVersion: string) => {
-    const compared = parseVersion(targetVersion)
-    if (!compared) {
-      throw new Error(
-        `Unexpected invalid version from computeSupportInfo: ${targetVersion}`,
-      )
-    }
+    const compared = parseVersion(targetVersion)!
     return (
-      v.major > compared.major ||
-      (v.major === compared.major && v.minor > compared.minor) ||
-      (v.major === compared.major &&
-        v.minor === compared.minor &&
-        v.patch >= compared.patch)
+      parsedVersion.major === compared.major &&
+      parsedVersion.minor >= compared.minor
     )
   }
   const satisifiesOneSupportedVersion =
+    parsedVersion.major >= parsedViteVersion.major || // Treat future major versions as supported
     supportInfo.regularPatches.some(satisfies) ||
     supportInfo.importantFixes.some(satisfies) ||
     supportInfo.securityPatches.some(satisfies)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,3 +1,7 @@
+<script setup>
+import ReleaseCalculator from './.vitepress/theme/components/ReleaseCalculator.vue';
+</script>
+
 # Releases
 
 Vite releases follow [Semantic Versioning](https://semver.org/). You can see the latest stable version of Vite in the [Vite npm package page](https://www.npmjs.com/package/vite).
@@ -19,12 +23,11 @@ The Vite version ranges that are supported by the Vite team are automatically de
 - **Second-to-last Major** (only for its latest minor) and **Second-to-last Minor** receives security patches.
 - All versions before these are no longer supported.
 
-As an example, if the Vite latest is at 5.3.10:
+::: tip Interactive Example
 
-- Regular patches are released for `vite@5.3`.
-- Important fixes and security patches are backported to `vite@4` and `vite@5.2`.
-- Security patches are also backported to `vite@3`, and `vite@5.1`.
-- `vite@2` and `vite@5.0` are no longer supported. Users should upgrade to receive updates.
+<ReleaseCalculator />
+
+:::
 
 We recommend updating Vite regularly. Check out the [Migration Guides](https://vite.dev/guide/migration.html) when you update to each Major. The Vite team works closely with the main projects in the ecosystem to ensure the quality of new versions. We test new Vite versions before releasing them through the [vite-ecosystem-ci project](https://github.com/vitejs/vite-ecosystem-ci). Most projects using Vite should be able to quickly offer support or migrate to new versions as soon as they are released.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,7 +18,7 @@ Vite does not have a fixed release cycle.
 
 ## Supported Versions
 
-In summary, the current supported versions are:
+In summary, the current supported Vite versions are:
 
 <SupportedVersions />
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,5 @@
 <script setup>
-import ReleaseCalculator from './.vitepress/theme/components/ReleaseCalculator.vue';
+import SupportedVersions from './.vitepress/theme/components/SupportedVersions.vue';
 </script>
 
 # Releases
@@ -16,18 +16,20 @@ Vite does not have a fixed release cycle.
 - **Minor** releases always contain new features and are released as needed. Minor releases always have a beta pre-release phase (usually every two months).
 - **Major** releases generally align with [Node.js EOL schedule](https://endoflife.date/nodejs), and will be announced ahead of time. These releases will go through long-term discussions with the ecosystem, and have alpha and beta pre-release phases (usually every year).
 
-The Vite version ranges that are supported by the Vite team are automatically determined by:
+## Supported Versions
+
+In summary, the current supported versions are:
+
+<SupportedVersions />
+
+<br>
+
+The supported version ranges are are automatically determined by:
 
 - **Current Minor** gets regular fixes.
 - **Previous Major** (only for its latest minor) and **Previous Minor** receives important fixes and security patches.
 - **Second-to-last Major** (only for its latest minor) and **Second-to-last Minor** receives security patches.
 - All versions before these are no longer supported.
-
-::: tip Interactive Example
-
-<ReleaseCalculator />
-
-:::
 
 We recommend updating Vite regularly. Check out the [Migration Guides](https://vite.dev/guide/migration.html) when you update to each Major. The Vite team works closely with the main projects in the ecosystem to ensure the quality of new versions. We test new Vite versions before releasing them through the [vite-ecosystem-ci project](https://github.com/vitejs/vite-ecosystem-ci). Most projects using Vite should be able to quickly offer support or migrate to new versions as soon as they are released.
 


### PR DESCRIPTION
### Description

Updates https://vite.dev/releases.html#release-cycle. I found the example using `5.3.10` makes it hard to grasp what's the actual supported versions today with the latest Vite version.

I've updated to make the description dynamic, and also included a small interactive input for users to verify if a certain version is considered supported.

<img width="686" height="307" alt="image" src="https://github.com/user-attachments/assets/efc736fb-9f44-4a7c-8f66-ca356e4eea46" />
