### PR TITLE
docs: clarify browser support wording

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,7 +24,7 @@ You can learn more about the rationale behind the project in the [Why Vite](./wh
 
 During development, Vite assumes that a modern browser is used. This means the browser supports most of the latest JavaScript and CSS features. For that reason, Vite sets [`esnext` as the transform target](https://esbuild.github.io/api/#target). This prevents syntax lowering, letting Vite serve modules as close as possible to the original source code. Vite injects some runtime code to make the development server work. This code uses features included in [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available at the time of each major release (2026-01-01 for this major).
 
-For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. These are browsers that were released at least 2.5 years ago. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
+For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. That means it only uses features which have been available across browsers for at least 2.5 years. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
 
 ## Trying Vite Online
 


### PR DESCRIPTION
## What

Clarifies the browser support documentation wording that was flagged as confusing in #21144.

## Why

The original phrasing — "These are browsers that were released at least 2.5 years ago" — reads as if Vite _targets_ browsers from 2.5+ years ago. In reality, the Baseline Widely Available threshold means Vite only uses **features** that have been available across all major browsers for at least 2.5 years.

## Change

```diff
- These are browsers that were released at least 2.5 years ago.
+ That means it only uses features which have been available across browsers for at least 2.5 years.
```

Closes #21144