### PR TITLE
fix(dev): prevent concurrent server restarts

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1267,6 +1267,8 @@ async function restartServer(server: ViteDevServer) {
     const middlewares = server.middlewares
     newServer._configServerPort = server._configServerPort
     newServer._currentServerPort = server._currentServerPort
+    newServer._restartPromise = server._restartPromise
+    newServer._forceOptimizeOnRestart = server._forceOptimizeOnRestart
     Object.assign(server, newServer)
 
     // Keep the same connect instance so app.use(vite.middlewares) works


### PR DESCRIPTION
When `server.restart()` is called, the `_restartPromise` property is used to prevent concurrent restarts. However, during the restart process, `Object.assign(server, newServer)` copies all properties from the newly created server, which overwrites the active promise with `null`.
This creates a race condition where if `restart()` is called again after `Object.assign` but before the restart completes, it sees `_restartPromise === null` and starts a second concurrent restart.
The same issue affects `_forceOptimizeOnRestart`.

This PR fixes this by preserving `_restartPromise` and `_forceOptimizeOnRestart` across the `Object.assign()` by copying them from the old server to the new server beforehand.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
