### PR TITLE
docs: update link to Laravel

### DIFF
--- a/docs/guide/philosophy.md
+++ b/docs/guide/philosophy.md
@@ -20,7 +20,7 @@ Vite has been focused on performance since its [origins](./why.md). Its dev serv
 
 ## Building Frameworks on Top of Vite
 
-Although Vite can be used by users directly, it shines as a tool to create frameworks. Vite core is framework agnostic, but there are polished plugins for each UI framework. Its [JS API](./api-javascript.md) allows App Framework authors to use Vite features to create tailored experiences for their users. Vite includes support for [SSR primitives](./ssr.md), usually present in higher-level tools but fundamental to building modern web frameworks. And Vite plugins complete the picture by offering a way to share between frameworks. Vite is also a great fit when paired with [Backend frameworks](./backend-integration.md) like [Ruby](https://vite-ruby.netlify.app/) and [Laravel](https://laravel.com/docs/10.x/vite).
+Although Vite can be used by users directly, it shines as a tool to create frameworks. Vite core is framework agnostic, but there are polished plugins for each UI framework. Its [JS API](./api-javascript.md) allows App Framework authors to use Vite features to create tailored experiences for their users. Vite includes support for [SSR primitives](./ssr.md), usually present in higher-level tools but fundamental to building modern web frameworks. And Vite plugins complete the picture by offering a way to share between frameworks. Vite is also a great fit when paired with [Backend frameworks](./backend-integration.md) like [Ruby](https://vite-ruby.netlify.app/) and [Laravel](https://laravel.com/docs/vite).
 
 ## An Active Ecosystem
 


### PR DESCRIPTION
By updating the link to `https://laravel.com/docs/vite` instead of something like `https://laravel.com/docs/10.x/vite`, we should hopefully always link to the latest stable version of the Laravel docs. 

