### PR TITLE
fix(create-vite): fix the safe value of isYarn1 in getFullCustomCommand

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -865,7 +865,7 @@ function editFile(file: string, callback: (content: string) => string) {
 
 function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
   const pkgManager = pkgInfo ? pkgInfo.name : 'npm'
-  const isYarn1 = pkgManager === 'yarn' && pkgInfo?.version.startsWith('1.')
+  const isYarn1 = pkgManager === 'yarn' && pkgInfo?.version?.startsWith?.('1.')
 
   return (
     customCommand


### PR DESCRIPTION
**- What is this PR solving? Write a clear and concise description.**
This PR changes the `isYarn1` check in the `getFullCustomCommandfunction` in the `create-vite `package to use safe value access.