### PR TITLE
docs(features): add license section

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -193,7 +193,7 @@ export default defineConfig({
 
 When set to `true`, the build will generate a `.vite/license.md` file that includes all bundled dependencies' licenses.
 
-If `fileName` is passed, it will be used as the license file name relative to the `outDir`. If the it ends with `.json`, the raw JSON metadata will be generated instead and can be used for further processing. For example:
+If `fileName` is passed, it will be used as the license file name relative to the `outDir`. If it ends with `.json`, the raw JSON metadata will be generated instead and can be used for further processing. For example:
 
 ```json
 [

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -189,28 +189,11 @@ export default defineConfig({
 
 - **Type:** `boolean | { fileName?: string }`
 - **Default:** `false`
+- **Related:** [License](/guide/features#license)
 
-When set to `true`, the build will generate a `.vite/license.md` file that includes all bundled dependencies' licenses. It can be hosted to display and acknowledge the dependencies used by the app. When `fileName` is passed, it will be used as the license file name relative to the `outDir`. An example output may look like this:
+When set to `true`, the build will generate a `.vite/license.md` file that includes all bundled dependencies' licenses.
 
-```md
-# Licenses
-
-The app bundles dependencies which contain the following licenses:
-
-## dep-1 - 1.2.3 (CC0-1.0)
-
-CC0 1.0 Universal
-
-...
-
-## dep-2 - 4.5.6 (MIT)
-
-MIT License
-
-...
-```
-
-If the `fileName` ends with `.json`, the raw JSON metadata will be generated instead and can be used for further processing. For example:
+If `fileName` is passed, it will be used as the license file name relative to the `outDir`. If the it ends with `.json`, the raw JSON metadata will be generated instead and can be used for further processing. For example:
 
 ```json
 [

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -789,6 +789,42 @@ By default, during build, Vite inlines small assets as data URIs. Allowing `data
 Do not allow `data:` for [`script-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src). It will allow injection of arbitrary scripts.
 :::
 
+## License
+
+Vite can generate a file of all the dependencies' licenses used in the build with the [`build.license`](/config/build-options.md#build-license) option. It can be hosted to display and acknowledge the dependencies used by the app.
+
+```js twoslash [vite.config.js]
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    license: true,
+  },
+})
+```
+
+This will generate a `.vite/license.md` file with an output that may look like this:
+
+```md
+# Licenses
+
+The app bundles dependencies which contain the following licenses:
+
+## dep-1 - 1.2.3 (CC0-1.0)
+
+CC0 1.0 Universal
+
+...
+
+## dep-2 - 4.5.6 (MIT)
+
+MIT License
+
+...
+```
+
+To serve the file at a different path, you can pass `{ fileName: 'license.md' }` for example, so that it's served at `https://example.com/license.md`. See the [`build.license`](/config/build-options.md#build-license) docs for more information.
+
 ## Build Optimizations
 
 > Features listed below are automatically applied as part of the build process and there is no need for explicit configuration unless you want to disable them.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,7 +24,7 @@ In summary, the current supported Vite versions are:
 
 <br>
 
-The supported version ranges are are automatically determined by:
+The supported version ranges are automatically determined by:
 
 - **Current Minor** gets regular fixes.
 - **Previous Major** (only for its latest minor) and **Previous Minor** receives important fixes and security patches.


### PR DESCRIPTION
### Description

Adds a license section in the features guide so it's not only documented in the API reference. Also move some info to the new section.

I think this should help make the feature more visible.