### PR TITLE
fix(create-vite): fix "too many arguments error" when using TanStack Router template with pnpm

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -910,6 +910,7 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
       // including Yarn 1.x and other custom npm clients.
       return 'npm exec '
     })
+    // fixed issue #21618
     .replace(
       /^pnpm dlx (\S+) -- /,
       // `npm exec <pkg> -- <args>` uses `--` to split npm flags from package args.

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -870,7 +870,7 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
   const pkgManager = pkgInfo ? pkgInfo.name : 'npm'
   const isYarn1 = pkgManager === 'yarn' && pkgInfo?.version.startsWith('1.')
 
-  let command = customCommand
+  const command = customCommand
     .replace(/^npm create (?:-- )?/, () => {
       // `bun create` uses it's own set of templates,
       // the closest alternative is using `bun x` directly on the package
@@ -910,11 +910,12 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
       // including Yarn 1.x and other custom npm clients.
       return 'npm exec '
     })
-
-  if (pkgManager === 'pnpm') {
-    // `npm exec <pkg> -- <args>` uses `--` to split npm flags from package args. `pnpm dlx` doesn't need this separator, and keeping it can break CLIs.
-    command = command.replace(/^pnpm dlx (\S+) -- /, 'pnpm dlx $1 ')
-  }
+    .replace(
+      /^pnpm dlx (\S+) -- /,
+      // `npm exec <pkg> -- <args>` uses `--` to split npm flags from package args.
+      // `pnpm dlx` doesn't need this separator, and keeping it can break CLIs.
+      'pnpm dlx $1 ',
+    )
 
   return command
 }


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

When running `pnpm create vite@latest` and selecting the TanStack Router variant, the generated command uses an npm-style `--` separator which `pnpm dlx` does not require. Keeping the separator causes args to be interpreted as extra positional arguments, resulting in:

> error: too many arguments for 'create'. Expected 1 argument but got 4.

This PR normalizes the pnpm path by removing the npm-only separator so the TanStack Router flow works correctly with pnpm.

~~Fixes #21618.~~ fixes #21614

---

- For `pkgManager === 'pnpm'`, normalize the custom command string so:
  - `pnpm dlx <pkg> -- <args>` becomes `pnpm dlx <pkg> <args>`
- Refactored the pnpm handling to live inside the existing `.replace(/^npm exec /, ...)` flow (matching the pattern used by `npm create`), per reviewer suggestion.

---

- Leaving the `--` separator in place and trying to special-case downstream args parsing.
  - Rejected because `--` is npm-specific here and causes pnpm to pass arguments differently.

---

I wasn't able to run an end-to-end reproduction of the TanStack Router flow due to TanStack/cli#364, but local checks/build pass and the fix is isolated to command normalization.

If there’s a preferred test location/approach for validating the generated command string, I’m happy to add it.