### PR TITLE
fix(deps): guard against undefined deps in commitProcessing

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -366,6 +366,7 @@ export function createDepsOptimizer(
         metadata.hash !== newData.hash ||
         Object.keys(metadata.optimized).some((dep) => {
           return (
+            newData.optimized[dep] &&
             metadata.optimized[dep].fileHash !== newData.optimized[dep].fileHash
           )
         })
@@ -388,9 +389,10 @@ export function createDepsOptimizer(
             newData.chunks[dep].browserHash = metadata.browserHash
           }
           for (const dep in newData.optimized) {
-            newData.optimized[dep].browserHash = (
-              metadata.optimized[dep] || metadata.discovered[dep]
-            ).browserHash
+            const prev = metadata.optimized[dep] || metadata.discovered[dep]
+            if (prev) {
+              newData.optimized[dep].browserHash = prev.browserHash
+            }
           }
         }
 


### PR DESCRIPTION
When the dependency optimizer re-runs during dev startup (e.g. due to virtual module content changes), commitProcessing may encounter deps in newData.optimized that don't exist in metadata.optimized/discovered, or deps in metadata.optimized that were removed from newData.optimized.

This adds null guards to prevent TypeError when accessing browserHash and fileHash on undefined entries.
