### PR TITLE
fix(module-runner): initialize CSS module cache for non-client enviro…

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -331,6 +331,15 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       )
     },
 
+    configureServer() {
+      // Initialize module cache for dev mode in case buildStart is not called
+      // (e.g. when using createServerModuleRunner)
+      if (!cssModulesCache.has(config)) {
+        moduleCache = new Map<string, Record<string, string>>()
+        cssModulesCache.set(config, moduleCache)
+      }
+    },
+
     buildEnd() {
       preprocessorWorkerController?.close()
     },
@@ -552,7 +561,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         const inlined = inlineRE.test(id)
-        const modules = cssModulesCache.get(config)!.get(id)
+        const modules = cssModulesCache.get(config)?.get(id)
 
         // #6984, #7552
         // `foo.module.css` => modulesCode


### PR DESCRIPTION
## Description

Importing CSS files via `createServerModuleRunner` in dev mode throws a `TypeError` because the CSS module cache is never initialized for non-client environments.

- `.module.css`: _TypeError: Cannot read properties of undefined (reading 'set')_
- Plain `.css`: _TypeError: Cannot read properties of undefined (reading 'get')_

## Root cause

Both `cssPlugin` and `cssPostPlugin` depend on a `moduleCache` / `cssModulesCache` that is only initialized inside the `buildStart` hook. However, in the dev server's plugin container, `buildStart` is conditionally called per-plugin - it only fires for plugins that have `perEnvironmentStartEndDuringDev: true` or when the environment is "client". Since the CSS plugins don't set that flag, their `buildStart` callback is skipped for the SSR environment, leaving the cache undefined.

When using `middlewareMode: true`, this is masked because `initServer()` explicitly calls `buildStart` on the client environment, and the shared plugin closure variable gets initialized. But without middleware mode (the common
`createServerModuleRunner` pattern), no `buildStart` fires before the first CSS transform, causing the crash.

You can work around this by running `await server.pluginContainer.buildStart({})` first, but it seems a little hacky/non-intuitive.

## Fix

- Add a `configureServer` hook to `cssPlugin` that eagerly initializes `moduleCache` and `cssModulesCache` if not already set. This hook always runs during `createServer()`, regardless of middleware mode or environment.
- Change the unsafe non-null assertion (!) in `cssPostPlugin` to optional chaining (?.), consistent with how `cssAnalysisPlugin` already accesses the same cache.

## Testing

Added a test that creates a server without `middlewareMode` and imports both `.css` and `.module.css` files through `createServerModuleRunner`. This test fails before the fix and passes after.
