### PR TITLE
fix(build): handle commented dynamic import vars (fix #21855)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -1,5 +1,8 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { rolldown } from 'rolldown'
 import {
   dynamicImportVarsPlugin,
   transformDynamicImport,
@@ -43,6 +46,36 @@ async function createPluginTransform() {
       normalizePath(resolve(dirname, 'index.js')),
     )
     return result?.code || result
+  }
+}
+
+async function bundleWithNativePlugin(code: string) {
+  const root = await mkdtemp(resolve(tmpdir(), 'vite-dynamic-import-vars-'))
+
+  try {
+    const entry = resolve(root, 'entry.js')
+    const modsDir = resolve(root, 'mods')
+    await mkdir(modsDir)
+    await writeFile(entry, code)
+    await writeFile(resolve(modsDir, 'hello.js'), 'export default "hello"\n')
+    await writeFile(resolve(modsDir, 'hi.js'), 'export default "hi"\n')
+
+    const config = await resolveConfig({ configFile: false, root }, 'build')
+    const instance = dynamicImportVarsPlugin(config)
+    const environment = new PartialEnvironment('client', config)
+    // @ts-expect-error applyToEnvironment exists on per-environment plugins
+    const nativePlugin = await instance.applyToEnvironment(environment)
+    const bundler = await rolldown({
+      input: entry,
+      plugins: [nativePlugin],
+      experimental: {
+        attachDebugInfo: 'none',
+      },
+    })
+
+    return await bundler.generate()
+  } finally {
+    await rm(root, { force: true, recursive: true })
   }
 }
 
@@ -106,5 +139,19 @@ describe('dynamicImportVarsPlugin', async () => {
 
     expect(result).toContain('__variableDynamicImportRuntimeHelper')
     expect(result).toContain('import.meta.glob("./mods/*.js")')
+  })
+
+  it('transforms bundled template literal imports with leading comments', async () => {
+    const output = await bundleWithNativePlugin(
+      'export async function load(base) { return import(/* strings */ `./mods/${base}.js`) }',
+    )
+    const chunks = output.output.filter((item) => item.type === 'chunk')
+    const entryChunk = chunks.find((item) => item.isEntry)
+
+    expect(entryChunk?.code).toContain('import.meta.glob("./mods/*.js")')
+    expect(entryChunk?.code).toContain('`./mods/${base}.js`')
+    expect(entryChunk?.code).not.toContain(
+      'import(/* strings */ `./mods/${base}.js`)',
+    )
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -1,8 +1,13 @@
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { transformDynamicImport } from '../../../plugins/dynamicImportVars'
+import {
+  dynamicImportVarsPlugin,
+  transformDynamicImport,
+} from '../../../plugins/dynamicImportVars'
 import { normalizePath } from '../../../utils'
 import { isWindows } from '../../../../shared/utils'
+import { resolveConfig } from '../../../config'
+import { PartialEnvironment } from '../../../baseEnvironment'
 
 const dirname = import.meta.dirname
 
@@ -18,6 +23,27 @@ async function run(input: string) {
       dirname,
     )) || {}
   return `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`)`
+}
+
+async function createPluginTransform() {
+  const config = await resolveConfig({ configFile: false }, 'serve')
+  const instance = dynamicImportVarsPlugin(config)
+  const environment = new PartialEnvironment('client', config)
+
+  return async (code: string) => {
+    // @ts-expect-error transform.handler should exist
+    const result = await instance.transform.handler.call(
+      {
+        environment,
+        warn() {
+          return undefined
+        },
+      },
+      code,
+      normalizePath(resolve(dirname, 'index.js')),
+    )
+    return result?.code || result
+  }
 }
 
 describe('parse positives', () => {
@@ -67,5 +93,18 @@ describe('parse positives', () => {
     expect(
       await run('`../../plugins/dynamicImportVar/${name}.js`'),
     ).toMatchSnapshot()
+  })
+})
+
+describe('dynamicImportVarsPlugin', async () => {
+  const transform = await createPluginTransform()
+
+  it('transforms template literal imports with leading comments', async () => {
+    const result = await transform(
+      'const strings = await import(/* strings */ `./mods/${base}.js`)',
+    )
+
+    expect(result).toContain('__variableDynamicImportRuntimeHelper')
+    expect(result).toContain('import.meta.glob("./mods/*.js")')
   })
 })

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -43,6 +43,19 @@ interface DynamicImportPattern {
   rawPattern: string
 }
 
+function toWarningMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const { message } = error
+    if (typeof message === 'string') {
+      return message
+    }
+  }
+  return String(error)
+}
+
 const dynamicImportHelper = (
   glob: Record<string, any>,
   path: string,
@@ -166,6 +179,82 @@ export async function transformDynamicImport(
   }
 }
 
+async function transformDynamicImportVars(
+  source: string,
+  importer: string,
+  resolve: (
+    url: string,
+    importer?: string,
+  ) => Promise<string | undefined> | string | undefined,
+  config: ResolvedConfig,
+  warn: (warning: string) => void,
+) {
+  await init
+
+  let imports: readonly ImportSpecifier[] = []
+  try {
+    imports = parseImports(source)[0]
+  } catch {
+    // ignore as it might not be a JS file, the subsequent plugins will catch the error
+    return null
+  }
+
+  if (!imports.length) {
+    return null
+  }
+
+  let s: MagicString | undefined
+  let needDynamicImportHelper = false
+
+  for (let index = 0; index < imports.length; index++) {
+    const { s: start, e: end, ss: expStart, se: expEnd, d: dynamicIndex } =
+      imports[index]
+
+    if (dynamicIndex === -1 || source[start] !== '`') {
+      continue
+    }
+
+    if (hasViteIgnoreRE.test(source.slice(expStart, expEnd))) {
+      continue
+    }
+
+    s ||= new MagicString(source)
+    let result
+    try {
+      result = await transformDynamicImport(
+        source.slice(start, end),
+        importer,
+        resolve,
+        config.root,
+      )
+    } catch (error) {
+      warn(toWarningMessage(error))
+    }
+
+    if (!result) {
+      continue
+    }
+
+    const { rawPattern, glob } = result
+
+    needDynamicImportHelper = true
+    s.overwrite(
+      expStart,
+      expEnd,
+      `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`, ${rawPattern.split('/').length})`,
+    )
+  }
+
+  if (s) {
+    if (needDynamicImportHelper) {
+      s.prepend(
+        `import __variableDynamicImportRuntimeHelper from "${dynamicImportHelperId}";`,
+      )
+    }
+    return transformStableResult(s, importer, config)
+  }
+}
+
 export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
   const resolve = createBackCompatIdResolver(config, {
     preferRelative: true,
@@ -218,80 +307,16 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
         code: hasDynamicImportRE,
       },
       async handler(source, importer) {
-        const { environment } = this
         if (!getFilter(this)(importer)) {
           return
         }
-
-        await init
-
-        let imports: readonly ImportSpecifier[] = []
-        try {
-          imports = parseImports(source)[0]
-        } catch {
-          // ignore as it might not be a JS file, the subsequent plugins will catch the error
-          return null
-        }
-
-        if (!imports.length) {
-          return null
-        }
-
-        let s: MagicString | undefined
-        let needDynamicImportHelper = false
-
-        for (let index = 0; index < imports.length; index++) {
-          const {
-            s: start,
-            e: end,
-            ss: expStart,
-            se: expEnd,
-            d: dynamicIndex,
-          } = imports[index]
-
-          if (dynamicIndex === -1 || source[start] !== '`') {
-            continue
-          }
-
-          if (hasViteIgnoreRE.test(source.slice(expStart, expEnd))) {
-            continue
-          }
-
-          s ||= new MagicString(source)
-          let result
-          try {
-            result = await transformDynamicImport(
-              source.slice(start, end),
-              importer,
-              (id, importer) => resolve(environment, id, importer),
-              config.root,
-            )
-          } catch (error) {
-            this.warn(error)
-          }
-
-          if (!result) {
-            continue
-          }
-
-          const { rawPattern, glob } = result
-
-          needDynamicImportHelper = true
-          s.overwrite(
-            expStart,
-            expEnd,
-            `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`, ${rawPattern.split('/').length})`,
-          )
-        }
-
-        if (s) {
-          if (needDynamicImportHelper) {
-            s.prepend(
-              `import __variableDynamicImportRuntimeHelper from "${dynamicImportHelperId}";`,
-            )
-          }
-          return transformStableResult(s, importer, config)
-        }
+        return transformDynamicImportVars(
+          source,
+          importer,
+          (id, importer) => resolve(this.environment, id, importer),
+          config,
+          (error) => this.warn(error),
+        )
       },
     },
   }

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -43,6 +43,15 @@ interface DynamicImportPattern {
   rawPattern: string
 }
 
+function hasCommentsBetweenImportAndSource(
+  source: string,
+  expStart: number,
+  start: number,
+): boolean {
+  const between = source.slice(expStart, start)
+  return between.includes('/*') || between.includes('//')
+}
+
 function toWarningMessage(error: unknown): string {
   if (typeof error === 'string') {
     return error
@@ -188,6 +197,7 @@ async function transformDynamicImportVars(
   ) => Promise<string | undefined> | string | undefined,
   config: ResolvedConfig,
   warn: (warning: string) => void,
+  onlyIfCommented = false,
 ) {
   await init
 
@@ -215,6 +225,13 @@ async function transformDynamicImportVars(
     }
 
     if (hasViteIgnoreRE.test(source.slice(expStart, expEnd))) {
+      continue
+    }
+
+    if (
+      onlyIfCommented &&
+      !hasCommentsBetweenImportAndSource(source, expStart, start)
+    ) {
       continue
     }
 
@@ -267,14 +284,48 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
       const { include, exclude } =
         environment.config.build.dynamicImportVarsOptions
 
-      return nativeDynamicImportVarsPlugin({
-        include,
-        exclude,
-        resolver(id, importer) {
-          return resolve(environment, id, importer)
+      return [
+        {
+          name: 'vite:dynamic-import-vars-comment-fallback',
+          enforce: 'pre',
+          resolveId: {
+            filter: { id: exactRegex(dynamicImportHelperId) },
+            handler(id) {
+              return id
+            },
+          },
+          load: {
+            filter: { id: exactRegex(dynamicImportHelperId) },
+            handler() {
+              return `export default ${dynamicImportHelper.toString()}`
+            },
+          },
+          transform: {
+            filter: {
+              id: { exclude: exactRegex(CLIENT_ENTRY) },
+              code: hasDynamicImportRE,
+            },
+            handler(source, importer) {
+              return transformDynamicImportVars(
+                source,
+                importer,
+                (id, importer) => resolve(environment, id, importer),
+                config,
+                (error) => this.warn(error),
+                true,
+              )
+            },
+          },
         },
-        sourcemap: !!environment.config.build.sourcemap,
-      })
+        nativeDynamicImportVarsPlugin({
+          include,
+          exclude,
+          resolver(id, importer) {
+            return resolve(environment, id, importer)
+          },
+          sourcemap: !!environment.config.build.sourcemap,
+        }),
+      ]
     })
   }
 


### PR DESCRIPTION
 ## Summary

  This PR fixes #21855.

  Bundled builds were leaving dynamic imports untransformed when a comment appeared between `import(` and the template literal source, for example:

  ```js
  await import(/* strings */ `./translations/${locale}/strings.json`)
```

  The dev transform path already handled this, but the bundled/native path did not.

  ## Changes

  - extracted the shared dynamic import vars transform flow into a helper
  - narrowed warning handling so the shared helper no longer passes unknown into this.warn
  - added a build-only fallback before the native Rolldown dynamic import vars plugin
  - limited that fallback to commented template literal imports only
  - added regression coverage for:
      - the dev transform path
      - the bundled/native transform path

  ## Notes

  I kept the native Rolldown plugin in place and only added a narrow pre-transform fallback for the commented cases. That keeps the fix scoped to the
  regression without changing the normal bundled path.

  ## Testing

  - pnpm exec eslint packages/vite/src/node/plugins/dynamicImportVars.ts packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
  - pnpm exec tsc -p packages/vite/src/node/tsconfig.json --noEmit
  - pnpm --filter ./packages/vite run build
  - pnpm exec vitest run packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts