### PR TITLE
fix: revert "refactor: use fs.cpSync (#21019)"

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -644,11 +644,7 @@ async function init() {
       )
       fs.writeFileSync(targetPath, updatedContent)
     } else {
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is not experimental in Node 22.3+
-      fs.cpSync(path.join(templateDir, file), targetPath, {
-        recursive: true,
-        mode: fs.constants.COPYFILE_FICLONE,
-      })
+      copy(path.join(templateDir, file), targetPath)
     }
   }
 
@@ -714,6 +710,15 @@ function formatTargetDir(targetDir: string) {
   return targetDir.trim().replace(/\/+$/g, '')
 }
 
+function copy(src: string, dest: string) {
+  const stat = fs.statSync(src)
+  if (stat.isDirectory()) {
+    copyDir(src, dest)
+  } else {
+    fs.copyFileSync(src, dest)
+  }
+}
+
 function isValidPackageName(projectName: string) {
   return /^(?:@[a-z\d\-*~][a-z\d\-*._~]*\/)?[a-z\d\-~][a-z\d\-._~]*$/.test(
     projectName,
@@ -727,6 +732,15 @@ function toValidPackageName(projectName: string) {
     .replace(/\s+/g, '-')
     .replace(/^[._]/, '')
     .replace(/[^a-z\d\-~]+/g, '-')
+}
+
+function copyDir(srcDir: string, destDir: string) {
+  fs.mkdirSync(destDir, { recursive: true })
+  for (const file of fs.readdirSync(srcDir)) {
+    const srcFile = path.resolve(srcDir, file)
+    const destFile = path.resolve(destDir, file)
+    copy(srcFile, destFile)
+  }
 }
 
 function isEmpty(path: string) {

--- a/packages/vite/src/node/plugins/prepareOutDir.ts
+++ b/packages/vite/src/node/plugins/prepareOutDir.ts
@@ -4,7 +4,7 @@ import colors from 'picocolors'
 import type { Plugin } from '../plugin'
 import { getResolvedOutDirs, resolveEmptyOutDir } from '../watch'
 import type { Environment } from '../environment'
-import { emptyDir, normalizePath } from '../utils'
+import { copyDir, emptyDir, normalizePath } from '../utils'
 import { withTrailingSlash } from '../../shared/utils'
 
 export function prepareOutDirPlugin(): Plugin {
@@ -86,11 +86,7 @@ function prepareOutDir(
           ),
         )
       }
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is not experimental in Node 22.3+
-      fs.cpSync(publicDir, outDir, {
-        recursive: true,
-        mode: fs.constants.COPYFILE_FICLONE,
-      })
+      copyDir(publicDir, outDir)
     }
   }
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -624,6 +624,8 @@ export function emptyDir(dir: string, skip?: string[]): void {
   }
 }
 
+// NOTE: we cannot use `fs.cpSync` because of a bug in Node.js (https://github.com/nodejs/node/issues/58768, https://github.com/nodejs/node/issues/59168)
+//       also note that we should set `deference: true` when we use `fs.cpSync`
 export function copyDir(srcDir: string, destDir: string): void {
   fs.mkdirSync(destDir, { recursive: true })
   for (const file of fs.readdirSync(srcDir)) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -625,7 +625,7 @@ export function emptyDir(dir: string, skip?: string[]): void {
 }
 
 // NOTE: we cannot use `fs.cpSync` because of a bug in Node.js (https://github.com/nodejs/node/issues/58768, https://github.com/nodejs/node/issues/59168)
-//       also note that we should set `deference: true` when we use `fs.cpSync`
+//       also note that we should set `dereference: true` when we use `fs.cpSync`
 export function copyDir(srcDir: string, destDir: string): void {
   fs.mkdirSync(destDir, { recursive: true })
   for (const file of fs.readdirSync(srcDir)) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -624,6 +624,23 @@ export function emptyDir(dir: string, skip?: string[]): void {
   }
 }
 
+export function copyDir(srcDir: string, destDir: string): void {
+  fs.mkdirSync(destDir, { recursive: true })
+  for (const file of fs.readdirSync(srcDir)) {
+    const srcFile = path.resolve(srcDir, file)
+    if (srcFile === destDir) {
+      continue
+    }
+    const destFile = path.resolve(destDir, file)
+    const stat = fs.statSync(srcFile)
+    if (stat.isDirectory()) {
+      copyDir(srcFile, destFile)
+    } else {
+      fs.copyFileSync(srcFile, destFile)
+    }
+  }
+}
+
 export const ERR_SYMLINK_IN_RECURSIVE_READDIR =
   'ERR_SYMLINK_IN_RECURSIVE_READDIR'
 export async function recursiveReaddir(dir: string): Promise<string[]> {


### PR DESCRIPTION
It seems `fs.cpSync` has a bug that affects Windows non-ascii paths (https://github.com/nodejs/node/issues/58768), that causes the file to be written to a different path (and then the process crashes). It also has a bug for `dereference: true` flag (https://github.com/nodejs/node/issues/59168), which we should have set (mentioned in https://github.com/vitejs/vite/pull/21019#issuecomment-3495996914).

This PR reverts #21019 to solve these issues. We can re-apply it after all the fixes lands in all the Node versions we support.

fixes #21065
fixes #21077

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
