### PR TITLE
fix(html): handle trailing slash in htmlPath for relative URL pre-transform

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -163,11 +163,12 @@ const processNodeUrl = (
       if (url[0] === '/' && url[1] !== '/') {
         preTransformUrl = url
       } else if (url[0] === '.' || isBareRelative(url)) {
-        preTransformUrl = path.posix.join(
-          config.base,
-          path.posix.dirname(htmlPath),
-          url,
-        )
+        // When htmlPath ends with '/', treat it as a directory and use it directly
+        // for dirname calculation, otherwise dirname('/a/b/') returns '/a' instead of '/a/b'
+        const htmlDir = htmlPath.endsWith('/')
+          ? htmlPath.slice(0, -1)
+          : path.posix.dirname(htmlPath)
+        preTransformUrl = path.posix.join(config.base, htmlDir, url)
       }
     }
 


### PR DESCRIPTION
## Description

When implementing an SSR dev server following the [SSR guide](https://vite.dev/guide/ssr#setting-up-the-dev-server), the URL passed to `transformIndexHtml()` may end with a slash (e.g., `/example/dir/` instead of `/example/dir/index.html`).

In this case, `path.posix.dirname()` returns the parent directory instead of the expected current directory:
- `path.posix.dirname('/example/dir/')` returns `/example` (wrong)
- Expected: `/example/dir`

This causes relative script URLs in the HTML to be pre-transformed with the wrong base path, resulting in:
```
Pre-transform error: Failed to load url /example/filename.js (resolved id: /example/filename.js). Does the file exist?
```

## Fix

When `htmlPath` ends with `/`, we treat it as a directory path and remove the trailing slash to get the correct directory, instead of calling `dirname()`.

## Related Issue

Fixes #18964

## What is the purpose of this pull request?

- [x] Bug fix

## Checklist

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Related issue linked in the description
