### PR TITLE
fix(bundled-dev): properly disable `inlineConst` optimization

### DIFF
--- a/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
+++ b/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
@@ -283,10 +283,10 @@ export class FullBundleDevEnvironment extends DevEnvironment {
       implement: await getHmrImplementation(this.getTopLevelConfig()),
     }
 
-    if (rolldownOptions.optimization) {
-      // disable inlineConst optimization due to a bug in Rolldown
-      rolldownOptions.optimization.inlineConst = false
-    }
+    // disable inlineConst optimization due to a bug in Rolldown
+    // https://github.com/vitejs/vite/issues/21843
+    rolldownOptions.optimization ??= {}
+    rolldownOptions.optimization.inlineConst = false
 
     // set filenames to make output paths predictable so that `renderChunk` hook does not need to be used
     if (Array.isArray(rolldownOptions.output)) {


### PR DESCRIPTION
## Summary

- Always disable rolldown's `inlineConst` optimization in bundledDev mode, regardless of whether the user has configured `optimization` options
- Previously, the guard `if (rolldownOptions.optimization)` was falsy in the default case, so `inlineConst` ran unchecked and incorrectly replaced JSX factory references with `(void 0)` in conditional expressions (`&&`, `?:`)

Fixes #21843

## Test plan

- [x] All 726 existing unit tests pass
- [ ] Verify with the [reproduction repo](https://github.com/0rvar/vite-bundled-dev-void0-repro) that `jsxDEV` is no longer replaced with `(void 0)` in conditional expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)