### PR TITLE
docs(landing): optimize fonts loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.log
 /.vscode/
 /docs/.vitepress/cache
+/docs/.vitepress/.temp
 /packages/vite/LICENSE
 dist
 dist-ssr

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,22 @@ layout: home
 aside: false
 editLink: false
 markdownStyles: false
+
+head:
+  - - link
+    - rel: preconnect
+      href: https://fonts.googleapis.com
+  - - link
+    - rel: preconnect
+      href: https://fonts.gstatic.com
+      crossorigin: ''
+  - - link
+    - rel: preload
+      href: https://fonts.googleapis.com/css2?family=Manrope:wght@600&family=IBM+Plex+Mono:wght@400&display=swap
+      as: style
+  - - link
+    - rel: stylesheet
+      href: https://fonts.googleapis.com/css2?family=Manrope:wght@600&family=IBM+Plex+Mono:wght@400&display=swap
 ---
 
 <script setup>


### PR DESCRIPTION
The google fonts for the landing page was loaded for all pages, I moved the links to the landing page only so they won't be loaded on other pages.

Also, the link was fetching Inter when VitePress already bundles its own, so I updated the link as there's no need to fetch Inter from google fonts again.