### PR TITLE
feat(hmr): truncate list of files on hmr update

### DIFF
--- a/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
+++ b/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
@@ -13,7 +13,7 @@ import { getHmrImplementation } from '../../plugins/clientInjections'
 import { DevEnvironment, type DevEnvironmentContext } from '../environment'
 import type { ResolvedConfig } from '../../config'
 import type { ViteDevServer } from '../../server'
-import { createDebugger } from '../../utils'
+import { createDebugger, formatAndTruncateFileList } from '../../utils'
 import { type NormalizedHotChannelClient, getShortName } from '../hmr'
 import { prepareError } from '../middlewares/error'
 
@@ -361,7 +361,9 @@ export class FullBundleDevEnvironment extends DevEnvironment {
     })
     this.logger.info(
       colors.green(`hmr update `) +
-        colors.dim([...new Set(updates.map((u) => u.path))].join(', ')),
+        colors.dim(
+          formatAndTruncateFileList([...new Set(updates.map((u) => u.path))]),
+        ),
       { clear: !invalidateInformation, timestamp: true },
     )
   }

--- a/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
+++ b/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
@@ -14,7 +14,7 @@ import { DevEnvironment, type DevEnvironmentContext } from '../environment'
 import type { ResolvedConfig } from '../../config'
 import type { ViteDevServer } from '../../server'
 import { createDebugger, formatAndTruncateFileList } from '../../utils'
-import { type NormalizedHotChannelClient, getShortName } from '../hmr'
+import { type NormalizedHotChannelClient, debugHmr, getShortName } from '../hmr'
 import { prepareError } from '../middlewares/error'
 
 const debug = createDebugger('vite:full-bundle-mode')
@@ -359,13 +359,13 @@ export class FullBundleDevEnvironment extends DevEnvironment {
       type: 'update',
       updates,
     })
-    this.logger.info(
-      colors.green(`hmr update `) +
-        colors.dim(
-          formatAndTruncateFileList([...new Set(updates.map((u) => u.path))]),
-        ),
-      { clear: !invalidateInformation, timestamp: true },
-    )
+    const filePaths = [...new Set(updates.map((u) => u.path))]
+    const { formatted, truncated } = formatAndTruncateFileList(filePaths)
+    if (truncated) debugHmr?.(`hmr update ${filePaths.join(', ')}`)
+    this.logger.info(colors.green(`hmr update `) + colors.dim(formatted), {
+      clear: !invalidateInformation,
+      timestamp: true,
+    })
   }
 }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -10,7 +10,12 @@ import type {
   InvokeSendData,
 } from '../../shared/invokeMethods'
 import { CLIENT_DIR } from '../constants'
-import { createDebugger, monotonicDateNow, normalizePath } from '../utils'
+import {
+  createDebugger,
+  formatAndTruncateFileList,
+  monotonicDateNow,
+  normalizePath,
+} from '../utils'
 import type { InferCustomEventPayload, ViteDevServer } from '..'
 import { getHookHandler } from '../plugins'
 import { isExplicitImportRequired } from '../plugins/importAnalysis'
@@ -732,7 +737,9 @@ export function updateModules(
 
   environment.logger.info(
     colors.green(`hmr update `) +
-      colors.dim([...new Set(updates.map((u) => u.path))].join(', ')),
+      colors.dim(
+        formatAndTruncateFileList([...new Set(updates.map((u) => u.path))]),
+      ),
     { clear: !firstInvalidatedBy, timestamp: true },
   )
   hot.send({

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -735,13 +735,13 @@ export function updateModules(
     return
   }
 
-  environment.logger.info(
-    colors.green(`hmr update `) +
-      colors.dim(
-        formatAndTruncateFileList([...new Set(updates.map((u) => u.path))]),
-      ),
-    { clear: !firstInvalidatedBy, timestamp: true },
-  )
+  const filePaths = [...new Set(updates.map((u) => u.path))]
+  const { formatted, truncated } = formatAndTruncateFileList(filePaths)
+  if (truncated) debugHmr?.(`hmr update ${filePaths.join(', ')}`)
+  environment.logger.info(colors.green(`hmr update `) + colors.dim(formatted), {
+    clear: !firstInvalidatedBy,
+    timestamp: true,
+  })
   hot.send({
     type: 'update',
     updates,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1795,3 +1795,8 @@ export function monotonicDateNow(): number {
   lastDateNow++
   return lastDateNow
 }
+
+export function formatAndTruncateFileList(files: string[]): string {
+  if (files.length <= 10) return files.join(', ')
+  return `${files.slice(0, 9).join(', ')} and ${files.length - 9} more`
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1796,7 +1796,24 @@ export function monotonicDateNow(): number {
   return lastDateNow
 }
 
-export function formatAndTruncateFileList(files: string[]): string {
-  if (files.length <= 10) return files.join(', ')
-  return `${files.slice(0, 9).join(', ')} and ${files.length - 9} more`
+export function formatAndTruncateFileList(files: string[]): {
+  formatted: string
+  truncated: boolean
+} {
+  const MAX_LOG_LENGTH = 500
+  let log = ''
+  let truncated = false
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    if (log === '') {
+      log = file
+    } else if (log.length + 2 + file.length < MAX_LOG_LENGTH) {
+      log += ', ' + file
+    } else {
+      log += ` and ${files.length - i} more`
+      truncated = true
+      break
+    }
+  }
+  return { formatted: log, truncated }
 }


### PR DESCRIPTION
It's been a long time since I wanted to do this. When I ran the codegen on my project, all the React files which imports the DB enums from it updates and the terminal a just a wall of useless text. I think truncating at 10 is a good tradeoff.

I can add a test in the hmr playground, but I'm not sure it's worth the 12 files to setup it up given how simple the code is.

Before:
<img width="904" height="474" alt="Screenshot 2026-02-01 at 13 06 58" src="https://github.com/user-attachments/assets/846e50ff-2766-4869-812f-0d5d9ef32ae1" />

After:
<img width="887" height="85" alt="Screenshot 2026-02-01 at 13 09 19" src="https://github.com/user-attachments/assets/dfbc7c25-6540-499c-8dac-f8fbcbcc17cb" />