### PR TITLE
feat: add cssInject option for library mode

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -793,4 +793,26 @@ exports.foo = foo;
       })();"
     `)
   })
+
+  test('should inject helper for cjs format', async () => {
+    const result = getInlinedCSSInjectedCode(
+      `"use strict";
+
+//#region src/index.js
+const foo = "foo";
+
+//#endregion
+exports.foo = foo;`,
+      'cjs',
+    )
+    expect(result).toMatchInlineSnapshot(`
+      "injectCSS();"use strict";
+
+      //#region src/index.js
+      const foo = "foo";
+
+      //#endregion
+      exports.foo = foo;"
+    `)
+  })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -331,6 +331,15 @@ export interface LibraryOptions {
    * back to the name option of the project package.json.
    */
   cssFileName?: string
+  /**
+   * Whether to inject CSS into the JavaScript output by appending it to the
+   * document head at runtime, instead of emitting a separate CSS file.
+   * This is useful when you want consumers to import a single JS file
+   * without needing to separately import CSS.
+   * Note: this makes the library incompatible with SSR environments.
+   * @default false
+   */
+  cssInject?: boolean
 }
 
 export type LibraryFormats = 'es' | 'cjs' | 'umd' | 'iife' // | 'system'

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -120,6 +120,18 @@ describe.runIf(isBuild)('build', () => {
     expect(cjs2).toContain('css-entry-2')
   })
 
+  test('single entry with css inject', () => {
+    const js = readFile('dist/css-inject/test-my-lib.js')
+    const umd = readFile('dist/css-inject/test-my-lib.umd.cjs')
+    // CSS should be injected into JS, not emitted as a separate file
+    expect(js).toMatch('entry-1.css')
+    expect(js).toMatch('createElement')
+    expect(umd).toMatch('entry-1.css')
+    expect(umd).toMatch('createElement')
+    // No separate CSS file should be emitted
+    expect(() => readFile('dist/css-inject/test-my-lib.css')).toThrow()
+  })
+
   test('multi entry with css and code split', () => {
     const css1 = readFile('dist/css-code-split/css-entry-1.css')
     const css2 = readFile('dist/css-code-split/css-entry-2.css')

--- a/playground/lib/__tests__/serve.ts
+++ b/playground/lib/__tests__/serve.ts
@@ -113,6 +113,12 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
       configFile: path.resolve(dirname, '../vite.terser.config.js'),
     })
 
+    await build({
+      root: rootDir,
+      logLevel: 'warn', // output esbuild warns
+      configFile: path.resolve(dirname, '../vite.css-inject.config.js'),
+    })
+
     // start static file server
     const serve = sirv(path.resolve(rootDir, 'dist'))
     const httpServer = http.createServer((req, res) => {

--- a/playground/lib/vite.css-inject.config.js
+++ b/playground/lib/vite.css-inject.config.js
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: fileURLToPath(new URL('src/css-entry-1.js', import.meta.url)),
+      name: 'css-inject',
+      cssInject: true,
+    },
+    outDir: 'dist/css-inject',
+  },
+})


### PR DESCRIPTION
Closes #1579

## What this does

When building a library with `build.lib`, CSS gets extracted to a separate `.css` file by default. This means consumers have to manually import both the JS and the CSS, which is a pain point for component libraries.

This PR adds a `build.lib.cssInject` option that injects the CSS directly into the JavaScript output at runtime using a lightweight `styleInject` helper. When the library is loaded, it creates a `<style>` element and appends it to `<head>`.

### Usage

```js
export default defineConfig({
  build: {
    lib: {
      entry: 'src/index.ts',
      name: 'MyLib',
      cssInject: true,
    },
  },
})
```

This produces a single JS file with no separate CSS file. The CSS is injected at runtime when the module is loaded.

### Changes

- Added `cssInject` option to `LibraryOptions` interface
- Modified `cssPostPlugin`'s `generateBundle` to inject CSS into entry chunks instead of emitting a separate CSS file when `cssInject: true`
- Added `cjs` format support to `injectInlinedCSS` (was missing, only supported `es`, `iife`, `umd`)
- Added unit test for CJS format injection
- Added playground test with a dedicated config (`vite.css-inject.config.js`)

### Notes

- The `cssInject` option wraps the injection in a try/catch so it won't break in non-DOM environments (though it won't inject styles there either)
- Works with all library formats: `es`, `cjs`, `umd`, `iife`
- Default is `false` to maintain backwards compatibility