### PR TITLE
fix: add types conditions to package.json exports

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -17,12 +17,21 @@
     "vite"
   ],
   "exports": {
-    ".": "./dist/node/index.js",
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "default": "./dist/node/index.js"
+    },
     "./client": {
       "types": "./client.d.ts"
     },
-    "./module-runner": "./dist/node/module-runner.js",
-    "./internal": "./dist/node/internal.js",
+    "./module-runner": {
+      "types": "./dist/node/module-runner.d.ts",
+      "default": "./dist/node/module-runner.js"
+    },
+    "./internal": {
+      "types": "./dist/node/internal.d.ts",
+      "default": "./dist/node/internal.js"
+    },
     "./dist/client/*": "./dist/client/*",
     "./types/*": {
       "types": "./types/*"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -16,6 +16,7 @@
     "build-tool",
     "vite"
   ],
+  "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/node/index.d.ts",


### PR DESCRIPTION
## Description

This PR makes two changes to improve TypeScript type resolution for the vite package:

1. **Adds explicit `types` conditions to the exports map** - This is the recommended best practice for TypeScript packages with exports.

2. **Restores the top-level `types` field** - When `resolvePackageJsonExports: false` is set in tsconfig (e.g., as a workaround for tsgo/TypeScript Go compatibility), TypeScript ignores the exports field entirely and falls back to the top-level `types` field. This was removed in #21194.

## Reproduction

1. Create a tsconfig with `resolvePackageJsonExports: false`
2. Try to import from `vite`
3. TypeScript fails to find types without the top-level `types` field