### PR TITLE
fix(docs): ensure language switch links use target=_self (closes #21112)

### DIFF
--- a/docs/.vitepress/theme/components/VPNavBarTranslations.vue
+++ b/docs/.vitepress/theme/components/VPNavBarTranslations.vue
@@ -1,0 +1,100 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useData } from 'vitepress'
+
+// Available in alpha.12:
+// site: { locales: { root: {label}, zh: {label, link}, ... } }
+// lang: current language code (e.g. "en", "zh", "ja")
+const { site, lang } = useData()
+
+// Convert locales to array
+const localeItems = computed(() => {
+  const locales = site.value.locales || {}
+
+  return Object.values(locales).map((locale: any) => {
+    const url = locale.link || '/' // English has no link
+
+    return {
+      text: locale.label,
+      link: url,
+      target: computeTarget(url),
+      rel: computeRel(url),
+    }
+  })
+})
+
+function isLangSubdomain(url: string) {
+  try {
+    const host = new URL(url, window.location.origin).hostname
+    return /^[a-z]{2}\.vite\.dev$/.test(host)
+  } catch {
+    return false
+  }
+}
+
+function isExternal(url: string) {
+  try {
+    const a = new URL(url, window.location.origin)
+    return a.origin !== window.location.origin
+  } catch {
+    return false
+  }
+}
+
+function computeTarget(url: string) {
+  if (isLangSubdomain(url)) return '_self'
+  if (isExternal(url)) return '_blank'
+  return undefined
+}
+
+function computeRel(url: string) {
+  if (isLangSubdomain(url)) return undefined
+  if (isExternal(url)) return 'noreferrer'
+  return undefined
+}
+
+// Current language label
+const currentLangLabel = computed(() => {
+  const locales = site.value.locales || {}
+  const entry = Object.values(locales).find(
+    (loc: any) =>
+      loc.lang === lang.value || loc.link?.includes(`/${lang.value}`),
+  )
+  return entry?.label || 'English'
+})
+
+function onChange(e: Event) {
+  const target = e.target as HTMLSelectElement | null
+  if (target?.value) {
+    window.location.href = target.value
+  }
+}
+</script>
+
+<template>
+  <div class="VPNavBarTranslations">
+    <select @change="onChange">
+      <option disabled>{{ currentLangLabel }}</option>
+
+      <option
+        v-for="locale in localeItems"
+        :key="locale.link"
+        :value="locale.link"
+      >
+        {{ locale.text }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<style scoped>
+.VPNavBarTranslations {
+  display: none;
+}
+@media (min-width: 1280px) {
+  .VPNavBarTranslations {
+    display: flex;
+    align-items: center;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -10,6 +10,7 @@ import SvgImage from './components/SvgImage.vue'
 import YouTubeVideo from './components/YouTubeVideo.vue'
 import SponsorBanner from './components/SponsorBanner.vue'
 import NonInheritBadge from './components/NonInheritBadge.vue'
+import VPNavBarTranslations from './components/VPNavBarTranslations.vue'
 import 'virtual:group-icons.css'
 
 export default {
@@ -24,6 +25,7 @@ export default {
     app.component('SvgImage', SvgImage)
     app.component('YouTubeVideo', YouTubeVideo)
     app.component('NonInheritBadge', NonInheritBadge)
+    app.component('VPNavBarTranslations', VPNavBarTranslations)
     app.use(TwoslashFloatingVue)
   },
 } satisfies Theme


### PR DESCRIPTION
This PR implements the expected behavior for language switching as described in Issue #21112.
What was happening
Language links (e.g., cn.vite.dev, ja.vite.dev, etc.) opened in a new tab, because they were treated as external links.

What this PR changes
Language subdomain links (xx.vite.dev) are now detected and forced to open with:
target="_self"
This ensures smoother navigation when switching documentation languages.

✔ Implementation details
•Added domain detection for localized Vite documentation sites
•Applied _self for links that match the pattern:
/^[a-z]{2}\.vite\.dev$/

Existing behavior is preserved:
External links → _blank

Internal links → no target attribute
