### PR TITLE
fix: require path separators in isInNodeModules check

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -16,6 +16,7 @@ import {
   getServerUrlByHost,
   injectQuery,
   isFileReadable,
+  isInNodeModules,
   isParentDirectory,
   mergeWithDefaults,
   normalizePath,
@@ -1056,5 +1057,40 @@ describe('resolveServerUrls', () => {
     )
 
     expect(result.local).toContain('https://localhost:3000/')
+  })
+})
+
+describe('isInNodeModules', () => {
+  test('should return true for paths containing /node_modules/ as a directory', () => {
+    expect(isInNodeModules('/path/to/node_modules/package/index.js')).toBe(true)
+    expect(isInNodeModules('/project/node_modules/.vite/dep.js')).toBe(true)
+    expect(
+      isInNodeModules('C:/Users/user/project/node_modules/foo/bar.js'),
+    ).toBe(true)
+  })
+
+  test('should return false for paths containing node_modules as substring of directory name', () => {
+    expect(isInNodeModules('/path/to/node_modules_bug/index.js')).toBe(false)
+    expect(isInNodeModules('/path/to/my_node_modules/index.js')).toBe(false)
+    expect(isInNodeModules('/path/to/node_modules_test/src/main.ts')).toBe(
+      false,
+    )
+  })
+
+  test('should return true for backslash paths on Windows', () => {
+    expect(
+      isInNodeModules('C:\\Users\\user\\project\\node_modules\\foo\\bar.js'),
+    ).toBe(true)
+  })
+
+  test('should return false for backslash paths with node_modules as substring', () => {
+    expect(isInNodeModules('C:\\Users\\user\\node_modules_bug\\index.js')).toBe(
+      false,
+    )
+  })
+
+  test('should return false when node_modules is not present', () => {
+    expect(isInNodeModules('/path/to/project/src/main.ts')).toBe(false)
+    expect(isInNodeModules('/path/to/project/index.html')).toBe(false)
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -134,7 +134,7 @@ export function isNodeBuiltin(id: string): boolean {
 }
 
 export function isInNodeModules(id: string): boolean {
-  return id.includes('node_modules')
+  return id.includes('/node_modules/') || id.includes('\\node_modules\\')
 }
 
 export function moduleListContains(


### PR DESCRIPTION
## What this does

Fixes `isInNodeModules` to require path separators around `node_modules`, preventing false positives when the string appears as a substring of a directory name.

## The problem

If your project path contains "node_modules" as part of a directory name (e.g., `/path/to/node_modules_bug/`), the current `isInNodeModules` check returns `true` for all files in that project. This causes `ensureVersionQuery` to inject version hashes into URLs that shouldn't have them, which breaks html-proxy regex matching and results in inline `<script>` tags failing with "invalid JS syntax" errors.

Reproduction is straightforward: just name your project directory something like `node_modules_bug` and add an inline script tag to `index.html`.

## The fix

Changed `id.includes('node_modules')` to check for `/node_modules/` and `\node_modules\` — requiring actual path separators on both sides so it only matches when `node_modules` is a real directory segment in the path.

Added unit tests covering:
- Standard forward-slash paths (Unix/normalized)
- Backslash paths (Windows)
- False positive cases (substring matches like `node_modules_bug`, `my_node_modules`)
- Paths without `node_modules` at all

Fixes #17467