### PR TITLE
fix(resolve): handle base-prefixed virtual imports in bundledDev

### DIFF
--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -53,6 +53,35 @@ describe('import and resolveId', () => {
       expect.stringContaining('dir/index.module.js'),
     ])
   })
+
+  test('bundledDev strips base for virtual /@ imports', async () => {
+    const server = await createServer({
+      configFile: false,
+      root: import.meta.dirname,
+      logLevel: 'error',
+      base: '/ui/',
+      experimental: {
+        bundledDev: true,
+      },
+      plugins: [
+        {
+          name: 'test-virtual-react-refresh',
+          resolveId(id) {
+            if (id === '/@react-refresh') {
+              return '\0virtual-react-refresh'
+            }
+          },
+        },
+      ],
+    })
+    onTestFinished(() => server.close())
+
+    const resolved =
+      await server.environments.client.pluginContainer.resolveId(
+        '/ui/@react-refresh',
+      )
+    expect(resolved?.id).toBe('/@react-refresh')
+  })
 })
 
 describe('file url', () => {


### PR DESCRIPTION
Fixes #21679.

Summary:
- fix bundledDev resolution when base is not root and virtual imports are base-prefixed
- strip base for /<base>@... virtual ids before normal resolve handling

Why:
With bundledDev and a base like /ui/, html-proxy imports /ui/@react-refresh. It should resolve as /@react-refresh but currently fails unresolved.

Changes:
- add a serve+bundledDev resolve plugin in packages/vite/src/node/plugins/resolve.ts to strip base from base-prefixed /@... virtual ids
- add regression test in packages/vite/src/node/__tests__/resolve.spec.ts for /ui/@react-refresh -> /@react-refresh

Validation:
- pnpm vitest run src/node/__tests__/resolve.spec.ts (packages/vite)
- pnpm run typecheck (packages/vite)

Implementation on this branch is original (no copied patch content from other contributors).
