### PR TITLE
docs: fix optimizeDeps type links

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -53,11 +53,7 @@ export default defineConfig({
 
 ## optimizeDeps.rolldownOptions <NonInheritBadge />
 
-- **Type:** [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)`<`[`RolldownOptions`](https://rolldown.rs/reference/), `'input' | 'logLevel' | 'output'> & {
-  output?: [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)`<`
-    [`RolldownOutputOptions`](https://rolldown.rs/reference/),
-    `'format' | 'sourcemap' | 'dir' | 'banner'>`
-`}`
+- **Type:** <code>Omit<<a href="https://rolldown.rs/reference/">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
 
 Options to pass to Rolldown during the dep scanning and optimization.
 
@@ -67,17 +63,7 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 ## optimizeDeps.esbuildOptions <NonInheritBadge />
 
-- **Type:** [`Omit`](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys)`<`[`EsbuildBuildOptions`](https://esbuild.github.io/api/#general-options)`,
-| 'bundle'
-| 'entryPoints'
-| 'external'
-| 'write'
-| 'watch'
-| 'outdir'
-| 'outfile'
-| 'outbase'
-| 'outExtension'
-| 'metafile'>`
+- **Type:** <code>Omit<<a href="https://esbuild.github.io/api/#general-options">EsbuildBuildOptions</a>, 'bundle' | 'entryPoints' | 'external' | 'write' | 'watch' | 'outdir' | 'outfile' | 'outbase' | 'outExtension' | 'metafile'></code>
 - **Deprecated**
 
 This option is converted to `optimizeDeps.rolldownOptions` internally. Use `optimizeDeps.rolldownOptions` instead.

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -53,7 +53,7 @@ export default defineConfig({
 
 ## optimizeDeps.rolldownOptions <NonInheritBadge />
 
-- **Type:** <code>Omit<<a href="https://rolldown.rs/reference/">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
+- **Type:** <code>Omit<<a href="https://rolldown.rs/reference/Interface.RolldownOptions">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/#:~:text=Output%20Options">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
 
 Options to pass to Rolldown during the dep scanning and optimization.
 
@@ -63,7 +63,7 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 ## optimizeDeps.esbuildOptions <NonInheritBadge />
 
-- **Type:** <code>Omit<<a href="https://esbuild.github.io/api/#general-options">EsbuildBuildOptions</a>, 'bundle' | 'entryPoints' | 'external' | 'write' | 'watch' | 'outdir' | 'outfile' | 'outbase' | 'outExtension' | 'metafile'></code>
+- **Type:** <code>Omit<<a href="https://rolldown.rs/reference/Interface.RolldownOptions">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/#:~:text=Output%20Options">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
 - **Deprecated**
 
 This option is converted to `optimizeDeps.rolldownOptions` internally. Use `optimizeDeps.rolldownOptions` instead.

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -63,7 +63,7 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 ## optimizeDeps.esbuildOptions <NonInheritBadge />
 
-- **Type:** <code>Omit<<a href="https://rolldown.rs/reference/Interface.RolldownOptions">RolldownOptions</a>, 'input' | 'logLevel' | 'output'> & { output?: Omit<<a href="https://rolldown.rs/reference/#:~:text=Output%20Options">RolldownOutputOptions</a>, 'format' | 'sourcemap' | 'dir' | 'banner'> }</code>
+- **Type:** <code>Omit<<a href="https://esbuild.github.io/api/#general-options">EsbuildBuildOptions</a>, 'bundle' | 'entryPoints' | 'external' | 'write' | 'watch' | 'outdir' | 'outfile' | 'outbase' | 'outExtension' | 'metafile'></code>
 - **Deprecated**
 
 This option is converted to `optimizeDeps.rolldownOptions` internally. Use `optimizeDeps.rolldownOptions` instead.


### PR DESCRIPTION
Currently they look a bit weird, https://main.vite.dev/config/dep-optimization-options#optimizedeps-rolldownoptions:

<img width="740" height="183" alt="image" src="https://github.com/user-attachments/assets/e28a6421-f1fa-4775-ae2c-f31fa6b31eae" />

<img width="700" height="155" alt="image" src="https://github.com/user-attachments/assets/ccbba74e-51d2-4062-9bc1-3b63edb04123" />

This PR fixes it:

<img width="686" height="123" alt="image" src="https://github.com/user-attachments/assets/695f4d24-ca19-4f12-b313-2501b86e6688" />

<img width="624" height="152" alt="image" src="https://github.com/user-attachments/assets/9be7c01e-981d-4f2f-979a-279b6152e5fe" />


---

~~I've updated the `esbuildOptions` to use the same type as `rolldownOptions` as that's what it is [internally](https://github.com/vitejs/vite/blob/d1bcc91becf737cf8a36fe2202e14dadfb9e9a63/packages/vite/src/node/optimizer/index.ts#L105-L127) now. Not sure if it's intended to reference the old type.~~

I also removed the link to `Omit` since I think it's not necessary to link typescript builtins, and we have other types not linking it as well. Happy to revert that if we feel otherwise.