### PR TITLE
chore: replace caniuse link for ES2024

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3404,7 +3404,7 @@ const esMap: Record<number, string[]> = {
   2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
   2023: ['chrome110', 'edge110', 'safari16.4', 'firefox146', 'opera96'],
-  // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby,wf-array-group,wf-promise-withresolvers,mdn-javascript_builtins_arraybuffer_transfer,mdn-javascript_builtins_string_iswellformed,mdn-javascript_builtins_string_towellformed,wf-atomics-wait-async,mdn-javascript_builtins_arraybuffer_resize,mdn-javascript_builtins_sharedarraybuffer_grow
+  // https://caniuse.com/sr-es15
   2024: ['chrome119', 'edge119', 'safari17.4', 'firefox145', 'opera105'],
 }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3404,8 +3404,8 @@ const esMap: Record<number, string[]> = {
   2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
   2023: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
-  // Not provided by caniuse; keep parity with ES2023 until we have a reliable source.
-  2024: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
+  // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby%2Cwf-array-group%2Cwf-promise-withresolvers%2Cmdn-javascript_builtins_arraybuffer_resize%2Cmdn-javascript_builtins_arraybuffer_transfer%2Cmdn-javascript_builtins_string_iswellformed%2Cmdn-javascript_builtins_string_towellformed%2Cwf-atomics-wait-async
+  2024: ['chrome119', 'edge119', 'safari17.4', 'opera105'],
 }
 
 const esRE = /es(\d{4})/

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3404,6 +3404,8 @@ const esMap: Record<number, string[]> = {
   2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
   2023: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
+  // Not provided by caniuse; keep parity with ES2023 until we have a reliable source.
+  2024: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
 }
 
 const esRE = /es(\d{4})/

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3403,9 +3403,9 @@ const esMap: Record<number, string[]> = {
   // https://caniuse.com/?search=es2022
   2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
-  2023: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
+  2023: ['chrome110', 'edge110', 'safari16.4', 'firefox146', 'opera96'],
   // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby,wf-array-group,wf-promise-withresolvers,mdn-javascript_builtins_arraybuffer_transfer,mdn-javascript_builtins_string_iswellformed,mdn-javascript_builtins_string_towellformed,wf-atomics-wait-async,mdn-javascript_builtins_arraybuffer_resize,mdn-javascript_builtins_sharedarraybuffer_grow
-  2024: ['chrome119', 'edge119', 'safari17.4', 'opera105'],
+  2024: ['chrome119', 'edge119', 'safari17.4', 'firefox145', 'opera105'],
 }
 
 const esRE = /es(\d{4})/

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3404,7 +3404,7 @@ const esMap: Record<number, string[]> = {
   2022: ['chrome94', 'edge94', 'safari16.4', 'firefox93', 'opera80'],
   // https://caniuse.com/?search=es2023
   2023: ['chrome110', 'edge110', 'safari16.4', 'opera96'],
-  // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby%2Cwf-array-group%2Cwf-promise-withresolvers%2Cmdn-javascript_builtins_arraybuffer_resize%2Cmdn-javascript_builtins_arraybuffer_transfer%2Cmdn-javascript_builtins_string_iswellformed%2Cmdn-javascript_builtins_string_towellformed%2Cwf-atomics-wait-async
+  // https://caniuse.com/?feats=mdn-javascript_builtins_object_groupby,wf-array-group,wf-promise-withresolvers,mdn-javascript_builtins_arraybuffer_transfer,mdn-javascript_builtins_string_iswellformed,mdn-javascript_builtins_string_towellformed,wf-atomics-wait-async,mdn-javascript_builtins_arraybuffer_resize,mdn-javascript_builtins_sharedarraybuffer_grow
   2024: ['chrome119', 'edge119', 'safari17.4', 'opera105'],
 }
 


### PR DESCRIPTION
This is a a follow-up to https://github.com/vitejs/vite/pull/21294, replacing the verbose caniuse link with a short link which has now been added at caniuse (https://github.com/Fyrd/caniuse/pull/7440).