### PR TITLE
docs: `alwaysStrict` does not affect the build result anymore

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -117,7 +117,6 @@ Note that this feature has a performance cost and is [discouraged by the TypeScr
 - [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
 - [`jsxImportSource`](https://www.typescriptlang.org/tsconfig#jsxImportSource)
 - [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig#experimentalDecorators)
-- [`alwaysStrict`](https://www.typescriptlang.org/tsconfig#alwaysStrict)
 
 ::: tip `skipLibCheck`
 Vite starter templates have `"skipLibCheck": "true"` by default to avoid typechecking dependencies, as they may choose to only support specific versions and configurations of TypeScript. You can learn more at [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688).


### PR DESCRIPTION
esbuild respects this, but Oxc does not have an equivalent option and I didn't implement it on Vite side as I don't think it matters.
