### PR TITLE
feat(create-vite): bump eslint-plugin-react-refresh

### DIFF
--- a/packages/create-vite/template-react-ts/eslint.config.js
+++ b/packages/create-vite/template-react-ts/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import { reactRefresh } from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -13,7 +13,7 @@ export default defineConfig([
       js.configs.recommended,
       tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
+      reactRefresh.configs.vite(),
     ],
     languageOptions: {
       globals: globals.browser,

--- a/packages/create-vite/template-react/eslint.config.js
+++ b/packages/create-vite/template-react/eslint.config.js
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import { reactRefresh } from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -11,7 +11,7 @@ export default defineConfig([
     extends: [
       js.configs.recommended,
       reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
+      reactRefresh.configs.vite(),
     ],
     languageOptions: {
       globals: globals.browser,


### PR DESCRIPTION
I did a [major bump](https://github.com/ArnaudBarre/eslint-plugin-react-refresh/releases/tag/v0.5.0) to my eslint plugin for multiple reasons.

The configs are now functions which allow users to merge additional settings with the default settings. But ESLint typing forbids this to be on `<default export>.config`, so this why a named export it used