### PR TITLE
docs: update Rollup links to Rolldown

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -149,11 +149,9 @@ Generate production source maps. If `true`, a separate sourcemap file will be cr
 
 ## build.rolldownOptions
 
-- **Type:** [`RolldownOptions`](https://rollupjs.org/configuration-options/)
+- **Type:** [`RolldownOptions`](https://rolldown.rs/reference/)
 
-<!-- TODO: update the link above and below to Rolldown's documentation -->
-
-Directly customize the underlying Rolldown bundle. This is the same as options that can be exported from a Rolldown config file and will be merged with Vite's internal Rolldown options. See [Rolldown options docs](https://rollupjs.org/configuration-options/) for more details.
+Directly customize the underlying Rolldown bundle. This is the same as options that can be exported from a Rolldown config file and will be merged with Vite's internal Rolldown options. See [Rolldown options docs](https://rolldown.rs/reference/) for more details.
 
 ## build.rollupOptions
 
@@ -352,9 +350,7 @@ Limit for chunk size warnings (in kB). It is compared against the uncompressed c
 
 ## build.watch
 
-<!-- TODO: update the link below to Rolldown's documentation -->
-
-- **Type:** [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch)`| null`
+- **Type:** [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch)`| null`
 - **Default:** `null`
 
 Set to `{}` to enable rollup watcher. This is mostly used in cases that involve build-only plugins or integrations processes.

--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -18,9 +18,7 @@ The function should return new plugin instances as they are used in parallel rol
 
 ## worker.rolldownOptions
 
-<!-- TODO: update the link below to Rolldown's documentation -->
-
-- **Type:** [`RolldownOptions`](https://rollupjs.org/configuration-options/)
+- **Type:** [`RolldownOptions`](https://rolldown.rs/reference/)
 
 Rollup options to build worker bundle.
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -50,7 +50,7 @@ If you don't know the base path in advance, you may set a relative base path wit
 
 ## Customizing the Build
 
-The build can be customized via various [build config options](/config/build-options.md). Specifically, you can directly adjust the underlying [Rolldown options](https://rollupjs.org/configuration-options/) via `build.rolldownOptions`:
+The build can be customized via various [build config options](/config/build-options.md). Specifically, you can directly adjust the underlying [Rolldown options](https://rolldown.rs/reference/) via `build.rolldownOptions`:
 
 <!-- TODO: update the link above and below to Rolldown's documentation -->
 
@@ -58,7 +58,7 @@ The build can be customized via various [build config options](/config/build-opt
 export default defineConfig({
   build: {
     rolldownOptions: {
-      // https://rollupjs.org/configuration-options/
+      // https://rolldown.rs/reference/
     },
   },
 })
@@ -84,7 +84,7 @@ When a new deployment occurs, the hosting service may delete the assets from pre
 
 ## Rebuild on Files Changes
 
-You can enable rollup watcher with `vite build --watch`. Or, you can directly adjust the underlying [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch) via `build.watch`:
+You can enable rollup watcher with `vite build --watch`. Or, you can directly adjust the underlying [`WatcherOptions`](https://rolldown.rs/reference/InputOptions.watch) via `build.watch`:
 
 <!-- TODO: update the link above to Rolldown's documentation -->
 
@@ -92,7 +92,7 @@ You can enable rollup watcher with `vite build --watch`. Or, you can directly ad
 export default defineConfig({
   build: {
     watch: {
-      // https://rollupjs.org/configuration-options/#watch
+      // https://rolldown.rs/reference/InputOptions.watch
     },
   },
 })


### PR DESCRIPTION
While migrating to Vite 8 beta, I noticed that the docs still referenced Rollup.  
The link has been updated to Rolldown accordingly.


<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
