### PR TITLE
fix(build): support tree-shaking for dynamic import with arrow function

### DIFF
--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -192,3 +192,37 @@ test.runIf(isBuild)('should not preload for non-analyzable urls', () => {
   // should match e.g. await import(e.jss);o(".view",p===i)
   expect(js).to.match(/\.jss\);/)
 })
+
+test('dynamic import treeshaken log', async () => {
+  const log = browserLogs.join('\n')
+  expect(log).toContain('treeshaken foo')
+  expect(log).toContain('treeshaken bar')
+  expect(log).toContain('treeshaken baz1')
+  expect(log).toContain('treeshaken baz2')
+  expect(log).toContain('treeshaken baz3')
+  expect(log).toContain('treeshaken baz4')
+  expect(log).toContain('treeshaken baz5')
+  expect(log).toContain('treeshaken baz6')
+  expect(log).toContain('treeshaken usedWithThen')
+  expect(log).toContain('treeshaken default')
+
+  expect(log).not.toContain('treeshaken removed')
+  expect(log).not.toContain('treeshaken removedWithThen')
+})
+
+test('dynamic import syntax parsing', async () => {
+  const log = browserLogs.join('\n')
+  expect(log).toContain('treeshaken syntax foo')
+  expect(log).toContain('treeshaken syntax default')
+})
+
+test.runIf(isBuild)('dynamic import treeshaken file', async () => {
+  const content = findAssetFile(/treeshaken.+\.js$/)
+  expect(content).not.toContain('treeshaken removed')
+  expect(content).not.toContain('treeshaken removedWithThen')
+})
+
+test.runIf(isBuild)('should not preload for non-analyzable urls', () => {
+  const js = findAssetFile(/index-[-\w]{8}\.js$/)
+  expect(js).to.match(/\.jss\);/)
+})

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -202,3 +202,25 @@ import(`../nested/static.js`).then((mod) => {
 })
 
 console.log('index.js')
+;(async function () {
+  const result1 = await import('./treeshaken/treeshaken.js').then(
+    (m) => m.usedWithThen,
+  )
+  result1()
+
+  const result2 = await import('./treeshaken/treeshaken.js').then(
+    (m) => m.usedWithThen,
+  )
+  result2()
+
+  const result3 = await import('./treeshaken/treeshaken.js').then(function (m) {
+    return m.usedWithThen
+  })
+  result3()
+
+  function loadModule() {
+    return import('./treeshaken/treeshaken.js').then((m) => m.usedWithThen)
+  }
+  const result4 = await loadModule()
+  result4()
+})()

--- a/playground/dynamic-import/nested/treeshaken/treeshaken.js
+++ b/playground/dynamic-import/nested/treeshaken/treeshaken.js
@@ -26,8 +26,14 @@ export const baz5 = () => {
 export const baz6 = () => {
   console.log('treeshaken baz6')
 }
+export const usedWithThen = () => {
+  console.log('treeshaken usedWithThen')
+}
 export const removed = () => {
   console.log('treeshaken removed')
+}
+export const removedWithThen = () => {
+  console.log('treeshaken removedWithThen')
 }
 export default () => {
   console.log('treeshaken default')


### PR DESCRIPTION
## Description

Fixes #21121 

Dynamic imports using `.then((m) => m.prop)` pattern were not being tree-shaken. Unused exports were incorrectly included in the final bundle.

```js
// This pattern didn't tree-shake
import('./bar').then((m) => m.baz)

// Only this pattern worked
import('./bar').then(({baz}) => {})
```

The issue occurs because importAnalysisBuild.ts wraps dynamic imports with __vitePreload helper for module preloading. This prevents Rollup from analyzing which exports are actually used. Vite uses regex to detect common patterns and extract export names to help Rollup, but the regex didn't cover arrow function patterns.

## Solution
Extended dynamicImportTreeshakenRE in importAnalysisBuild.ts to match,

- import('./foo').then((m) => m.bar) (arrow with parens)
- import('./foo').then(m => m.bar) (arrow without parens)
- import('./foo').then(function(m) { return m.bar }) (function expression)
Added corresponding logic to extract export names from these patterns.

## Testing
Added test cases in `playground/dynamic-import/__tests__/dynamic-import.spec.ts`

## Reviewer Notes

I'm not very experienced with complex regular expressions, so I used ChatGPT (GPT-5.1) to help design and review the regex and match-group handling in this change. The pattern and group indices are a bit tricky, so I’d really appreciate an extra look to confirm that the captured groups are correct and that edge cases are handled as expected. 

If you see a simpler or more robust way to express the regex, I’m happy to revise the implementation accordingly.