### PR TITLE
fix(dev): only treat EADDRINUSE as port conflict in wildcard pre-check

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -177,9 +177,9 @@ async function isPortAvailable(port: number): Promise<boolean> {
 function tryListen(port: number, host: string): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer()
-    server.once('error', () => {
-      // Ensure server is closed even on error to prevent resource leaks
-      server.close(() => resolve(false))
+    server.once('error', (e: Error & { code?: string }) => {
+      // Only EADDRINUSE means the port is actually in use
+      server.close(() => resolve(e.code !== 'EADDRINUSE'))
     })
     server.once('listening', () => {
       server.close(() => resolve(true))

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -177,8 +177,7 @@ async function isPortAvailable(port: number): Promise<boolean> {
 function tryListen(port: number, host: string): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer()
-    server.once('error', (e: Error & { code?: string }) => {
-      // Only EADDRINUSE means the port is actually in use
+    server.once('error', (e: NodeJS.ErrnoException) => {
       server.close(() => resolve(e.code !== 'EADDRINUSE'))
     })
     server.once('listening', () => {
@@ -193,10 +192,10 @@ async function tryBindServer(
   port: number,
   host: string | undefined,
 ): Promise<
-  { success: true } | { success: false; error: Error & { code?: string } }
+  { success: true } | { success: false; error: NodeJS.ErrnoException }
 > {
   return new Promise((resolve) => {
-    const onError = (e: Error & { code?: string }) => {
+    const onError = (e: NodeJS.ErrnoException) => {
       httpServer.off('error', onError)
       httpServer.off('listening', onListening)
       resolve({ success: false, error: e })


### PR DESCRIPTION
`tryListen()` resolves `false` for any socket error, but only `EADDRINUSE` means the port is actually in use. On systems where wildcard binds fail with non-`EADDRINUSE` errors (e.g., `EACCES` from Hyper-V port reservations), all ports are falsely reported as unavailable.

This checks `e.code !== 'EADDRINUSE'` so only genuine port conflicts block selection. Other errors are deferred to `tryBindServer`.

Fixes regression from #21381 (see comment)
