### PR TITLE
feat(legacy)!: bump modern browser threshold to `import.meta.resolve` support

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -49,7 +49,7 @@ npm add -D terser
 ### `modernTargets`
 
 - **Type:** `string | string[]`
-- **Default:** [`'edge>=105, firefox>=106, chrome>=105, safari>=16.4, chromeAndroid>=105, iOS>=16.4'`](https://browsersl.ist/#q=edge%3E%3D105%2C+firefox%3E%3D106%2C+chrome%3E%3D105%2C+safari%3E%3D16.4%2C+chromeAndroid%3E%3D105%2C+iOS%3E%3D16.42)
+- **Default:** [`'edge>=105, firefox>=106, chrome>=105, safari>=16.4, chromeAndroid>=105, iOS>=16.4'`](https://browsersl.ist/#q=edge%3E%3D105%2C+firefox%3E%3D106%2C+chrome%3E%3D105%2C+safari%3E%3D16.4%2C+chromeAndroid%3E%3D105%2C+iOS%3E%3D16.4)
 
   It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when collecting polyfills for **modern chunks**. The value set here will override the `build.target` option.
 

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -49,7 +49,7 @@ npm add -D terser
 ### `modernTargets`
 
 - **Type:** `string | string[]`
-- **Default:** [`'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'`](https://browsersl.ist/#q=edge%3E%3D79%2C+firefox%3E%3D67%2C+chrome%3E%3D64%2C+safari%3E%3D12%2C+chromeAndroid%3E%3D64%2C+iOS%3E%3D12)
+- **Default:** [`'edge>=105, firefox>=106, chrome>=105, safari>=16.4, chromeAndroid>=105, iOS>=16.4'`](https://browsersl.ist/#q=edge%3E%3D105%2C+firefox%3E%3D106%2C+chrome%3E%3D105%2C+safari%3E%3D16.4%2C+chromeAndroid%3E%3D105%2C+iOS%3E%3D16.42)
 
   It's passed on to [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#targets) when collecting polyfills for **modern chunks**. The value set here will override the `build.target` option.
 
@@ -138,13 +138,13 @@ npm add -D terser
 The legacy plugin offers a way to use widely-available features natively in the modern build, while falling back to the legacy build in browsers with native ESM but without those features supported (e.g. Legacy Edge). This feature works by injecting a runtime check and loading the legacy bundle with SystemJS runtime if needed. There are the following drawbacks:
 
 - Modern bundle is downloaded in all ESM browsers
-- Modern bundle throws `SyntaxError` in browsers without those features support
+- Modern bundle throws an error in browsers without those features support
 
-The following syntax are considered as widely-available:
+The following features are considered as widely-available:
 
 - dynamic import
-- `import.meta`
 - async generator
+- `import.meta.resolve`
 
 ## Polyfill Specifiers
 
@@ -183,7 +183,7 @@ The current values are:
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
-- `sha256-ZxAi3a7m9Mzbc+Z1LGuCCK5Xee6reDkEPRas66H9KSo=`
+- `sha256-w36slEqa9euNKxfvkw+LLGsDIr++3rsZXpZxtmRh8Aw=`
 - `sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=`
 
 <!--

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -125,19 +125,20 @@ const _require = createRequire(import.meta.url)
 const nonLeadingHashInFileNameRE = /[^/]+\[hash(?::\d+)?\]/
 const prefixedHashInFileNameRE = /\W?\[hash(?::\d+)?\]/
 
-// browsers supporting ESM + dynamic import + import.meta + async generator
+// browsers supporting dynamic import + import.meta.resolve + async generator
 const modernTargetsEsbuild = [
   'es2020',
-  'edge79',
-  'firefox67',
-  'chrome64',
-  'safari12',
+  'edge105',
+  'firefox106',
+  'chrome105',
+  'safari16.4',
+  'ios16.4',
 ]
 // same with above but by browserslist syntax
 // es2020 = chrome 80+, safari 13.1+, firefox 72+, edge 80+
 // https://github.com/evanw/esbuild/issues/121#issuecomment-646956379
 const modernTargetsBabel =
-  'edge>=79, firefox>=67, chrome>=64, safari>=12, chromeAndroid>=64, iOS>=12'
+  'edge>=105, firefox>=106, chrome>=105, safari>=16.4, chromeAndroid>=105, iOS>=16.4'
 
 const outputOptionsForLegacyChunks =
   new WeakSet<Rollup.NormalizedOutputOptions>()

--- a/packages/plugin-legacy/src/snippets.ts
+++ b/packages/plugin-legacy/src/snippets.ts
@@ -7,8 +7,11 @@ export const legacyEntryId: string = 'vite-legacy-entry'
 export const systemJSInlineCode: string = `System.import(document.getElementById('${legacyEntryId}').getAttribute('data-src'))`
 
 const detectModernBrowserVarName = '__vite_is_modern_browser'
+// inline module to execute the code before other imports
+const detectImportMetaResolveSupportModule: string =
+  'data:text/javascript,if(!import.meta.resolve)throw Error("import.meta.resolve not supported")'
 export const detectModernBrowserDetector: string = `import.meta.url;import("_").catch(()=>1);(async function*(){})().next()`
-export const detectModernBrowserCode: string = `${detectModernBrowserDetector};window.${detectModernBrowserVarName}=true`
+export const detectModernBrowserCode: string = `import'${detectImportMetaResolveSupportModule}';${detectModernBrowserDetector};window.${detectModernBrowserVarName}=true`
 export const dynamicFallbackInlineCode: string = `!function(){if(window.${detectModernBrowserVarName})return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}();`
 
-export const modernChunkLegacyGuard: string = `export function __vite_legacy_guard(){${detectModernBrowserDetector}};`
+export const modernChunkLegacyGuard: string = `import'${detectImportMetaResolveSupportModule}';export function __vite_legacy_guard(){${detectModernBrowserDetector}};`


### PR DESCRIPTION
_Split from #21580_

#21580 relies on `import.meta.resolve`. This means the modern chunks will only run successfully on browsers that supports `import.meta.resolve` when `build.chunkImportMap` option is enabled. To fallback browsers that doesn't support `import.meta.resolve` to the legacy chunks, this PR bumps the modern browser threshold to `import.meta.resolve` support, specifically:

- Edge 79+ -> 105+ (released in 2022-09-01)
- Firefox 67+ -> 106+ (released in 2022-10-18)
- Chrome 64+ -> 105+ (released in 2022-09-02)
- Safari 12+ -> 16.4+ (released in 2023-03-27)

This change also has the upside of reducing the modern chunk polyfills.
