### PR TITLE
chore: enable trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,3 +40,5 @@ onlyBuiltDependencies:
   - "simple-git-hooks"
   - "unrs-resolver"
   - "workerd"
+
+trustPolicy: no-downgrade


### PR DESCRIPTION
Since we are using pnpm 10.21, it has a very good security feature for enabling trust policy. i think maybe we can use it. 
https://pnpm.io/settings#trustpolicy