### PR TITLE
fix(hmr): buffer messages when WebSocket clients are not ready (#21349)

### DIFF
--- a/packages/vite/src/node/server/__tests__/ws.spec.ts
+++ b/packages/vite/src/node/server/__tests__/ws.spec.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ErrorPayload, FullReloadPayload } from '#types/hmrPayload'
+
+/**
+ * Mock WebSocket client for testing
+ */
+class MockWebSocket {
+  readyState: number = 1 // 1 = OPEN
+  messages: string[] = []
+
+  send(data: string) {
+    this.messages.push(data)
+  }
+
+  close() {
+    this.readyState = 3 // CLOSED
+  }
+}
+
+/**
+ * Creates a minimal mock WebSocket server for testing buffering logic
+ */
+function createMockWsServer() {
+  const clients = new Set<MockWebSocket>()
+  let bufferedMessages: (ErrorPayload | FullReloadPayload)[] = []
+
+  const connectionHandlers: ((socket: MockWebSocket) => void)[] = []
+
+  return {
+    clients,
+    bufferedMessages,
+
+    // Simulate the send logic from ws.ts
+    send(payload: ErrorPayload | FullReloadPayload | { type: string }) {
+      if (payload.type === 'error' || payload.type === 'full-reload') {
+        // full-reload invalidates previous errors and redundant full-reloads
+        if (payload.type === 'full-reload') {
+          bufferedMessages = []
+        }
+
+        if (!clients.size) {
+          bufferedMessages.push(payload as ErrorPayload | FullReloadPayload)
+          return
+        }
+
+        const stringified = JSON.stringify(payload)
+        let sent = false
+        clients.forEach((client) => {
+          if (client.readyState === 1) {
+            client.send(stringified)
+            sent = true
+          }
+        })
+
+        // Buffer if no client received the message
+        if (!sent) {
+          bufferedMessages.push(payload as ErrorPayload | FullReloadPayload)
+        }
+        return
+      }
+
+      const stringified = JSON.stringify(payload)
+      clients.forEach((client) => {
+        if (client.readyState === 1) {
+          client.send(stringified)
+        }
+      })
+    },
+
+    // Simulate connection event
+    onConnection(handler: (socket: MockWebSocket) => void) {
+      connectionHandlers.push(handler)
+    },
+
+    // Simulate a new client connecting
+    simulateConnection(): MockWebSocket {
+      const socket = new MockWebSocket()
+      clients.add(socket)
+
+      // Send connected message
+      socket.send(JSON.stringify({ type: 'connected' }))
+
+      // Send buffered messages (copy and clear immediately)
+      if (bufferedMessages.length > 0) {
+        const messagesToSend = bufferedMessages.slice()
+        bufferedMessages = []
+        for (const msg of messagesToSend) {
+          socket.send(JSON.stringify(msg))
+        }
+      }
+
+      connectionHandlers.forEach((handler) => handler(socket))
+      return socket
+    },
+
+    // Simulate client disconnection
+    simulateDisconnection(socket: MockWebSocket) {
+      socket.readyState = 3 // CLOSED
+      clients.delete(socket)
+    },
+
+    getBufferedMessages() {
+      return bufferedMessages
+    },
+  }
+}
+
+describe('WebSocket message buffering', () => {
+  let server: ReturnType<typeof createMockWsServer>
+
+  beforeEach(() => {
+    server = createMockWsServer()
+  })
+
+  describe('buffering when no clients connected', () => {
+    it('should buffer error message when no clients', () => {
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: {
+          message: 'Test error',
+          stack: 'Error stack',
+        },
+      }
+
+      server.send(errorPayload)
+
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(server.getBufferedMessages()[0]).toEqual(errorPayload)
+    })
+
+    it('should buffer full-reload message when no clients', () => {
+      const reloadPayload: FullReloadPayload = {
+        type: 'full-reload',
+        path: '*',
+      }
+
+      server.send(reloadPayload)
+
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(server.getBufferedMessages()[0]).toEqual(reloadPayload)
+    })
+
+    it('should buffer multiple error messages', () => {
+      const error1: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 1', stack: '' },
+      }
+      const error2: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 2', stack: '' },
+      }
+
+      server.send(error1)
+      server.send(error2)
+
+      expect(server.getBufferedMessages()).toHaveLength(2)
+      expect(server.getBufferedMessages()[0]).toEqual(error1)
+      expect(server.getBufferedMessages()[1]).toEqual(error2)
+    })
+
+    it('should clear buffer when full-reload arrives', () => {
+      const error1: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 1', stack: '' },
+      }
+      const error2: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 2', stack: '' },
+      }
+      const reload: FullReloadPayload = {
+        type: 'full-reload',
+        path: '*',
+      }
+
+      server.send(error1)
+      server.send(error2)
+      server.send(reload)
+
+      // Buffer should only contain the full-reload
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(server.getBufferedMessages()[0]).toEqual(reload)
+    })
+
+    it('should not accumulate multiple full-reloads', () => {
+      const reload1: FullReloadPayload = {
+        type: 'full-reload',
+        path: '/a.js',
+      }
+      const reload2: FullReloadPayload = {
+        type: 'full-reload',
+        path: '/b.js',
+      }
+
+      server.send(reload1)
+      server.send(reload2)
+
+      // Only the last full-reload should be buffered
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(server.getBufferedMessages()[0]).toEqual(reload2)
+    })
+  })
+
+  describe('sending buffered messages on connection', () => {
+    it('should send buffered messages to newly connected client', () => {
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Buffered error', stack: '' },
+      }
+
+      // Buffer message before client connects
+      server.send(errorPayload)
+      expect(server.getBufferedMessages()).toHaveLength(1)
+
+      // Connect client
+      const client = server.simulateConnection()
+
+      // Buffer should be cleared
+      expect(server.getBufferedMessages()).toHaveLength(0)
+
+      // Client should receive 'connected' + buffered error
+      expect(client.messages).toHaveLength(2)
+      expect(JSON.parse(client.messages[0])).toEqual({ type: 'connected' })
+      expect(JSON.parse(client.messages[1])).toEqual(errorPayload)
+    })
+
+    it('should send all buffered messages in order', () => {
+      const error1: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 1', stack: '' },
+      }
+      const error2: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 2', stack: '' },
+      }
+
+      server.send(error1)
+      server.send(error2)
+
+      const client = server.simulateConnection()
+
+      // Client should receive: connected, error1, error2
+      expect(client.messages).toHaveLength(3)
+      expect(JSON.parse(client.messages[1])).toEqual(error1)
+      expect(JSON.parse(client.messages[2])).toEqual(error2)
+    })
+  })
+
+  describe('buffering when clients exist but not ready', () => {
+    it('should buffer message when client readyState is not OPEN', () => {
+      // Add a client that's not ready (CONNECTING state)
+      const notReadyClient = new MockWebSocket()
+      notReadyClient.readyState = 0 // CONNECTING
+      server.clients.add(notReadyClient)
+
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error', stack: '' },
+      }
+
+      server.send(errorPayload)
+
+      // Message should be buffered since no client could receive it
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(notReadyClient.messages).toHaveLength(0)
+    })
+
+    it('should send to ready clients and not buffer', () => {
+      // Connect a ready client
+      const readyClient = server.simulateConnection()
+      readyClient.messages = [] // Clear connection messages
+
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error', stack: '' },
+      }
+
+      server.send(errorPayload)
+
+      // Message should be sent, not buffered
+      expect(server.getBufferedMessages()).toHaveLength(0)
+      expect(readyClient.messages).toHaveLength(1)
+      expect(JSON.parse(readyClient.messages[0])).toEqual(errorPayload)
+    })
+  })
+
+  describe('multiple clients scenario', () => {
+    it('should send to all ready clients', () => {
+      const client1 = server.simulateConnection()
+      const client2 = server.simulateConnection()
+      client1.messages = []
+      client2.messages = []
+
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error', stack: '' },
+      }
+
+      server.send(errorPayload)
+
+      // Both clients should receive the message
+      expect(client1.messages).toHaveLength(1)
+      expect(client2.messages).toHaveLength(1)
+      expect(server.getBufferedMessages()).toHaveLength(0)
+    })
+
+    it('should buffer if all clients are not ready', () => {
+      const client1 = server.simulateConnection()
+      const client2 = server.simulateConnection()
+
+      // Make both clients not ready
+      client1.readyState = 0
+      client2.readyState = 0
+      client1.messages = []
+      client2.messages = []
+
+      const errorPayload: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error', stack: '' },
+      }
+
+      server.send(errorPayload)
+
+      // Message should be buffered
+      expect(server.getBufferedMessages()).toHaveLength(1)
+      expect(client1.messages).toHaveLength(0)
+      expect(client2.messages).toHaveLength(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle rapid connect/disconnect cycles', () => {
+      const error: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error', stack: '' },
+      }
+
+      // Buffer a message
+      server.send(error)
+
+      // Connect and immediately disconnect
+      const client1 = server.simulateConnection()
+      server.simulateDisconnection(client1)
+
+      // Buffer is cleared after first connection
+      expect(server.getBufferedMessages()).toHaveLength(0)
+
+      // New message should be buffered (no clients now)
+      const error2: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Test error 2', stack: '' },
+      }
+      server.send(error2)
+      expect(server.getBufferedMessages()).toHaveLength(1)
+
+      // New client should receive the new message
+      const client2 = server.simulateConnection()
+      expect(client2.messages).toHaveLength(2) // connected + error2
+      expect(JSON.parse(client2.messages[1])).toEqual(error2)
+    })
+
+    it('should handle interleaved errors and full-reloads', () => {
+      const error1: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 1', stack: '' },
+      }
+      const reload: FullReloadPayload = {
+        type: 'full-reload',
+        path: '*',
+      }
+      const error2: ErrorPayload = {
+        type: 'error',
+        err: { message: 'Error 2', stack: '' },
+      }
+
+      server.send(error1) // Buffer: [error1]
+      server.send(reload) // Buffer: [reload] (error1 cleared)
+      server.send(error2) // Buffer: [reload, error2]
+
+      const client = server.simulateConnection()
+
+      // Client should receive: connected, reload, error2
+      expect(client.messages).toHaveLength(3)
+      expect(JSON.parse(client.messages[1])).toEqual(reload)
+      expect(JSON.parse(client.messages[2])).toEqual(error2)
+    })
+  })
+})


### PR DESCRIPTION
When dependency optimization completes before the WebSocket connection is fully established, the `full-reload` message could be lost because the server only buffered messages when `wss.clients.size === 0`.

This causes the first page load to fail in cold start scenarios, especially in remote/containerized environments where there's network latency between the client and server.

Fixes #21349 

### Problem Scenario

1. Browser requests page
2. Server starts dependency optimization  
3. Browser initiates WebSocket connection (CONNECTING state)
4. Server completes optimization, sends `full-reload`
   - `wss.clients.size > 0`, but `readyState !== OPEN`
   - Message NOT buffered → **lost!**
5. WebSocket connection established
6. Client never receives `full-reload` → Page load fails

### Changes

- Changed buffer from single message to array to preserve multiple messages (e.g., consecutive errors)
- Buffer messages when clients exist but none have `readyState === OPEN`
- Clear the buffer when `full-reload` arrives (previous errors and redundant reloads become invalid)
- Use array copy before clearing to prevent race conditions

### Alternatives Considered

1. **Client-side retry mechanism**: Add retry logic in the client to request a reload if deps are stale. Rejected because it adds complexity to the client and doesn't address the root cause.

2. **Delay sending full-reload until client connects**: Use a timeout or wait for connection event. Rejected because it could delay the reload unnecessarily and doesn't handle edge cases well.

3. **Send reload message via HTTP response header**: Embed reload signal in the initial HTML response. Rejected because it requires changes to multiple parts of the codebase.

The chosen approach (improved buffering) is minimal, backwards-compatible, and addresses the root cause directly.

### Reviewer Notes

- The buffer is cleared when `full-reload` arrives because previous errors become invalid after a reload
- Array copy (`slice()`) before clearing prevents potential race conditions in the connection handler
- Added unit tests covering various buffering scenarios