### PR TITLE
fix(module-graph): prevent memory leak from rejected URL resolution p…

### DIFF
--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { EnvironmentModuleNode } from '../moduleGraph';
+import type { EnvironmentModuleNode } from '../moduleGraph'
 import { EnvironmentModuleGraph } from '../moduleGraph'
 import type { ModuleNode } from '../mixedModuleGraph'
 import { ModuleGraph } from '../mixedModuleGraph'

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -385,6 +385,14 @@ export class EnvironmentModuleGraph {
     // Also register the clean url to the module, so that we can short-circuit
     // resolving the same url twice
     this._setUnresolvedUrlToModule(rawUrl, modPromise)
+    // Clean up the pending promise on failure to avoid a memory leak where rejected
+    // promises accumulate indefinitely in the map. The identity check ensures we
+    // don't remove a newer entry that may have already replaced this one.
+    modPromise.catch(() => {
+      if (this._unresolvedUrlToModuleMap.get(rawUrl) === modPromise) {
+        this._unresolvedUrlToModuleMap.delete(rawUrl)
+      }
+    })
     return modPromise
   }
 


### PR DESCRIPTION
…romises

Pending promises stored in `_unresolvedUrlToModuleMap` were never cleaned up when `_resolveUrl` threw, causing the map to grow unbounded over time. Add a `.catch()` with an identity guard on `modPromise` to delete the stale entry on failure without risking removal of a newer successful resolution.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
