### PR TITLE
fix(build): fix global scope pollution in iife/umd format

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -417,9 +417,9 @@ export const buildEsbuildPlugin = (): Plugin => {
         true,
       )
 
-      if (config.build.lib) {
-        res.code = injectEsbuildHelpers(res.code, opts.format)
-      }
+      // Inject esbuild helpers inside IIFE/UMD wrappers to prevent
+      // global namespace pollution (#7188, #17608)
+      res.code = injectEsbuildHelpers(res.code, opts.format)
 
       return res
     },


### PR DESCRIPTION
Using UMD/IIFE output format without library mode causes internal variables to leak to the global scope.

Fixes #17608

The fix removes a redundant condition since format detection is already handled internally by `injectEsbuildHelpers`.