### PR TITLE
fix(create-vite): use `create-rwsdk` for redwood template

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -172,8 +172,7 @@ const FRAMEWORKS: Framework[] = [
         name: 'redwoodsdk-standard',
         display: 'RedwoodSDK ↗',
         color: red,
-        customCommand:
-          'npm exec degit redwoodjs/sdk/starters/standard TARGET_DIR',
+        customCommand: 'npm create rwsdk@latest TARGET_DIR',
       },
       {
         name: 'rsc',


### PR DESCRIPTION
This was referencing an outdated method for installing RedwoodSDK. 