### PR TITLE
refactor(wasm): remove native wasm helper plugin usage

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -98,7 +98,7 @@ export async function resolvePlugins(
     esbuildBannerFooterCompatPlugin(config),
     config.oxc !== false ? oxcPlugin(config) : null,
     nativeJsonPlugin({ ...config.json, minify: isBuild }),
-    wasmHelperPlugin(config),
+    wasmHelperPlugin(),
     webWorkerPlugin(config),
     assetPlugin(config),
 

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,7 +1,5 @@
 import { exactRegex } from 'rolldown/filter'
-import { viteWasmHelperPlugin as nativeWasmHelperPlugin } from 'rolldown/experimental'
 import type { Plugin } from '../plugin'
-import type { ResolvedConfig } from '..'
 import { fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper.js'
@@ -50,13 +48,7 @@ const wasmHelper = async (opts = {}, url: string) => {
 
 const wasmHelperCode = wasmHelper.toString()
 
-export const wasmHelperPlugin = (config: ResolvedConfig): Plugin => {
-  if (config.isBundled) {
-    return nativeWasmHelperPlugin({
-      decodedBase: config.decodedBase,
-    })
-  }
-
+export const wasmHelperPlugin = (): Plugin => {
   return {
     name: 'vite:wasm-helper',
 


### PR DESCRIPTION
Prepare for #21102

I noticed it introduces a ⁨⁨`renderChunk`⁩⁩ hook where it calls ⁨⁨`chunk.viteMetadata!.importedAssets.add(cleanUrl(file))`⁩⁩. Since the ⁨⁨`viteMetadata`⁩⁩ on the chunk is stored on the JS side, this means I have to use a JS-side plugin to patch ⁨⁨`renderChunk`⁩⁩.
Additionally, the ⁨`load`⁩ hook in ⁨`wasmHelperPlugin`⁩ uses ⁨`fileToUrl`⁩, which introduces differences from ⁨`nativeWasmHelperPlugin`⁩ and can even lead to some issues.
https://github.com/vitejs/vite/blob/59700ae401a038ad4d98d302a5ea97bd658b58e5/packages/vite/src/node/plugins/asset.ts#L421-L485