### PR TITLE
refactor(create-vite): remove extra brackets in React Compiler babel plugins

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -792,7 +792,7 @@ function setupReactCompiler(root: string, isTs: boolean) {
         `  plugins: [
     react({
       babel: {
-        plugins: [['babel-plugin-react-compiler']],
+        plugins: ['babel-plugin-react-compiler'],
       },
     }),
   ],`,


### PR DESCRIPTION
fixes #21673