### PR TITLE
fix(create-vue): add `lang="ts"` to vue files to fix type errors in vue-ts template

### DIFF
--- a/packages/create-vite/template-vue-ts/src/App.vue
+++ b/packages/create-vite/template-vue-ts/src/App.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import HelloWorld from './components/HelloWorld.vue'
 </script>
 

--- a/packages/create-vite/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-vite/template-vue-ts/src/components/HelloWorld.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 import viteLogo from '../assets/vite.svg'
 import heroImg from '../assets/hero.png'


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

Fix: Build Failure After Creating a Vue + TypeScript Project with `bun create vite` (with vite v8.0.0):
```
src/main.ts:3:17 - error TS7016: Could not find a declaration file for module './App.vue'. '/path/to/project/src/App.vue' implicitly has an 'any' type.

3 import App from './App.vue'
                  ~~~~~~~~~~~


Found 1 error.
```