### PR TITLE
fix(create-vite): strip invalid directory characters from project name

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -716,7 +716,10 @@ async function init() {
 }
 
 function formatTargetDir(targetDir: string) {
-  return targetDir.trim().replace(/\/+$/g, '')
+  return targetDir
+    .trim()
+    .replace(/[<>:"\\|?*]/g, '')
+    .replace(/\/+$/g, '')
 }
 
 function copy(src: string, dest: string) {


### PR DESCRIPTION
Fixes #21550

When you enter characters like `< > : " \ | ? *` in the project name during `create vite`, `fs.mkdirSync` throws `ENOENT` because these characters aren't valid in directory names (especially on Windows).

`formatTargetDir` already strips trailing slashes and whitespace, so this just extends the same pattern to also strip OS-reserved characters. If someone enters *only* invalid characters, the existing validation catches it and shows "Invalid project name".

Kept it minimal — just one extra `.replace()` in the chain.