### PR TITLE
docs: add links to releases docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,3 +352,5 @@ If you have publish access, the steps below explain how to cut a release for a p
 3. Click on the "Review deployments" button in the yellow box, a popup will appear.
 4. Check "Release" and click "Approve and deploy".
 5. The package will start publishing to npm.
+
+To learn more about how and when Vite does releases, check out the [Releases](https://vite.dev/releases) documentation.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -259,6 +259,8 @@ pnpm link --global # use your preferred package manager for this step
 
 Then go to your Vite based project and run `pnpm link --global vite` (or the package manager that you used to link `vite` globally). Now restart the development server to ride on the bleeding edge!
 
+To learn more about how and when Vite does releases, check out the [Releases](../releases.md) documentation.
+
 ::: tip Dependencies using Vite
 To replace the Vite version used by dependencies transitively, you should use [npm overrides](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides) or [pnpm overrides](https://pnpm.io/9.x/package_json#pnpmoverrides).
 :::


### PR DESCRIPTION
### Description

We currently don't have links to the releases docs, except from through the navbar. Hopefully this change will allow more people to notice and understand the release process.