### PR TITLE
docs(rolldown): use devDependencies in package.json

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -36,7 +36,7 @@ The rolldown-powered version of Vite is currently available as a separate packag
 
 ```json
 {
-  "dependencies": {
+  "devDependencies": {
     "vite": "^7.0.0" // [!code --]
     "vite": "npm:rolldown-vite@latest" // [!code ++]
   }


### PR DESCRIPTION
In package.json, vite is usually listed as a ·dependency in `devDependencies`, not `dependencies`. If this was intentionally written this way, I think it's easily misunderstood and might require further clarification. For example, do `devDependencies` and `dependencies` behave the same way? Most projects I've encountered seem to treat `vite` as a `devDependencies` , rather than a `dependencies`.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
