### PR TITLE
refactor!: remove `isFileServingAllowed`

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -341,8 +341,7 @@ The following options are deprecated and will be removed in the future:
 ## Removed Deprecated Features [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
 - Passing an URL to `import.meta.hot.accept` is no longer supported. Please pass an id instead. ([#21382](https://github.com/vitejs/vite/pull/21382))
-
-**_TODO: This change is not implemented yet, but will be implemented before stable release._**
+- `isFileServingAllowed` function is removed. Please use `isFileLoadingAllowed` instead.
 
 ## Advanced
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -96,10 +96,7 @@ export { send } from './server/send'
 export { createLogger } from './logger'
 export { searchForWorkspaceRoot } from './server/searchRoot'
 
-export {
-  isFileServingAllowed,
-  isFileLoadingAllowed,
-} from './server/middlewares/static'
+export { isFileLoadingAllowed } from './server/middlewares/static'
 export { loadEnv, resolveEnvPrefix } from './env'
 
 // additional types

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -9,7 +9,6 @@ import type { ResolvedConfig } from '../../config'
 import { FS_PREFIX } from '../../constants'
 import {
   decodeURIIfPossible,
-  fsPathFromUrl,
   isFileReadable,
   isImportRequest,
   isInternalRequest,
@@ -240,34 +239,6 @@ export function serveRawFsMiddleware(
       next()
     }
   }
-}
-
-/**
- * Check if the url is allowed to be served, via the `server.fs` config.
- * @deprecated Use the `isFileLoadingAllowed` function instead.
- */
-export function isFileServingAllowed(
-  config: ResolvedConfig,
-  url: string,
-): boolean
-export function isFileServingAllowed(
-  url: string,
-  server: ViteDevServer,
-): boolean
-export function isFileServingAllowed(
-  configOrUrl: ResolvedConfig | string,
-  urlOrServer: string | ViteDevServer,
-): boolean {
-  const config = (
-    typeof urlOrServer === 'string' ? configOrUrl : urlOrServer.config
-  ) as ResolvedConfig
-  const url = (
-    typeof urlOrServer === 'string' ? urlOrServer : configOrUrl
-  ) as string
-
-  if (!config.server.fs.strict) return true
-  const filePath = fsPathFromUrl(url)
-  return isFileLoadingAllowed(config, filePath)
 }
 
 /**


### PR DESCRIPTION
`isFileServingAllowed` was deprecated in 6.3.4 by #19965. This PR removes that function.

refs https://github.com/vitest-dev/vitest/pull/9160, https://github.com/vitest-dev/vitest/pull/9490
