### PR TITLE
fix(optimizer): skip `rolldownCjsExternalPlugin` for `platform: neutral`

### DIFF
--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -315,10 +315,14 @@ export function rolldownCjsExternalPlugin(
   if (platform === 'node') {
     return undefined
   }
+  // Skip this plugin for `platform: 'neutral'` as we are not sure whether `require` is available
+  if (platform === 'neutral') {
+    return undefined
+  }
 
   // Apply this plugin for `platform: 'browser'` as `require` is not available in browser and
   // converting to `import` would be necessary to make the code work
-  platform satisfies 'browser' | 'neutral'
+  platform satisfies 'browser'
 
   const filter = new RegExp(externals.map(matchesEntireLine).join('|'))
 


### PR DESCRIPTION
Since Vite does not know whether `require` is available, `rolldownCjsExternalPlugin` should be skipped for `platform: neutral`.

refs #18611, https://github.com/cloudflare/workers-sdk/issues/11948#issuecomment-3761510521
