### PR TITLE
fix: disable `tsconfig` option when loading config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2315,6 +2315,9 @@ async function bundleConfigFile(
     },
     // disable treeshake to include files that is not sideeffectful to `moduleIds`
     treeshake: false,
+    // disable tsconfig as it's confusing to respect tsconfig options in the config file
+    // this also aligns with other config loader behaviors
+    tsconfig: false,
     plugins: [
       {
         name: 'externalize-deps',


### PR DESCRIPTION
Disable `tsconfig` option when loading the config with the bundle config loader for the following reasons:

- breaks sveltekit because `tsconfig.json` will contain a path to a non-existent file until sveltekit is initialized
  https://github.com/vitejs/vite-ecosystem-ci/actions/runs/21462434949/job/61817573024#step:7:1782
- tsconfig paths were not supported previously and enabling it may break some apps
- other config loaders do not respect tsconfig.json
