### PR TITLE
fix(create-vite): add `@babel/core` and `@types/babel__core` for react compiler template

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -788,7 +788,9 @@ function setupReactCompiler(root: string, isTs: boolean) {
       `^${reactCompilerPluginVersion}`,
     ])
     devDepsEntries.push(['@babel/core', `^${babelCoreVersion}`])
-    devDepsEntries.push(['@types/babel__core', `^${typesBabelCoreVersion}`])
+    if (isTs) {
+      devDepsEntries.push(['@types/babel__core', `^${typesBabelCoreVersion}`])
+    }
     devDepsEntries.sort()
     asObject.devDependencies = Object.fromEntries(devDepsEntries)
     return JSON.stringify(asObject, null, 2) + '\n'

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -775,9 +775,9 @@ function setupReactCompiler(root: string, isTs: boolean) {
   // renovate: datasource=npm depName=babel-plugin-react-compiler
   const reactCompilerPluginVersion = '1.0.0'
   // renovate: datasource=npm depName=@babel/core
-  const babelCoreVersion = '^7.29.0'
+  const babelCoreVersion = '7.29.0'
   // renovate: datasource=npm depName=@types/babel__core
-  const typesBabelCoreVersion = '^7.20.5'
+  const typesBabelCoreVersion = '7.20.5'
 
   editFile(path.resolve(root, 'package.json'), (content) => {
     const asObject = JSON.parse(content)

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -774,6 +774,10 @@ function setupReactCompiler(root: string, isTs: boolean) {
   const babelPluginVersion = '0.2.0'
   // renovate: datasource=npm depName=babel-plugin-react-compiler
   const reactCompilerPluginVersion = '1.0.0'
+  // renovate: datasource=npm depName=@babel/core
+  const babelCoreVersion = '^7.29.0'
+  // renovate: datasource=npm depName=@types/babel__core
+  const typesBabelCoreVersion = '^7.20.5'
 
   editFile(path.resolve(root, 'package.json'), (content) => {
     const asObject = JSON.parse(content)
@@ -783,6 +787,8 @@ function setupReactCompiler(root: string, isTs: boolean) {
       'babel-plugin-react-compiler',
       `^${reactCompilerPluginVersion}`,
     ])
+    devDepsEntries.push(['@babel/core', `^${babelCoreVersion}`])
+    devDepsEntries.push(['@types/babel__core', `^${typesBabelCoreVersion}`])
     devDepsEntries.sort()
     asObject.devDependencies = Object.fromEntries(devDepsEntries)
     return JSON.stringify(asObject, null, 2) + '\n'


### PR DESCRIPTION
`@rolldown/plugin-babel` has `@babel/core` as a peer dep, so it needs to be added. Also `@types/babel__core` is needed for babel 7 so that the type error doesn't happen.