### PR TITLE
fix(lib): keep annotation comments for es output

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -741,7 +741,11 @@ export function resolveRolldownOptions(
         typeof output.comments === 'boolean'
           ? output.comments
           : {
-              annotation: !options.minify,
+              // Do not minify whitespace for ES lib output since that would remove
+              // pure annotations and break tree-shaking
+              annotation:
+                !options.minify ||
+                (libOptions && (format === 'es' || format === 'esm')),
               jsdoc: !options.minify,
               legal: !options.minify,
               ...output.comments,

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -53,7 +53,7 @@ describe.runIf(isBuild)('build', () => {
     expect(code).not.toMatch('__vitePreload')
 
     // Test that library chunks are hashed
-    expect(code).toMatch(/await import\("\.\/message-[-\w]{8}.js"\)/)
+    expect(code).toMatch(/await import\(['"`]\.\/message-[-\w]{8}.js['"`]\)/)
   })
 
   test('Library mode does not have any reference to pure CSS chunks', async () => {
@@ -64,6 +64,16 @@ describe.runIf(isBuild)('build', () => {
       /await import\(['"`]\.\/dynamic-[-\w]{8}.js['"`]\)/,
     )
     expect(code).toMatch(/await Promise.resolve\(\{.*\}\)/)
+  })
+
+  test('pure annotations are kept for es output', () => {
+    const es = readFile('dist/my-lib-custom-filename.js')
+    expect(es).toMatch(/[@#]__PURE__/)
+  })
+
+  test('pure annotations are removed for non-es output', () => {
+    const es = readFile('dist/my-lib-custom-filename.iife.js')
+    expect(es).not.toMatch(/[@#]__PURE__/)
   })
 
   test('@import hoist', async () => {


### PR DESCRIPTION
Fixes this ecosystem-ci failure: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/22609533793/job/65508961801#step:7:937
