### PR TITLE
fix(optimizer): avoid duplicate modules when `preserveSymlinks` is enabled

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -783,7 +783,7 @@ async function prepareRolldownOptimizerRun(
         jsxLoader = true
       }
       const flatId = flattenId(id)
-      flatIdDeps[flatId] = src
+      flatIdDeps[flatId] = isWindows ? src.replaceAll('/', '\\') : src
       idToExports[id] = exportsData
     }),
   )


### PR DESCRIPTION
The root cause is probably the behavior difference https://github.com/rolldown/rolldown/pull/8483

Adding a workaround for now.

https://github.com/yannbf/rolldown-windows-symlinks-issue is the reproduction for this issue.
