### PR TITLE
chore: move static-deploy comment to top

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -1,3 +1,21 @@
+<!--
+  READ THIS IF YOU WANT TO ADD A NEW DEPLOYMENT PLATFORM.
+
+  Feel free to submit a PR that adds a new section with a link to your platform's
+  deployment guide, as long as it meets these criteria:
+
+  1. Users should be able to deploy their site for free.
+  2. Free tier offerings should host the site indefinitely and are not time-bound.
+     Offering a limited number of computation resource or site counts in exchange is fine.
+  3. The linked guides should not contain any malicious content.
+
+  New sections should be added last in the file. Please reference the existing sections at
+  the bottom of this file for examples of how to format the new section.
+
+  The Vite team may change the criteria and audit the current list from time to time.
+  If a section is removed, we will ping the original PR authors before doing so.
+-->
+
 # Deploying a Static Site
 
 The following guides are based on some shared assumptions:
@@ -273,20 +291,6 @@ You can deploy your Vite app as a Static Site on [Render](https://render.com/).
 By default, any new commit pushed to the specified branch will automatically trigger a new deployment. [Auto-Deploy](https://render.com/docs/deploys#toggling-auto-deploy-for-a-service) can be configured in the project settings.
 
 You can also add a [custom domain](https://render.com/docs/custom-domains) to your project.
-
-<!--
-  NOTE: The sections below are reserved for more deployment platforms not listed above.
-  Feel free to submit a PR that adds a new section with a link to your platform's
-  deployment guide, as long as it meets these criteria:
-
-  1. Users should be able to deploy their site for free.
-  2. Free tier offerings should host the site indefinitely and are not time-bound.
-     Offering a limited number of computation resource or site counts in exchange is fine.
-  3. The linked guides should not contain any malicious content.
-
-  The Vite team may change the criteria and audit the current list from time to time.
-  If a section is removed, we will ping the original PR authors before doing so.
--->
 
 ## Flightcontrol
 


### PR DESCRIPTION
It feels like this comment is often missed because it's in the middle of a wordy file, moving it to the top so hopefully it's more visible.