### PR TITLE
fix(tests): correct typo in hoistAtRules test comments

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -188,13 +188,13 @@ describe('hoist @ rules', () => {
     )
   })
 
-  test('dont hoist @import in comments', async () => {
+  test("don't hoist @import in comments", async () => {
     const css = `.foo{color:red;}/* @import "bla"; */@import "bar";`
     const result = await hoistAtRules(css)
     expect(result).toBe(`@import "bar";.foo{color:red;}/* @import "bla"; */`)
   })
 
-  test('dont hoist @charset in comments', async () => {
+  test("don't hoist @charset in comments", async () => {
     const css = `.foo{color:red;}/* @charset "utf-8"; */@charset "utf-8";`
     const result = await hoistAtRules(css)
     expect(result).toBe(
@@ -202,7 +202,7 @@ describe('hoist @ rules', () => {
     )
   })
 
-  test('dont hoist @import and @charset in comments', async () => {
+  test("don't hoist @import and @charset in comments", async () => {
     const css = `
 .foo{color:red;}
 /*


### PR DESCRIPTION
### What this PR does

Fixes a minor typo in test comments for `hoistAtRules`. 
Changed `dont -> don't` inside test comments.

No functional changes — only a comment typo correction.

### Related issue

No issue filed; this is a minor improvement to test readability.

### Notes for reviewers

Just a simple typo fix, no code logic affected.
