### PR TITLE
fix(config): avoid watching rolldown runtime virtual module

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2441,7 +2441,8 @@ async function bundleConfigFile(
 
   return {
     code: entryChunk.code,
-    dependencies: [...allModules],
+    // exclude `\x00rolldown/runtime.js`
+    dependencies: [...allModules].filter((m) => !m.startsWith('\0')),
   }
 }
 


### PR DESCRIPTION
fixes https://github.com/vitejs/rolldown-vite/issues/584
fixes https://github.com/vitejs/rolldown-vite/issues/587
