### PR TITLE
refactor: use parseEnv

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -466,36 +466,6 @@ Repository: https://github.com/mathiasbynens/cssesc
 
 ---------------------------------------
 
-## dotenv
-License: BSD-2-Clause
-Repository: https://github.com/motdotla/dotenv
-
-> Copyright (c) 2015, Scott Motte
-> All rights reserved.
-> 
-> Redistribution and use in source and binary forms, with or without
-> modification, are permitted provided that the following conditions are met:
-> 
-> * Redistributions of source code must retain the above copyright notice, this
->   list of conditions and the following disclaimer.
-> 
-> * Redistributions in binary form must reproduce the above copyright notice,
->   this list of conditions and the following disclaimer in the documentation
->   and/or other materials provided with the distribution.
-> 
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-> AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-> IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-> DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-> FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-> DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-> SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-> CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-> OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----------------------------------------
-
 ## dotenv-expand
 License: BSD-2-Clause
 By: motdotla

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -106,7 +106,6 @@
     "cors": "^2.8.6",
     "cross-spawn": "^7.0.6",
     "obug": "^1.0.2",
-    "dotenv": "^17.2.3",
     "dotenv-expand": "^12.0.3",
     "es-module-lexer": "^1.7.0",
     "esbuild": "^0.27.2",

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -50,7 +50,8 @@ export function loadEnv(
       // Support FIFOs (named pipes) for apps like 1Password
       if (!stat || (!stat.isFile() && !stat.isFIFO())) return []
 
-      return Object.entries(parseEnv(fs.readFileSync(filePath, 'utf-8')))
+      const parsedEnv = parseEnv(fs.readFileSync(filePath, 'utf-8'))
+      return Object.entries(parsedEnv as Record<string, string>)
     }),
   )
 

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { parse } from 'dotenv'
+import { parseEnv } from 'node:util'
 import { type DotenvPopulateInput, expand } from 'dotenv-expand'
 import colors from 'picocolors'
 import { arraify, createDebugger, normalizePath, tryStatSync } from './utils'
@@ -50,7 +50,7 @@ export function loadEnv(
       // Support FIFOs (named pipes) for apps like 1Password
       if (!stat || (!stat.isFile() && !stat.isFIFO())) return []
 
-      return Object.entries(parse(fs.readFileSync(filePath)))
+      return Object.entries(parseEnv(fs.readFileSync(filePath, 'utf-8')))
     }),
   )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,9 +319,6 @@ importers:
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
       dotenv-expand:
         specifier: ^12.0.3
         version: 12.0.3(patch_hash=49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889)
@@ -4978,10 +4975,6 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
-
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
   dts-resolver@2.1.3:
@@ -11023,8 +11016,6 @@ snapshots:
       dotenv: 16.6.1
 
   dotenv@16.6.1: {}
-
-  dotenv@17.2.3: {}
 
   dts-resolver@2.1.3: {}
 


### PR DESCRIPTION
Use builtin [`parseEnv`](https://nodejs.org/api/util.html#utilparseenvcontent) that exists since Node.js v21.7.0, v20.12.0.

I cloned https://github.com/motdotla/dotenv locally and replace with `parseEnv` to run its test, and all of them pass except for treating `\r` as new line. Node.js only treats it as new line if it's `\r\n`. This seems to be [an intentional decision](https://github.com/nodejs/node/blob/3ab9dd86e7df43d275c952b6a308d50519963c5f/src/node_dotenv.cc#L141-L142). I think this is fine and shouldn't break apps in practice though.

References:
- Node's implementation: https://github.com/nodejs/node/blob/main/src/node_dotenv.cc
- `dotenv-expand` not supported yet: https://github.com/nodejs/node/issues/49148#issuecomment-2083962965
