### PR TITLE
fix(assets): allow absolute ?raw imports from publicDir

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -47,6 +47,7 @@ import {
   moduleListContains,
   normalizePath,
   prettifyUrl,
+  rawRE,
   removeImportQuery,
   removeTimestampQuery,
   stripBase,
@@ -546,7 +547,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               specifier[0] === '/' &&
               !(
                 config.assetsInclude(cleanUrl(specifier)) ||
-                urlRE.test(specifier)
+                urlRE.test(specifier) ||
+                rawRE.test(specifier)
               ) &&
               checkPublicFile(specifier, config)
             ) {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -480,6 +480,10 @@ test('Unknown extension assets import', async () => {
   )
 })
 
+test('?raw import absolute', async () => {
+  expect(await page.textContent('.raw-import-absolute')).toMatch('raw-text')
+})
+
 test('?raw import', async () => {
   expect(await page.textContent('.raw')).toMatch('SVG')
   expect(await page.textContent('.raw-html')).toBe('<div>partial</div>\n')

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -267,6 +267,9 @@
 <h2>Unknown extension assets import</h2>
 <code class="unknown-ext"></code>
 
+<h2>?raw import absolute</h2>
+<code class="raw-import-absolute"></code>
+
 <h2>?raw import</h2>
 <code class="raw"></code>
 <code class="raw-html"></code>
@@ -554,6 +557,9 @@
 
   import rawSvg from './nested/fragment.svg?raw'
   text('.raw', rawSvg)
+
+  import rawText from '/raw.txt?raw'
+  text('.raw-import-absolute', rawText)
 
   import rawHtml from './nested/partial.html?raw'
   text('.raw-html', rawHtml)

--- a/playground/assets/static/raw.txt
+++ b/playground/assets/static/raw.txt
@@ -1,0 +1,1 @@
+raw-text


### PR DESCRIPTION
### What is this PR solving?

This PR fixes an issue where absolute `?raw` imports from files in `publicDir`(e.g. `/raw.txt?raw`) throw an import analysis error, even though they work correctly at runtime.

This mismatch causes unnecessary IDE errors and confusion for users.

Fixes https://github.com/vitejs/vite/issues/21277