### PR TITLE
refactor: remove `experimental.enableNativePlugin: 'resolver'`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -556,15 +556,14 @@ export interface ExperimentalOptions {
   /**
    * Enable builtin plugin that written by rust, which is faster than js plugin.
    *
-   * - 'resolver' (deprecated, will be removed in v8 stable): Enable only the native resolver plugin.
-   * - 'v1' (will be deprecated, will be removed in v8 stable): Enable the first stable set of native plugins (including resolver).
+   * - 'v1' (will be deprecated, will be removed in v8 stable): Enable the first stable set of native plugins.
    * - 'v2' (will be deprecated, will be removed in v8 stable): Enable the improved dynamicImportVarsPlugin and importGlobPlugin.
    * - true: Enable all native plugins (currently an alias of 'v2', it will map to a newer one in the future versions).
    *
    * @experimental
    * @default 'v2'
    */
-  enableNativePlugin?: boolean | 'resolver' | 'v1' | 'v2'
+  enableNativePlugin?: boolean | 'v1' | 'v2'
   /**
    * Enable full bundle mode.
    *
@@ -2071,17 +2070,6 @@ assetFileNames isn't equal for every build.rollupOptions.output. A single patter
     )
   }
 
-  if (
-    resolved.resolve.tsconfigPaths &&
-    resolved.experimental.enableNativePlugin === false
-  ) {
-    resolved.logger.warn(
-      colors.yellow(`
-(!) resolve.tsconfigPaths is set to true, but native plugins are disabled. To use resolve.tsconfigPaths, please enable native plugins via experimental.enableNativePlugin.
-`),
-    )
-  }
-
   return resolved
 }
 
@@ -2092,8 +2080,6 @@ function resolveNativePluginEnabledLevel(
   >,
 ) {
   switch (enableNativePlugin) {
-    case 'resolver':
-      return 0
     case 'v1':
       return 1
     case 'v2':

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -3,7 +3,7 @@ import aliasPlugin from '@rollup/plugin-alias'
 import type { ResolvedConfig } from './config'
 import type { EnvironmentPluginContainer } from './server/pluginContainer'
 import { createEnvironmentPluginContainer } from './server/pluginContainer'
-import { oxcResolvePlugin, resolvePlugin } from './plugins/resolve'
+import { oxcResolvePlugin } from './plugins/resolve'
 import type { InternalResolveOptions } from './plugins/resolve'
 import type { Environment } from './environment'
 import type { PartialEnvironment } from './baseEnvironment'
@@ -61,34 +61,20 @@ export function createIdResolver(
         [
           // @ts-expect-error  the aliasPlugin uses rollup types
           aliasPlugin({ entries: environment.config.resolve.alias }),
-          ...(config.experimental.enableNativePlugin
-            ? oxcResolvePlugin(
-                {
-                  root: config.root,
-                  isProduction: config.isProduction,
-                  isBuild: config.command === 'build',
-                  asSrc: true,
-                  preferRelative: false,
-                  tryIndex: true,
-                  ...options,
-                  // Ignore sideEffects and other computations as we only need the id
-                  idOnly: true,
-                },
-                environment.config,
-              )
-            : [
-                resolvePlugin({
-                  root: config.root,
-                  isProduction: config.isProduction,
-                  isBuild: config.command === 'build',
-                  asSrc: true,
-                  preferRelative: false,
-                  tryIndex: true,
-                  ...options,
-                  // Ignore sideEffects and other computations as we only need the id
-                  idOnly: true,
-                }),
-              ]),
+          ...oxcResolvePlugin(
+            {
+              root: config.root,
+              isProduction: config.isProduction,
+              isBuild: config.command === 'build',
+              asSrc: true,
+              preferRelative: false,
+              tryIndex: true,
+              ...options,
+              // Ignore sideEffects and other computations as we only need the id
+              idOnly: true,
+            },
+            environment.config,
+          ),
         ],
         undefined,
         false,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../plugin'
 import { watchPackageDataPlugin } from '../packages'
 import { jsonPlugin } from './json'
-import { oxcResolvePlugin, resolvePlugin } from './resolve'
+import { oxcResolvePlugin } from './resolve'
 import { optimizedDepsPlugin } from './optimizedDeps'
 import { importAnalysisPlugin } from './importAnalysis'
 import { cssAnalysisPlugin, cssPlugin, cssPostPlugin } from './css'
@@ -47,7 +47,6 @@ export async function resolvePlugins(
     ? await (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
   const { modulePreload } = config.build
-  const enableNativePlugin = config.nativePluginEnabledLevel >= 0
   const enableNativePluginV1 = config.nativePluginEnabledLevel >= 1
 
   return [
@@ -76,33 +75,21 @@ export async function resolvePlugins(
     modulePreload !== false && modulePreload.polyfill
       ? modulePreloadPolyfillPlugin(config)
       : null,
-    ...(enableNativePlugin
-      ? oxcResolvePlugin(
-          {
-            root: config.root,
-            isProduction: config.isProduction,
-            isBuild,
-            packageCache: config.packageCache,
-            asSrc: true,
-            optimizeDeps: true,
-            externalize: true,
-            legacyInconsistentCjsInterop: config.legacy?.inconsistentCjsInterop,
-          },
-          isWorker
-            ? { ...config, consumer: 'client', optimizeDepsPluginNames: [] }
-            : undefined,
-        )
-      : [
-          resolvePlugin({
-            root: config.root,
-            isProduction: config.isProduction,
-            isBuild,
-            packageCache: config.packageCache,
-            asSrc: true,
-            optimizeDeps: true,
-            externalize: true,
-          }),
-        ]),
+    ...oxcResolvePlugin(
+      {
+        root: config.root,
+        isProduction: config.isProduction,
+        isBuild,
+        packageCache: config.packageCache,
+        asSrc: true,
+        optimizeDeps: true,
+        externalize: true,
+        legacyInconsistentCjsInterop: config.legacy?.inconsistentCjsInterop,
+      },
+      isWorker
+        ? { ...config, consumer: 'client', optimizeDepsPluginNames: [] }
+        : undefined,
+    ),
     htmlInlineProxyPlugin(config),
     cssPlugin(config),
     esbuildBannerFooterCompatPlugin(config),

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1491,17 +1491,6 @@ export function stripBomTag(content: string): string {
   return content
 }
 
-const windowsDrivePathPrefixRE = /^[A-Za-z]:[/\\]/
-
-/**
- * path.isAbsolute also returns true for drive relative paths on windows (e.g. /something)
- * this function returns false for them but true for absolute paths (e.g. C:/something)
- */
-export const isNonDriveRelativeAbsolutePath = (p: string): boolean => {
-  if (!isWindows) return p[0] === '/'
-  return windowsDrivePathPrefixRE.test(p)
-}
-
 /**
  * Determine if a file is being requested with the correct case, to ensure
  * consistent behavior between dev and prod and across operating systems.

--- a/playground/resolve-tsconfig-paths/vite.config.js
+++ b/playground/resolve-tsconfig-paths/vite.config.js
@@ -4,7 +4,4 @@ export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
-  experimental: {
-    enableNativePlugin: 'resolver',
-  },
 })


### PR DESCRIPTION
Remove `experimental.enableNativePlugin: 'resolver'`. The native resolver plugin is always enabled.

Part of https://github.com/vitejs/rolldown-vite/issues/539
