### PR TITLE
fix: respect build.lib.fileName in custom environments

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1200,3 +1200,69 @@ function getOutputHashChanges(
     unchanged: names.filter((name) => map1[name] === map2[name]),
   }
 }
+
+test('environments.*.build.lib.fileName should be respected', async () => {
+  const fileNameCalls: Array<{
+    env: string
+    format: string
+    entryName: string
+  }> = []
+
+  const builder = await createBuilder({
+    logLevel: 'silent',
+    build: {
+      lib: {
+        entry: resolve(__dirname, 'fixtures/test-lib-entry.js'),
+        name: 'TestLib',
+        fileName: (format, entryName) => {
+          fileNameCalls.push({ env: 'root', format, entryName })
+          return `root.${format}.js`
+        },
+        formats: ['es'],
+      },
+    },
+    environments: {
+      browser: {
+        build: {
+          lib: {
+            entry: resolve(__dirname, 'fixtures/test-lib-entry.js'),
+            name: 'BrowserLib',
+            fileName: (format, entryName) => {
+              fileNameCalls.push({ env: 'browser', format, entryName })
+              return `browser.${format}.js`
+            },
+            formats: ['es', 'umd'],
+          },
+        },
+      },
+    },
+    plugins: [
+      {
+        name: 'test-lib-entry',
+        resolveId(id) {
+          if (id.includes('test-lib-entry.js')) {
+            return '\0test-lib-entry.js'
+          }
+        },
+        load(id) {
+          if (id === '\0test-lib-entry.js') {
+            return 'export const test = "test"'
+          }
+        },
+      },
+    ],
+  })
+
+  for (const name of Object.keys(builder.environments)) {
+    await builder.build(builder.environments[name])
+  }
+
+  const browserCalls = fileNameCalls.filter((c) => c.env === 'browser')
+  expect(browserCalls.length).toBeGreaterThan(0)
+  expect(browserCalls.some((c) => c.format === 'es')).toBe(true)
+  expect(browserCalls.some((c) => c.format === 'umd')).toBe(true)
+
+  const rootCalls = fileNameCalls.filter((c) => c.env === 'root')
+  expect(rootCalls.length).toBeGreaterThan(0)
+  expect(rootCalls.some((c) => c.format === 'es')).toBe(true)
+})

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -712,18 +712,18 @@ export function resolveRolldownOptions(
       generatedCode: {
         preset: 'es2015',
       },
-      entryFileNames: ssr
-        ? `[name].${jsExt}`
-        : libOptions
-          ? ({ name }) =>
-              resolveLibFilename(
-                libOptions,
-                format,
-                name,
-                root,
-                jsExt,
-                packageCache,
-              )
+      entryFileNames: libOptions
+        ? ({ name }) =>
+            resolveLibFilename(
+              libOptions,
+              format,
+              name,
+              root,
+              jsExt,
+              packageCache,
+            )
+        : ssr
+          ? `[name].${jsExt}`
           : path.posix.join(options.assetsDir, `[name]-[hash].${jsExt}`),
       chunkFileNames: libOptions
         ? `[name]-[hash].${jsExt}`


### PR DESCRIPTION
## What / Why
Custom environments default to `consumer: 'server'` (SSR), which caused library filename resolution to be unintentionally bypassed in lib mode.

## Reproduction
Config
```ts
export default {
  environments: {
    client: {
      build: {
        lib: {
          fileName: 'index.root',
        },
      },
    },
    browser: {
      build: {
        lib: {
          fileName: (format) => `index.browser.${format}.js`,
        },
      },
    },
  },
}
```

### Expected
- Each environment respects its own build.lib.fileName (including function form).

### Actual
- client (ssr=false, libOptions=true) -> fileName callback is called.
- browser (ssr=true, libOptions=true) -> fileName callback is not called.
Example output option difference
- client: { entryFileNames: [Function] }
- browser: { entryFileNames: "[name].js" }

### Root Cause
In packages/vite/src/node/build.ts, entryFileNames selected the SSR naming pattern before checking libOptions, so library filename resolution (resolveLibFilename) never ran when ssr === true.

### Fix
Prefer library mode (libOptions) over SSR when deciding entryFileNames, ensuring that resolveLibFilename(...) is used whenever build.lib is enabled (even if ssr === true).

### Tests
- Added a unit test that builds multiple environments and asserts that
  environment-specific `build.lib.fileName` callbacks are invoked per environment and per format.
- Test: packages/vite/src/node/__tests__/build.spec.ts

### Verification
- pnpm --filter vite build
- pnpm vitest run packages/vite/src/node/__tests__/build.spec.ts

## Issue
Closes #21445