### PR TITLE
feat: warn when `vite-tsconfig-paths` plugin is detected

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1465,7 +1465,6 @@ export async function resolveConfig(
     customLogger: config.customLogger,
   })
 
-  // Warn if vite-tsconfig-paths plugin is detected, as Vite now has built-in support
   const tsconfigPathsPlugin = userPlugins.find(
     (p) =>
       p.name === 'vite-tsconfig-paths' ||
@@ -1474,9 +1473,9 @@ export async function resolveConfig(
   if (tsconfigPathsPlugin) {
     logger.warnOnce(
       colors.yellow(
-        `The plugin ${JSON.stringify(tsconfigPathsPlugin.name)} is no longer needed. ` +
+        `The plugin ${JSON.stringify(tsconfigPathsPlugin.name)} is detected. ` +
           `Vite now supports tsconfig paths resolution natively via the ${colors.bold('resolve.tsconfigPaths')} option. ` +
-          `You could remove the plugin and set ${colors.bold('resolve.tsconfigPaths: true')} in your Vite config instead.`,
+          `You can remove the plugin and set ${colors.bold('resolve.tsconfigPaths: true')} in your Vite config instead.`,
       ),
     )
   }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1465,6 +1465,22 @@ export async function resolveConfig(
     customLogger: config.customLogger,
   })
 
+  // Warn if vite-tsconfig-paths plugin is detected, as Vite now has built-in support
+  const tsconfigPathsPlugin = userPlugins.find(
+    (p) =>
+      p.name === 'vite-tsconfig-paths' ||
+      p.name === 'vite-plugin-tsconfig-paths',
+  )
+  if (tsconfigPathsPlugin) {
+    logger.warnOnce(
+      colors.yellow(
+        `The plugin ${JSON.stringify(tsconfigPathsPlugin.name)} is no longer needed. ` +
+          `Vite now supports tsconfig paths resolution natively via the ${colors.bold('resolve.tsconfigPaths')} option. ` +
+          `You could remove the plugin and set ${colors.bold('resolve.tsconfigPaths: true')} in your Vite config instead.`,
+      ),
+    )
+  }
+
   // resolve root
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),


### PR DESCRIPTION
### Description

Vite now natively supports tsconfig paths resolution via `resolve.tsconfigPaths`. Detect the `vite-tsconfig-paths` plugin by name and emit a one-time warning guiding users to the built-in option instead. Also covers `vite-plugin-tsconfig-paths`, which still has ~10k weekly downloads.

### References

- https://www.npmjs.com/package/vite-tsconfig-paths
- https://www.npmjs.com/package/vite-plugin-tsconfig-paths