### PR TITLE
fix: avoid using deprecated `output.inlineDynamicImport` option

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -731,11 +731,14 @@ export function resolveRolldownOptions(
       assetFileNames: libOptions
         ? `[name].[ext]`
         : path.posix.join(options.assetsDir, `[name]-[hash].[ext]`),
-      inlineDynamicImports:
-        output.format === 'umd' ||
+      codeSplitting:
+        output.codeSplitting ??
+        (output.format === 'umd' ||
         output.format === 'iife' ||
         (isSsrTargetWebworkerEnvironment &&
-          (typeof input === 'string' || Object.keys(input).length === 1)),
+          (typeof input === 'string' || Object.keys(input).length === 1))
+          ? false
+          : undefined),
       legalComments: 'none',
       minify:
         options.minify === 'oxc'

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2436,7 +2436,7 @@ async function bundleConfigFile(
       return path.resolve(fileName, relative)
     },
     // we want to generate a single chunk like esbuild does with `splitting: false`
-    inlineDynamicImports: true,
+    codeSplitting: false,
   })
   await bundle.close()
 

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -319,7 +319,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
     },
 
     renderChunk(_, chunk, options) {
-      if (!options.inlineDynamicImports) {
+      if (options.codeSplitting !== false) {
         for (const id of chunk.moduleIds) {
           const module = this.getModuleInfo(id)
           if (!module) continue

--- a/playground/dynamic-import-inline/__tests__/dynamic-import-inline.spec.ts
+++ b/playground/dynamic-import-inline/__tests__/dynamic-import-inline.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { isBuild, serverLogs } from '~utils'
 
 test.runIf(isBuild)(
-  "don't warn when inlineDynamicImports is set to true",
+  "don't warn when codeSplitting is set to false",
   async () => {
     const log = serverLogs.join('\n')
     expect(log).not.toContain(

--- a/playground/dynamic-import-inline/vite.config.js
+++ b/playground/dynamic-import-inline/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        inlineDynamicImports: true,
+        codeSplitting: false,
       },
     },
   },

--- a/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
+++ b/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
@@ -30,7 +30,7 @@ test('supports nodejs_compat', async () => {
   )
 })
 
-test.runIf(isBuild)('inlineDynamicImports', () => {
+test.runIf(isBuild)('codeSplitting: false', () => {
   const dynamicJsContent = findAssetFile(/dynamic-[-\w]+\.js/, 'worker')
   expect(dynamicJsContent).toBeUndefined()
 })


### PR DESCRIPTION
refs https://github.com/rolldown/rolldown/pull/7870