### PR TITLE
perf: use tsconfig cache for oxc transform in dev

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -523,7 +523,9 @@ function prettifyMessage(m: EsbuildMessage, code: string): string {
 let globalTSConfigResolutionCache: TsconfigCache | undefined
 const tsconfigResolutionCacheMap = new WeakMap<ResolvedConfig, TsconfigCache>()
 
-function getTSConfigResolutionCache(config?: ResolvedConfig) {
+export function getTSConfigResolutionCache(
+  config?: ResolvedConfig,
+): TsconfigCache {
   if (!config) {
     return (globalTSConfigResolutionCache ??= new TsconfigCache())
   }

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -17,7 +17,7 @@ import { type Environment, perEnvironmentPlugin } from '..'
 import type { ViteDevServer } from '../server'
 import { JS_TYPES_RE, VITE_PACKAGE_DIR } from '../constants'
 import type { Logger } from '../logger'
-import type { ESBuildOptions } from './esbuild'
+import { type ESBuildOptions, getTSConfigResolutionCache } from './esbuild'
 
 // IIFE content looks like `var MyLib = (function() {` or `this.nested.myLib = (function() {`.
 export const IIFE_BEGIN_RE: RegExp =
@@ -31,7 +31,14 @@ const validExtensionRE = /\.\w+$/
 
 export interface OxcOptions extends Omit<
   OxcTransformOptions,
-  'cwd' | 'sourceType' | 'lang' | 'sourcemap' | 'helpers'
+  | 'cwd'
+  | 'sourceType'
+  | 'lang'
+  | 'sourcemap'
+  | 'helpers'
+  | 'inject'
+  | 'tsconfig'
+  | 'inputMap'
 > {
   include?: string | RegExp | ReadonlyArray<string | RegExp>
   exclude?: string | RegExp | ReadonlyArray<string | RegExp>
@@ -143,7 +150,12 @@ export async function transformWithOxc(
     lang,
   }
 
-  const result = transformSync(filename, code, resolvedOptions)
+  const result = transformSync(
+    filename,
+    code,
+    resolvedOptions,
+    getTSConfigResolutionCache(config),
+  )
   if (
     watcher &&
     config &&


### PR DESCRIPTION
Pass the tsconfigCache parameter to avoid resolving the same tsconfig multiple times.