### PR TITLE
docs: enable cleanUrls

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,6 +87,7 @@ function inlineScript(file: string): HeadConfig {
 export default defineConfig({
   title: `Vite${additionalTitle}`,
   description: 'Next Generation Frontend Tooling',
+  cleanUrls: true,
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],


### PR DESCRIPTION
### Description

So VitePress doesn't generate `.html` links.

I kept the canonical links generation since people might still be accessing `.html` links, and algolia still have indexes for `.html` links, but we can technically remove that later if we want to, as also explained at https://github.com/vitejs/vite/pull/15984#issuecomment-1956225554