### PR TITLE
fix: fix `external: true` merging

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -166,21 +166,24 @@ describe('mergeConfig', () => {
   })
 
   test('handles ssr.noExternal', () => {
-    const baseConfig = {
+    const baseConfig: UserConfig = {
       ssr: {
         noExternal: true,
+        external: true,
       },
     }
 
-    const newConfig = {
+    const newConfig: UserConfig = {
       ssr: {
         noExternal: ['foo'],
+        external: ['bar'],
       },
     }
 
-    const mergedConfig = {
+    const mergedConfig: UserConfig = {
       ssr: {
         noExternal: true,
+        external: true,
       },
     }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1260,7 +1260,7 @@ function mergeConfigRecursively(
       merged[key] = [].concat(existing, value)
       continue
     } else if (
-      ((key === 'noExternal' &&
+      (((key === 'noExternal' || key === 'external') &&
         (rootPath === 'ssr' || rootPath === 'resolve')) ||
         (key === 'allowedHosts' && rootPath === 'server')) &&
       (existing === true || value === true)


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->

I noticed a following config crashes on rolldown-vite
https://stackblitz.com/edit/vitejs-rolldown-vite-bq4yd9u3?file=vite.config.ts 

```js
import { defineConfig } from 'vite';

export default defineConfig({
  ssr: {
    external: true,
  },
  environments: {
    ssr: {
      resolve: {
        external: ['node:path'],
      },
    },
  },
});
```

```sh
$ vite
...
error when starting dev server:
Error: Value is non of these types `True`, `Array<T>`,  on BindingViteResolvePluginConfig.external
    at napi_create_error (/tmp/rolldown-1.0.0-beta.52/node_modules/.pnpm/@emnapi+core@1.7.1/node_modules/@emnapi/core/dist/emnapi-
```

I think this is rather unusual setup, but Vitest happens to have a test test failing due to this https://github.com/vitest-dev/vitest/pull/9121#discussion_r2570310640.
