### PR TITLE
docs(config): add `build.license` comment example

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -223,6 +223,30 @@ If `fileName` is passed, it will be used as the license file name relative to th
 ]
 ```
 
+::: tip
+
+If you'd like to reference the license file in the built code, you can use `build.rolldownOptions.output.postBanner` to inject a comment at the top of the files. For example:
+
+<!-- TODO: add a link for output.postBanner above to Rolldown's documentation -->
+
+```js twoslash [vite.config.js]
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    license: true,
+    rollupOptions: {
+      output: {
+        postBanner:
+          '/* See licenses of bundled dependencies at https://example.com/license.md */',
+      },
+    },
+  },
+})
+```
+
+:::
+
 ## build.manifest
 
 - **Type:** `boolean | string`


### PR DESCRIPTION
Added back the example that was removed in https://github.com/vitejs/vite/pull/21073, using `output.postBanner`.

close #21076
