### PR TITLE
ocs: clarify VITE_* env var exposure and security impact #21592

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -31,11 +31,7 @@ Some built-in constants are available in all cases:
 
 Vite exposes env variables under `import.meta.env` object as strings automatically.
 
-To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code.
-
-:::warning
-`VITE_` variables will be statically replaced in your client source code. Do not store sensitive information in them.
-:::
+Only variables prefixed with `VITE_` are exposed to your Vite-processed code. To prevent accidentally leaking env variables to the client, do not prefix sensitive variables with `VITE_`.
 
 e.g. for the following env variables:
 
@@ -45,6 +41,8 @@ DB_PASSWORD=foobar
 ```
 
 Only `VITE_SOME_KEY` will be exposed as `import.meta.env.VITE_SOME_KEY` to your client source code, but `DB_PASSWORD` will not.
+
+In this example, the parsed value of `VITE_SOME_KEY` – `"123"` – will be exposed to your source code, but the value of `DB_PASSWORD` will not.
 
 ```js
 console.log(import.meta.env.VITE_SOME_KEY) // "123"

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -31,7 +31,13 @@ Some built-in constants are available in all cases:
 
 Vite exposes env variables under `import.meta.env` object as strings automatically.
 
-To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code. e.g. for the following env variables:
+To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code.
+
+:::warning
+`VITE_` variables will be statically replaced in your client source code. Do not store sensitive information in them.
+:::
+
+e.g. for the following env variables:
 
 ```[.env]
 VITE_SOME_KEY=123
@@ -95,7 +101,9 @@ NEW_KEY3=test$KEY   # test123
 
 - `.env.*.local` files are local-only and can contain sensitive variables. You should add `*.local` to your `.gitignore` to avoid them being checked into git.
 
-- Since any variables exposed to your Vite source code will end up in your client bundle, `VITE_*` variables should _not_ contain any sensitive information.
+- `VITE_*` variables should _not_ contain any sensitive information such as API keys or secrets.
+
+- The values of these variables are exposed to the client during build time. Consider a backend server, serverless functions, or backend as a service to properly protect secrets instead.
 
 :::
 


### PR DESCRIPTION
## Description
Improves clarity around `VITE_*` environment variable exposure as requested in #21592.
- Explicitly states that `VITE_` prefix *causes* exposure, rather than preventing it.
- Warns against using `VITE_` for sensitive variables.
- Clarifies that variable *values* are embedded in the client bundle.
- Removes redundant warning block in favor of the dedicated Security Notes section.
## Related Issue
Fixes #21592