### PR TITLE
fix: add TypeScript support for ?url&raw imports

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -270,6 +270,11 @@ declare module '*?url&no-inline' {
   export default src
 }
 
+declare module '*?url&raw' {
+  const src: string
+  export default src
+}
+
 declare interface VitePreloadErrorEvent extends Event {
   payload: Error
 }

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -205,6 +205,19 @@ describe('asset imports from js', () => {
       )
     }
   })
+
+  test('from /public (?url&raw)', async () => {
+    expect(await page.textContent('.public-redirects-url')).toMatch(
+      '/foo/bar/_redirects',
+    )
+    expect(await page.textContent('.public-redirects-url-content'))
+      .toMatchInlineSnapshot(`
+      "/old-path /new-path 301
+      /test /test-new 302
+      
+      "
+    `)
+  })
 })
 
 describe('css url() references', () => {

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -51,6 +51,11 @@
     <code class="public-mts-import-content"></code> Content-Type:
     <code class="public-mts-import-content-type"></code>
   </li>
+  <li>
+    From publicDir (?url&raw):
+    <code class="public-redirects-url"></code> Content:
+    <code class="public-redirects-url-content"></code>
+  </li>
 </ul>
 
 <h2>CSS url references</h2>
@@ -575,6 +580,13 @@
 
   import inlinePublicJson from '/foo.json?url&inline'
   text('.inline-public-json', inlinePublicJson)
+
+  import publicRedirectsUrl from '/_redirects?url&raw'
+  text('.public-redirects-url', publicRedirectsUrl)
+  ;(async () => {
+    const res = await fetch(publicRedirectsUrl)
+    text('.public-redirects-url-content', await res.text())
+  })()
 
   import fooUrl from './foo.js?url'
   text('.url', fooUrl)

--- a/playground/assets/static/_redirects
+++ b/playground/assets/static/_redirects
@@ -1,0 +1,3 @@
+/old-path /new-path 301
+/test /test-new 302
+


### PR DESCRIPTION
- Add declare module '*?url&raw' in client.d.ts
- Fix asset plugin to return URL when both url and raw are present
- Add integration test to verify the fix
- Fixes #21277

Contribution by Gittensor, learn more at https://gittensor.io/

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
