### PR TITLE
fix(plugin-container): add defensive check for undefined transform handler

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -568,6 +568,9 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
       const start = debugPluginTransform ? performance.now() : 0
       let result: TransformResult | string | undefined
       const handler = getHookHandler(plugin.transform)
+      if (!handler) {
+        continue
+      }
       try {
         result = await this.handleHookPromise(
           handler.call(ctx as any, code, id, optionsWithSSR),


### PR DESCRIPTION
## Description

This PR fixes an intermittent crash that causes the error `Cannot read properties of undefined (reading 'call')` during HMR and server restarts.

Fixes #21162


## Problem

This error occurs intermittently and repeatedly, primarily when:
- Making significant code changes (mass formatting or refactoring)
- Switching branches
- Modifying `package.json`

The error appears in both the browser and terminal, effectively stopping the HMR process and requiring a manual server restart. This is particularly common with Astro + Tailwind + React setups.

### Root Cause

1. `vite-plugin-react` intentionally removes its `transform` hook during the `configResolved` phase for performance optimization ([source](https://github.com/vitejs/vite-plugin-react/blob/80417060f7bc239d5100e1b47c819e8364c7d551/packages/plugin-react/src/index.ts#L209-L215))
2. During server restarts (especially triggered by `package.json` changes), the `pluginContainer` may iterate over cached plugin references where the `transform` hook has been dynamically deleted
3. `getHookHandler(plugin.transform)` returns `undefined`, and attempting to call it throws the error

Credit to @sapphi-red for identifying the root cause.

## Solution

Added a defensive check in `pluginContainer.ts` before calling the transform handler:

```typescript
const handler = getHookHandler(plugin.transform)
if (!handler) {
  continue
}