### PR TITLE
docs: add host to new Request()

### DIFF
--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -151,7 +151,7 @@ const server = await createServer({
 // Any consumer of the environment API can now call `dispatchFetch`
 if (isFetchableDevEnvironment(server.environments.custom)) {
   const response: Response = await server.environments.custom.dispatchFetch(
-    new Request(HOST_NAME + '/request-to-handle'),
+    new Request('http://example.com/request-to-handle'),
   )
 }
 ```
@@ -196,7 +196,7 @@ if (ssrEnvironment instanceof CustomDevEnvironment) {
 // virtual:entrypoint
 const { createHandler } = await import('./entrypoint.js')
 const handler = createHandler(input)
-const response = handler(new Request(HOST_NAME + '/'))
+const response = handler(new Request('http://example.com/'))
 
 // -------------------------------------
 // ./entrypoint.js
@@ -266,7 +266,7 @@ if (ssrEnvironment instanceof RunnableDevEnvironment) {
   throw new Error(`Unsupported runtime for ${ssrEnvironment.name}`)
 }
 
-const req = new Request(HOST_NAME + '/')
+const req = new Request('http://example.com/')
 
 const uniqueId = 'a-unique-id'
 ssrEnvironment.send('request', serialize({ req, uniqueId }))
@@ -290,7 +290,7 @@ import.meta.hot.on('request', (data) => {
   import.meta.hot.send('response', serialize({ res: res, uniqueId }))
 })
 
-const response = handler(new Request(HOST_NAME + '/'))
+const response = handler(new Request('http://example.com/'))
 
 // -------------------------------------
 // ./entrypoint.js

--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -151,7 +151,7 @@ const server = await createServer({
 // Any consumer of the environment API can now call `dispatchFetch`
 if (isFetchableDevEnvironment(server.environments.custom)) {
   const response: Response = await server.environments.custom.dispatchFetch(
-    new Request('/request-to-handle'),
+    new Request(HOST_NAME + '/request-to-handle'),
   )
 }
 ```
@@ -196,7 +196,7 @@ if (ssrEnvironment instanceof CustomDevEnvironment) {
 // virtual:entrypoint
 const { createHandler } = await import('./entrypoint.js')
 const handler = createHandler(input)
-const response = handler(new Request('/'))
+const response = handler(new Request(HOST_NAME + '/'))
 
 // -------------------------------------
 // ./entrypoint.js
@@ -266,7 +266,7 @@ if (ssrEnvironment instanceof RunnableDevEnvironment) {
   throw new Error(`Unsupported runtime for ${ssrEnvironment.name}`)
 }
 
-const req = new Request('/')
+const req = new Request(HOST_NAME + '/')
 
 const uniqueId = 'a-unique-id'
 ssrEnvironment.send('request', serialize({ req, uniqueId }))
@@ -290,7 +290,7 @@ import.meta.hot.on('request', (data) => {
   import.meta.hot.send('response', serialize({ res: res, uniqueId }))
 })
 
-const response = handler(new Request('/'))
+const response = handler(new Request(HOST_NAME + '/'))
 
 // -------------------------------------
 // ./entrypoint.js


### PR DESCRIPTION
The `FetchableDevEnvironment` examples in the docs use bare URLs with the `Request` constructor like `new Request('/request-to-handle')` but in Node, this constructor requires a full URL with a host, otherwise a `TypeError: Failed to parse URL from /request-to-handle` will be thrown.

~~But this is not a complete fix, we need to explain where the `HOST_NAME` constant will come from and what it should contain. If we don't care about the actual host, a simple `http://example.com` will work but it would be confusing and require some explanation at least.~~ UPDATE: Changed host name to `http://example.com`.


Opening this PR to start the discussion.