### PR TITLE
fix(dev): avoid event emitter leak caused by `server.listen` callback

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
@@ -57,9 +57,9 @@ const createPreviewServerWithPlugin = async (plugin: Plugin) => {
         name: 'mock-preview',
         configurePreviewServer({ httpServer }) {
           // NOTE: make httpServer.listen no-op to avoid starting a server
-          httpServer.listen = (...args: unknown[]) => {
-            const listener = args.at(-1) as () => void
-            listener()
+          httpServer.listen = () => {
+            const lastListener = httpServer.listeners('listening').at(-1)!
+            lastListener.call(httpServer)
             return httpServer as any
           }
         },

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -197,14 +197,20 @@ async function tryBindServer(
 > {
   return new Promise((resolve) => {
     const onError = (e: Error & { code?: string }) => {
-      httpServer.removeListener('error', onError)
+      httpServer.off('error', onError)
+      httpServer.off('listening', onListening)
       resolve({ success: false, error: e })
     }
-    httpServer.on('error', onError)
-    httpServer.listen(port, host, () => {
-      httpServer.removeListener('error', onError)
+    const onListening = () => {
+      httpServer.off('error', onError)
+      httpServer.off('listening', onListening)
       resolve({ success: true })
-    })
+    }
+
+    httpServer.on('error', onError)
+    httpServer.on('listening', onListening)
+
+    httpServer.listen(port, host)
   })
 }
 


### PR DESCRIPTION
Fixed the following warning:

> MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 listening listeners added to [Server]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

It seems `server.listen(host, port, cb)` registers the cb. I assumed it works like `.once`.


refs #21381 
