### PR TITLE
fix: allow multiple `bindCLIShortcuts` calls with shortcut merging

### DIFF
--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createServer } from '../server'
+import { bindCLIShortcuts } from '../shortcuts'
+
+describe('bindCLIShortcuts', () => {
+  const originalIsTTY = process.stdin.isTTY
+
+  beforeEach(() => {
+    process.stdin.isTTY = true
+    vi.stubEnv('CI', '')
+  })
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY
+    vi.unstubAllEnvs()
+  })
+
+  test('binding custom shortcuts with the dev server', async () => {
+    const server = await createServer({
+      server: { host: 'localhost', port: 0 },
+    })
+    const xAction = vi.fn()
+    const yAction = vi.fn()
+
+    bindCLIShortcuts(server, {
+      customShortcuts: [
+        {
+          key: 'x',
+          description: 'shortcut that is overriden in the 2nd call',
+          action: xAction,
+        },
+        {
+          key: 'y',
+          description: 'shortcut that is omitted from 2nd call',
+          action: yAction,
+        },
+      ],
+    })
+
+    expect.assert(
+      server._rl,
+      'The readline interface should be defined after binding shortcuts.',
+    )
+    expect(xAction).not.toHaveBeenCalled()
+
+    server._rl.emit('line', 'x')
+    await vi.waitFor(() => expect(xAction).toHaveBeenCalledOnce())
+
+    const xUpdatedAction = vi.fn()
+    const zAction = vi.fn()
+
+    xAction.mockClear()
+    bindCLIShortcuts(server, {
+      customShortcuts: [
+        {
+          key: 'x',
+          description: 'new shortcut with duplicated "x" key',
+          action: xUpdatedAction,
+        },
+        { key: 'z', description: 'new shortcut with new key', action: zAction },
+      ],
+    })
+
+    expect(xUpdatedAction).not.toHaveBeenCalled()
+    server._rl.emit('line', 'x')
+    await vi.waitFor(() => expect(xUpdatedAction).toHaveBeenCalledOnce())
+
+    // Ensure original xAction is not called again
+    expect(xAction).not.toBeCalled()
+
+    expect(yAction).not.toHaveBeenCalled()
+    server._rl.emit('line', 'y')
+    await vi.waitFor(() => expect(yAction).toHaveBeenCalledOnce())
+
+    expect(zAction).not.toHaveBeenCalled()
+    server._rl.emit('line', 'z')
+    await vi.waitFor(() => expect(zAction).toHaveBeenCalledOnce())
+  })
+})

--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { createServer } from '../server'
+import { preview } from '../preview'
 import { bindCLIShortcuts } from '../shortcuts'
 
 describe('bindCLIShortcuts', () => {
@@ -15,65 +16,59 @@ describe('bindCLIShortcuts', () => {
     vi.unstubAllEnvs()
   })
 
-  test('binding custom shortcuts with the dev server', async () => {
-    const server = await createServer({
-      server: { host: 'localhost', port: 0 },
-    })
-    const xAction = vi.fn()
-    const yAction = vi.fn()
+  test.each([
+    ['dev server', () => createServer()],
+    ['preview server', () => preview()],
+  ])('binding custom shortcuts with the %s', async (_, startServer) => {
+    const server = await startServer()
 
-    bindCLIShortcuts(server, {
-      customShortcuts: [
-        {
-          key: 'x',
-          description: 'shortcut that is overriden in the 2nd call',
-          action: xAction,
-        },
-        {
-          key: 'y',
-          description: 'shortcut that is omitted from 2nd call',
-          action: yAction,
-        },
-      ],
-    })
+    try {
+      const xAction = vi.fn()
+      const yAction = vi.fn()
 
-    expect.assert(
-      server._rl,
-      'The readline interface should be defined after binding shortcuts.',
-    )
-    expect(xAction).not.toHaveBeenCalled()
+      bindCLIShortcuts(server, {
+        customShortcuts: [
+          { key: 'x', description: 'test x', action: xAction },
+          { key: 'y', description: 'test y', action: yAction },
+        ],
+      })
 
-    server._rl.emit('line', 'x')
-    await vi.waitFor(() => expect(xAction).toHaveBeenCalledOnce())
+      expect.assert(
+        server._rl,
+        'The readline interface should be defined after binding shortcuts.',
+      )
+      expect(xAction).not.toHaveBeenCalled()
 
-    const xUpdatedAction = vi.fn()
-    const zAction = vi.fn()
+      server._rl.emit('line', 'x')
+      await vi.waitFor(() => expect(xAction).toHaveBeenCalledOnce())
 
-    xAction.mockClear()
-    bindCLIShortcuts(server, {
-      customShortcuts: [
-        {
-          key: 'x',
-          description: 'new shortcut with duplicated "x" key',
-          action: xUpdatedAction,
-        },
-        { key: 'z', description: 'new shortcut with new key', action: zAction },
-      ],
-    })
+      const xUpdatedAction = vi.fn()
+      const zAction = vi.fn()
 
-    expect(xUpdatedAction).not.toHaveBeenCalled()
-    server._rl.emit('line', 'x')
-    await vi.waitFor(() => expect(xUpdatedAction).toHaveBeenCalledOnce())
+      xAction.mockClear()
+      bindCLIShortcuts(server, {
+        customShortcuts: [
+          { key: 'x', description: 'test x updated', action: xUpdatedAction },
+          { key: 'z', description: 'test z', action: zAction },
+        ],
+      })
 
-    // Ensure original xAction is not called again
-    expect(xAction).not.toBeCalled()
+      expect(xUpdatedAction).not.toHaveBeenCalled()
+      server._rl.emit('line', 'x')
+      await vi.waitFor(() => expect(xUpdatedAction).toHaveBeenCalledOnce())
 
-    expect(yAction).not.toHaveBeenCalled()
-    server._rl.emit('line', 'y')
-    await vi.waitFor(() => expect(yAction).toHaveBeenCalledOnce())
+      // Ensure original xAction is not called again
+      expect(xAction).not.toBeCalled()
 
-    expect(zAction).not.toHaveBeenCalled()
-    server._rl.emit('line', 'z')
-    await vi.waitFor(() => expect(zAction).toHaveBeenCalledOnce())
+      expect(yAction).not.toHaveBeenCalled()
+      server._rl.emit('line', 'y')
+      await vi.waitFor(() => expect(yAction).toHaveBeenCalledOnce())
+
+      expect(zAction).not.toHaveBeenCalled()
+      server._rl.emit('line', 'z')
+      await vi.waitFor(() => expect(zAction).toHaveBeenCalledOnce())
+    } finally {
+      await server.close()
+    }
   })
 })

--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -1,21 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createServer } from '../server'
 import { preview } from '../preview'
 import { bindCLIShortcuts } from '../shortcuts'
 
 describe('bindCLIShortcuts', () => {
-  const originalIsTTY = process.stdin.isTTY
-
-  beforeEach(() => {
-    process.stdin.isTTY = true
-    vi.stubEnv('CI', '')
-  })
-
-  afterEach(() => {
-    process.stdin.isTTY = originalIsTTY
-    vi.unstubAllEnvs()
-  })
-
   test.each([
     ['dev server', () => createServer()],
     ['preview server', () => preview()],
@@ -26,12 +14,16 @@ describe('bindCLIShortcuts', () => {
       const xAction = vi.fn()
       const yAction = vi.fn()
 
-      bindCLIShortcuts(server, {
-        customShortcuts: [
-          { key: 'x', description: 'test x', action: xAction },
-          { key: 'y', description: 'test y', action: yAction },
-        ],
-      })
+      bindCLIShortcuts(
+        server,
+        {
+          customShortcuts: [
+            { key: 'x', description: 'test x', action: xAction },
+            { key: 'y', description: 'test y', action: yAction },
+          ],
+        },
+        true,
+      )
 
       expect.assert(
         server._rl,
@@ -46,12 +38,16 @@ describe('bindCLIShortcuts', () => {
       const zAction = vi.fn()
 
       xAction.mockClear()
-      bindCLIShortcuts(server, {
-        customShortcuts: [
-          { key: 'x', description: 'test x updated', action: xUpdatedAction },
-          { key: 'z', description: 'test z', action: zAction },
-        ],
-      })
+      bindCLIShortcuts(
+        server,
+        {
+          customShortcuts: [
+            { key: 'x', description: 'test x updated', action: xUpdatedAction },
+            { key: 'z', description: 'test z', action: zAction },
+          ],
+        },
+        true,
+      )
 
       expect(xUpdatedAction).not.toHaveBeenCalled()
       server._rl.emit('line', 'x')

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import type readline from 'node:readline'
 import sirv from 'sirv'
 import compression from '@polka/compression'
 import connect from 'connect'
@@ -107,6 +108,14 @@ export interface PreviewServer {
    * Bind CLI shortcuts
    */
   bindCLIShortcuts(options?: BindCLIShortcutsOptions<PreviewServer>): void
+  /**
+   * @internal
+   */
+  _shortcutsOptions?: BindCLIShortcutsOptions<PreviewServer>
+  /**
+   * @internal
+   */
+  _rl?: readline.Interface | undefined
 }
 
 export type PreviewServerHook = (

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -6,6 +6,7 @@ import { get as httpsGet } from 'node:https'
 import type * as http from 'node:http'
 import { performance } from 'node:perf_hooks'
 import type { Http2SecureServer } from 'node:http2'
+import type readline from 'node:readline'
 import connect from 'connect'
 import corsMiddleware from 'cors'
 import colors from 'picocolors'
@@ -408,6 +409,10 @@ export interface ViteDevServer {
    * @internal
    */
   _shortcutsOptions?: BindCLIShortcutsOptions<ViteDevServer>
+  /**
+   * @internal
+   */
+  _rl?: readline.Interface | undefined
   /**
    * @internal
    */

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -42,7 +42,7 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
   // Merge custom shortcuts from existing options
   // with new shortcuts taking priority
   for (const shortcut of server._shortcutsOptions?.customShortcuts ?? []) {
-    if (!customShortcuts.find((s) => s.key === shortcut.key)) {
+    if (!customShortcuts.some((s) => s.key === shortcut.key)) {
       customShortcuts.push(shortcut)
     }
   }

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -28,8 +28,9 @@ export type CLIShortcut<Server = ViteDevServer | PreviewServer> = {
 export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
   server: Server,
   opts?: BindCLIShortcutsOptions<Server>,
+  enabled: boolean = process.stdin.isTTY && !process.env.CI,
 ): void {
-  if (!server.httpServer || !process.stdin.isTTY || process.env.CI) {
+  if (!server.httpServer || !enabled) {
     return
   }
 

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -36,12 +36,16 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
 
   const isDev = isDevServer(server)
 
-  // Merge custom shortcuts from both new opts and existing options
+  const customShortcuts: CLIShortcut<ViteDevServer | PreviewServer>[] =
+    opts?.customShortcuts ?? []
+
+  // Merge custom shortcuts from existing options
   // with new shortcuts taking priority
-  const customShortcuts: CLIShortcut<ViteDevServer | PreviewServer>[] = [
-    ...(opts?.customShortcuts ?? []),
-    ...(server._shortcutsOptions?.customShortcuts ?? []),
-  ]
+  for (const shortcut of server._shortcutsOptions?.customShortcuts ?? []) {
+    if (!customShortcuts.find((s) => s.key === shortcut.key)) {
+      customShortcuts.push(shortcut)
+    }
+  }
 
   server._shortcutsOptions = {
     ...opts,

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -95,11 +95,9 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
     actionRunning = false
   }
 
-  const rl = readline.createInterface({ input: process.stdin })
-
-  server._rl?.close()
-  server._rl = rl
-
+  server._rl ??= readline.createInterface({ input: process.stdin })
+  const rl = server._rl
+  rl.removeAllListeners('line')
   rl.on('line', onInput)
   server.httpServer.on('close', () => rl.close())
 }

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -96,11 +96,15 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
     actionRunning = false
   }
 
-  server._rl ??= readline.createInterface({ input: process.stdin })
-  const rl = server._rl
-  rl.removeAllListeners('line')
-  rl.on('line', onInput)
-  server.httpServer.on('close', () => rl.close())
+  if (!server._rl) {
+    const rl = readline.createInterface({ input: process.stdin })
+    server._rl = rl
+    server.httpServer.on('close', () => rl.close())
+  } else {
+    server._rl.removeAllListeners('line')
+  }
+
+  server._rl.on('line', onInput)
 }
 
 const BASE_DEV_SHORTCUTS: CLIShortcut<ViteDevServer>[] = [


### PR DESCRIPTION
Fixes #15781.
Closes #15881.

This fixes an issue where calling `bindCLIShortcuts()` multiple times would create duplicate readline instances and lose custom shortcuts from previous calls. This is useful for plugins adding their own shortcuts while Vite CLI continues to print the help message.

Now when you bind shortcuts multiple times, they are properly merged, with new custom shortcuts taking priority:

```ts
server.bindCLIShortcuts({
  customShortcuts: [
    { key: 's', description: 'My shortcut', action: () => console.log('foo') },
    { key: 'g', description: 'Greeting', action: () => console.log('Hello World') },
  ]
});

// The "enter + g" shortcut will remain available after binding
server.bindCLIShortcuts({
  customShortcuts: [
    // This overrides the previous "enter + s" shortcut
    { key: 's', description: 'my updated shortcut', action: () => console.log('foobar') },
  ]
});
```

This works for both dev and preview server.
