### PR TITLE
docs: update `build.dynamicImportVarsOptions`

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -162,12 +162,10 @@ This option is an alias of `build.rolldownOptions` option. Use `build.rolldownOp
 
 ## build.dynamicImportVarsOptions
 
-- **Type:** [`RollupDynamicImportVarsOptions`](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#options)
+- **Type:** `{ include?: string | RegExp | (string | RegExp)[], exclude?: string | RegExp | (string | RegExp)[] }`
 - **Related:** [Dynamic Import](/guide/features#dynamic-import)
 
-Options to pass on to [@rollup/plugin-dynamic-import-vars](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars).
-
-<!-- TODO: we need to have a more detailed explanation here as we no longer use @rollup/plugin-dynamic-import-vars. we should say it's compatible with it though -->
+Whether to transform dynamic imports with variables.
 
 ## build.lib
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -642,6 +642,14 @@ const module = await import(`./dir/${file}.js`)
 
 Note that variables only represent file names one level deep. If `file` is `'foo/bar'`, the import would fail. For more advanced usage, you can use the [glob import](#glob-import) feature.
 
+Also note that the dynamic import must match the following rules to be bundled:
+
+- Imports must start with `./` or `../`: ``import(`./dir/${foo}.js`)`` is valid, but ``import(`${foo}.js`)`` is not.
+- Imports must end with a file extension: ``import(`./dir/${foo}.js`)`` is valid, but ``import(`./dir/${foo}`)`` is not.
+- Imports to the own directory must specify a file name pattern: ``import(`./prefix-${foo}.js`)`` is valid, but ``import(`./${foo}.js`)`` is not.
+
+These rules are enforced to prevent accidentally importing files that are not intended to be bundled. For example, without these rules, `import(foo)` would bundle everything in the file system.
+
 ## WebAssembly
 
 Pre-compiled `.wasm` files can be imported with `?init`.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -335,6 +335,7 @@ The following options are deprecated and will be removed in the future:
 - `build.rollupOptions`: renamed to `build.rolldownOptions`
 - `worker.rollupOptions`: renamed to `worker.rolldownOptions`
 - `build.commonjsOptions`: it is now no-op
+- `build.dynamicImportVarsOptions.warnOnError`: it is now no-op
 
 ## General Changes [<Badge text="NRV" type="warning" />](#migration-from-v7)
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -394,7 +394,6 @@ const _buildEnvironmentOptionsDefaults = Object.freeze({
     extensions: ['.js', '.cjs'],
   },
   dynamicImportVarsOptions: {
-    warnOnError: true,
     exclude: [/node_modules/],
   },
   write: true,

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -272,11 +272,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
               config.root,
             )
           } catch (error) {
-            if (environment.config.build.dynamicImportVarsOptions.warnOnError) {
-              this.warn(error)
-            } else {
-              this.error(error)
-            }
+            this.warn(error)
           }
 
           if (!result) {

--- a/packages/vite/src/types/dynamicImportVars.d.ts
+++ b/packages/vite/src/types/dynamicImportVars.d.ts
@@ -10,8 +10,7 @@ export interface RollupDynamicImportVarsOptions {
    */
   exclude?: string | RegExp | (string | RegExp)[]
   /**
-   * By default, the plugin quits the build process when it encounters an error. If you set this option to true, it will throw a warning instead and leave the code untouched.
-   * @default false
+   * @deprecated This option is no-op and will be removed in future versions.
    */
   warnOnError?: boolean
 }


### PR DESCRIPTION
Expanded docs around dynamic import vars behavior as we don't use `@rollup/plugin-dynamic-import-vars` as long as native plugins are enabled.
