### PR TITLE
feat: add `ignoreOutdatedRequests` option to `optimizeDeps`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -829,6 +829,8 @@ const configDefaults = Object.freeze({
     // entries
     /** @experimental */
     force: false,
+    /** @experimental */
+    ignoreOutdatedRequests: false,
   },
   ssr: ssrConfigDefaults,
   environments: {},

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -165,7 +165,8 @@ export interface DepOptimizationConfig {
   holdUntilCrawlEnd?: boolean
   /**
    * When enabled, Vite will not throw an error when an outdated optimized
-   * dependency is requested.
+   * dependency is requested. Enabling this option may cause a single module
+   * to have a multiple reference.
    * @default false
    * @experimental
    */

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -163,6 +163,13 @@ export interface DepOptimizationConfig {
    * @experimental
    */
   holdUntilCrawlEnd?: boolean
+  /**
+   * When enabled, Vite will not throw an error when an outdated optimized
+   * dependency is requested.
+   * @default false
+   * @experimental
+   */
+  ignoreOutdatedRequests?: boolean
 }
 
 export type DepOptimizationOptions = DepOptimizationConfig & {

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -50,7 +50,11 @@ export function optimizedDepsPlugin(): Plugin {
         // Search in both the currently optimized and newly discovered deps
         const info = optimizedDepInfoFromFile(metadata, file)
         if (info) {
-          if (browserHash && info.browserHash !== browserHash) {
+          if (
+            browserHash &&
+            info.browserHash !== browserHash &&
+            !environment.config.optimizeDeps.ignoreOutdatedRequests
+          ) {
             throwOutdatedRequest(id)
           }
           try {
@@ -65,7 +69,10 @@ export function optimizedDepsPlugin(): Plugin {
           const newMetadata = depsOptimizer.metadata
           if (metadata !== newMetadata) {
             const currentInfo = optimizedDepInfoFromFile(newMetadata!, file)
-            if (info.browserHash !== currentInfo?.browserHash) {
+            if (
+              info.browserHash !== currentInfo?.browserHash &&
+              !environment.config.optimizeDeps.ignoreOutdatedRequests
+            ) {
               throwOutdatedRequest(id)
             }
           }
@@ -77,7 +84,10 @@ export function optimizedDepsPlugin(): Plugin {
         try {
           return await fsp.readFile(file, 'utf-8')
         } catch {
-          if (browserHash) {
+          if (
+            browserHash &&
+            !environment.config.optimizeDeps.ignoreOutdatedRequests
+          ) {
             // Outdated optimized files loaded after a rerun
             throwOutdatedRequest(id)
           }


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite/issues/20867.

This adds an experimental `optimizeDeps.ignoreOutdatedRequests` option that prevents throwing errors when outdated dependencies are encountered. I haven't added docs as I see this more as a temporary workaround for a specific issue. The longer term fix is to use full-bundle mode rather than `optimizeDeps` in the Cloudflare plugin.

Note that I haven't applied this change to the following code in the import analysis plugin. Let me know if I should:

https://github.com/vitejs/vite/blob/2ba4e990192845e01c733aa186c9599cdb5bb8fe/packages/vite/src/node/plugins/importAnalysis.ts#L290-L296

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
