### PR TITLE
fix: skip watching non-existent public directory

### DIFF
--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -53,4 +53,17 @@ describe('watcher configuration', () => {
       )
     })
   })
+
+  it('should not watch a non-existent public directory', async () => {
+    const root = fileURLToPath(
+      new URL('./fixtures/watcher/nested-root', import.meta.url),
+    )
+    const nonExistentPublicDir = resolve(root, '../non-existent-public')
+    server = await createServer({ root, publicDir: nonExistentPublicDir })
+    await new Promise((resolve) => server!.watcher.once('ready', resolve))
+    await vi.waitFor(() => {
+      const watchedDirs = Object.keys(server!.watcher.getWatched())
+      expect(watchedDirs).not.toContain(nonExistentPublicDir)
+    })
+  })
 })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -548,7 +548,7 @@ export async function _createServer(
           ...getEnvFilesForMode(config.mode, config.envDir),
           // Watch the public directory explicitly because it might be outside
           // of the root directory.
-          ...(publicDir && publicFiles ? [publicDir] : []),
+          ...(publicDir && publicFiles?.size ? [publicDir] : []),
         ],
 
         resolvedWatchOptions,


### PR DESCRIPTION
When publicDir is configured but the directory does not exist, initPublicFiles returns an empty Set (truthy), causing the non-existent path to be added to chokidar's watch list. This silently breaks HMR as chokidar fails to detect file changes.

Check publicFiles.size instead of just publicFiles to ensure only existing, non-empty public directories are watched.

Fixes #19864

## What does this PR solve?

Fixes a bug where Hot Module Replacement (HMR) silently breaks when `publicDir` is configured in `vite.config.js` but the specified directory does not exist on disk.

## Why was this approach chosen?

The root cause was in the file watcher setup in `packages/vite/src/node/server/index.ts`. When `publicDir` is configured but doesn't exist:

1. `initPublicFiles()` calls `recursiveReaddir()` which returns `[]` for non-existent directories
2. This creates an empty `Set` (`publicFiles = new Set([])`)
3. Empty Sets are truthy in JavaScript, so the condition `publicDir && publicFiles` evaluates to `true`
4. The non-existent path gets added to chokidar's watch list, silently breaking HMR

The fix checks `publicFiles?.size` instead of just `publicFiles` to ensure only existing, non-empty public directories are watched.

## Testing

- Added a unit test that verifies non-existent public directories are not added to the watcher
- All existing tests continue to pass (727 tests across 53 files)
- Lint passes with no issues

**Fixes #19864**
