### PR TITLE
docs: undo syntactic mashup in FeatureGrid1.vue

### DIFF
--- a/docs/.vitepress/theme/landing/FeatureGrid1.vue
+++ b/docs/.vitepress/theme/landing/FeatureGrid1.vue
@@ -60,7 +60,7 @@ import viteAnimation from '@assets/vite/animations/563_x_420_rich_features.riv'
     <div class="p-5 sm:p-10 pb-0 sm:pb-0 flex flex-col gap-3 lg:border-b-0">
       <h5 class="text-white">Rich Features Out of the Box</h5>
       <p class="sm:max-w-[28rem] text-pretty">
-        TypeScript, JSX, CSS, Workers, Web Assembly... and more with just a
+        TypeScript, JSX, CSS, Workers, Web Assembly... and more just a
         plugin away.
       </p>
       <RiveAnimation

--- a/docs/.vitepress/theme/landing/FeatureGrid1.vue
+++ b/docs/.vitepress/theme/landing/FeatureGrid1.vue
@@ -60,8 +60,8 @@ import viteAnimation from '@assets/vite/animations/563_x_420_rich_features.riv'
     <div class="p-5 sm:p-10 pb-0 sm:pb-0 flex flex-col gap-3 lg:border-b-0">
       <h5 class="text-white">Rich Features Out of the Box</h5>
       <p class="sm:max-w-[28rem] text-pretty">
-        TypeScript, JSX, CSS, Workers, Web Assembly... and more just a
-        plugin away.
+        TypeScript, JSX, CSS, Workers, WebAssembly... and more just a plugin
+        away.
       </p>
       <RiveAnimation
         :desktop-src="viteAnimation"


### PR DESCRIPTION
There are two perfectly good English sentences that got combined into one.  I'll focus on the sentence fragment that matters, and italicize the words that are unique to each one:

- ...and more *with* just a plugin.
- ...and more just a plugin *away*.

Both express the same general idea, and both are grammatically perfectly conventional.  But combining them breaks them, so that the combination is no longer following normal English grammar patterns.

The first option is a little simpler for a non-native speaker to understand, since it just uses a plain vanilla prepositional phrase.  The second feels a little more playful with "plugin" used as a unit of measurement, as in the phrase "just a mile away".

I kept the more playful version in my proposed change, but either is fine.
