### PR TITLE
docs: list VirtualBox as source of cross drive links

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -255,10 +255,17 @@ Try disabling extensions if you have this issue.
 
 If there's a cross drive links in your project on Windows, Vite may not work.
 
+An example error you may encounter is:
+
+```console
+Error: EISDIR: illegal operation on a directory, watch 'C:/Users/me/project/vite.config.js'
+```
+
 An example of cross drive links are:
 
 - a virtual drive linked to a folder by `subst` command
 - a symlink/junction to a different drive by `mklink` command (e.g. Yarn global cache)
+- A VirtualBox shared folder
 
 Related issue: [#10802](https://github.com/vitejs/vite/issues/10802)
 


### PR DESCRIPTION
Additionally this mentions the error message that may be displayed.

I ran into this error, so I searched for it. It would have helped if the page contains the error message, so it can be searched for.