### PR TITLE
feat(ssr): avoid errors when rewriting already rewritten stacktrace

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -648,6 +648,7 @@ export async function _createServer(
         "ssrRewriteStacktrace doesn't need to be used for Environment Module Runners.",
       )
       return ssrRewriteStacktrace(stack, server.environments.ssr.moduleGraph)
+        .result
     },
     async reloadModule(module) {
       warnFutureDeprecation(config, 'removeServerReloadModule')

--- a/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 import { createServer } from '../../server'
 
 const root = fileURLToPath(new URL('./', import.meta.url))
@@ -22,8 +22,26 @@ test('call rewriteStacktrace twice', async () => {
   for (let i = 0; i < 2; i++) {
     try {
       await server.ssrLoadModule('/fixtures/modules/has-error.js')
-    } catch (e) {
+    } catch (e: any) {
       server.ssrFixStacktrace(e)
     }
+  }
+})
+
+test('outputs message when stacktrace appears to be already rewritten', async () => {
+  const server = await createDevServer()
+  try {
+    await server.ssrLoadModule('/fixtures/modules/has-error.js')
+  } catch (e: any) {
+    // Manually craft an already-rewritten stacktrace with invalid line/column
+    // that will trigger the alreadyRewritten flag
+    e.stack = e.stack.replace(
+      /fixtures\/modules\/has-error\.js:\d+:\d+/,
+      'fixtures/modules/has-error.js:1:1',
+    )
+    server.ssrFixStacktrace(e)
+    expect(e.message).toContain(
+      'The stacktrace appears to be already rewritten by something else',
+    )
   }
 })


### PR DESCRIPTION
When an error happens while rewriting the stacktrace (e.g. ``Error: `line` must be greater than 0``), it hides the original error. This is better to avoid because the original error message is more important.

This PR fixes that by checking whether the ``Error: `line` must be greater than 0`` error may happen and skipping that line when detected.
