### PR TITLE
docs(config): add TS callback literal widening note

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -101,6 +101,8 @@ export default defineConfig(async ({ command, mode }) => {
 })
 ```
 
+When using TypeScript with callback-based config (`defineConfig(() => ...)` or `defineConfig(async () => ...)`), some nested string literals may be widened to `string` by TypeScript. If you see an overload error for a literal option (for example `build.minify`), add `as const` to that value or annotate the callback return type.
+
 ## Using Environment Variables in Config
 
 Environment variables available while the config itself is being evaluated are only those that already exist in the current process environment (`process.env`). Vite deliberately defers loading any `.env*` files until _after_ the user config has been resolved because the set of files to load depends on config options like [`root`](/guide/#index-html-and-project-root) and [`envDir`](/config/shared-options.md#envdir), and also on the final `mode`.


### PR DESCRIPTION
## Summary
- add a docs note for TypeScript users about callback-based `defineConfig` literal widening
- document practical workarounds (`as const` or explicit callback return type) for overload errors in async/sync callback config

## Why
Issue #21684 reports that in callback-based config, some nested string literals can be widened by TypeScript and trigger overload errors. This PR documents the existing TypeScript limitation and recommended workaround in the Async Config section.

## Changes
- update `docs/config/index.md` under **Async Config** with a short note and guidance

## Validation
- `pnpm run docs-build`

Refs #21684
