### PR TITLE
docs: make footer copyright year dynamic

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -175,7 +175,7 @@ const config = defineConfig({
     },
 
     footer: {
-      copyright: `© 2025 VoidZero Inc. and Vite contributors. (${commitRef})`,
+      copyright: `© ${new Date().getFullYear()} VoidZero Inc. and Vite contributors. (${commitRef})`,
       nav: [
         {
           title: 'Vite',


### PR DESCRIPTION
Fixes #21430 

This PR fixes the outdated copyright year shown in the footer of the Vite
official website (vite.dev).

The year was previously hardcoded, which required manual updates. This change
replaces it with a dynamically generated value based on the current year to
prevent the issue from recurring in the future.

### Changes

- Replaced hardcoded footer year with `new Date().getFullYear()`
- Ensures the footer stays up to date automatically each year

### Impact

- Documentation-only change
- No impact on Vite core, build, or runtime behavior
