### PR TITLE
docs(migration): make it clear whether the section is applicable for rolldown-vite users

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,6 +1,8 @@
 # Migration from v7
 
-## Default Browser Target change
+If you are migrating from `rolldown-vite`, the technical preview release for Rolldown integrated Vite for v6 & v7, only the sections with <Badge text="non-rolldown-vite" type="warning" /> in the title are applicable.
+
+## Default Browser Target change <Badge text="non-rolldown-vite" type="warning" />
 
 The default browser value of `build.target` and `'baseline-widely-available'`, is updated to newer browser version:
 
@@ -334,9 +336,9 @@ The following options are deprecated and will be removed in the future:
 - `worker.rollupOptions`: renamed to `worker.rolldownOptions`
 - `build.commonjsOptions`: it is now no-op
 
-## General Changes
+## General Changes <Badge text="non-rolldown-vite" type="warning" />
 
-## Removed deprecated features
+## Removed deprecated features <Badge text="non-rolldown-vite" type="warning" />
 
 **_TODO: This change is not implemented yet, but will be implemented before stable release._**
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,8 +1,8 @@
 # Migration from v7
 
-If you are migrating from `rolldown-vite`, the technical preview release for Rolldown integrated Vite for v6 & v7, only the sections with <Badge text="non-rolldown-vite" type="warning" /> in the title are applicable.
+If you are migrating from `rolldown-vite`, the technical preview release for Rolldown integrated Vite for v6 & v7, only the sections with <Badge text="NRV" type="warning" /> in the title are applicable.
 
-## Default Browser Target change <Badge text="non-rolldown-vite" type="warning" />
+## Default Browser Target change [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
 The default browser value of `build.target` and `'baseline-widely-available'`, is updated to newer browser version:
 
@@ -336,9 +336,9 @@ The following options are deprecated and will be removed in the future:
 - `worker.rollupOptions`: renamed to `worker.rolldownOptions`
 - `build.commonjsOptions`: it is now no-op
 
-## General Changes <Badge text="non-rolldown-vite" type="warning" />
+## General Changes [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
-## Removed deprecated features <Badge text="non-rolldown-vite" type="warning" />
+## Removed deprecated features [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
 **_TODO: This change is not implemented yet, but will be implemented before stable release._**
 


### PR DESCRIPTION
Added `non-rolldown-vite` badge for the sections that are applicable for rolldown-vite users.