### PR TITLE
feat(shortcuts): show quit shortcut in default CLI output

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -65,6 +65,12 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
         colors.bold('h + enter') +
         colors.dim(' to show help'),
     )
+    server.config.logger.info(
+      colors.dim(colors.green('  ➜')) +
+        colors.dim('  press ') +
+        colors.bold('q + enter') +
+        colors.dim(' to quit'),
+    )
   }
 
   const shortcuts = customShortcuts.concat(


### PR DESCRIPTION
Makes the `q + enter` quit shortcut visible by default in the dev server startup message, instead of hiding it behind the help menu.

```
  ➜  press q + enter to quit
```

This appears right after the existing "press h + enter to show help" line, making both the most essential shortcuts immediately visible.

## Why?

When teaching Vite to newcomers (journalism students at CUNY, workshop participants), a common point of frustration is not knowing how to exit the dev server. New developers often:

- Try `Ctrl+C` repeatedly (which can leave processes hanging)
- Close the entire terminal window
- Don't realize keyboard shortcuts exist at all

The quit shortcut is arguably the most important one for beginners to know, yet it's currently hidden behind `h + enter`. By the time they discover it, they've already developed workarounds.
