### PR TITLE
fix(server): disable WebSocket server when server.hmr is false (#21041)

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -120,7 +120,7 @@ export function createWebSocketServer(
   config: ResolvedConfig,
   httpsOptions?: HttpsServerOptions,
 ): WebSocketServer {
-  if (config.server.ws === false) {
+  if (config.server.ws === false || config.server.hmr === false) {
     return {
       [isWebSocketServer]: true,
       get clients() {

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -120,7 +120,7 @@ export function createWebSocketServer(
   config: ResolvedConfig,
   httpsOptions?: HttpsServerOptions,
 ): WebSocketServer {
-  if (config.server.ws === false || config.server.hmr === false) {
+  if (config.server.ws === false || config.server.hmr == false) {
     return {
       [isWebSocketServer]: true,
       get clients() {


### PR DESCRIPTION
When using the Environment API, setting `server.hmr: false` should fully disable the HMR pipeline, including preventing the WebSocket server from starting. However, Vite only checked `server.ws === false`, which caused the WS server to initialize even when HMR was disabled.

This resulted in `EADDRINUSE` errors in monorepos and SSR environments that run multiple Vite instances in parallel (e.g., Nuxt).

This change updates `createWebSocketServer()` to treat `server.hmr: false` as a hard disable for the WebSocket server, matching expected behavior and ensuring no WS port is opened when HMR is turned off.

Fixes #21041.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
