### PR TITLE
fix: ensure devDependencies exists before setting vite version

### DIFF
--- a/scripts/releaseUtils.ts
+++ b/scripts/releaseUtils.ts
@@ -64,6 +64,7 @@ export async function updateTemplateVersions(): Promise<void> {
   for (const template of templates) {
     const pkgPath = path.join(dir, template, `package.json`)
     const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf-8'))
+    pkg.devDependencies ??= {}
     pkg.devDependencies.vite = `^` + viteVersion
     await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
   }


### PR DESCRIPTION
Guard against missing devDependencies when updating template vite version