### PR TITLE
fix(module-runner): use `process.getBuiltinModule` instead of `import('node:module')`

### DIFF
--- a/packages/vite/src/module-runner/createImportMeta.ts
+++ b/packages/vite/src/module-runner/createImportMeta.ts
@@ -1,8 +1,5 @@
 import { isWindows } from '../shared/utils'
-import {
-  type ImportMetaResolver,
-  createImportMetaResolver,
-} from './importMetaResolver'
+import { createImportMetaResolver } from './importMetaResolver'
 import type { ModuleRunnerImportMeta } from './types'
 import { posixDirname, posixPathToFileHref, toWindowsPath } from './utils'
 
@@ -39,19 +36,16 @@ export function createDefaultImportMeta(
   } satisfies Omit<ModuleRunnerImportMeta, 'main'> as any
 }
 
-let importMetaResolverCache: Promise<ImportMetaResolver | undefined> | undefined
-
 /**
  * Create import.meta object for Node.js.
  */
-export async function createNodeImportMeta(
+export function createNodeImportMeta(
   modulePath: string,
-): Promise<ModuleRunnerImportMeta> {
+): ModuleRunnerImportMeta {
   const defaultMeta = createDefaultImportMeta(modulePath)
   const href = defaultMeta.url
 
-  importMetaResolverCache ??= createImportMetaResolver()
-  const importMetaResolver = await importMetaResolverCache
+  const importMetaResolver = createImportMetaResolver()
 
   return {
     ...defaultMeta,

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -35,15 +35,10 @@ function customizationHookResolve(
   return nextResolve(specifier, context)
 }
 
-export async function createImportMetaResolver(): Promise<
-  ImportMetaResolver | undefined
-> {
+export function createImportMetaResolver(): ImportMetaResolver | undefined {
   let module: typeof import('node:module')
   try {
-    const importUrl = 'node:module'
-    module = process.getBuiltinModule
-      ? process.getBuiltinModule('node:module').Module
-      : (await import(/* @vite-ignore */ importUrl)).Module
+    module = process.getBuiltinModule('node:module').Module
   } catch {
     return
   }

--- a/packages/vite/src/module-runner/importMetaResolver.ts
+++ b/packages/vite/src/module-runner/importMetaResolver.ts
@@ -1,3 +1,5 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
+
 import type { ResolveFnOutput, ResolveHookContext } from 'node:module'
 
 export type ImportMetaResolver = (specifier: string, importer: string) => string
@@ -38,7 +40,10 @@ export async function createImportMetaResolver(): Promise<
 > {
   let module: typeof import('node:module')
   try {
-    module = (await import('node:module')).Module
+    const importUrl = 'node:module'
+    module = process.getBuiltinModule
+      ? process.getBuiltinModule('node:module').Module
+      : (await import(/* @vite-ignore */ importUrl)).Module
   } catch {
     return
   }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2388,7 +2388,7 @@ async function bundleConfigFile(
         name: 'inject-file-scope-variables',
         transform: {
           filter: { id: /\.[cm]?[jt]s$/ },
-          async handler(code, id) {
+          handler(code, id) {
             let injectValues =
               `const ${dirnameVarName} = ${JSON.stringify(path.dirname(id))};` +
               `const ${filenameVarName} = ${JSON.stringify(id)};` +
@@ -2399,7 +2399,7 @@ async function bundleConfigFile(
               if (isESM) {
                 if (!importMetaResolverRegistered) {
                   importMetaResolverRegistered = true
-                  await createImportMetaResolver()
+                  createImportMetaResolver()
                 }
                 injectValues += `const ${importMetaResolveVarName} = (specifier, importer = ${importMetaUrlVarName}) => (${importMetaResolveWithCustomHookString})(specifier, importer);`
               } else {


### PR DESCRIPTION
`process.getBuiltinModule` is available in v22.3.0, v20.16.0 which is in line with the current Node.js requirements in `package.json`.

This also remove the warning that `node:module` was externalized if module runner is imported in the browser under certain conditions.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
