### PR TITLE
fix(legacy): skip preload helper in legacy chunks

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -118,6 +118,7 @@ function toAssetPathFromHtml(
 }
 
 const legacyEnvVarMarker = `__VITE_IS_LEGACY__`
+const modernEnvVarMarker = `__VITE_IS_MODERN__`
 
 const _require = createRequire(import.meta.url)
 
@@ -590,6 +591,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
               plugins: [
                 recordAndRemovePolyfillBabelPlugin(polyfillsDiscovered.legacy),
                 replaceLegacyEnvBabelPlugin(),
+                replaceModernEnvBabelPlugin(),
                 wrapIIFEBabelPlugin(),
               ],
             }),
@@ -1008,6 +1010,19 @@ function replaceLegacyEnvBabelPlugin(): BabelPlugin {
       Identifier(path) {
         if (path.node.name === legacyEnvVarMarker) {
           path.replaceWith(t.booleanLiteral(true))
+        }
+      },
+    },
+  })
+}
+
+function replaceModernEnvBabelPlugin(): BabelPlugin {
+  return ({ types: t }): BabelPlugin => ({
+    name: 'vite-replace-env-modern',
+    visitor: {
+      Identifier(path) {
+        if (path.node.name === modernEnvVarMarker) {
+          path.replaceWith(t.booleanLiteral(false))
         }
       },
     },

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -5,6 +5,7 @@ import {
   isBuild,
   listAssets,
   page,
+  readFile,
   readManifest,
 } from '~utils'
 
@@ -160,5 +161,15 @@ describe.runIf(isBuild)('build', () => {
 
     expect(findAssetFile(/chunk-async(?!-legacy)/)).not.toMatch(guard)
     expect(findAssetFile(/index-legacy/)).not.toMatch(guard)
+  })
+
+  test('should not include preload helper in legacy chunks', async () => {
+    expect(
+      listAssets().filter(
+        (filename) =>
+          filename.includes('-legacy') &&
+          readFile(`dist/assets/${filename}`).includes('Unable to preload'),
+      ),
+    ).toStrictEqual([])
   })
 })


### PR DESCRIPTION
Since the format conversion is done in the plugin, this condition is `true` for the legacy chunks as well.
https://github.com/vitejs/vite/blob/5003de6253ffdb23d1a52b1b5e06281d34f3a6ec/packages/vite/src/node/plugins/importAnalysisBuild.ts#L406
This PR fixes that problem by replacing the modern flag in the legacy plugin.
