### PR TITLE
docs: add sitemap and send algolia events

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -87,7 +87,9 @@ export default defineConfig({
   title: `Vite${additionalTitle}`,
   description: 'Next Generation Frontend Tooling',
   cleanUrls: true,
-
+  sitemap: {
+    hostname: 'https://vite.dev',
+  },
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
     [
@@ -150,6 +152,7 @@ export default defineConfig({
       searchParameters: {
         facetFilters: ['tags:en'],
       },
+      insights: true,
     },
 
     carbonAds: {


### PR DESCRIPTION
Update documentation technical:

1. Add sitemap: Helps search engines, like Google, crawl and index Vite docs content more efficiently
2. Send Algolia search events: Enables sending search events to better understand what users are clicking on. ([More info](https://docsearch.algolia.com/docs/docsearch/#sending-events))