### PR TITLE
docs: update handleHotUpdate example to use server.hot API

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -444,7 +444,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
           true
         )
       }
-      server.ws.send({ type: 'full-reload' })
+      server.hot.send({ type: 'full-reload' })
       return []
     }
     ```
@@ -453,7 +453,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
     ```js
     handleHotUpdate({ server }) {
-      server.ws.send({
+      server.hot.send({
         type: 'custom',
         event: 'special-update',
         data: {}


### PR DESCRIPTION
### What is this PR solving?

The `handleHotUpdate` examples in the Plugin API documentation were still using
`server.ws.send`, which has been deprecated in favor of the `server.hot` API
since Vite 5.1+.

This PR updates the examples to use `server.hot.send` so the documentation
reflects current HMR best practices.

### Related Issue

Fixes #21317

### Alternatives considered

Keeping the existing examples and mentioning the deprecation was considered,
but updating the examples directly avoids confusion for plugin authors copying
code from the docs.

### Reviewer notes

This is a documentation-only change and is limited to the `handleHotUpdate`
examples. No runtime behavior or APIs are affected.

