### PR TITLE
docs: link to vite plugin registry

### DIFF
--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -33,9 +33,7 @@ Falsy plugins will be ignored, which can be used to easily activate or deactivat
 Vite aims to provide out-of-the-box support for common web development patterns. Before searching for a Vite or compatible Rollup plugin, check out the [Features Guide](../guide/features.md). A lot of the cases where a plugin would be needed in a Rollup project are already covered in Vite.
 :::
 
-Check out the [Plugins section](../plugins/) for information about official plugins. Community plugins are listed in [awesome-vite](https://github.com/vitejs/awesome-vite#plugins).
-
-You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search for vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) for Rollup plugins.
+Check out the [Plugins section](../plugins/) for information about official plugins. Community plugins that are published to npm are listed in [Vite Plugin Registry](https://registry.vite.dev/plugins).
 
 ## Enforcing Plugin Ordering
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -40,7 +40,7 @@ Provides legacy browsers support for the production build.
 
 ## Community Plugins
 
-Check out [awesome-vite](https://github.com/vitejs/awesome-vite#plugins) - you can also submit a PR to list your plugins there.
+Check out [Vite Plugin Registry](https://registry.vite.dev/plugins) for the list of plugins published to npm.
 
 ## Rolldown Builtin Plugins
 
@@ -48,6 +48,6 @@ Vite uses [Rolldown](https://rolldown.rs/) under the hood and it provides a few 
 
 Read the [Rolldown Builtin Plugins section](https://rolldown.rs/builtin-plugins/) for more information.
 
-## Rollup Plugins
+## Rolldown / Rollup Plugins
 
-[Vite plugins](../guide/api-plugin) are an extension of Rollup's plugin interface. Check out the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) for more information.
+[Vite plugins](../guide/api-plugin) are an extension of Rollup's plugin interface. Check out the [Rollup Plugin Compatibility section](../guide/api-plugin#rolldown-plugin-compatibility) for more information.


### PR DESCRIPTION
Added links to vite plugin registry instead of awesome vite. This allows users to filter plugins with supported versions and also find rollup / rolldown plugins.

We probably should archive the plugin section of awesome vite.

~~TODO: do the same for Rolldown docs~~ done
