### PR TITLE
docs(releases): update v7 latest minor

### DIFF
--- a/docs/.vitepress/theme/components/SupportedVersions.vue
+++ b/docs/.vitepress/theme/components/SupportedVersions.vue
@@ -18,6 +18,7 @@ const previousMajorLatestMinors: Record<string, string> = {
   '4': '4.5',
   '5': '5.4',
   '6': '6.4',
+  '7': '7.3',
 }
 
 // Current latest Vite version and support info


### PR DESCRIPTION
Right now at https://vite.dev/releases#supported-versions second bullet point, it shows `vite@7` and not `vite@7.3` (the latest minor), which can be vague:

<img width="661" height="273" alt="image" src="https://github.com/user-attachments/assets/97d6611a-27f7-4e65-abc0-a6d995b9a791" />

This PR adds the latest minor data for v7 to fix it. This isn't scalable but I guess it's the simplest 😄 