### PR TITLE
fix(create-vite): filter invalid directory name characters (fix

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -716,7 +716,10 @@ async function init() {
 }
 
 function formatTargetDir(targetDir: string) {
-  return targetDir.trim().replace(/\/+$/g, '')
+  return targetDir
+    .trim()
+    .replace(/[<>:"\\|?*]+/g, '')
+    .replace(/\/+$/g, '')
 }
 
 function copy(src: string, dest: string) {


### PR DESCRIPTION
## Summary

  - Filter out characters that are invalid for directory names (\`< > : \" \\ |
  ? *\`) in the \`formatTargetDir\` function
  - These characters cause \`ENOENT\` errors on Windows and most filesystems
  when creating the project directory
  - Follows the existing pattern of silently removing invalid characters (like
  trailing slashes)

  ## Related Issue

  Fixes #21550

  ## Test Plan

  - [x] Run \`pnpm create vite\` locally
  - [x] Enter a project name with invalid characters (e.g., \`test:project\`,
  \`my|app\`)
  - [x] Verify the project is created successfully with the invalid characters
  stripped
