### PR TITLE
fix(server): skip WebSocket creation when HMR is disabled

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -234,7 +234,10 @@ export function createWebSocketServer(
       }
     }
     wsServer.on('upgrade', hmrServerWsListener)
-  } else {
+  } else if (hmr !== false) {
+    // Only create standalone WebSocket server when HMR is enabled.
+    // When hmr === false (e.g., SSR environment in Nuxt), skip WebSocket creation
+    // to avoid port conflicts when running multiple Vite-based apps simultaneously.
     // http server request handler keeps the same with
     // https://github.com/websockets/ws/blob/45e17acea791d865df6b255a55182e9c42e5877a/lib/websocket-server.js#L88-L96
     const route = ((_, res) => {


### PR DESCRIPTION
## Description

When running Vite in middleware mode with multiple environments (e.g., Nuxt), the SSR environment has `hmr: false`. Previously, `createWebSocketServer` would still attempt to create a standalone WebSocket server on port 24678, causing port conflicts when running multiple Vite-based apps simultaneously.

## Changes

Added a check to skip WebSocket server creation when `hmr === false`, preventing the port conflict issue.

```js
// Before
} else {
  // Create standalone WebSocket - ALWAYS runs when wsServer is falsy

// After  
} else if (hmr !== false) {
  // Only create standalone WebSocket when HMR is enabled
```

## Related Issues

- Fixes https://github.com/vitejs/vite/issues/21318
- Fixes https://github.com/vitejs/vite/issues/21041
- Related Nuxt issue: https://github.com/nuxt/cli/issues/1170
- Related Nuxt PR: https://github.com/nuxt/nuxt/pull/33929

## What is the purpose of this pull request?

- [x] Bug fix