### PR TITLE
fix(module-runner): prevent crash on negative column in stacktrace

### DIFF
--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -358,8 +358,8 @@ function wrapCallSite(frame: CallSite, state: State) {
   // from getScriptNameOrSourceURL() instead
   const source = frame.getFileName() || frame.getScriptNameOrSourceURL()
   if (source) {
-    const line = frame.getLineNumber() as number
-    const column = (frame.getColumnNumber() as number) - 1
+    const line = frame.getLineNumber() ?? 0
+    const column = (frame.getColumnNumber() ?? 1) - 1
 
     const position = mapSourcePosition({
       name: null,


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
-->

- Fixes https://github.com/vitejs/vite/issues/21587

On Vite's side the root cause is `as number`, as `CallSite` can return `null` in line/col. 

