### PR TITLE
chore: revert "chore: only allow pnpm using devEngines (#20201)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,6 @@
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
-  },
   "homepage": "https://vite.dev/",
   "repository": {
     "type": "git",
@@ -24,6 +18,7 @@
     "vite"
   ],
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "postinstall": "simple-git-hooks",
     "format": "prettier --write --cache .",
     "lint": "eslint --cache .",


### PR DESCRIPTION
This PR reverts #20201.

It seems the devEngine field blocks `npm info vite version --json` which is used in `@vitejs/release-scripts`. I also tested `pnpm info vite version --json` but that was also blocked (probably because pnpm redirects to npm for `pnpm info`).

That caused the release to fail.
https://github.com/vitejs/vite/actions/runs/19812718571/job/56758041883#step:7:43

cc @bluwy
