### PR TITLE
test: add regression test for #/ in subpath imports

### DIFF
--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -228,6 +228,12 @@ test('Resolving dot-prefixed directory with imports field', async () => {
   expect(await page.textContent('.imports-dot-prefixed')).toMatch('[success]')
 })
 
+test('Resolving #/ root alias pattern with imports field', async () => {
+  // This tests the new Node.js behavior from https://github.com/nodejs/node/pull/60864
+  // which allows "#/*" patterns (slash immediately after #) in package.json imports
+  expect(await page.textContent('.imports-root-slash')).toMatch('[success]')
+})
+
 test("Resolve doesn't interrupt page request with trailing query and .css", async () => {
   await page.goto(viteTestUrl + '/?test.css')
   expect(await page.locator('vite-error-overlay').count()).toBe(0)

--- a/playground/resolve/imports-path/root-slash/index.js
+++ b/playground/resolve/imports-path/root-slash/index.js
@@ -1,0 +1,1 @@
+export const msg = '[success] subpath imports with #/ root alias pattern'

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -67,6 +67,9 @@
 <h2>Resolving dot-prefixed directory with imports field</h2>
 <p class="imports-dot-prefixed">fail</p>
 
+<h2>Resolving #/ root alias pattern with imports field</h2>
+<p class="imports-root-slash">fail</p>
+
 <h2>Resolve /index.*</h2>
 <p class="index">fail</p>
 
@@ -274,6 +277,9 @@
 
   import { msg as importsDotPrefixed } from './imports-path/importer.js'
   text('.imports-dot-prefixed', importsDotPrefixed)
+
+  import { msg as importsRootSlash } from '#/index.js'
+  text('.imports-root-slash', importsRootSlash)
 
   // implicit index resolving
   import { foo } from './util'

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -17,7 +17,8 @@
     "#slash/": "./imports-path/slash/",
     "#other-pkg-slash/": "@vitejs/test-resolve-imports-pkg/nest/",
     "#query": "./imports-path/query.json",
-    "#dot-prefixed": "./imports-path/.dot-prefixed/index.js"
+    "#dot-prefixed": "./imports-path/.dot-prefixed/index.js",
+    "#/*": "./imports-path/root-slash/*"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.4",


### PR DESCRIPTION
See nodejs commit: https://github.com/nodejs/node/pull/60864

This behavior happened to already be legal in Vite but this adds explicit tests to document that it's supposed to work.