### PR TITLE
fix(wasm): reset assetUrlRE.lastIndex before .test() in SSR builds

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/wasm.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/wasm.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+import { assetUrlRE } from '../../plugins/asset'
+
+describe('wasm plugin assetUrlRE usage', () => {
+  // Regression test: assetUrlRE has the /g flag, which makes .test()
+  // stateful via lastIndex. When the wasm plugin called assetUrlRE.test()
+  // on consecutive asset URLs without resetting lastIndex, the second call
+  // would fail because lastIndex was already past the end of the string.
+  // This caused a non-deterministic bug where ~half of wasm files would
+  // miss the __VITE_ASSET__ -> __VITE_WASM_INIT__ replacement in SSR
+  // builds, leading to ENOENT errors at runtime.
+  test('assetUrlRE.test() fails on second call without lastIndex reset', () => {
+    const url1 = '__VITE_ASSET__abc123__'
+    const url2 = '__VITE_ASSET__def456__'
+
+    // Simulate the bug: two consecutive .test() calls without resetting lastIndex
+    assetUrlRE.lastIndex = 0
+    expect(assetUrlRE.test(url1)).toBe(true)
+    // After the first successful match, lastIndex is advanced past the string
+    expect(assetUrlRE.lastIndex).toBeGreaterThan(0)
+    // The second call fails because lastIndex > url2.length
+    expect(assetUrlRE.test(url2)).toBe(false)
+
+    // Clean up
+    assetUrlRE.lastIndex = 0
+  })
+
+  test('assetUrlRE.test() succeeds on consecutive calls with lastIndex reset', () => {
+    const url1 = '__VITE_ASSET__abc123__'
+    const url2 = '__VITE_ASSET__def456__'
+
+    assetUrlRE.lastIndex = 0
+    expect(assetUrlRE.test(url1)).toBe(true)
+
+    // The fix: reset lastIndex before the next call
+    assetUrlRE.lastIndex = 0
+    expect(assetUrlRE.test(url2)).toBe(true)
+
+    // Clean up
+    assetUrlRE.lastIndex = 0
+  })
+})

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -98,6 +98,7 @@ export default ${wasmHelperCode}
 
           id = id.split('?')[0]
           let url = await fileToUrl(this, id, ssr)
+          assetUrlRE.lastIndex = 0
           if (ssr && assetUrlRE.test(url)) {
             url = url.replace('__VITE_ASSET__', '__VITE_WASM_INIT__')
           }


### PR DESCRIPTION
`assetUrlRE` is a global regex (`/g` flag), making `.test()` stateful via lastIndex. Consecutive calls without resetting `lastIndex` cause alternating success/failure, so ~half of non-inlined wasm files miss the `__VITE_ASSET__` -> `__VITE_WASM_INIT__` replacement. Without that marker, `renderChunk` cannot transform the path to `import.meta.url`-relative, producing an absolute web path like `/assets/foo.wasm` that resolves to `file:///assets/foo.wasm` in Node.js SSR — ENOENT.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
