### PR TITLE
fix(ssr): use proxyModuleUrl instead of proxyModulePath for CSS proxy URLs (fix #21836)

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -377,7 +377,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
   await Promise.all([
     ...styleUrl.map(async ({ start, end, code }, index) => {
-      const url = `${proxyModulePath}?html-proxy&direct&index=${index}.css`
+      const url = `${proxyModuleUrl}?html-proxy&direct&index=${index}.css`
 
       // ensure module in graph after successful load
       const mod =
@@ -405,7 +405,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     }),
     ...inlineStyles.map(async ({ index, location, code }) => {
       // will transform with css plugin and cache result with css-post plugin
-      const url = `${proxyModulePath}?html-proxy&inline-css&style-attr&index=${index}.css`
+      const url = `${proxyModuleUrl}?html-proxy&inline-css&style-attr&index=${index}.css`
 
       const mod =
         await server!.environments.client.moduleGraph.ensureEntryFromUrl(

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -41,6 +41,22 @@ describe.runIf(isServe)('injected inline scripts', () => {
       expect(code).toBeTruthy()
     }
   })
+
+  test('CSS in SSR transformIndexHtml works without errors', async () => {
+    // Verify page loads successfully (would throw error in Vite 8.0.0 with bug)
+    // The server includes both inline styles via DYNAMIC_STYLES and calls
+    // vite.transformIndexHtml('/'), which processes CSS proxy URLs
+    const response = await page.goto(url)
+    expect(response?.status()).toBe(200)
+    
+    // Verify styles are applied
+    const bgColor = await page.evaluate(() => {
+      const h1 = document.querySelector('h1')
+      return h1 ? window.getComputedStyle(h1).backgroundColor : null
+    })
+    // Style is applied (exact color varies by browser, but should not be default)
+    expect(bgColor).toBeTruthy()
+  })
 })
 
 describe.runIf(isServe)('hmr', () => {


### PR DESCRIPTION
Fixes #21836

When using vite.transformIndexHtml() for SSR, virtual HTML files have proxyModulePath starting with backslash-zero (Vite's virtual file marker). Using this directly in URL construction creates invalid query strings.

This causes the error:
\\\
Error: The specifiers must be a non-empty string. Received question-mark-html-proxy-and-direct-and-index=0-dot-css
\\\

The fix uses proxyModuleUrl instead, which is properly formatted with the base path and correctly handles virtual file paths. This restores the behavior from Vite 7.3.1.