### PR TITLE
fix: rolldownOptions/rollupOptions merging at environment level

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -620,8 +620,7 @@ describe('mergeConfig', () => {
 
   describe('later plugin can read `rollupOptions` set via `rolldownOptions` in earlier plugin', () => {
     test('top-level config', async () => {
-      let value: string | undefined
-
+      expect.assertions(2)
       await resolveConfig(
         {
           plugins: [
@@ -631,7 +630,12 @@ describe('mergeConfig', () => {
                 return {
                   build: {
                     rolldownOptions: {
-                      input: './from-plugin-a.ts',
+                      platform: 'neutral',
+                    },
+                  },
+                  worker: {
+                    rolldownOptions: {
+                      platform: 'neutral',
                     },
                   },
                 }
@@ -640,20 +644,18 @@ describe('mergeConfig', () => {
             {
               name: 'plugin-b',
               config(config) {
-                value = config.build?.rollupOptions?.input as string
+                expect(config.build?.rollupOptions?.platform).toBe('neutral')
+                expect(config.worker?.rollupOptions?.platform).toBe('neutral')
               },
             },
           ],
         },
         'build',
       )
-
-      expect(value).toBe('./from-plugin-a.ts')
     })
 
     test('new `environments` object', async () => {
-      let value: string | undefined
-
+      expect.assertions(1)
       await resolveConfig(
         {
           plugins: [
@@ -665,7 +667,7 @@ describe('mergeConfig', () => {
                     ssr: {
                       build: {
                         rolldownOptions: {
-                          input: './from-plugin-a.ts',
+                          platform: 'neutral',
                         },
                       },
                     },
@@ -676,16 +678,15 @@ describe('mergeConfig', () => {
             {
               name: 'plugin-b',
               config(config) {
-                value = config.environments?.ssr?.build?.rollupOptions
-                  ?.input as string
+                expect(
+                  config.environments?.ssr?.build?.rollupOptions?.platform,
+                ).toBe('neutral')
               },
             },
           ],
         },
         'build',
       )
-
-      expect(value).toBe('./from-plugin-a.ts')
     })
 
     test('new environment on existing `environments` object', async () => {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -690,8 +690,7 @@ describe('mergeConfig', () => {
     })
 
     test('new environment on existing `environments` object', async () => {
-      let value: string | undefined
-
+      expect.assertions(1)
       await resolveConfig(
         {
           environments: {
@@ -707,7 +706,7 @@ describe('mergeConfig', () => {
                     ssr: {
                       build: {
                         rolldownOptions: {
-                          input: './from-plugin-a.ts',
+                          platform: 'neutral',
                         },
                       },
                     },
@@ -718,16 +717,15 @@ describe('mergeConfig', () => {
             {
               name: 'plugin-b',
               config(config) {
-                value = config.environments?.ssr?.build?.rollupOptions
-                  ?.input as string
+                expect(
+                  config.environments?.ssr?.build?.rollupOptions?.platform,
+                ).toBe('neutral')
               },
             },
           ],
         },
         'build',
       )
-
-      expect(value).toBe('./from-plugin-a.ts')
     })
   })
 })

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -617,6 +617,38 @@ describe('mergeConfig', () => {
       testRolldownOptions.environments.client.build.rolldownOptions.platform,
     ).toBe('browser')
   })
+
+  test('later plugin can read top-level rollupOptions set via rolldownOptions by earlier plugin', async () => {
+    let readValue: string | undefined
+    await resolveConfig(
+      {
+        plugins: [
+          {
+            name: 'plugin-a',
+            config() {
+              return {
+                build: {
+                  rolldownOptions: {
+                    input: './from-plugin-a.ts',
+                  },
+                },
+              }
+            },
+          },
+          {
+            name: 'plugin-b',
+            config(config) {
+              readValue = config.build?.rollupOptions?.input as
+                | string
+                | undefined
+            },
+          },
+        ],
+      },
+      'build',
+    )
+    expect(readValue).toBe('./from-plugin-a.ts')
+  })
 })
 
 describe('resolveEnvPrefix', () => {


### PR DESCRIPTION
When a plugin sets `build.rolldownOptions` at the root level in the `config` hook, a later plugin can read the options via `build.rollupOptions`. However, this does not work when `rolldownOptions` is set at the environment level e.g. `environments.ssr.build.rolldownOptions`. This results in incorrect behaviour when plugins read options set by earlier plugins (see https://github.com/cloudflare/workers-sdk/issues/12497). This PR fixes this.