### PR TITLE
fix(ssr): throw friendly error when calling `ssrLoadModule` with non-runnable ssr env

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import { stripVTControlCharacters } from 'node:util'
 import { expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../../server'
+import { DevEnvironment } from '../../server/environment'
 import { normalizePath } from '../../utils'
 
 const root = fileURLToPath(new URL('./', import.meta.url))
@@ -317,6 +318,32 @@ test('named exports overwrite export all', async () => {
       "d": "dep1-d",
     }
   `)
+})
+
+test('throws when ssr environment is not runnable', async () => {
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'silent',
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    environments: {
+      ssr: {
+        dev: {
+          createEnvironment: (name, config) =>
+            new DevEnvironment(name, config, { hot: false }),
+        },
+      },
+    },
+  })
+  onTestFinished(() => server.close())
+
+  await expect(
+    server.ssrLoadModule('/fixtures/modules/has-invalid-import.js'),
+  ).rejects.toThrow(
+    "ssrLoadModule requires the 'ssr' environment to be a runnable environment.",
+  )
 })
 
 test('buildStart before transform', async () => {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -10,6 +10,7 @@ import { unwrapId } from '../../shared/utils'
 import type { DevEnvironment } from '../server/environment'
 import type { NormalizedServerHotChannel } from '../server/hmr'
 import { buildErrorMessage } from '../server/middlewares/error'
+import { isRunnableDevEnvironment } from '../server/environments/runnableEnvironment'
 import { ssrFixStacktrace } from './ssrStacktrace'
 import { createServerModuleRunnerTransport } from './runtime/serverModuleRunner'
 
@@ -21,6 +22,9 @@ export async function ssrLoadModule(
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
   const environment = server.environments.ssr
+  if (!isRunnableDevEnvironment(environment)) {
+    throw new Error(`ssrLoadModule requires the 'ssr' environment to be a runnable environment.`)
+  }
   server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(environment)
   url = unwrapId(url)
 

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -10,7 +10,7 @@ import { unwrapId } from '../../shared/utils'
 import type { DevEnvironment } from '../server/environment'
 import type { NormalizedServerHotChannel } from '../server/hmr'
 import { buildErrorMessage } from '../server/middlewares/error'
-import { isRunnableDevEnvironment } from '../server/environments/runnableEnvironment'
+import { isRunnableDevEnvironment } from '../../node'
 import { ssrFixStacktrace } from './ssrStacktrace'
 import { createServerModuleRunnerTransport } from './runtime/serverModuleRunner'
 
@@ -23,7 +23,9 @@ export async function ssrLoadModule(
 ): Promise<SSRModule> {
   const environment = server.environments.ssr
   if (!isRunnableDevEnvironment(environment)) {
-    throw new Error(`ssrLoadModule requires the 'ssr' environment to be a runnable environment.`)
+    throw new Error(
+      `ssrLoadModule requires the 'ssr' environment to be a runnable environment.`,
+    )
   }
   server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(environment)
   url = unwrapId(url)


### PR DESCRIPTION
The error message was not clear:
```
TypeError: Cannot read properties of undefined (reading 'outsideEmitter')
 ❯ Object.connect packages/vite/src/node/ssr/runtime/serverModuleRunner.ts:92:28
     90|   return {
     91|     connect({ onMessage }) {
     92|       options.channel.api!.outsideEmitter.on('send', onMessage)
       |                            ^
     93|       options.channel.api!.innerEmitter.emit(
     94|         'vite:client:connect',
```

saw this error in https://github.com/vitejs/vite/issues/21726
