### PR TITLE
fix(create-vite): strip invalid filesystem characters from project name

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -255,3 +255,20 @@ test('accepts immediate flag and skips install prompt', () => {
   expect(stdout).not.toContain('Installing dependencies')
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)
 })
+
+test('strips invalid filesystem characters from project name', () => {
+  // Characters < > : " / \ | ? * are invalid on Windows
+  const invalidProjectName = ':test<app>name'
+  const sanitizedPath = path.join(import.meta.dirname, 'testappname')
+
+  const { stdout } = run([invalidProjectName, '--template', 'vue'], {
+    cwd: import.meta.dirname,
+  })
+
+  // Should successfully scaffold with sanitized name
+  expect(stdout).toContain(`Scaffolding project in ${sanitizedPath}`)
+  expect(fs.existsSync(sanitizedPath)).toBe(true)
+
+  // Cleanup
+  fs.rmSync(sanitizedPath, { recursive: true, force: true })
+})

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -716,7 +716,12 @@ async function init() {
 }
 
 function formatTargetDir(targetDir: string) {
-  return targetDir.trim().replace(/\/+$/g, '')
+  // Remove invalid characters for directory names on Windows and Unix
+  // < > : " / \ | ? * are forbidden on Windows, / is forbidden on Unix
+  return targetDir
+    .trim()
+    .replace(/[<>:"/\\|?*]+/g, '')
+    .replace(/\/+$/g, '')
 }
 
 function copy(src: string, dest: string) {


### PR DESCRIPTION
## Description

Characters like `< > : " / \ | ? *` are forbidden in directory names on Windows, and `/` is forbidden on Unix. Previously, using these characters in the project name would cause an `ENOENT` error when creating the directory.

This PR updates `formatTargetDir` to strip these invalid characters before using the project name as a directory path.

## Changes

- Updated `formatTargetDir` function to remove invalid filesystem characters
- Added test case to verify the behavior

## Before

```
pnpm create vite :repo-name
# Error: ENOENT: no such file or directory, mkdir '...\:repo-name'
```

## After

```
pnpm create vite :repo-name
# Creates directory 'repo-name' (colon stripped)
```

Fixes #21550