### PR TITLE
fix: fixing bug in project creation with marko framework (fix: #21353)

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -612,9 +612,6 @@ async function init() {
     }
   }
 
-  const root = path.join(cwd, targetDir)
-  fs.mkdirSync(root, { recursive: true })
-
   // determine template
   let isReactSwc = false
   if (template.includes('-swc')) {
@@ -643,6 +640,10 @@ async function init() {
     })
     process.exit(status ?? 0)
   }
+
+  // Create the project folder
+  const root = path.join(cwd, targetDir)
+  fs.mkdirSync(root, { recursive: true })
 
   prompts.log.step(`Scaffolding project in ${root}...`)
 


### PR DESCRIPTION
### Why this PR was made?

I made this Pull Request to resolve a bug reported in Issue ID: #21353. The problem described was that when trying to create a Vite project with the Marko framework, an error occurred where Vite said that a folder with the same name already existed. The real problem was that the project folder was created empty before the initial dependencies were installed. When the dependencies were about to be installed, this error was triggered by Vite:                                                              
Project path already exists '/home/lucas/marko-project'

```bash
Error: Project path already exists '/home/lucas/marko-project'
    at assertAllGood (/home/lucas/.cache/pnpm/dlx/7dcbf9fba94832045da040ff38b1246af2e6c8f7a27af3cedf07f5b6fbbaf175/19b9333df80-17a7/node_modules/.pnpm/@marko+create@6.1.0/node_modules/@marko/create/dist/index.js:113:11)
    at async create (/home/lucas/.cache/pnpm/dlx/7dcbf9fba94832045da040ff38b1246af2e6c8f7a27af3cedf07f5b6fbbaf175/19b9333df80-17a7/node_modules/.pnpm/@marko+create@6.1.0/node_modules/@marko/create/dist/index.js:51:3)
    at async run (/home/lucas/.cache/pnpm/dlx/7dcbf9fba94832045da040ff38b1246af2e6c8f7a27af3cedf07f5b6fbbaf175/19b9333df80-17a7/node_modules/.pnpm/@marko+create@6.1.0/node_modules/@marko/create/dist/cli.js:151:9)
^C

```

### How this bug was solved:

This bug is present in the index.ts file in **packages/create-vite/src**. The problematic code snippet was located here:

```typescript

const root = path.join(cwd, targetDir)
fs.mkdirSync(root, { recursive: true })

```

Instead of modifying or removing it, I decided to simply move those two lines of code after the **customCommand** code block

```typescript
// Lines 627 to 646
const { customCommand } =
    FRAMEWORKS.flatMap((f) => f.variants).find((v) => v.name === template) ?? {}

  if (customCommand) {
    const fullCustomCommand = getFullCustomCommand(customCommand, pkgInfo)

    const [command, ...args] = fullCustomCommand.split(' ')
    // we replace TARGET_DIR here because targetDir may include a space
    const replacedArgs = args.map((arg) =>
      arg.replace('TARGET_DIR', () => targetDir),
    )
    const { status } = spawn.sync(command, replacedArgs, {
      stdio: 'inherit',
    })
    process.exit(status ?? 0)
  }

  // Create the project folder
  const root = path.join(cwd, targetDir)
  fs.mkdirSync(root, { recursive: true })
```
On this way, the project folder is created at the right time, as soon as the initial dependencies begin to be installed.

### Tests made after this PR:

I ran some local tests before making this pull request outside of the Vite repository folder, and Marko's error was resolved with these changes:

```bash


 ter  6 jan - 10:13  ~/marko-test 
 @lucas  node ~/vite/packages/create-vite/dist/index.js
│
◇  Project name:
│  marko-project
│
◇  Select a framework:
│  Marko
│
◇  Select a variant:
│  Marko Run ↗
│
◇  Install with npm and start now?
│  Yes

> npx
> create-marko --name marko-project

✔ Choose a template · Default starter app
✔ Project created! To get started, run:

    cd marko-project
    npm run dev


 ter  6 jan - 10:14  ~/marko-test 
 @lucas  cd ./marko-project/               

 ter  6 jan - 10:14  ~/marko-test/marko-project   main ✔ 
 @lucas  npm run dev                                   

> marko-project@1.0.0 dev
> marko-run

╭───────────────────────────────────────────────────╮
│     ____  ____  ____                              │
│    ╱╲╲╲╲╲╱╲╲╲╲╲ ╲╲╲╲╲                             │
│   ╱╱╱╲╲╲╱╱╱╲╲╲╲╲ ╲╲╲╲╲    Marko Run v0.9.4        │
│  ╱╱╱╱╱╲╱╱╱╱╱╲╲╲╲╲ ╲╲╲╲╲                           │
│  ╲╲╲╲╲ ‾‾‾‾ ╱╱╱╱╱ ╱╱╱╱╱   Server listening at     │
│   ╲╲╲╲╲    ╱╱╱╱╱ ╱╱╱╱╱    http://localhost:3000   │
│    ╲╲╲╲╲  ╱╱╱╱╱ ╱╱╱╱╱                             │
│     ‾‾‾‾  ‾‾‾‾  ‾‾‾‾                              │
╰───────────────────────────────────────────────────╯

◀━━ GET /
━━▶ GET / 200 421ms 3.81kb
^C

 ✘  ter  6 jan - 10:34  ~/marko-test/marko-project   main ✔ 
 @lucas  

```
