### PR TITLE
ci(docs): don't skip for build runs without cache

### DIFF
--- a/scripts/docs-check.sh
+++ b/scripts/docs-check.sh
@@ -1,5 +1,9 @@
 echo "prev commit: $CACHED_COMMIT_REF"
 echo "current commit: $COMMIT_REF"
+if [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ]; then
+  # builds runs without cache
+  exit 1
+fi
 git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF docs package.json pnpm-lock.yaml netlify.toml packages/vite/package.json scripts/docs-check.sh
 status=$?
 echo "diff exit code: $status"


### PR DESCRIPTION
The production builds were skipped even if there's a change: https://app.netlify.com/projects/vitejs/deploys/698b71323ddbcd0008998afa

Maybe this is caused by `CACHED_COMMIT_REF` and `COMMIT_REF` having the same value like https://answers.netlify.com/t/cached-commit-ref-eqals-commit-ref/81697. This PR changes the ignore command to trigger the build if those are the same value.

