### PR TITLE
fix: inject esbuild helpers for iife/umd format without lib mode

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
@@ -21,15 +21,9 @@ describe('buildEsbuildPlugin renderChunk', () => {
 
     const result = await plugin.renderChunk.call(plugin, code, chunk, opts)
     
-    // Without the fix, the helpers would be outside the wrapper or not injected at all 
-    // by this specific plugin logic because config.build.lib is false.
-    // The fix ensures injectEsbuildHelpers is called if format is iife/umd.
-    
-    // Note: injectEsbuildHelpers expects certain patterns to find the wrapper.
-    // Since transformWithEsbuild with iife format will produce a wrapper, 
-    // we check if the result code contains the expected injected pattern.
     expect(result.code).toContain('(function')
-    // esbuild helpers for spread usually look like __assign or similar depending on version
-    // but the point is they should be moved inside if they exist.
+    // Verification that helpers are injected inside the wrapper
+    // injectEsbuildHelpers replaces "use strict"; with "use strict"; + helpers
+    expect(result.code).toMatch(/"use strict";\s*var\s+__/)
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
@@ -15,15 +15,16 @@ describe('buildEsbuildPlugin renderChunk', () => {
       },
     }
 
-    const code = 'const a = { ...b }; export default a;'
+    // code contains esbuild helpers followed by the IIFE wrapper
+    const code =
+      'var __defProp = Object.defineProperty; var MyModule = (function() { "use strict"; const a = { ...b }; return a; })();'
     const chunk: any = { fileName: 'test.js' }
     const opts: any = { format: 'iife' }
 
     const result = await plugin.renderChunk.call(plugin, code, chunk, opts)
-    
-    expect(result.code).toContain('(function')
-    // Verification that helpers are injected inside the wrapper
-    // injectEsbuildHelpers replaces "use strict"; with "use strict"; + helpers
-    expect(result.code).toMatch(/"use strict";\s*var\s+__/)
+
+    expect(result.code).toContain('var MyModule = (function()')
+    // Verification that helpers are injected inside the wrapper after "use strict";
+    expect(result.code).toMatch(/"use strict";\s*var\s+__defProp/)
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild_renderChunk.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { buildEsbuildPlugin } from '../../plugins/esbuild'
+
+describe('buildEsbuildPlugin renderChunk', () => {
+  test('injects helpers when format is iife even if not in lib mode', async () => {
+    const plugin: any = buildEsbuildPlugin()
+    // Mock the environment config
+    plugin.environment = {
+      config: {
+        build: {
+          target: 'es2015',
+          minify: false,
+        },
+        esbuild: {},
+      },
+    }
+
+    const code = 'const a = { ...b }; export default a;'
+    const chunk: any = { fileName: 'test.js' }
+    const opts: any = { format: 'iife' }
+
+    const result = await plugin.renderChunk.call(plugin, code, chunk, opts)
+    
+    // Without the fix, the helpers would be outside the wrapper or not injected at all 
+    // by this specific plugin logic because config.build.lib is false.
+    // The fix ensures injectEsbuildHelpers is called if format is iife/umd.
+    
+    // Note: injectEsbuildHelpers expects certain patterns to find the wrapper.
+    // Since transformWithEsbuild with iife format will produce a wrapper, 
+    // we check if the result code contains the expected injected pattern.
+    expect(result.code).toContain('(function')
+    // esbuild helpers for spread usually look like __assign or similar depending on version
+    // but the point is they should be moved inside if they exist.
+  })
+})

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -415,7 +415,7 @@ export const buildEsbuildPlugin = (): Plugin => {
         true,
       )
 
-      if (config.build.lib) {
+      if (opts.format === 'iife' || opts.format === 'umd') {
         res.code = injectEsbuildHelpers(res.code, opts.format)
       }
 


### PR DESCRIPTION
Fixes #17608. When using rollupOptions.output.format of iife or umd without build.lib, esbuild helpers were added outside the wrapper function, causing global namespace pollution. Changed condition from checking config.build.lib to checking opts.format === iife or umd.