### PR TITLE
feat(create-vite): make vitePreprocess not the default in svelte

### DIFF
--- a/packages/create-vite/template-svelte-ts/svelte.config.js
+++ b/packages/create-vite/template-svelte-ts/svelte.config.js
@@ -1,8 +1,2 @@
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
-
 /** @type {import("@sveltejs/vite-plugin-svelte").SvelteConfig} */
-export default {
-  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
-  // for more information about preprocessors
-  preprocess: vitePreprocess(),
-}
+export default {}

--- a/packages/create-vite/template-svelte/svelte.config.js
+++ b/packages/create-vite/template-svelte/svelte.config.js
@@ -1,8 +1,2 @@
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
-
 /** @type {import("@sveltejs/vite-plugin-svelte").SvelteConfig} */
-export default {
-  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
-  // for more information about preprocessors
-  preprocess: vitePreprocess(),
-}
+export default {}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
vitePreprocess isn't needed in most projects: https://svelte.dev/docs/kit/integrations#:~:text=TypeScript%20is%20supported%20natively%20in%20Svelte%205%2C%20so%20if%20you%20are%20using%20Svelte%205%20and%20you%20don%E2%80%99t%20need%20to%20use%20advanced%20TypeScript%20features%20that%20emit%20code%2C%20you%20probably%20don%E2%80%99t%20need%20to%20use%20vitePreprocess%2E

it was removed from SvelteKit templates: https://github.com/sveltejs/cli/pull/876

this PR removes it. (config isn't entirely removed to allow for discovery and to prevent `[vite-plugin-svelte] no Svelte config found at [path] - using default configuration.`)