### PR TITLE
refactor(create-vite): remove `rolldown` boolean flag

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -29,7 +29,7 @@ const argv = mri<{
   immediate?: boolean
   interactive?: boolean
 }>(process.argv.slice(2), {
-  boolean: ['help', 'overwrite', 'immediate', 'rolldown', 'interactive'],
+  boolean: ['help', 'overwrite', 'immediate', 'interactive'],
   alias: { h: 'help', t: 'template', i: 'immediate' },
   string: ['template'],
 })


### PR DESCRIPTION
The flag implementation itself was removed in #21189, but the flag was left.
