### PR TITLE
chore(create-vite): add `.rolldown` to gitignore

### DIFF
--- a/packages/create-vite/template-lit-ts/_gitignore
+++ b/packages/create-vite/template-lit-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-lit/_gitignore
+++ b/packages/create-vite/template-lit/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-preact-ts/_gitignore
+++ b/packages/create-vite/template-preact-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-preact/_gitignore
+++ b/packages/create-vite/template-preact/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-qwik-ts/_gitignore
+++ b/packages/create-vite/template-qwik-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-qwik/_gitignore
+++ b/packages/create-vite/template-qwik/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-react-ts/_gitignore
+++ b/packages/create-vite/template-react-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-react/_gitignore
+++ b/packages/create-vite/template-react/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-solid-ts/_gitignore
+++ b/packages/create-vite/template-solid-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-solid/_gitignore
+++ b/packages/create-vite/template-solid/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-svelte-ts/_gitignore
+++ b/packages/create-vite/template-svelte-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-svelte/_gitignore
+++ b/packages/create-vite/template-svelte/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-vanilla-ts/_gitignore
+++ b/packages/create-vite/template-vanilla-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-vanilla/_gitignore
+++ b/packages/create-vite/template-vanilla/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-vue-ts/_gitignore
+++ b/packages/create-vite/template-vue-ts/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist

--- a/packages/create-vite/template-vue/_gitignore
+++ b/packages/create-vite/template-vue/_gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.rolldown
 
 node_modules
 dist


### PR DESCRIPTION
Not very sure about this, but I think it makes sense to ignore the `.rolldown` logs generated by rolldown debug mode. Most of the time, users don't want them uploaded to the remote repository.

More context: As Vite DevTools gets integrated into Vite Core, the rolldown debug mode will be enabled when users enabled DevTools (see: https://github.com/vitejs/vite/pull/21331/files#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745R2041), so I think it's necessary to add it.