### PR TITLE
chore: improve import-analysis error message for inline <script> HTML termination #21150

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -891,11 +891,24 @@ export function createParseErrorInfo(
           importer,
         )}" to \`assetsInclude\` in your configuration.`
 
+  const htmlScriptNote =
+    `\n\nNote: If this code is inside an inline <script> in an HTML file, ` +
+    `the literal sequence \`</script>\` (even inside a string or template literal)` +
+    ` will terminate the script early due to HTML parsing rules. This results in ` +
+    `truncated/invalid JS being passed to import analysis. To fix, escape the slash ` +
+    `like \`<\\/script>\` in the HTML source, break the sequence (e.g. \`"</" + "script>"\`), ` +
+    `or move the code to an external .js/.ts module.`
+
+  const isHtmlImporter = !!importer && /\.html?$/i.test(importer)
+
+  const finalMessage =
+    `Failed to parse source for import analysis because the content ` +
+    `contains invalid JS syntax. ` +
+    msg +
+    (isHtmlImporter ? htmlScriptNote : '')
+
   return {
-    message:
-      `Failed to parse source for import analysis because the content ` +
-      `contains invalid JS syntax. ` +
-      msg,
+    message: finalMessage,
     showCodeFrame: !probablyBinary,
   }
 }

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -1,6 +1,6 @@
 import colors from 'picocolors'
-import type { FSWatcher } from '#dep-types/chokidar'
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
+import type { FSWatcher } from '#dep-types/chokidar'
 import { BaseEnvironment } from '../baseEnvironment'
 import type {
   EnvironmentOptions,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -13,9 +13,9 @@ import colors from 'picocolors'
 import chokidar from 'chokidar'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
+import type { ModuleRunner } from 'vite/module-runner'
 import type { FSWatcher, WatchOptions } from '#dep-types/chokidar'
 import type { Connect } from '#dep-types/connect'
-import type { ModuleRunner } from 'vite/module-runner'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs'
-import type { HotPayload } from '#types/hmrPayload'
 import { ModuleRunner, createNodeImportMeta } from 'vite/module-runner'
 import type {
   ModuleEvaluator,
   ModuleRunnerHmr,
   ModuleRunnerOptions,
 } from 'vite/module-runner'
+import type { HotPayload } from '#types/hmrPayload'
 import type { DevEnvironment } from '../../server/environment'
 import type {
   HotChannelClient,


### PR DESCRIPTION
What is this PR solving?

-This PR improves the error message produced by the vite:import-analysis plugin when an inline <script> in an HTML file is prematurely terminated because the literal sequence </script> appears inside a JavaScript string or template literal.
The updated message clearly explains why the script was truncated and how to fix it (escape as <\/script> or move the code to an external file), making the error much easier to understand for users.

-Fixes #21150.

-Leaving the existing generic error message as-is.
This was rejected because it provides no guidance for a very common and confusing HTML parsing pitfall.

Always showing the </script> hint.
This would introduce noise for non-HTML importers such as .js, .ts, or .vue.

The chosen approach — showing the note only for .html/.htm importers — keeps the message relevant and minimal.

-This is a messaging-only change; no logic or behavior is modified.

The only added check is isHtmlImporter, which ensures the hint appears only for HTML files.

Reviewers may want to confirm that this condition aligns with Vite's existing conventions for detecting HTML importers.

-Previously Vite produced an unclear message:
([vite] (client) Pre-transform error: Failed to parse source for import analysis because the content contains invalid JS syntax.
You may need to install appropriate plugins to handle the .js file format...)

This was especially confusing when triggered by the following valid HTML:

<!doctype html>
<html>
  <head>
    <script type="module">
      // problematic line: HTML parser will see </script> unless escaped
      const s = `</script>`;
    </script>
  </head>
  <body></body>
</html>
