### PR TITLE
fix(scanner): respect tsconfig.json

### DIFF
--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -53,7 +53,9 @@ export interface OxcOptions extends Omit<
   jsxRefreshExclude?: string | RegExp | ReadonlyArray<string | RegExp>
 }
 
-function getRollupJsxPresets(preset: 'react' | 'react-jsx'): OxcJsxOptions {
+export function getRollupJsxPresets(
+  preset: 'react' | 'react-jsx',
+): OxcJsxOptions {
   switch (preset) {
     case 'react':
       return {
@@ -72,7 +74,7 @@ function getRollupJsxPresets(preset: 'react' | 'react-jsx'): OxcJsxOptions {
   preset satisfies never
 }
 
-export function setOxcTransformOptionsFromTsconfigOptions(
+function setOxcTransformOptionsFromTsconfigOptions(
   oxcOptions: Omit<OxcTransformOptions, 'jsx'> & {
     jsx?:
       | OxcTransformOptions['jsx']


### PR DESCRIPTION
The proper fix for #15206. Now that Rolldown loads tsconfig.json in the same way Vite does, we can remove this part and rely on it.