### PR TITLE
fix: strip import attributes from dynamic imports to fix Firefox compatibility

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -520,7 +520,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           const isDynamicImport = dynamicIndex > -1
 
           // strip import attributes as we can process them ourselves
-          if (!isDynamicImport && attributeIndex > -1) {
+          if (attributeIndex > -1) {
             str().remove(end + 1, expEnd)
           }
 

--- a/playground/import-assertion/__tests__/import-assertion.spec.ts
+++ b/playground/import-assertion/__tests__/import-assertion.spec.ts
@@ -8,3 +8,7 @@ test('from source code', async () => {
 test('from dependency', async () => {
   expect(await page.textContent('.dep'), 'world')
 })
+
+test('dynamic import with attributes', async () => {
+  expect(await page.textContent('.dynamic'), 'bar')
+})

--- a/playground/import-assertion/index.html
+++ b/playground/import-assertion/index.html
@@ -6,12 +6,17 @@
 <h2>From dependency</h2>
 <p class="dep"></p>
 
+<h2>Dynamic import with attributes</h2>
+<p class="dynamic"></p>
+
 <script type="module">
   import * as data from './data.json' assert { type: 'json' }
   text('.src', data.foo)
 
   import * as depData from '@vitejs/test-import-assertion-dep'
   text('.dep', depData.hello)
+
+  import('./data.json', { with: { type: 'json' } }).then((m) => text('.dynamic', m.foo))
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/playground/import-assertion/index.html
+++ b/playground/import-assertion/index.html
@@ -16,7 +16,9 @@
   import * as depData from '@vitejs/test-import-assertion-dep'
   text('.dep', depData.hello)
 
-  import('./data.json', { with: { type: 'json' } }).then((m) => text('.dynamic', m.foo))
+  import('./data.json', { with: { type: 'json' } }).then((m) =>
+    text('.dynamic', m.foo),
+  )
 
   function text(el, text) {
     document.querySelector(el).textContent = text


### PR DESCRIPTION
Fixes #19095

## Description

Dynamic imports with import attributes cause a syntax error in Firefox:

```js
import('./file.json', { with: { type: 'json' } })  // SyntaxError in Firefox
```

Firefox doesn't support import attributes yet ([Firefox bug 1736059](https://bugzilla.mozilla.org/show_bug.cgi?id=1736059)).

## Root Cause

Vite was only stripping import attributes from **static** imports, not dynamic ones:

```ts
if (!isDynamicImport && attributeIndex > -1) {
  str().remove(end + 1, expEnd)
}
```

This meant dynamic imports kept their attributes, causing Firefox to fail parsing.

## Fix

Remove the `!isDynamicImport` check so attributes are stripped from both static and dynamic imports:

```ts
if (attributeIndex > -1) {
  str().remove(end + 1, expEnd)
}
```

## Testing

Added test case to `playground/import-assertion` verifying dynamic imports with attributes work in Firefox.
