### PR TITLE
fix(client): use trusted types in client runtime when available

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -358,7 +358,7 @@ function hasErrorOverlay() {
 }
 
 function waitForSuccessfulPing(socketUrl: string) {
-  if (typeof SharedWorker === 'undefined') {
+  const useMainThreadFallback = () => {
     const visibilityManager: VisibilityManager = {
       currentState: document.visibilityState,
       listeners: new Set(),
@@ -371,6 +371,10 @@ function waitForSuccessfulPing(socketUrl: string) {
     }
     document.addEventListener('visibilitychange', onVisibilityChange)
     return waitForSuccessfulPingInternal(socketUrl, visibilityManager)
+  }
+
+  if (typeof SharedWorker === 'undefined') {
+    return useMainThreadFallback()
   }
 
   // needs to be inlined to
@@ -386,7 +390,29 @@ function waitForSuccessfulPing(socketUrl: string) {
     { type: 'application/javascript' },
   )
   const objURL = URL.createObjectURL(blob)
-  const sharedWorker = new SharedWorker(objURL)
+
+  // Handle TrustedTypes enforcement - create a policy to bless the blob URL
+  let workerURL: string | TrustedScriptURL = objURL
+  if (typeof trustedTypes !== 'undefined') {
+    try {
+      const policy = trustedTypes.createPolicy('vite-hmr', {
+        createScriptURL: (url: string) => {
+          if (url.startsWith('blob:')) {
+            return url
+          }
+          throw new Error('URL not allowed')
+        },
+      })
+      workerURL = policy.createScriptURL(objURL)
+    } catch {
+      // Policy creation blocked (e.g., CSP doesn't allow 'vite-hmr' policy)
+      // Fall back to main thread implementation
+      URL.revokeObjectURL(objURL)
+      return useMainThreadFallback()
+    }
+  }
+
+  const sharedWorker = new SharedWorker(workerURL as string)
   return new Promise<void>((resolve, reject) => {
     const onVisibilityChange = () => {
       sharedWorker.port.postMessage({ visibility: document.visibilityState })

--- a/packages/vite/src/types/shims.d.ts
+++ b/packages/vite/src/types/shims.d.ts
@@ -31,3 +31,22 @@ declare module 'postcss-import' {
 declare var __vite_profile_session: import('node:inspector').Session | undefined
 // eslint-disable-next-line no-var
 declare var __vite_start_time: number | undefined
+
+// TrustedTypes API (https://w3c.github.io/trusted-types/dist/spec/)
+interface TrustedScriptURL {
+  toString(): string
+}
+
+interface TrustedTypePolicy {
+  createScriptURL(input: string): TrustedScriptURL
+}
+
+interface TrustedTypePolicyFactory {
+  createPolicy(
+    policyName: string,
+    policyOptions: { createScriptURL?: (input: string) => string },
+  ): TrustedTypePolicy
+}
+
+// eslint-disable-next-line no-var
+declare var trustedTypes: TrustedTypePolicyFactory | undefined

--- a/playground/trusted-types/__tests__/trusted-types.spec.ts
+++ b/playground/trusted-types/__tests__/trusted-types.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import {
+  browserErrors,
+  browserLogs,
+  editFile,
+  isServe,
+  page,
+  untilBrowserLogAfter,
+} from '~utils'
+
+describe.runIf(isServe)('trusted-types', () => {
+  test('should connect without trusted types violations', async () => {
+    // Wait for HMR connection to establish (with timeout)
+    const maxWait = 5000
+    const startTime = Date.now()
+    while (
+      !browserLogs.some((msg) => msg.includes('connected')) &&
+      Date.now() - startTime < maxWait
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+
+    // Verify HMR connected successfully
+    expect(browserLogs.some((msg) => msg.includes('connected'))).toBe(true)
+
+    // Verify no Trusted Types violations occurred
+    const trustedTypesErrors = browserErrors.filter(
+      (error) =>
+        error.message.includes('TrustedTypes') ||
+        error.message.includes('trusted types') ||
+        error.message.includes("requires 'TrustedScriptURL'"),
+    )
+    expect(trustedTypesErrors).toHaveLength(0)
+  })
+
+  test('should render initial content', async () => {
+    expect(await page.textContent('.hmr-status')).toBe('initial')
+  })
+
+  test('should handle HMR update', async () => {
+    await untilBrowserLogAfter(
+      () =>
+        editFile('main.js', (code) =>
+          code.replace("'initial'", "'updated via HMR'"),
+        ),
+      ['[trusted-types] hot update accepted'],
+    )
+    expect(await page.textContent('.hmr-status')).toBe('updated via HMR')
+  })
+})

--- a/playground/trusted-types/index.html
+++ b/playground/trusted-types/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Trusted Types Test</title>
+  </head>
+  <body>
+    <h1>Trusted Types Test</h1>
+    <p class="hmr-status">initial</p>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/playground/trusted-types/main.js
+++ b/playground/trusted-types/main.js
@@ -1,0 +1,7 @@
+document.querySelector('.hmr-status').textContent = 'initial'
+
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    console.log('[trusted-types] hot update accepted')
+  })
+}

--- a/playground/trusted-types/package.json
+++ b/playground/trusted-types/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-trusted-types",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/playground/trusted-types/vite.config.js
+++ b/playground/trusted-types/vite.config.js
@@ -1,0 +1,70 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import url from 'node:url'
+import crypto from 'node:crypto'
+import { defineConfig } from 'vite'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+const noncePlaceholder = '#$NONCE$#'
+const createNonce = () => crypto.randomBytes(16).toString('base64')
+
+/**
+ * @param {import('node:http').ServerResponse} res
+ * @param {string} nonce
+ */
+const setTrustedTypesHeader = (res, nonce) => {
+  // CSP with Trusted Types enforcement
+  // - require-trusted-types-for 'script': enforces trusted types for script URLs
+  // - trusted-types vite-hmr: allows the vite-hmr policy that Vite creates
+  res.setHeader(
+    'Content-Security-Policy',
+    `require-trusted-types-for 'script'; trusted-types vite-hmr; default-src 'self'; script-src 'nonce-${nonce}' 'strict-dynamic'; connect-src 'self' ws: wss:; worker-src blob:`,
+  )
+}
+
+/**
+ * @param {string} file
+ * @param {(input: string, originalUrl: string) => Promise<string>} transform
+ * @returns {import('vite').Connect.NextHandleFunction}
+ */
+const createMiddleware = (file, transform) => async (req, res) => {
+  const nonce = createNonce()
+  setTrustedTypesHeader(res, nonce)
+  const content = await fs.readFile(path.join(__dirname, file), 'utf-8')
+  const transformedContent = await transform(content, req.originalUrl)
+  res.setHeader('Content-Type', 'text/html')
+  res.end(transformedContent.replaceAll(noncePlaceholder, nonce))
+}
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'trusted-types-csp',
+      config() {
+        return {
+          appType: 'custom',
+          html: {
+            cspNonce: noncePlaceholder,
+          },
+        }
+      },
+      configureServer({ transformIndexHtml, middlewares }) {
+        return () => {
+          middlewares.use(
+            createMiddleware('./index.html', (input, originalUrl) =>
+              transformIndexHtml(originalUrl, input),
+            ),
+          )
+        }
+      },
+      configurePreviewServer({ middlewares }) {
+        return () => {
+          middlewares.use(
+            createMiddleware('./dist/index.html', async (input) => input),
+          )
+        }
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1806,6 +1806,8 @@ importers:
 
   playground/transform-plugin: {}
 
+  playground/trusted-types: {}
+
   playground/tsconfig-json: {}
 
   playground/tsconfig-json-load-error: {}


### PR DESCRIPTION
This fixes a client runtime crash when using Vite on a page with trusted types enforcement enabled.
It's valuable to allow testing trusted types behavior in development so issues aren't discovered later
when going back and fixing code becomes much more expensive.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->
