### PR TITLE
chore: tiny typo

### DIFF
--- a/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
+++ b/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
@@ -33,7 +33,7 @@ test.runIf(isBuild)('correctly resolve entrypoints', async () => {
 })
 
 test.runIf(isBuild)(
-  'node builtins should not be bundled if not used',
+  'node built-ins should not be bundled if not used',
   async () => {
     const contents = readFile('dist/main.mjs')
     expect(contents).not.include(`node:url`)

--- a/playground/ssr-webworker/vite.config.js
+++ b/playground/ssr-webworker/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
   ssr: {
     target: 'webworker',
     noExternal: ['this-should-be-replaced-by-the-boolean'],
-    // Some webworker builds may choose to externalize node builtins as they may be implemented
+    // Some webworker builds may choose to externalize node built-ins as they may be implemented
     // in the runtime, and so we can externalize it when bundling.
     external: ['node:assert'],
     resolve: {


### PR DESCRIPTION
I think the correct spelling would be `built-ins` with hyphen.