### PR TITLE
fix(css-order): preserve import order for CSS chunks

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1049,9 +1049,16 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                 const { importedCss, importedAssets } = (
                   bundle[file] as OutputChunk
                 ).viteMetadata!
-                importedCss.forEach((file) =>
-                  chunk.viteMetadata!.importedCss.add(file),
-                )
+                // Preserve original import order: ensure CSS coming from imported
+                // pure CSS chunks appears before the parent's existing CSS.
+                if (importedCss.size > 0) {
+                  const parentCss = chunk.viteMetadata!.importedCss
+                  const ordered = new Set<string>([
+                    ...importedCss,
+                    ...parentCss,
+                  ])
+                  chunk.viteMetadata!.importedCss = ordered
+                }
                 importedAssets.forEach((file) =>
                   chunk.viteMetadata!.importedAssets.add(file),
                 )

--- a/playground/css-order-manual-chunks/__tests__/order.spec.ts
+++ b/playground/css-order-manual-chunks/__tests__/order.spec.ts
@@ -22,6 +22,5 @@ test('runtime style precedence matches import order', async () => {
   // lib.css sets .box { color: green }, base.css sets .box { color: red }
   // If lib.css is loaded before index.css, final color should be red
   const color = await page.$eval('#app', (el) => getComputedStyle(el).color)
-  // smoke check page loaded
   expect(color).toBe('rgb(255, 0, 0)')
 })

--- a/playground/css-order-manual-chunks/__tests__/order.spec.ts
+++ b/playground/css-order-manual-chunks/__tests__/order.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { isBuild, page, readFile } from '~utils'
+
+describe.runIf(isBuild)('build', () => {
+  test('css links respect import order with manualChunks', async () => {
+    const html = readFile('dist/index.html') as string
+    // expect lib.css link appears before entry css link (index.css)
+    const libHref = /href="(.*?)\/assets\/lib-([\w-]+)\.css"/g
+    const indexHref = /href="(.*?)\/assets\/index-([\w-]+)\.css"/g
+
+    const libMatch = libHref.exec(html)
+    const indexMatch = indexHref.exec(html)
+
+    expect(libMatch, 'lib.css link should exist').toBeTruthy()
+    expect(indexMatch, 'index.css link should exist').toBeTruthy()
+
+    expect(libMatch!.index).toBeLessThan(indexMatch!.index)
+  })
+})
+
+test('runtime style precedence matches import order', async () => {
+  // lib.css sets .box { color: green }, base.css sets .box { color: red }
+  // If lib.css is loaded before index.css, final color should be red
+  const color = await page.$eval('#app', (el) => getComputedStyle(el).color)
+  // smoke check page loaded
+  expect(color).toBe('rgb(255, 0, 0)')
+})

--- a/playground/css-order-manual-chunks/base.css
+++ b/playground/css-order-manual-chunks/base.css
@@ -1,0 +1,3 @@
+.box {
+  color: red;
+}

--- a/playground/css-order-manual-chunks/index.html
+++ b/playground/css-order-manual-chunks/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CSS Order Manual Chunks</title>
+  </head>
+  <body>
+    <div id="app">css order manual chunks</div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/playground/css-order-manual-chunks/lib.css
+++ b/playground/css-order-manual-chunks/lib.css
@@ -1,0 +1,3 @@
+.box {
+  color: green;
+}

--- a/playground/css-order-manual-chunks/main.js
+++ b/playground/css-order-manual-chunks/main.js
@@ -1,0 +1,5 @@
+// simulate third-party big css split via manualChunks
+import './lib.css'
+import './base.css'
+
+document.getElementById('app').className = 'box'

--- a/playground/css-order-manual-chunks/vite.config.js
+++ b/playground/css-order-manual-chunks/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.endsWith('/lib.css')) return 'lib'
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Description

This PR fixes CSS link order in generated HTML when using `manualChunks` to split CSS into separate chunks. Previously, when third-party CSS (like `animate.css`) was split into a separate chunk via `manualChunks`, the resulting CSS links in `index.html` would appear in the wrong order (e.g., `index.css` before `animate.css`), even though the source code imported them in the correct order.

**Problem:**
When pure CSS chunks are removed and their CSS files are merged into parent chunks' `viteMetadata.importedCss`, the merged CSS was being added after the parent's existing CSS, causing the final HTML to have the wrong link order.

**Solution:**
Modified the CSS merging logic in `packages/vite/src/node/plugins/css.ts` to prepend CSS from pure CSS chunks before the parent's existing CSS, preserving the original import order. This ensures that when CSS is injected into HTML, dependencies appear before the entry CSS.

**Changes:**
- Updated `generateBundle` in `cssPostPlugin` to merge CSS from pure CSS chunks in the correct order
- Added integration test in `playground/css-order-manual-chunks` to verify CSS link order respects import order

**Testing:**
- Added e2e test that verifies CSS links in `dist/index.html` appear in the correct order when using `manualChunks`

Fixes #20995