### PR TITLE
docs(static-deploy): improve Cloudflare documentation to highlight Workers

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -100,6 +100,8 @@ Note that the `ssr` top-level property is going to be deprecated once the Enviro
 
 Low level configuration APIs are available so runtime providers can provide environments with proper defaults for their runtimes. These environments can also spawn other processes or threads to run the modules during dev in a closer runtime to the production environment.
 
+For example, the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) uses the Environment API to run code in the Cloudflare Workers runtime (`workerd`) during development.
+
 ```js
 import { customEnvironment } from 'vite-environment-provider'
 
@@ -139,4 +141,4 @@ Plugin authors have a more consistent API available to interact with the current
 
 Frameworks could decide to expose environments at different levels. If you're a framework author, continue reading the [Environment API Frameworks Guide](./api-environment-frameworks) to learn about the Environment API programmatic side.
 
-For Runtime providers, the [Environment API Runtimes Guide](./api-environment-runtimes.md) explains how to offer custom environment to be consumed by frameworks and users.
+For Runtime providers, the [Environment API Runtimes Guide](./api-environment-runtimes.md) explains how to offer custom environments to be consumed by frameworks and users.

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -201,8 +201,6 @@ export default defineConfig({
 
 After running `npm run build`, your application can now be deployed with `npx wrangler deploy`.
 
-#### Adding a Backend API
-
 You can also easily add backend APIs to your Vite application to securely communicate with Cloudflare resources. This runs in the Workers runtime during development and deploys alongside your frontend. See the [Cloudflare Vite plugin tutorial](https://developers.cloudflare.com/workers/vite-plugin/tutorial/) for a complete walkthrough.
 
 ### Cloudflare Pages

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -207,38 +207,15 @@ You can also easily add backend APIs to your Vite application to securely commun
 
 ### Cloudflare Pages
 
-For existing projects using Cloudflare Pages, you can continue to deploy static sites via Wrangler or Git integration:
-
-#### Cloudflare Pages via Wrangler
-
-1. Install [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/).
-2. Authenticate Wrangler with your Cloudflare account using `wrangler login`.
-3. Run your build command.
-4. Deploy using `npx wrangler pages deploy dist`.
-
-```bash
-# Install Wrangler CLI
-$ npm install -g wrangler
-
-# Login to Cloudflare account from CLI
-$ wrangler login
-
-# Run your build command
-$ npm run build
-
-# Create new deployment
-$ npx wrangler pages deploy dist
-```
-
-After your assets are uploaded, Wrangler will give you a preview URL to inspect your site. When you log into the Cloudflare Pages dashboard, you will see your new project.
-
 #### Cloudflare Pages with Git
 
+Cloudflare Pages gives you a way to deploy directly to Cloudflare without having to manage a Wrangler file.
+
 1. Push your code to your git repository (GitHub, GitLab).
-2. Log in to the Cloudflare dashboard and select your account in **Account Home** > **Pages**.
-3. Select **Create a new Project** and the **Connect Git** option.
+2. Log in to the Cloudflare dashboard and select your account in **Account Home** > **Workers & Pages**.
+3. Select **Create a new Project** and the **Pages** option, then select Git.
 4. Select the git project you want to deploy and click **Begin setup**
-5. Select the corresponding framework preset in the build setting depending on the Vite framework you have selected.
+5. Select the corresponding framework preset in the build setting depending on the Vite framework you have selected. Otherwise enter your build commands for your project and your expected output directory.
 6. Then save and deploy!
 7. Your application is deployed! (e.g `https://<PROJECTNAME>.pages.dev/`)
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -172,9 +172,59 @@ After your project has been imported and deployed, all subsequent pushes to bran
 
 Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/git).
 
-## Cloudflare Pages
+## Cloudflare
 
-### Cloudflare Pages via Wrangler
+### Cloudflare Workers
+
+The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) provides integration with Cloudflare Workers and uses Vite's Environment API to run your code in the Cloudflare Workers runtime during development.
+
+#### Create a new app
+
+You can create a new Vite project configured for Cloudflare Workers using `create-cloudflare`:
+
+```bash
+$ npm create cloudflare@latest my-vite-app -- --framework=react
+```
+
+#### Update an existing app
+
+To add Cloudflare Workers support to an existing Vite project:
+
+1. Install the Cloudflare Vite plugin:
+
+   ```bash
+   $ npm install --save-dev @cloudflare/vite-plugin
+   ```
+
+2. Add the plugin to your `vite.config.js`:
+
+   ```js [vite.config.js]
+   import { defineConfig } from 'vite'
+   import { cloudflare } from '@cloudflare/vite-plugin'
+
+   export default defineConfig({
+     plugins: [cloudflare()],
+   })
+   ```
+
+3. Create a `wrangler.jsonc` configuration file:
+
+   ```jsonc [wrangler.jsonc]
+   {
+     "name": "my-vite-app",
+     "compatibility_date": "2025-01-14", // Use a recent date in YYYY-MM-DD format
+   }
+   ```
+
+Your application can now be developed with `npm run dev`, built with `npm run build`, previewed with `npm run preview`, and deployed with `npx wrangler deploy`.
+
+The Cloudflare Vite plugin supports the full [Cloudflare Developer Platform](https://developers.cloudflare.com/workers/), including KV, D1, Durable Objects, Workflows, and more. Learn more in the [Cloudflare Vite Plugin documentation](https://developers.cloudflare.com/workers/vite-plugin/).
+
+### Cloudflare Pages
+
+For existing projects using Cloudflare Pages, you can continue to deploy static sites via Wrangler or Git integration:
+
+#### Cloudflare Pages via Wrangler
 
 1. Install [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/).
 2. Authenticate Wrangler with your Cloudflare account using `wrangler login`.
@@ -197,7 +247,7 @@ $ npx wrangler pages deploy dist
 
 After your assets are uploaded, Wrangler will give you a preview URL to inspect your site. When you log into the Cloudflare Pages dashboard, you will see your new project.
 
-### Cloudflare Pages with Git
+#### Cloudflare Pages with Git
 
 1. Push your code to your git repository (GitHub, GitLab).
 2. Log in to the Cloudflare dashboard and select your account in **Account Home** > **Pages**.
@@ -207,7 +257,7 @@ After your assets are uploaded, Wrangler will give you a preview URL to inspect 
 6. Then save and deploy!
 7. Your application is deployed! (e.g `https://<PROJECTNAME>.pages.dev/`)
 
-After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://developers.cloudflare.com/pages/platform/preview-deployments/) unless specified not to in your [branch build controls](https://developers.cloudflare.com/pages/platform/branch-build-controls/). All changes to the Production Branch (commonly “main”) will result in a Production Deployment.
+After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://developers.cloudflare.com/pages/platform/preview-deployments/) unless specified not to in your [branch build controls](https://developers.cloudflare.com/pages/platform/branch-build-controls/). All changes to the Production Branch (commonly "main") will result in a Production Deployment.
 
 You can also add custom domains and handle custom build settings on Pages. Learn more about [Cloudflare Pages Git Integration](https://developers.cloudflare.com/pages/get-started/#manage-your-site).
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -193,7 +193,7 @@ To add Cloudflare Workers support to an existing Vite project:
 1. Install the Cloudflare Vite plugin:
 
    ```bash
-   $ npm install --save-dev @cloudflare/vite-plugin
+   $ npm install --save-dev @cloudflare/vite-plugin wrangler
    ```
 
 2. Add the plugin to your `vite.config.js`:

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -199,7 +199,7 @@ export default defineConfig({
 }
 ```
 
-Your application can now be developed with `npm run dev`, built with `npm run build`, previewed with `npm run preview`, and deployed with `npx wrangler deploy`.
+After running `npm run build`, your application can now be deployed with `npx wrangler deploy`.
 
 #### Adding a Backend API
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -203,37 +203,7 @@ Your application can now be developed with `npm run dev`, built with `npm run bu
 
 #### Adding a Backend API
 
-To add a backend API, create a Worker entry file and update your config:
-
-Add a `main` entry point to `wrangler.jsonc`:
-
-```jsonc [wrangler.jsonc]
-{
-  "name": "my-vite-app",
-  "main": "./worker/index.ts",
-  "assets": {
-    "not_found_handling": "single-page-application",
-  },
-}
-```
-
-Create `worker/index.ts`:
-
-```ts [worker/index.ts]
-export default {
-  fetch(request) {
-    const url = new URL(request.url)
-    if (url.pathname.startsWith('/api/')) {
-      return Response.json({ hello: 'world' })
-    }
-    return new Response(null, { status: 404 })
-  },
-} satisfies ExportedHandler
-```
-
-The API runs in the Workers runtime during development and deploys alongside your frontend. See the [Cloudflare Vite plugin tutorial](https://developers.cloudflare.com/workers/vite-plugin/tutorial/) for a complete walkthrough.
-
-The Cloudflare Vite plugin supports the full [Cloudflare Developer Platform](https://developers.cloudflare.com/workers/), including KV, D1, Durable Objects, Workflows, and more. Learn more in the [Cloudflare Vite Plugin documentation](https://developers.cloudflare.com/workers/vite-plugin/).
+You can also easily add backend APIs to your Vite application to securely communicate with Cloudflare resources. This runs in the Workers runtime during development and deploys alongside your frontend. See the [Cloudflare Vite plugin tutorial](https://developers.cloudflare.com/workers/vite-plugin/tutorial/) for a complete walkthrough.
 
 ### Cloudflare Pages
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -178,47 +178,60 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 
 The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) provides integration with Cloudflare Workers and uses Vite's Environment API to run your server-side code in the Cloudflare Workers runtime during development.
 
-#### Create a new app
-
-You can create a new Vite project configured for Cloudflare Workers using `create-cloudflare`:
+To add Cloudflare Workers to an existing Vite project, install the plugin and add it to your config:
 
 ```bash
-$ npm create cloudflare@latest my-vite-app -- --framework=react
+$ npm install --save-dev @cloudflare/vite-plugin
 ```
 
-#### Update an existing app
+```js [vite.config.js]
+import { defineConfig } from 'vite'
+import { cloudflare } from '@cloudflare/vite-plugin'
 
-To add Cloudflare Workers support to an existing Vite project:
+export default defineConfig({
+  plugins: [cloudflare()],
+})
+```
 
-1. Install the Cloudflare Vite plugin:
-
-   ```bash
-   $ npm install --save-dev @cloudflare/vite-plugin wrangler
-   ```
-
-2. Add the plugin to your `vite.config.js`:
-
-   ```js [vite.config.js]
-   import { defineConfig } from 'vite'
-   import { cloudflare } from '@cloudflare/vite-plugin'
-
-   export default defineConfig({
-     plugins: [cloudflare()],
-   })
-   ```
-
-3. Create a `wrangler.jsonc` configuration file:
-
-   ```jsonc [wrangler.jsonc]
-   {
-     "name": "my-vite-app",
-	"assets": {
-		"not_found_handling": "single-page-application",
-	},
-   }
-   ```
+```jsonc [wrangler.jsonc]
+{
+  "name": "my-vite-app",
+}
+```
 
 Your application can now be developed with `npm run dev`, built with `npm run build`, previewed with `npm run preview`, and deployed with `npx wrangler deploy`.
+
+#### Adding a Backend API
+
+To add a backend API, create a Worker entry file and update your config:
+
+Add a `main` entry point to `wrangler.jsonc`:
+
+```jsonc [wrangler.jsonc]
+{
+  "name": "my-vite-app",
+  "main": "./worker/index.ts",
+  "assets": {
+    "not_found_handling": "single-page-application",
+  },
+}
+```
+
+Create `worker/index.ts`:
+
+```ts [worker/index.ts]
+export default {
+  fetch(request) {
+    const url = new URL(request.url)
+    if (url.pathname.startsWith('/api/')) {
+      return Response.json({ hello: 'world' })
+    }
+    return new Response(null, { status: 404 })
+  },
+} satisfies ExportedHandler
+```
+
+The API runs in the Workers runtime during development and deploys alongside your frontend. See the [Cloudflare Vite plugin tutorial](https://developers.cloudflare.com/workers/vite-plugin/tutorial/) for a complete walkthrough.
 
 The Cloudflare Vite plugin supports the full [Cloudflare Developer Platform](https://developers.cloudflare.com/workers/), including KV, D1, Durable Objects, Workflows, and more. Learn more in the [Cloudflare Vite Plugin documentation](https://developers.cloudflare.com/workers/vite-plugin/).
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -212,7 +212,9 @@ To add Cloudflare Workers support to an existing Vite project:
    ```jsonc [wrangler.jsonc]
    {
      "name": "my-vite-app",
-     "compatibility_date": "2025-01-14", // Use a recent date in YYYY-MM-DD format
+	"assets": {
+		"not_found_handling": "single-page-application",
+	},
    }
    ```
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -176,7 +176,7 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 
 ### Cloudflare Workers
 
-The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) provides integration with Cloudflare Workers and uses Vite's Environment API to run your code in the Cloudflare Workers runtime during development.
+The [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/) provides integration with Cloudflare Workers and uses Vite's Environment API to run your server-side code in the Cloudflare Workers runtime during development.
 
 #### Create a new app
 


### PR DESCRIPTION
Hello!

I work on the authoring team at Cloudflare responsible for Vite on the Cloudflare Workers and Pages platform.

We wanted to suggest some updates to the documentation to highlight some of our work that we think will improve users experience using Cloudflare. The changes are summarised below:

- Rename 'Cloudflare Pages' section to 'Cloudflare' in deployment guide
- Add Cloudflare Workers as the primary deployment option
  - Include setup instructions for create-cloudflare CLI
  - Document how to add plugin to existing projects
  - Highlight Environment API integration and full platform support
- Keep Cloudflare Pages as secondary option for existing projects
- Reference Cloudflare Vite plugin as example in Environment API docs

Thanks so much, happy to work on this with you if you want further changes or clarifications,

Matt

cc: @jamesopstad 

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
