### PR TITLE
refactor: don't add `optimization.inlineConst: { mode: 'smart' }` as it's enabled by default

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -648,16 +648,6 @@ export function resolveRolldownOptions(
       ...options.rollupOptions.experimental,
       viteMode: true,
     },
-    optimization: {
-      inlineConst:
-        typeof options.rollupOptions.optimization?.inlineConst === 'boolean'
-          ? options.rollupOptions.optimization.inlineConst
-          : {
-              mode: 'smart',
-              ...options.rollupOptions.optimization?.inlineConst,
-            },
-      ...options.rollupOptions.optimization,
-    },
   }
 
   const isSsrTargetWebworkerEnvironment =


### PR DESCRIPTION
Follow up to https://github.com/vitejs/vite/pull/21790
