### PR TITLE
docs: add example for Node.js polyfills

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -256,6 +256,21 @@ This is because Vite does not automatically polyfill Node.js modules.
 
 We recommend avoiding Node.js modules for browser code to reduce the bundle size, although you can add polyfills manually. If the module is imported from a third-party library (that's meant to be used in the browser), it's advised to report the issue to the respective library.
 
+If you still need to provide Node.js polyfills for browser code, you can use a plugin such as `vite-plugin-node-polyfills`.
+
+Example:
+
+```js
+import { defineConfig } from 'vite'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
+
+export default defineConfig({
+  plugins: [nodePolyfills()],
+})
+```
+
+This can help when a dependency expects Node.js built-ins such as `Buffer` or `process`.
+
 ### Syntax Error / Type Error happens
 
 Vite cannot handle and does not support code that only runs on non-strict mode (sloppy mode). This is because Vite uses ESM and it is always [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) inside ESM.


### PR DESCRIPTION
Current PR adds an example to the troubleshooting guide showing how to provide Node.js polyfills with vite-plugin-node-polyfills.
The current troubleshooting section explains that Node.js modules are not polyfilled automatically and mentions that polyfills can be added manually, but it does not show a concrete example. This change adds a small example for users whose dependencies expect built-ins like Buffer or process.
Addresses #21385
I checked the linked issue before opening this PR. I did not add tests because this is a documentation-only change.