### PR TITLE
feat: add a warning that is output when a plugin sets esbuild related options

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2542,6 +2542,18 @@ async function runConfigHook(
             `\`rollupOptions\` specified by that plugin will be ignored.`,
         )
       }
+      if (res.esbuild) {
+        context.warn(
+          `\`esbuild\` option was specified by ${JSON.stringify(p.name)} plugin. ` +
+            `This option is deprecated, please use \`oxc\` instead.`,
+        )
+      }
+      if (res.optimizeDeps?.esbuildOptions) {
+        context.warn(
+          `\`optimizeDeps.esbuildOptions\` option was specified by ${JSON.stringify(p.name)} plugin. ` +
+            `This option is deprecated, please use \`optimizeDeps.rolldownOptions\` instead.`,
+        )
+      }
       conf = mergeConfig(conf, res)
     }
   }


### PR DESCRIPTION
This does not handle some edge cases like:
```js
const plugin = {
  name: 'foo',
  config(c) {
    c.esbuild = { jsx: 'transform' } // mutation is not detected
  }
}
```
```js
const plugin = {
  name: 'foo',
  configResolved(c) {
    c.esbuild = { jsx: 'transform' } // mutation is not detected
  }
}
```
But should catch many cases.
