### PR TITLE
doc: Fix header for worker options in documentation

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -24,7 +24,7 @@ The function should return new plugin instances as they are used in parallel rol
 
 Rollup options to build worker bundle.
 
-## worker.rollupOptions
+## worker.rolldownOptions
 
 - **Type:** `RolldownOptions`
 - **Deprecated**


### PR DESCRIPTION
Updated section header from 'worker.rollupOptions' to 'worker.rolldownOptions'.
