### PR TITLE
fix(create-vite): prefix `logs` with `/` in .gitignore to avoid ignoring nested directories

### DIFF
--- a/packages/create-vite/template-lit-ts/_gitignore
+++ b/packages/create-vite/template-lit-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-lit/_gitignore
+++ b/packages/create-vite/template-lit/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-preact-ts/_gitignore
+++ b/packages/create-vite/template-preact-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-preact/_gitignore
+++ b/packages/create-vite/template-preact/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-qwik-ts/_gitignore
+++ b/packages/create-vite/template-qwik-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-qwik/_gitignore
+++ b/packages/create-vite/template-qwik/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-react-ts/_gitignore
+++ b/packages/create-vite/template-react-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-react/_gitignore
+++ b/packages/create-vite/template-react/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-solid-ts/_gitignore
+++ b/packages/create-vite/template-solid-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-solid/_gitignore
+++ b/packages/create-vite/template-solid/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-svelte-ts/_gitignore
+++ b/packages/create-vite/template-svelte-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-svelte/_gitignore
+++ b/packages/create-vite/template-svelte/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-vanilla-ts/_gitignore
+++ b/packages/create-vite/template-vanilla-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-vanilla/_gitignore
+++ b/packages/create-vite/template-vanilla/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-vue-ts/_gitignore
+++ b/packages/create-vite/template-vue-ts/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/packages/create-vite/template-vue/_gitignore
+++ b/packages/create-vite/template-vue/_gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
### Summary

Changes `logs` to `/logs` in the `.gitignore` template to only ignore a logs directory at the project root, not nested directories.

### Problem

We were ignoring `logs` everywhere and that pattern matches any directory named `logs`, including actual source paths like:
- `src/pages/logs/`
- `src/routes/logs/`

Some tools correctly respect `.gitignore`, which means they also correctly broke:
- Tailwind
- Prettier
- Other tooling quietly misbehaves