### PR TITLE
fix: strip import attributes from dynamic imports to fix Firefox compatibility

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -520,7 +520,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           const isDynamicImport = dynamicIndex > -1
 
           // strip import attributes as we can process them ourselves
-          if (!isDynamicImport && attributeIndex > -1) {
+          if (attributeIndex > -1) {
             str().remove(end + 1, expEnd)
           }
 

--- a/playground/import-assertion/__tests__/import-assertion.spec.ts
+++ b/playground/import-assertion/__tests__/import-assertion.spec.ts
@@ -8,3 +8,7 @@ test('from source code', async () => {
 test('from dependency', async () => {
   expect(await page.textContent('.dep'), 'world')
 })
+
+test('dynamic import with attributes', async () => {
+  expect(await page.textContent('.dynamic'), 'bar')
+})

--- a/playground/import-assertion/index.html
+++ b/playground/import-assertion/index.html
@@ -6,12 +6,18 @@
 <h2>From dependency</h2>
 <p class="dep"></p>
 
+<p class="dynamic"></p>
+
 <script type="module">
   import * as data from './data.json' assert { type: 'json' }
   text('.src', data.foo)
 
   import * as depData from '@vitejs/test-import-assertion-dep'
   text('.dep', depData.hello)
+
+  import('./data.json', { with: { type: 'json' } }).then((m) =>
+    text('.dynamic', m.foo),
+  )
 
   function text(el, text) {
     document.querySelector(el).textContent = text


### PR DESCRIPTION
Fixes #19095

Dynamic imports with import attributes cause a syntax error in Firefox because Firefox doesn't support import attributes yet.

This change strips import attributes from both static and dynamic imports, allowing dynamic imports to work in Firefox.
