### PR TITLE
fix: align the Plugin type with rollup (fix #21715)

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -143,7 +143,7 @@ export interface Plugin<A = any> extends RolldownPlugin<A> {
         isEntry: boolean
       },
     ) => Promise<ResolveIdResult> | ResolveIdResult,
-    { filter?: { id?: StringFilter<RegExp> } }
+    { filter?: { id?: StringFilter<RegExp> | undefined } | undefined }
   >
   load?: ObjectHook<
     (
@@ -153,7 +153,7 @@ export interface Plugin<A = any> extends RolldownPlugin<A> {
         ssr?: boolean | undefined
       },
     ) => Promise<LoadResult> | LoadResult,
-    { filter?: { id?: StringFilter } }
+    { filter?: { id?: StringFilter | undefined } | undefined }
   >
   transform?: ObjectHook<
     (
@@ -166,11 +166,13 @@ export interface Plugin<A = any> extends RolldownPlugin<A> {
       },
     ) => Promise<TransformResult> | TransformResult,
     {
-      filter?: {
-        id?: StringFilter
-        code?: StringFilter
-        moduleType?: ModuleTypeFilter
-      }
+      filter?:
+        | {
+            id?: StringFilter | undefined
+            code?: StringFilter | undefined
+            moduleType?: ModuleTypeFilter | undefined
+          }
+        | undefined
     }
   >
   /**

--- a/packages/vite/src/node/plugins/pluginFilter.ts
+++ b/packages/vite/src/node/plugins/pluginFilter.ts
@@ -15,8 +15,8 @@ export type StringFilter<Value = string | RegExp> =
   | Value
   | Array<Value>
   | {
-      include?: Value | Array<Value>
-      exclude?: Value | Array<Value>
+      include?: Value | Array<Value> | undefined
+      exclude?: Value | Array<Value> | undefined
     }
 
 type NormalizedStringFilter = {


### PR DESCRIPTION
I couldn't find an easy way to test this change without also enabling `strictOptionalPropertyTypes` for the whole project.