### PR TITLE
fix(create-vite): skip irrelevant "immediate" prompt for external commands

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -598,20 +598,6 @@ async function init() {
 
   const pkgManager = pkgInfo ? pkgInfo.name : 'npm'
 
-  // 5. Ask about immediate install and package manager
-  let immediate = argImmediate
-  if (immediate === undefined) {
-    if (interactive) {
-      const immediateResult = await prompts.confirm({
-        message: `Install with ${pkgManager} and start now?`,
-      })
-      if (prompts.isCancel(immediateResult)) return cancel()
-      immediate = immediateResult
-    } else {
-      immediate = false
-    }
-  }
-
   const root = path.join(cwd, targetDir)
   // determine template
   let isReactSwc = false
@@ -640,6 +626,20 @@ async function init() {
       stdio: 'inherit',
     })
     process.exit(status ?? 0)
+  }
+
+  // 5. Ask about immediate install and package manager
+  let immediate = argImmediate
+  if (immediate === undefined) {
+    if (interactive) {
+      const immediateResult = await prompts.confirm({
+        message: `Install with ${pkgManager} and start now?`,
+      })
+      if (prompts.isCancel(immediateResult)) return cancel()
+      immediate = immediateResult
+    } else {
+      immediate = false
+    }
   }
 
   // Only create directory for built-in templates, not for customCommand


### PR DESCRIPTION
Skip the following prompt when selecting a choice with `customCommand` — it doesn't have any effect.
<img width="315" height="72" alt="image" src="https://github.com/user-attachments/assets/f76b01ed-3dee-473a-a3d1-fa79a47bfc49" />

The only change is moving the block further below, after [the `process.exit(status ?? 0)` call](https://github.com/brillout/vite/blob/323716616014d9de22e17772eaa800423cf8fdf3/packages/create-vite/src/index.ts#L628). The block itself remains unchanged.