### PR TITLE
fix(client): add type declaration for ?url&raw imports

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -270,6 +270,11 @@ declare module '*?url&no-inline' {
   export default src
 }
 
+declare module '*?url&raw' {
+  const src: string
+  export default src
+}
+
 declare interface VitePreloadErrorEvent extends Event {
   payload: Error
 }


### PR DESCRIPTION
Add missing TypeScript declaration for combining url and raw query parameters.

This allows importing files with both `?url&raw` suffix without IDE errors, e.g.:
```ts
import _redirects from "/_redirects?url&raw";
```

Fixes #21277