### PR TITLE
fix: use precise regexes for transform filter to avoid backtracking

### DIFF
--- a/packages/vite/src/node/__tests__/filterRegex.spec.ts
+++ b/packages/vite/src/node/__tests__/filterRegex.spec.ts
@@ -14,22 +14,14 @@ describe('filter regexes do not cause catastrophic backtracking', () => {
     `new URL('https://example.com');\n`.repeat(200) +
     `var a = 1;\n`.repeat(200_000)
 
-  test('assetImportMetaUrlFilterRE completes in reasonable time on large files', () => {
-    const start = performance.now()
-    const result = assetImportMetaUrlFilterRE.test(largeCode)
-    const duration = performance.now() - start
-
-    expect(result).toBe(false)
-    expect(duration).toBeLessThan(1000)
+  // These tests rely on the default test timeout (5s) to catch backtracking.
+  // The old regexes took >1s on this input; the new ones complete in ~3ms.
+  test('assetImportMetaUrlFilterRE completes without backtracking on large files', () => {
+    expect(assetImportMetaUrlFilterRE.test(largeCode)).toBe(false)
   })
 
-  test('workerImportMetaUrlRE completes in reasonable time on large files', () => {
-    const start = performance.now()
-    const result = workerImportMetaUrlRE.test(largeCode)
-    const duration = performance.now() - start
-
-    expect(result).toBe(false)
-    expect(duration).toBeLessThan(1000)
+  test('workerImportMetaUrlRE completes without backtracking on large files', () => {
+    expect(workerImportMetaUrlRE.test(largeCode)).toBe(false)
   })
 
   test('assetImportMetaUrlFilterRE still matches valid patterns', () => {

--- a/packages/vite/src/node/__tests__/filterRegex.spec.ts
+++ b/packages/vite/src/node/__tests__/filterRegex.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest'
+import { assetImportMetaUrlFilterRE } from '../plugins/assetImportMetaUrl'
+import { workerImportMetaUrlRE } from '../plugins/workerImportMetaUrl'
+
+// These are the filter.code regexes used in the transform hooks.
+// They must not cause catastrophic backtracking on large files.
+// See https://github.com/vitejs/vite/issues/21696
+
+describe('filter regexes do not cause catastrophic backtracking', () => {
+  // Large file where `new URL(...)` appears many times but `import.meta.url`
+  // is absent. With the old /s + .+ pattern, each `new URL` occurrence would
+  // cause the regex engine to consume the rest of the file before backtracking.
+  const largeCode =
+    `new URL('https://example.com');\n`.repeat(200) +
+    `var a = 1;\n`.repeat(200_000)
+
+  test('assetImportMetaUrlFilterRE completes in reasonable time on large files', () => {
+    const start = performance.now()
+    const result = assetImportMetaUrlFilterRE.test(largeCode)
+    const duration = performance.now() - start
+
+    expect(result).toBe(false)
+    expect(duration).toBeLessThan(1000)
+  })
+
+  test('workerImportMetaUrlRE completes in reasonable time on large files', () => {
+    const start = performance.now()
+    const result = workerImportMetaUrlRE.test(largeCode)
+    const duration = performance.now() - start
+
+    expect(result).toBe(false)
+    expect(duration).toBeLessThan(1000)
+  })
+
+  test('assetImportMetaUrlFilterRE still matches valid patterns', () => {
+    expect(
+      assetImportMetaUrlFilterRE.test(
+        `new URL('./asset.png', import.meta.url)`,
+      ),
+    ).toBe(true)
+  })
+
+  test('workerImportMetaUrlRE still matches valid patterns', () => {
+    expect(
+      workerImportMetaUrlRE.test(
+        `new Worker(new URL('./worker.js', import.meta.url))`,
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/vite/src/node/__tests__/filterRegex.spec.ts
+++ b/packages/vite/src/node/__tests__/filterRegex.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { assetImportMetaUrlFilterRE } from '../plugins/assetImportMetaUrl'
+import { assetImportMetaUrlRE } from '../plugins/assetImportMetaUrl'
 import { workerImportMetaUrlRE } from '../plugins/workerImportMetaUrl'
 
 describe('filter regexes do not cause catastrophic backtracking', () => {
@@ -7,27 +7,25 @@ describe('filter regexes do not cause catastrophic backtracking', () => {
     `new URL('https://example.com');\n`.repeat(200) +
     `var a = 1;\n`.repeat(200_000)
 
-  test('assetImportMetaUrlFilterRE completes without backtracking on large files', () => {
-    expect(assetImportMetaUrlFilterRE.test(largeCode)).toBe(false)
+  test('assetImportMetaUrlRE completes without backtracking on large files', () => {
+    const re = new RegExp(assetImportMetaUrlRE)
+    expect(re.test(largeCode)).toBe(false)
   })
 
   test('workerImportMetaUrlRE completes without backtracking on large files', () => {
-    expect(workerImportMetaUrlRE.test(largeCode)).toBe(false)
+    const re = new RegExp(workerImportMetaUrlRE)
+    expect(re.test(largeCode)).toBe(false)
   })
 
-  test('assetImportMetaUrlFilterRE still matches valid patterns', () => {
-    expect(
-      assetImportMetaUrlFilterRE.test(
-        `new URL('./asset.png', import.meta.url)`,
-      ),
-    ).toBe(true)
+  test('assetImportMetaUrlRE still matches valid patterns', () => {
+    const re = new RegExp(assetImportMetaUrlRE)
+    expect(re.test(`new URL('./asset.png', import.meta.url)`)).toBe(true)
   })
 
   test('workerImportMetaUrlRE still matches valid patterns', () => {
-    expect(
-      workerImportMetaUrlRE.test(
-        `new Worker(new URL('./worker.js', import.meta.url))`,
-      ),
-    ).toBe(true)
+    const re = new RegExp(workerImportMetaUrlRE)
+    expect(re.test(`new Worker(new URL('./worker.js', import.meta.url))`)).toBe(
+      true,
+    )
   })
 })

--- a/packages/vite/src/node/__tests__/filterRegex.spec.ts
+++ b/packages/vite/src/node/__tests__/filterRegex.spec.ts
@@ -2,20 +2,11 @@ import { describe, expect, test } from 'vitest'
 import { assetImportMetaUrlFilterRE } from '../plugins/assetImportMetaUrl'
 import { workerImportMetaUrlRE } from '../plugins/workerImportMetaUrl'
 
-// These are the filter.code regexes used in the transform hooks.
-// They must not cause catastrophic backtracking on large files.
-// See https://github.com/vitejs/vite/issues/21696
-
 describe('filter regexes do not cause catastrophic backtracking', () => {
-  // Large file where `new URL(...)` appears many times but `import.meta.url`
-  // is absent. With the old /s + .+ pattern, each `new URL` occurrence would
-  // cause the regex engine to consume the rest of the file before backtracking.
   const largeCode =
     `new URL('https://example.com');\n`.repeat(200) +
     `var a = 1;\n`.repeat(200_000)
 
-  // These tests rely on the default test timeout (5s) to catch backtracking.
-  // The old regexes took >1s on this input; the new ones complete in ~3ms.
   test('assetImportMetaUrlFilterRE completes without backtracking on large files', () => {
     expect(assetImportMetaUrlFilterRE.test(largeCode)).toBe(false)
   })

--- a/packages/vite/src/node/__tests__/filterRegex.spec.ts
+++ b/packages/vite/src/node/__tests__/filterRegex.spec.ts
@@ -8,24 +8,28 @@ describe('filter regexes do not cause catastrophic backtracking', () => {
     `var a = 1;\n`.repeat(200_000)
 
   test('assetImportMetaUrlRE completes without backtracking on large files', () => {
-    const re = new RegExp(assetImportMetaUrlRE)
-    expect(re.test(largeCode)).toBe(false)
+    assetImportMetaUrlRE.lastIndex = 0
+    expect(assetImportMetaUrlRE.test(largeCode)).toBe(false)
   })
 
   test('workerImportMetaUrlRE completes without backtracking on large files', () => {
-    const re = new RegExp(workerImportMetaUrlRE)
-    expect(re.test(largeCode)).toBe(false)
+    workerImportMetaUrlRE.lastIndex = 0
+    expect(workerImportMetaUrlRE.test(largeCode)).toBe(false)
   })
 
   test('assetImportMetaUrlRE still matches valid patterns', () => {
-    const re = new RegExp(assetImportMetaUrlRE)
-    expect(re.test(`new URL('./asset.png', import.meta.url)`)).toBe(true)
+    assetImportMetaUrlRE.lastIndex = 0
+    expect(
+      assetImportMetaUrlRE.test(`new URL('./asset.png', import.meta.url)`),
+    ).toBe(true)
   })
 
   test('workerImportMetaUrlRE still matches valid patterns', () => {
-    const re = new RegExp(workerImportMetaUrlRE)
-    expect(re.test(`new Worker(new URL('./worker.js', import.meta.url))`)).toBe(
-      true,
-    )
+    workerImportMetaUrlRE.lastIndex = 0
+    expect(
+      workerImportMetaUrlRE.test(
+        `new Worker(new URL('./worker.js', import.meta.url))`,
+      ),
+    ).toBe(true)
   })
 })

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -22,6 +22,7 @@ import type { Environment } from '../environment'
 import { createBackCompatIdResolver } from '../idResolver'
 import { isWindows } from '../../shared/utils'
 import { hasViteIgnoreRE } from '../plugins/importAnalysis'
+import { assetImportMetaUrlFilterRE } from '../plugins/assetImportMetaUrl'
 
 const externalWithConversionNamespace =
   'vite:dep-pre-bundle:external-conversion'
@@ -313,7 +314,7 @@ export function rolldownDepPlugin(
       },
       transform: {
         filter: {
-          code: /new\s+URL.+import\.meta\.url/s,
+          code: assetImportMetaUrlFilterRE,
         },
         async handler(code, id) {
           let s: MagicString | undefined

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -318,11 +318,11 @@ export function rolldownDepPlugin(
         },
         async handler(code, id) {
           let s: MagicString | undefined
-          assetImportMetaUrlRE.lastIndex = 0
+          const re = new RegExp(assetImportMetaUrlRE)
           const cleanString = stripLiteral(code)
 
           let match: RegExpExecArray | null
-          while ((match = assetImportMetaUrlRE.exec(cleanString))) {
+          while ((match = re.exec(cleanString))) {
             const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
             if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -22,7 +22,7 @@ import type { Environment } from '../environment'
 import { createBackCompatIdResolver } from '../idResolver'
 import { isWindows } from '../../shared/utils'
 import { hasViteIgnoreRE } from '../plugins/importAnalysis'
-import { assetImportMetaUrlFilterRE } from '../plugins/assetImportMetaUrl'
+import { assetImportMetaUrlRE } from '../plugins/assetImportMetaUrl'
 
 const externalWithConversionNamespace =
   'vite:dep-pre-bundle:external-conversion'
@@ -314,16 +314,15 @@ export function rolldownDepPlugin(
       },
       transform: {
         filter: {
-          code: assetImportMetaUrlFilterRE,
+          code: assetImportMetaUrlRE,
         },
         async handler(code, id) {
           let s: MagicString | undefined
-          const assetImportMetaUrlRE =
-            /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg
+          const re = new RegExp(assetImportMetaUrlRE)
           const cleanString = stripLiteral(code)
 
           let match: RegExpExecArray | null
-          while ((match = assetImportMetaUrlRE.exec(cleanString))) {
+          while ((match = re.exec(cleanString))) {
             const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
             if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -318,11 +318,11 @@ export function rolldownDepPlugin(
         },
         async handler(code, id) {
           let s: MagicString | undefined
-          const re = new RegExp(assetImportMetaUrlRE)
+          assetImportMetaUrlRE.lastIndex = 0
           const cleanString = stripLiteral(code)
 
           let match: RegExpExecArray | null
-          while ((match = re.exec(cleanString))) {
+          while ((match = assetImportMetaUrlRE.exec(cleanString))) {
             const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
             if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -63,11 +63,11 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       },
       async handler(code, id) {
         let s: MagicString | undefined
-        const re = new RegExp(assetImportMetaUrlRE)
+        assetImportMetaUrlRE.lastIndex = 0
         const cleanString = stripLiteral(code)
 
         let match: RegExpExecArray | null
-        while ((match = re.exec(cleanString))) {
+        while ((match = assetImportMetaUrlRE.exec(cleanString))) {
           const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
           if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -31,8 +31,8 @@ import { hasViteIgnoreRE } from './importAnalysis'
  * import.meta.glob('./dir/**.png', { eager: true, import: 'default' })[`./dir/${name}.png`]
  * ```
  */
-export const assetImportMetaUrlFilterRE: RegExp =
-  /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url/
+export const assetImportMetaUrlRE: RegExp =
+  /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg
 
 export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const { publicDir } = config
@@ -59,16 +59,15 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         id: {
           exclude: [exactRegex(preloadHelperId), exactRegex(CLIENT_ENTRY)],
         },
-        code: assetImportMetaUrlFilterRE,
+        code: assetImportMetaUrlRE,
       },
       async handler(code, id) {
         let s: MagicString | undefined
-        const assetImportMetaUrlRE =
-          /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg
+        const re = new RegExp(assetImportMetaUrlRE)
         const cleanString = stripLiteral(code)
 
         let match: RegExpExecArray | null
-        while ((match = assetImportMetaUrlRE.exec(cleanString))) {
+        while ((match = re.exec(cleanString))) {
           const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
           if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -31,6 +31,9 @@ import { hasViteIgnoreRE } from './importAnalysis'
  * import.meta.glob('./dir/**.png', { eager: true, import: 'default' })[`./dir/${name}.png`]
  * ```
  */
+export const assetImportMetaUrlFilterRE: RegExp =
+  /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url/
+
 export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const { publicDir } = config
   let assetResolver: ResolveIdFn
@@ -56,7 +59,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         id: {
           exclude: [exactRegex(preloadHelperId), exactRegex(CLIENT_ENTRY)],
         },
-        code: /new\s+URL.+import\.meta\.url/s,
+        code: assetImportMetaUrlFilterRE,
       },
       async handler(code, id) {
         let s: MagicString | undefined

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -63,11 +63,11 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       },
       async handler(code, id) {
         let s: MagicString | undefined
-        assetImportMetaUrlRE.lastIndex = 0
+        const re = new RegExp(assetImportMetaUrlRE)
         const cleanString = stripLiteral(code)
 
         let match: RegExpExecArray | null
-        while ((match = assetImportMetaUrlRE.exec(cleanString))) {
+        while ((match = re.exec(cleanString))) {
           const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
           if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
 

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -209,10 +209,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       async handler(code, id) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
-        workerImportMetaUrlRE.lastIndex = 0
+        const re = new RegExp(workerImportMetaUrlRE)
 
         let match: RegExpExecArray | null
-        while ((match = workerImportMetaUrlRE.exec(cleanString))) {
+        while ((match = re.exec(cleanString))) {
           const [[, endIndex], [expStart, expEnd], [urlStart, urlEnd]] =
             match.indices!
 

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -182,7 +182,7 @@ async function getWorkerType(
 }
 
 export const workerImportMetaUrlRE: RegExp =
-  /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url/
+  /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*(new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\))/dg
 
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const isBundled = config.isBundled
@@ -209,11 +209,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       async handler(code, id) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
-        const workerImportMetaUrlRE =
-          /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*(new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\))/dg
+        const re = new RegExp(workerImportMetaUrlRE)
 
         let match: RegExpExecArray | null
-        while ((match = workerImportMetaUrlRE.exec(cleanString))) {
+        while ((match = re.exec(cleanString))) {
           const [[, endIndex], [expStart, expEnd], [urlStart, urlEnd]] =
             match.indices!
 

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -209,10 +209,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       async handler(code, id) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
-        const re = new RegExp(workerImportMetaUrlRE)
+        workerImportMetaUrlRE.lastIndex = 0
 
         let match: RegExpExecArray | null
-        while ((match = re.exec(cleanString))) {
+        while ((match = workerImportMetaUrlRE.exec(cleanString))) {
           const [[, endIndex], [expStart, expEnd], [urlStart, urlEnd]] =
             match.indices!
 

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -181,8 +181,8 @@ async function getWorkerType(
   return 'classic'
 }
 
-const workerImportMetaUrlRE =
-  /new\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL.+?import\.meta\.url/s
+export const workerImportMetaUrlRE: RegExp =
+  /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url/
 
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const isBundled = config.isBundled


### PR DESCRIPTION
## What this PR solves

Fixes #21696

The `filter.code` regexes in `workerImportMetaUrl`, `assetImportMetaUrl`, and `rolldownDepPlugin` used `.+` (or `.+?`) with the `/s` flag. On large files (5MB+) containing `new URL(...)` without `import.meta.url`, this caused catastrophic backtracking — leading to "Maximum call stack size exceeded" or multi-second stalls.

### What caused the bug

The `/s` flag makes `.` match newlines, so `.+` in `/new\s+URL.+import\.meta\.url/s` consumes the entire remaining file after each `new URL` occurrence. When `import.meta.url` is absent, the regex engine backtracks character by character across the whole file, repeated for each `new URL` match.

## Implementation

The filter and handler regexes are unified into a single exported regex per plugin, with `dg` flags and a precise pattern that requires a string literal argument (`'...'`, `"..."`, or `` `...` ``). Each handler creates a fresh copy via `new RegExp()` to avoid shared `lastIndex` state between concurrent async invocations.

- `assetImportMetaUrl.ts`: exports `assetImportMetaUrlRE`, used for both filter and handler
- `workerImportMetaUrl.ts`: exports `workerImportMetaUrlRE`, used for both filter and handler
- `rolldownDepPlugin.ts`: imports `assetImportMetaUrlRE` for both filter and handler

## Attention for reviewers

- The regexes no longer have the `/s` flag, so they do not match across newlines. This is intentional — the precise patterns use character classes like `[^']+` that do not need cross-line matching.
- The regex is slightly more restrictive than the old one (requires a string literal), but this matches the behavior of the transform handler itself, so no valid cases should be missed.

## Tests

Added unit tests that run the exported regexes against a large input (~2.4MB with 200 `new URL(...)` occurrences). Tests rely on the default test timeout to catch backtracking regressions.