### PR TITLE
docs: clarify NODE_ENV and Modes

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -192,36 +192,23 @@ And create a `.env.staging` file:
 VITE_APP_TITLE=My App (staging)
 ```
 
-As `vite build` runs a production build by default, you can also change this and run a development build by using a different mode and `.env` file configuration:
+### NODE_ENV
 
-```[.env.testing]
-NODE_ENV=development
-```
+The `NODE_ENV` environment variable determines the value of the `import.meta.env.PROD` and `import.meta.env.DEV` boolean properties.
 
-### NODE_ENV and Modes
+Note that `NODE_ENV` does _not_ affect the Mode. `NODE_ENV` and Modes are completely distinct settings.
 
-It's important to note that `NODE_ENV` (`process.env.NODE_ENV`) and modes are two different concepts. Here's how different commands affect the `NODE_ENV` and mode:
+Example values of `NODE_ENV` and corresponding `import.meta.env` properties:
 
-| Command                                              | NODE_ENV        | Mode            |
-| ---------------------------------------------------- | --------------- | --------------- |
-| `vite build`                                         | `"production"`  | `"production"`  |
-| `vite build --mode development`                      | `"production"`  | `"development"` |
-| `NODE_ENV=development vite build`                    | `"development"` | `"production"`  |
-| `NODE_ENV=development vite build --mode development` | `"development"` | `"development"` |
+| Command                           | `import.meta.env.PROD` | `import.meta.env.DEV` |
+| --------------------------------- | ---------------------- | --------------------- |
+| `NODE_ENV=production vite build`  | `true`                 | `false`               |
+| `NODE_ENV=development vite build` | `false`                | `true`                |
+| `NODE_ENV=other vite build`       | `false`                | `true`                |
 
-The different values of `NODE_ENV` and mode also reflect on its corresponding `import.meta.env` properties:
-
-| Command                | `import.meta.env.PROD` | `import.meta.env.DEV` |
-| ---------------------- | ---------------------- | --------------------- |
-| `NODE_ENV=production`  | `true`                 | `false`               |
-| `NODE_ENV=development` | `false`                | `true`                |
-| `NODE_ENV=other`       | `false`                | `true`                |
-
-| Command              | `import.meta.env.MODE` |
-| -------------------- | ---------------------- |
-| `--mode production`  | `"production"`         |
-| `--mode development` | `"development"`        |
-| `--mode staging`     | `"staging"`            |
+You can use either or both of Modes and `NODE_ENV`.
+If you need help choosing one over the other, we suggest using Modes.
+Modes has the advantage of supporting `.env.[mode]` files, and `NODE_ENV` is considered an antipattern by [some](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production).
 
 :::tip `NODE_ENV` in `.env` files
 


### PR DESCRIPTION
Fixes #21503

This tries to make the distinction between NODE_ENV and Modes less confusing after my own experience with trying to figure it out. I've detailed my changes and rationale below:

* The first change removes the last paragraph from the "Modes" section but before "NODE_ENV and Modes". I don't think it is adding any information that is not already covered immediately above. And I find that it lends to a misconception that `NODE_ENV=development` causes "development mode", when actually `NODE_ENV` is unrelated to Modes.
* "NODE_ENV and Modes" heading is changed to just "NODE_ENV". This lets the section have a more focused subject and perhaps lessens the implication that NODE_ENV impacts Modes.
   * The opening statement for `NODE_ENV` just states what `NODE_ENV` does in vite.
   * _Then_ there is a statement to clarify that Modes is distinct in case that wasn't clear.
      * Say two different "settings" instead of "concepts". I think it's more like two settings for _one_ concept (the environment). Otherwise we ought to explain what the two concepts are.
   * Removed the table that shows combinations of the two settings because it confused me, making me think that there is some relationship between the two settings or precedence rules between `NODE_ENV` and `--mode` - when in fact they are just entirely distinct.
   * Added `... vite build` to the example commands in the retained table for clarity.
   * Removed a table showing how Mode works since this is covered elsewhere in the same page.
   * Added a paragraph to guide the reader through choosing one or the other. This may be a bit controversial, but I really think _some_ guidance is needed, so hopefully this is okay.


