### PR TITLE
fix: plugin shortcut support

### DIFF
--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -38,7 +38,6 @@ describe('bindCLIShortcuts', () => {
       const xUpdatedAction = vi.fn()
       const zAction = vi.fn()
 
-      xAction.mockClear()
       bindCLIShortcuts(
         server,
         {
@@ -55,7 +54,7 @@ describe('bindCLIShortcuts', () => {
       await vi.waitFor(() => expect(xUpdatedAction).toHaveBeenCalledOnce())
 
       // Ensure original xAction is not called again
-      expect(xAction).not.toBeCalled()
+      expect(xAction).toHaveBeenCalledOnce()
 
       expect(yAction).not.toHaveBeenCalled()
       server._rl.emit('line', 'y')

--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -1,3 +1,4 @@
+import type { Mock } from 'vitest'
 import { describe, expect, test, vi } from 'vitest'
 import { createServer } from '../server'
 import { preview } from '../preview'
@@ -69,45 +70,93 @@ describe('bindCLIShortcuts', () => {
   })
 
   test('rebinds shortcuts after server restart', async () => {
-    const server = await createServer()
+    const manualShortcutAction = vi.fn()
+    const pluginShortcutActions: Array<Mock<any>> = []
+
+    const server = await createServer({
+      plugins: [
+        {
+          name: 'custom-shortcut-plugin',
+          configureServer(viteDevServer) {
+            const action = vi.fn()
+
+            // Keep track of actions created by the plugin
+            // To verify if they are overwritten on server restart
+            pluginShortcutActions.push(action)
+
+            // Bind custom shortcut from plugin
+            bindCLIShortcuts(
+              viteDevServer,
+              {
+                customShortcuts: [
+                  {
+                    key: 'y',
+                    description: 'plugin shortcut',
+                    action,
+                  },
+                ],
+              },
+              true,
+            )
+          },
+        },
+      ],
+    })
 
     try {
-      const action = vi.fn()
+      const readline = server._rl
 
+      expect.assert(
+        readline,
+        'The readline interface should be defined after binding shortcuts.',
+      )
+
+      readline.emit('line', 'y')
+      await vi.waitFor(() => {
+        expect(pluginShortcutActions).toHaveLength(1)
+        expect(pluginShortcutActions[0]).toHaveBeenCalledOnce()
+      })
+
+      // Manually bind another custom shortcut
       bindCLIShortcuts(
         server,
         {
-          customShortcuts: [{ key: 'x', description: 'test', action }],
+          customShortcuts: [
+            {
+              key: 'x',
+              description: 'manual shortcut',
+              action: manualShortcutAction,
+            },
+          ],
         },
         true,
       )
 
-      // Verify shortcut works initially
-      const initialReadline = server._rl
-
-      expect.assert(
-        initialReadline,
-        'The readline interface should be defined after binding shortcuts.',
+      readline.emit('line', 'x')
+      await vi.waitFor(() =>
+        expect(manualShortcutAction).toHaveBeenCalledOnce(),
       )
 
-      initialReadline.emit('line', 'x')
-
-      await vi.waitFor(() => expect(action).toHaveBeenCalledOnce())
-
       // Restart the server
-      action.mockClear()
       await server.restart()
 
-      const newReadline = server._rl
-
       expect.assert(
-        newReadline && newReadline !== initialReadline,
-        'A new readline interface should be created after server restart.',
+        server._rl === readline,
+        'The readline interface should be preserved.',
       )
 
       // Shortcuts should still work after restart
-      newReadline.emit('line', 'x')
-      await vi.waitFor(() => expect(action).toHaveBeenCalledOnce())
+      readline.emit('line', 'x')
+      await vi.waitFor(() =>
+        expect(manualShortcutAction).toHaveBeenCalledTimes(2),
+      )
+
+      readline.emit('line', 'y')
+      await vi.waitFor(() => {
+        expect(pluginShortcutActions).toHaveLength(2)
+        expect(pluginShortcutActions[1]).toHaveBeenCalledOnce()
+        expect(pluginShortcutActions[0]).toHaveBeenCalledOnce()
+      })
     } finally {
       await server.close()
     }

--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -137,8 +137,18 @@ describe('bindCLIShortcuts', () => {
         expect(manualShortcutAction).toHaveBeenCalledOnce(),
       )
 
+      // Check the order of shortcuts before restart
+      expect(
+        server._shortcutsOptions?.customShortcuts?.map((s) => s.key),
+      ).toEqual(['x', 'y'])
+
       // Restart the server
       await server.restart()
+
+      // Shortcut orders should be preserved after restart
+      expect(
+        server._shortcutsOptions?.customShortcuts?.map((s) => s.key),
+      ).toEqual(['x', 'y'])
 
       expect.assert(
         server._rl === readline,

--- a/packages/vite/src/node/__tests__/shortcuts.spec.ts
+++ b/packages/vite/src/node/__tests__/shortcuts.spec.ts
@@ -27,12 +27,12 @@ describe('bindCLIShortcuts', () => {
       )
 
       expect.assert(
-        server._rl,
+        server._shortcutsState?.rl,
         'The readline interface should be defined after binding shortcuts.',
       )
       expect(xAction).not.toHaveBeenCalled()
 
-      server._rl.emit('line', 'x')
+      server._shortcutsState.rl.emit('line', 'x')
       await vi.waitFor(() => expect(xAction).toHaveBeenCalledOnce())
 
       const xUpdatedAction = vi.fn()
@@ -50,18 +50,18 @@ describe('bindCLIShortcuts', () => {
       )
 
       expect(xUpdatedAction).not.toHaveBeenCalled()
-      server._rl.emit('line', 'x')
+      server._shortcutsState.rl.emit('line', 'x')
       await vi.waitFor(() => expect(xUpdatedAction).toHaveBeenCalledOnce())
 
       // Ensure original xAction is not called again
       expect(xAction).toHaveBeenCalledOnce()
 
       expect(yAction).not.toHaveBeenCalled()
-      server._rl.emit('line', 'y')
+      server._shortcutsState.rl.emit('line', 'y')
       await vi.waitFor(() => expect(yAction).toHaveBeenCalledOnce())
 
       expect(zAction).not.toHaveBeenCalled()
-      server._rl.emit('line', 'z')
+      server._shortcutsState.rl.emit('line', 'z')
       await vi.waitFor(() => expect(zAction).toHaveBeenCalledOnce())
     } finally {
       await server.close()
@@ -103,7 +103,7 @@ describe('bindCLIShortcuts', () => {
     })
 
     try {
-      const readline = server._rl
+      const readline = server._shortcutsState?.rl
 
       expect.assert(
         readline,
@@ -138,7 +138,7 @@ describe('bindCLIShortcuts', () => {
 
       // Check the order of shortcuts before restart
       expect(
-        server._shortcutsOptions?.customShortcuts?.map((s) => s.key),
+        server._shortcutsState?.options.customShortcuts?.map((s) => s.key),
       ).toEqual(['x', 'y'])
 
       // Restart the server
@@ -146,11 +146,11 @@ describe('bindCLIShortcuts', () => {
 
       // Shortcut orders should be preserved after restart
       expect(
-        server._shortcutsOptions?.customShortcuts?.map((s) => s.key),
+        server._shortcutsState?.options.customShortcuts?.map((s) => s.key),
       ).toEqual(['x', 'y'])
 
       expect.assert(
-        server._rl === readline,
+        server._shortcutsState?.rl === readline,
         'The readline interface should be preserved.',
       )
 

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type readline from 'node:readline'
 import sirv from 'sirv'
 import compression from '@polka/compression'
 import connect from 'connect'
@@ -36,7 +35,7 @@ import {
 } from './utils'
 import { printServerUrls } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
-import type { BindCLIShortcutsOptions } from './shortcuts'
+import type { BindCLIShortcutsOptions, ShortcutsState } from './shortcuts'
 import { resolveConfig } from './config'
 import type { InlineConfig, ResolvedConfig } from './config'
 import { DEFAULT_PREVIEW_PORT } from './constants'
@@ -113,11 +112,7 @@ export interface PreviewServer {
   /**
    * @internal
    */
-  _shortcutsOptions?: BindCLIShortcutsOptions<PreviewServer>
-  /**
-   * @internal
-   */
-  _rl?: readline.Interface | undefined
+  _shortcutsState?: ShortcutsState<PreviewServer>
 }
 
 export type PreviewServerHook = (

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -101,9 +101,11 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
   }
 
   if (!server._rl) {
-    const rl = readline.createInterface({ input: process.stdin })
-    server._rl = rl
-    server.httpServer.on('close', () => rl.close())
+    server._rl = readline.createInterface({ input: process.stdin })
+    server.httpServer.on('close', () => {
+      // Skip if detached during restart (readline is reused)
+      if (server._rl) server._rl.close()
+    })
   } else {
     server._rl.removeAllListeners('line')
   }

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -36,16 +36,16 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
 
   const isDev = isDevServer(server)
 
-  const customShortcuts: CLIShortcut<ViteDevServer | PreviewServer>[] =
-    opts?.customShortcuts ?? []
-
-  // Merge custom shortcuts from existing options
-  // with new shortcuts taking priority
-  for (const shortcut of server._shortcutsOptions?.customShortcuts ?? []) {
-    if (!customShortcuts.some((s) => s.key === shortcut.key)) {
-      customShortcuts.push(shortcut)
-    }
-  }
+  // Merge shortcuts: new at top, existing updated in place (keeps manual > plugin order)
+  const previousShortcuts = server._shortcutsOptions?.customShortcuts ?? []
+  const newShortcuts = opts?.customShortcuts ?? []
+  const previousKeys = new Set(previousShortcuts.map((s) => s.key))
+  const customShortcuts: CLIShortcut<ViteDevServer | PreviewServer>[] = [
+    ...newShortcuts.filter((s) => !previousKeys.has(s.key)),
+    ...previousShortcuts.map(
+      (s) => newShortcuts.find((n) => n.key === s.key) ?? s,
+    ),
+  ]
 
   server._shortcutsOptions = {
     ...opts,


### PR DESCRIPTION
Fix #21166

I am terribly sorry having to come back to this the 3rd time. My previous attempt resolves the server restart issue only when no plugin defines their own shortcut using `server.bindCliShortcuts()`.

When a plugin defines its own custom shortcut (e.g. `x + enter`), it works fine when the dev server is just started:

```sh
> pnpm run dev

> vite-plugin-shortcut-issue@0.0.0 dev /Users/edmund/Workspace/vite-plugin-shortcut-issue
> vite


  VITE v7.2.6  ready in 89 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
h

  Shortcuts
  press x + enter to log a message to the console
  press r + enter to restart the server
  press u + enter to show server url
  press o + enter to open in browser
  press c + enter to clear console
  press q + enter to quit
x
Hello World
```

However, if you change the shortcut message to `Hello updated server` defined in the config file and save it, the server restarts and this happens:

```sh
12:28:41 [vite] vite.config.ts changed, restarting server...
12:28:41 [vite] server restarted.
x
Hello updated server
Hello World
```

Here is a reproduction: https://github.com/edmundhung/vite-plugin-shortcut-issue

The issue here is when `restartServer()` creates a new server and the plugin calls `server.bindCLIShortcuts()`, a readline interface is also created. It gets detached because of my changes in #21166: 

https://github.com/vitejs/vite/blob/5d2c31f0d1384d85aaa512fa2ffef78514ac135f/packages/vite/src/node/server/index.ts#L1254-L1255

Another readline interface then get created with the stale shortcut options (the one that logs `Hello World` instead of the updated `Hello updated server` message) in https://github.com/vitejs/vite/blob/5d2c31f0d1384d85aaa512fa2ffef78514ac135f/packages/vite/src/node/server/index.ts#L1280-L1288

Initially, I tried detaching the `server._rl` instance instead so we preserve the new readline instance created in the plugin:

```diff
-newServer._rl = undefined
+server._rl = undefined
```

But it runs into another issue: closing a readline interface on `process.stdin` causes already opened readline interfaces to stop receiving input.

This PR:

1. Preserves the readline interface (`_rl`) across server restart (avoids issues when closing/reopening readline)
2. Transfers `_shortcutsOptions` to the new server so plugin shortcuts can be properly merged when plugin register custom shortcut
3. Maintains shortcut order (manually bound shortcuts stay above plugin shortcuts)







