### PR TITLE
docs: clarify import paths in additionalData

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -286,7 +286,7 @@ export default defineConfig({
 ```
 
 ::: tip Importing files
-Since the same code is prepended to files in different directories, relative paths won't resolve correctly. Use [aliases](#resolve-alias) instead.
+Since the same code is prepended to files in different directories, relative paths won't resolve correctly. Use absolute paths or [aliases](#resolve-alias) instead.
 :::
 
 ## css.preprocessorMaxWorkers

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -285,7 +285,7 @@ export default defineConfig({
 })
 ```
 
-::: warning Importing files
+::: tip Importing files
 Since the same code is prepended to files in different directories, relative paths won't resolve correctly. Use [aliases](#resolve-alias) instead.
 :::
 

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -285,6 +285,10 @@ export default defineConfig({
 })
 ```
 
+::: warning Importing files
+Since the same code is prepended to files in different directories, relative paths won't resolve correctly. Use [aliases](#resolve-alias) instead.
+:::
+
 ## css.preprocessorMaxWorkers
 
 - **Type:** `number | true`


### PR DESCRIPTION
Adds a warning note explaining that relative paths won't work when importing files in `additionalData`, and suggests using aliases instead.

fixes #19712

## What this PR does
- Adds a `::: warning` block in `css.preprocessorOptions[extension].additionalData` section
- Explains that relative paths won't resolve correctly because the same code is prepended to files in different directories
- Links to `resolve.alias` as the recommended solution

## Alternatives considered
- Adding an example with aliases (decided against to keep it concise)