### PR TITLE
refactor!: remove `import.meta.hot.accept` resolution fallback

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -340,6 +340,8 @@ The following options are deprecated and will be removed in the future:
 
 ## Removed Deprecated Features [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
+- Passing an URL to `import.meta.hot.accept` is no longer supported. Please pass an id instead. ([#21382](https://github.com/vitejs/vite/pull/21382))
+
 **_TODO: This change is not implemented yet, but will be implemented before stable release._**
 
 ## Advanced

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -318,8 +318,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const importedBindings = enablePartialAccept
         ? new Map<string, Set<string>>()
         : null
-      const toAbsoluteUrl = (url: string) =>
-        path.posix.resolve(path.posix.dirname(importerModule.url), url)
 
       const normalizeUrl = async (
         url: string,
@@ -788,22 +786,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
           normalized = mod.url
         } else {
-          try {
-            // this fallback is for backward compat and will be removed in Vite 7
-            const [resolved] = await moduleGraph.resolveUrl(toAbsoluteUrl(url))
-            normalized = resolved
-            if (resolved) {
-              this.warn({
-                message:
-                  `Failed to resolve ${JSON.stringify(url)} from ${importer}.` +
-                  ' An id should be written. Did you pass a URL?',
-                pos: start,
-              })
-            }
-          } catch {
-            this.error(`Failed to resolve ${JSON.stringify(url)}`, start)
-            return
-          }
+          this.error({
+            message: `Failed to resolve ${JSON.stringify(url)} from ${importer}.`,
+            pos: start,
+          })
         }
         normalizedAcceptedUrls.add(normalized)
         const hmrAccept = normalizeHmrUrl(normalized)


### PR DESCRIPTION
Removed the deprecated fallback

refs #18840
