### PR TITLE
test: use `oxc.target` instead of `esbuild.target`

### DIFF
--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -39,7 +39,7 @@ export default defineConfig({
       NODE_ENV: process.env.VITE_TEST_BUILD ? 'production' : 'development',
     },
   },
-  esbuild: {
+  oxc: {
     target: 'node20',
   },
   publicDir: false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     testTimeout: 20000,
     isolate: false,
   },
-  esbuild: {
+  oxc: {
     target: 'node20',
   },
   publicDir: false,


### PR DESCRIPTION
`esbuild.*` is deprecated.