### PR TITLE
docs: add Scrimba tutorial links across documentation

### DIFF
--- a/docs/.vitepress/theme/components/ScrimbaLink.vue
+++ b/docs/.vitepress/theme/components/ScrimbaLink.vue
@@ -18,9 +18,11 @@ defineProps<{
 
 <style scoped>
 .scrimba {
-  margin: 28px 0;
-  background-color: var(--vp-c-bg-soft);
-  padding: 1em 1.25em;
+  margin: 16px 0;
+  color: var(--vp-custom-block-info-text);
+  background-color: var(--vp-custom-block-info-bg);
+  border: 1px solid var(--vp-custom-block-info-border);
+  padding: 16px 20px;
   border-radius: 8px;
   display: flex;
   align-items: center;

--- a/docs/.vitepress/theme/components/ScrimbaLink.vue
+++ b/docs/.vitepress/theme/components/ScrimbaLink.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+defineProps<{
+  href: string
+  title: string
+}>()
+</script>
+
+<template>
+  <div class="scrimba">
+    <span class="play-button">
+      <span class="play-icon"></span>
+    </span>
+    <a :href="href" target="_blank" rel="sponsored noopener" :title="title">
+      <slot>Watch an interactive lesson on Scrimba</slot>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.scrimba {
+  margin: 28px 0;
+  background-color: var(--vp-c-bg-soft);
+  padding: 1em 1.25em;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.play-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
+  border-radius: 50%;
+  background-color: var(--vp-c-brand-1);
+}
+.play-icon {
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  border-style: solid;
+  border-width: 5px 0 5px 8px;
+  border-color: transparent transparent transparent #fff;
+}
+.scrimba a {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+.scrimba a:hover {
+  color: var(--vp-c-brand-2);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -10,6 +10,7 @@ import SvgImage from './components/SvgImage.vue'
 import YouTubeVideo from './components/YouTubeVideo.vue'
 import NonInheritBadge from './components/NonInheritBadge.vue'
 import AsideSponsors from './components/AsideSponsors.vue'
+import ScrimbaLink from './components/ScrimbaLink.vue'
 
 export default {
   Layout() {
@@ -23,6 +24,7 @@ export default {
     app.component('SvgImage', SvgImage)
     app.component('YouTubeVideo', YouTubeVideo)
     app.component('NonInheritBadge', NonInheritBadge)
+    app.component('ScrimbaLink', ScrimbaLink)
     app.use(TwoslashFloatingVue)
 
     Theme.enhanceApp(ctx)

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -14,8 +14,6 @@ export default {
 }
 ```
 
-<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05jg?via=vite" title="Configuring Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
-
 Note Vite supports using ES modules syntax in the config file even if the project is not using native Node ESM, e.g. `"type": "module"` in `package.json`. In this case, the config file is auto pre-processed before load.
 
 You can also explicitly specify a config file to use with the `--config` CLI option (resolved relative to `cwd`):
@@ -23,6 +21,8 @@ You can also explicitly specify a config file to use with the `--config` CLI opt
 ```bash
 vite --config my-config.js
 ```
+
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05jg?via=vite" title="Configuring Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
 
 ::: tip CONFIG LOADING
 By default, Vite uses [Rolldown](https://rolldown.rs/) to bundle the config into a temporary file and load it. This may cause issues when importing TypeScript files in a monorepo. If you encounter any issues with this approach, you can specify `--configLoader runner` to use the [module runner](/guide/api-environment-runtimes.html#modulerunner) instead, which will not create a temporary config and will transform any files on the fly. Note that module runner doesn't support CJS in config files, but external CJS packages should work as usual.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -14,6 +14,8 @@ export default {
 }
 ```
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05jg?via=vite" title="Configuring Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 Note Vite supports using ES modules syntax in the config file even if the project is not using native Node ESM, e.g. `"type": "module"` in `package.json`. In this case, the config file is auto pre-processed before load.
 
 You can also explicitly specify a config file to use with the `--config` CLI option (resolved relative to `cwd`):

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -2,6 +2,8 @@
 
 When it is time to deploy your app for production, simply run the `vite build` command. By default, it uses `<root>/index.html` as the build entry point, and produces an application bundle that is suitable to be served over a static hosting service. Check out the [Deploying a Static Site](./static-deploy) for guides about popular services.
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~037q?via=vite" title="Building for Production">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 ## Browser Compatibility
 
 By default, the production bundle assumes a modern browser that is included in the [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available targets. The default browser support range is:

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -1,5 +1,7 @@
 # Env Variables and Modes
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05an?via=vite" title="Env Variables in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 Vite exposes certain constants under the special `import.meta.env` object. These constants are defined as global variables during dev and statically replaced at build time to make tree-shaking effective.
 
 :::details Example

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -1,7 +1,5 @@
 # Env Variables and Modes
 
-<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05an?via=vite" title="Env Variables in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
-
 Vite exposes certain constants under the special `import.meta.env` object. These constants are defined as global variables during dev and statically replaced at build time to make tree-shaking effective.
 
 :::details Example
@@ -14,6 +12,8 @@ if (import.meta.env.DEV) {
 ```
 
 :::
+
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05an?via=vite" title="Env Variables in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
 
 ## Built-in Constants
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -30,8 +30,6 @@ Note you don't need to manually set these up - when you [create an app via `crea
 
 Vite supports importing `.ts` files out of the box.
 
-<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0t6?via=vite" title="TypeScript in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
-
 ### Transpile Only
 
 Note that Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -30,6 +30,8 @@ Note you don't need to manually set these up - when you [create an app via `crea
 
 Vite supports importing `.ts` files out of the box.
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0t6?via=vite" title="TypeScript in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 ### Transpile Only
 
 Note that Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process.
@@ -366,6 +368,8 @@ To configure CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lig
 By default, Vite uses esbuild to minify CSS. Lightning CSS can also be used as the CSS minifier with [`build.cssMinify: 'lightningcss'`](../config/build-options.md#build-cssminify).
 
 ## Static Assets
+
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~05pq?via=vite" title="Static Assets in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
 
 Importing a static asset will return the resolved public URL when it is served:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -18,6 +18,8 @@ Vite is also highly extensible via its [Plugin API](./api-plugin) and [JavaScrip
 
 You can learn more about the rationale behind the project in the [Why Vite](./why) section.
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq?via=vite" title="Free Vite Course on Scrimba">Learn Vite through interactive tutorials on Scrimba</ScrimbaLink>
+
 ## Browser Support
 
 During development, Vite assumes that a modern browser is used. This means the browser supports most of the latest JavaScript and CSS features. For that reason, Vite sets [`esnext` as the transform target](https://esbuild.github.io/api/#target). This prevents syntax lowering, letting Vite serve modules as close as possible to the original source code. Vite injects some runtime code to make the development server work. This code uses features included in [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available at the time of each major release (2026-01-01 for this major).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -71,6 +71,8 @@ $ deno init --npm vite
 
 Then follow the prompts!
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0yhj?via=vite" title="Scaffolding Your First Vite Project">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 ::: tip Compatibility Note
 Vite requires [Node.js](https://nodejs.org/en/) version 20.19+, 22.12+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 :::

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -25,8 +25,6 @@ Vite provides built-in support for server-side rendering (SSR). [`create-vite-ex
 
 You can also scaffold these projects locally by [running `create-vite`](./index.md#scaffolding-your-first-vite-project) and choose `Others > create-vite-extra` under the framework option.
 
-<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0yhj?via=vite" title="SSR in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
-
 ## Source Structure
 
 A typical SSR application will have the following source file structure:

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -25,6 +25,8 @@ Vite provides built-in support for server-side rendering (SSR). [`create-vite-ex
 
 You can also scaffold these projects locally by [running `create-vite`](./index.md#scaffolding-your-first-vite-project) and choose `Others > create-vite-extra` under the framework option.
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0yhj?via=vite" title="SSR in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 ## Source Structure
 
 A typical SSR application will have the following source file structure:

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -2,6 +2,8 @@
 
 Vite can be extended using plugins, which are based on Rollup's well-designed plugin interface with a few extra Vite-specific options. This means that Vite users can rely on the mature ecosystem of Rollup plugins, while also being able to extend the dev server and SSR functionality as needed.
 
+<ScrimbaLink href="https://scrimba.com/intro-to-vite-c03p6pbbdq/~0y4g?via=vite" title="Using Plugins in Vite">Watch an interactive lesson on Scrimba</ScrimbaLink>
+
 ## Adding a Plugin
 
 To use a plugin, it needs to be added to the `devDependencies` of the project and included in the `plugins` array in the `vite.config.js` config file. For example, to provide support for legacy browsers, the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) can be used:


### PR DESCRIPTION
This PR adds a ScrimbaLink component and uses it to integrate relevant tutorial links into the docs, as discussed with and agreed by @yyx990803 .

Here are the locations of the links:

- Getting Started page
- Features (TypeScript and Static Assets sections)
- Env Variables and Modes
- Building for Production
- Configuring Vite
- Using Plugins
- Server-Side Rendering


