### PR TITLE
fix(build): avoid redefining viteMetadata on chunk

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1399,10 +1399,12 @@ function injectChunkMetadata(
   }
   // define instead of assign to avoid detected as a change
   // https://github.com/rolldown/rolldown/blob/f4c5ff27799f2b0152c689c398e61bc7d30429ff/packages/rolldown/src/utils/transform-to-rollup-output.ts#L87
-  Object.defineProperty(chunk, 'viteMetadata', {
-    value: chunkMetadataMap.get(chunk),
-    enumerable: true,
-  })
+  if (!('viteMetadata' in chunk)) {
+    Object.defineProperty(chunk, 'viteMetadata', {
+      value: chunkMetadataMap.get(chunk),
+      enumerable: true,
+    })
+  }
   Object.defineProperty(chunk, 'modules', {
     get() {
       return chunk.viteMetadata!.__modules


### PR DESCRIPTION
This PR fixes the build failure reported in #21466, where Vite 8.0.0-beta.9 crashes during build with:

```
TypeError: Cannot redefine property: viteMetadata
```

This occurs when using Nitro/TanStack Start, where the same chunk object may be processed more than once during output normalization with the Rolldown-based pipeline.

### Root Cause

`injectChunkMetadata` previously unconditionally defined the `viteMetadata` property on the chunk using `Object.defineProperty`. When the function is re-entered for the same chunk, redefining the property throws at runtime.

### Fix

The metadata injection is now guarded so the property is only defined if it does not already exist. This makes the operation idempotent while preserving existing behavior for builds where chunks are processed only once.

```diff
- Object.defineProperty(chunk, 'viteMetadata', {
-   value: chunkMetadataMap.get(chunk),
-   enumerable: true,
- })
+ if (!('viteMetadata' in chunk)) {
+   Object.defineProperty(chunk, 'viteMetadata', {
+     value: chunkMetadataMap.get(chunk),
+     enumerable: true,
+   })
+ }
```

### Impact

* Fixes the crash in Vite 8.0.0-beta.9 when used with Nitro-based setups
* No public API changes
* No behavior changes for Rollup-style single-pass builds
* Improves robustness for re-entrant chunk normalization in the Rolldown pipeline

Closes #21466.
