### PR TITLE
feat(hmr): check boundary outside the circular imports

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -147,34 +147,19 @@ const hmrClient = new HMRClient(
   },
   transport,
   isBundleMode
-    ? async function importUpdatedModule({
-        url,
-        acceptedPath,
-        isWithinCircularImport,
-      }) {
-        const importPromise = import(base + url!).then(() =>
+    ? async function importUpdatedModule({ url, acceptedPath }) {
+        return await import(base + url!).then(() =>
           // @ts-expect-error globalThis.__rolldown_runtime__
           globalThis.__rolldown_runtime__.loadExports(acceptedPath),
         )
-        if (isWithinCircularImport) {
-          importPromise.catch(() => {
-            console.info(
-              `[hmr] ${acceptedPath} failed to apply HMR as it's within a circular import. Reloading page to reset the execution order. ` +
-                `To debug and break the circular import, you can run \`vite --debug hmr\` to log the circular dependency path if a file change triggered it.`,
-            )
-            pageReload()
-          })
-        }
-        return await importPromise
       }
     : async function importUpdatedModule({
         acceptedPath,
         timestamp,
         explicitImportRequired,
-        isWithinCircularImport,
       }) {
         const [acceptedPathWithoutQuery, query] = acceptedPath.split(`?`)
-        const importPromise = import(
+        return await import(
           /* @vite-ignore */
           base +
             acceptedPathWithoutQuery.slice(1) +
@@ -182,16 +167,6 @@ const hmrClient = new HMRClient(
               query ? `&${query}` : ''
             }`
         )
-        if (isWithinCircularImport) {
-          importPromise.catch(() => {
-            console.info(
-              `[hmr] ${acceptedPath} failed to apply HMR as it's within a circular import. Reloading page to reset the execution order. ` +
-                `To debug and break the circular import, you can run \`vite --debug hmr\` to log the circular dependency path if a file change triggered it.`,
-            )
-            pageReload()
-          })
-        }
-        return await importPromise
       },
 )
 transport.connect!(createHMRHandler(handleMessage))

--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -36,8 +36,6 @@ export interface Update {
   /** @internal */
   explicitImportRequired?: boolean
   /** @internal */
-  isWithinCircularImport?: boolean
-  /** @internal */
   firstInvalidatedBy?: string
   /** @internal */
   invalidates?: string[]

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -268,7 +268,7 @@ if (!isBuild) {
       'invalidation-circular-deps/circular-invalidate/child.js',
       (code) => code.replace('child', 'child updated'),
     )
-    await page.waitForEvent('load')
+    // hmr.ts which is outside the circular chain applies the update
     await expect
       .poll(() => page.textContent('.invalidation-circular-deps'))
       .toMatch('child updated')
@@ -1060,8 +1060,7 @@ if (!isBuild) {
       .poll(() => page.textContent('.self-accept-within-circular'))
       .toBe('cc')
     expect(serverLogs.length).greaterThanOrEqual(1)
-    // Should still keep hmr update, but it'll error on the browser-side and will refresh itself.
-    // Match on full log not possible because of color markers
+    // The boundary within the circular chain (c.js) is skipped, but the outer boundary (a.js) handles it
     expect(serverLogs.at(-1)!).toContain('hmr update')
   })
 

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -1078,6 +1078,50 @@ if (!isBuild) {
       .toBe('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
   })
 
+  test('hmr warns when boundary is skipped due to circular imports and page reloads', async () => {
+    await page.goto(viteTestUrl + '/circular-boundary-no-outer/index.html')
+    const el = await page.$('.circular-boundary-no-outer')
+    await expect.poll(() => el.textContent()).toBe('a:b')
+    serverLogs.length = 0
+    editFile('circular-boundary-no-outer/a.js', (code) =>
+      code.replace(`export const a = 'a:'`, `export const a = 'a2:'`),
+    )
+    await expect
+      .poll(() => page.textContent('.circular-boundary-no-outer'))
+      .toBe('a2:b')
+    await expect
+      .poll(() => serverLogs)
+      .toStrictEqual(
+        expect.arrayContaining([
+          expect.stringMatching(
+            /hmr boundary skipped due to circular imports.*page will reload/,
+          ),
+        ]),
+      )
+  })
+
+  test('hmr warns when boundary is skipped due to circular imports and many modules re-execute', async () => {
+    await page.goto(viteTestUrl + '/circular-boundary-many-modules/index.html')
+    const el = await page.$('.circular-boundary-many-modules')
+    await expect.poll(() => el.textContent()).toBe('a:b')
+    serverLogs.length = 0
+    editFile('circular-boundary-many-modules/a.js', (code) =>
+      code.replace(`export const value = 'a:'`, `export const value = 'a2:'`),
+    )
+    await expect
+      .poll(() => page.textContent('.circular-boundary-many-modules'))
+      .toBe('a2:b')
+    await expect
+      .poll(() => serverLogs)
+      .toStrictEqual(
+        expect.arrayContaining([
+          expect.stringMatching(
+            /hmr boundary skipped due to circular imports.*modules will re-execute/,
+          ),
+        ]),
+      )
+  })
+
   test('not inlined assets HMR', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('#logo-no-inline')

--- a/playground/hmr/circular-boundary-many-modules/a.js
+++ b/playground/hmr/circular-boundary-many-modules/a.js
@@ -1,0 +1,7 @@
+import { b } from './b'
+
+export const value = 'a:' + b
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/playground/hmr/circular-boundary-many-modules/b.js
+++ b/playground/hmr/circular-boundary-many-modules/b.js
@@ -1,0 +1,3 @@
+import './a'
+
+export const b = 'b'

--- a/playground/hmr/circular-boundary-many-modules/index.html
+++ b/playground/hmr/circular-boundary-many-modules/index.html
@@ -1,0 +1,2 @@
+<script type="module" src="index.js"></script>
+<div class="circular-boundary-many-modules"></div>

--- a/playground/hmr/circular-boundary-many-modules/index.js
+++ b/playground/hmr/circular-boundary-many-modules/index.js
@@ -1,0 +1,7 @@
+import { value } from './outer'
+
+document.querySelector('.circular-boundary-many-modules').textContent = value
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/playground/hmr/circular-boundary-many-modules/m1.js
+++ b/playground/hmr/circular-boundary-many-modules/m1.js
@@ -1,0 +1,2 @@
+import { value } from './m2'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m2.js
+++ b/playground/hmr/circular-boundary-many-modules/m2.js
@@ -1,0 +1,2 @@
+import { value } from './m3'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m3.js
+++ b/playground/hmr/circular-boundary-many-modules/m3.js
@@ -1,0 +1,2 @@
+import { value } from './m4'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m4.js
+++ b/playground/hmr/circular-boundary-many-modules/m4.js
@@ -1,0 +1,2 @@
+import { value } from './m5'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m5.js
+++ b/playground/hmr/circular-boundary-many-modules/m5.js
@@ -1,0 +1,2 @@
+import { value } from './m6'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m6.js
+++ b/playground/hmr/circular-boundary-many-modules/m6.js
@@ -1,0 +1,2 @@
+import { value } from './m7'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m7.js
+++ b/playground/hmr/circular-boundary-many-modules/m7.js
@@ -1,0 +1,2 @@
+import { value } from './m8'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m8.js
+++ b/playground/hmr/circular-boundary-many-modules/m8.js
@@ -1,0 +1,2 @@
+import { value } from './m9'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/m9.js
+++ b/playground/hmr/circular-boundary-many-modules/m9.js
@@ -1,0 +1,2 @@
+import { value } from './a'
+export { value }

--- a/playground/hmr/circular-boundary-many-modules/outer.js
+++ b/playground/hmr/circular-boundary-many-modules/outer.js
@@ -1,0 +1,3 @@
+import { value } from './m1'
+
+export { value }

--- a/playground/hmr/circular-boundary-no-outer/a.js
+++ b/playground/hmr/circular-boundary-no-outer/a.js
@@ -1,0 +1,7 @@
+import { b } from './b'
+
+export const a = 'a:' + b
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/playground/hmr/circular-boundary-no-outer/b.js
+++ b/playground/hmr/circular-boundary-no-outer/b.js
@@ -1,0 +1,3 @@
+import './a'
+
+export const b = 'b'

--- a/playground/hmr/circular-boundary-no-outer/index.html
+++ b/playground/hmr/circular-boundary-no-outer/index.html
@@ -1,0 +1,2 @@
+<script type="module" src="index.js"></script>
+<div class="circular-boundary-no-outer"></div>

--- a/playground/hmr/circular-boundary-no-outer/index.js
+++ b/playground/hmr/circular-boundary-no-outer/index.js
@@ -1,0 +1,3 @@
+import { a } from './a'
+
+document.querySelector('.circular-boundary-no-outer').textContent = a

--- a/playground/hmr/self-accept-within-circular/a.js
+++ b/playground/hmr/self-accept-within-circular/a.js
@@ -3,3 +3,7 @@ import { b } from './b'
 export const a = {
   b,
 }
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}


### PR DESCRIPTION
When a HMR boundary is detected within a circular import chain, skip it and continue propagation outward to find a boundary outside the chain.

```mermaid
graph LR
    B["b.js"] -->|import| C["c.js (boundary)"]
    C -->|import| B
    A["a.js (boundary)"] -->|import| B
```
When `c.js` is changed, `c.js` is now ignored and `a.js` is now treated as the boundary.

fixes #16580
fixes #18217
