### PR TITLE
feat: add ios to default esbuild targets

### DIFF
--- a/packages/vite/scripts/generateTarget.ts
+++ b/packages/vite/scripts/generateTarget.ts
@@ -4,11 +4,20 @@ import { getCompatibleVersions } from 'baseline-browser-mapping'
 const targetDate = '2026-01-01'
 
 // https://esbuild.github.io/api/#target
+const baselineToEsbuildTargetMap: Record<string, string> = {
+  chrome: 'chrome',
+  edge: 'edge',
+  firefox: 'firefox',
+  safari: 'safari',
+  safari_ios: 'ios',
+}
+
 const esbuildSupportedBrowsers = new Set([
   'chrome',
   'edge',
   'firefox',
   'safari',
+  'ios',
 ])
 
 const results = getCompatibleVersions({
@@ -16,6 +25,12 @@ const results = getCompatibleVersions({
 })
 
 const esbuildTargets = results
+  .map((target) => {
+    return {
+      browser: baselineToEsbuildTargetMap[target.browser],
+      version: target.version,
+    }
+  })
   .filter((target) => esbuildSupportedBrowsers.has(target.browser))
   .map((target) => `${target.browser}${target.version}`)
 

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -264,6 +264,7 @@ describe('convertTargets', () => {
       edge: 5177344,
       firefox: 3801088,
       safari: 786432,
+      ios_saf: 786432,
       opera: 3276800,
     })
     expect(convertTargets(['safari13.1', 'ios13', 'node14'])).toStrictEqual({

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -92,6 +92,7 @@ export const ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET: string[] = [
   'edge111',
   'firefox114',
   'safari16.4',
+  'ios16.4',
 ]
 
 export const DEFAULT_CONFIG_FILES: string[] = [

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3387,25 +3387,39 @@ const map: Record<
 
 const esMap: Record<number, string[]> = {
   // https://caniuse.com/?search=es2015
-  2015: ['chrome49', 'edge13', 'safari10', 'firefox44', 'opera36'],
+  2015: ['chrome49', 'edge13', 'safari10', 'ios10', 'firefox44', 'opera36'],
   // https://caniuse.com/?search=es2016
-  2016: ['chrome50', 'edge13', 'safari10', 'firefox43', 'opera37'],
+  2016: ['chrome50', 'edge13', 'safari10', 'ios10', 'firefox43', 'opera37'],
   // https://caniuse.com/?search=es2017
-  2017: ['chrome58', 'edge15', 'safari11', 'firefox52', 'opera45'],
+  2017: ['chrome58', 'edge15', 'safari11', 'ios11', 'firefox52', 'opera45'],
   // https://caniuse.com/?search=es2018
-  2018: ['chrome63', 'edge79', 'safari12', 'firefox58', 'opera50'],
+  2018: ['chrome63', 'edge79', 'safari12', 'ios12', 'firefox58', 'opera50'],
   // https://caniuse.com/?search=es2019
-  2019: ['chrome73', 'edge79', 'safari12.1', 'firefox64', 'opera60'],
+  2019: ['chrome73', 'edge79', 'safari12.1', 'ios12.1', 'firefox64', 'opera60'],
   // https://caniuse.com/?search=es2020
-  2020: ['chrome80', 'edge80', 'safari14.1', 'firefox80', 'opera67'],
+  2020: ['chrome80', 'edge80', 'safari14.1', 'ios14.1', 'firefox80', 'opera67'],
   // https://caniuse.com/?search=es2021
-  2021: ['chrome85', 'edge85', 'safari14.1', 'firefox80', 'opera71'],
+  2021: ['chrome85', 'edge85', 'safari14.1', 'ios14.1', 'firefox80', 'opera71'],
   // https://caniuse.com/?search=es2022
-  2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
+  2022: ['chrome94', 'edge94', 'safari16.4', 'ios16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
-  2023: ['chrome110', 'edge110', 'safari16.4', 'firefox146', 'opera96'],
+  2023: [
+    'chrome110',
+    'edge110',
+    'safari16.4',
+    'ios16.4',
+    'firefox146',
+    'opera96',
+  ],
   // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby,wf-array-group,wf-promise-withresolvers,mdn-javascript_builtins_arraybuffer_transfer,mdn-javascript_builtins_string_iswellformed,mdn-javascript_builtins_string_towellformed,wf-atomics-wait-async,mdn-javascript_builtins_arraybuffer_resize,mdn-javascript_builtins_sharedarraybuffer_grow
-  2024: ['chrome119', 'edge119', 'safari17.4', 'firefox145', 'opera105'],
+  2024: [
+    'chrome119',
+    'edge119',
+    'safari17.4',
+    'ios17.4',
+    'firefox145',
+    'opera105',
+  ],
 }
 
 const esRE = /es(\d{4})/
@@ -3453,8 +3467,6 @@ export const convertTargets = (
     }
     throw new Error(`Unsupported target "${entry}"`)
   }
-
-  targets.ios_saf ??= targets.safari
 
   convertTargetsCache.set(esbuildTarget, targets)
   return targets

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3454,6 +3454,8 @@ export const convertTargets = (
     throw new Error(`Unsupported target "${entry}"`)
   }
 
+  targets.ios_saf ??= targets.safari
+
   convertTargetsCache.set(esbuildTarget, targets)
   return targets
 }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3397,9 +3397,9 @@ const esMap: Record<number, string[]> = {
   // https://caniuse.com/?search=es2019
   2019: ['chrome73', 'edge79', 'safari12.1', 'ios12.1', 'firefox64', 'opera60'],
   // https://caniuse.com/?search=es2020
-  2020: ['chrome80', 'edge80', 'safari14.1', 'ios14.1', 'firefox80', 'opera67'],
+  2020: ['chrome80', 'edge80', 'safari14.1', 'ios14.5', 'firefox80', 'opera67'],
   // https://caniuse.com/?search=es2021
-  2021: ['chrome85', 'edge85', 'safari14.1', 'ios14.1', 'firefox80', 'opera71'],
+  2021: ['chrome85', 'edge85', 'safari14.1', 'ios14.5', 'firefox80', 'opera71'],
   // https://caniuse.com/?search=es2022
   2022: ['chrome94', 'edge94', 'safari16.4', 'ios16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023


### PR DESCRIPTION
## Current default target for Lightning CSS

The current default target for Lightning CSS is resolved by converting the default ESBuild targets to Lightning CSS targets. However, the default ESBuild targets does not differentiate between Safari and Safari on iOS:

```ts
export const ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET: string[] = [
  'chrome111',
  'edge111',
  'firefox114',
  'safari16.4',
]
```

Thus the converted default Lightning CSS targets **does not** include Safari on iOS, or `ios_saf`.

The problem is, Safari on iOS and Safari have some slightly different behaviors when handling CSS. For example, the `text-size-adjust` property. As of now:
- Chrome supports the unprefixed `text-size-adjust`
- Safari on iOS supports the prefixed `-webkit-text-size-adjust`
- Safari does not support `text-size-adjust`
- Firefox supports the prefixed `-moz-text-size-adjust`

<img width="731" height="333" alt="image" src="https://github.com/user-attachments/assets/ab4e5c02-20ae-44a3-9f53-d08913be9ae9" />

_The upper window is for Safari on iOS, and the lower for Safari_

However, Lightning CSS treats Safari on iOS and Safari differently, introducing some problems with vendor prifixing. With the default targets, Lighting CSS does not provide prefix for `-webkit`, only for `-moz`:

<img width="935" height="226" alt="image" src="https://github.com/user-attachments/assets/8d8f0141-4e5b-4dbe-999d-d6e97bca842f" />

## Adding the `ios_saf` target

We can resolve the issue by simply providing a default target for `ios_saf`, taking the same value of `safari`, if not otherwise specified
<img width="942" height="218" alt="image" src="https://github.com/user-attachments/assets/147d5643-b5bb-4d3b-813b-f9ad86d974a0" />

## About this PR

This PR copies the `targets.safari` value to `targets.ios_saf` value when converting ESBuild targets to Lightning CSS targets, if `ios_saf` is not otherwise specified.

This PR passes relevant tests.