### PR TITLE
fix: clear tsconfig cache only when tsconfig.json is cached

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -543,7 +543,7 @@ export async function reloadOnTsconfigChange(
   // any json file in the tsconfig cache could have been used to compile ts
   if (changedFile.endsWith('.json')) {
     const cache = getTSConfigResolutionCache(server.config)
-    if (changedFile.endsWith('/tsconfig.json') || cache.size() > 0) {
+    if (changedFile.endsWith('/tsconfig.json') && cache.size() > 0) {
       server.config.logger.info(
         `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
         { clear: server.config.clearScreen, timestamp: true },

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -543,7 +543,7 @@ export async function reloadOnTsconfigChange(
   // any json file in the tsconfig cache could have been used to compile ts
   if (changedFile.endsWith('.json')) {
     const cache = getTSConfigResolutionCache(server.config)
-    if (changedFile.endsWith('/tsconfig.json') && cache.size() > 0) {
+    if (changedFile.endsWith('/tsconfig.json')) {
       server.config.logger.info(
         `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
         { clear: server.config.clearScreen, timestamp: true },


### PR DESCRIPTION
fix for https://github.com/vitejs/vite/pull/21577/changes/BASE..5437e2fe17ff87c50c2207baf9d59c95ebee4e0e#r2796800061

This condition is still not proper as it doesn't clear the cache when the referenced / extended tsconfig is changed. That said, the code doesn't work as the referenced / extended tsconfigs are not watched.

