### PR TITLE
chore: remove `rolldown-vite` issue link from issue create modal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Rolldown-Vite & Vite 8 beta Issues
-    url: https://github.com/vitejs/rolldown-vite/issues/new/choose
-    about: Rolldown-Vite related issues should be reported on the rolldown-vite repository.
   - name: Vite Plugin React Issues
     url: https://github.com/vitejs/vite-plugin-react/issues/new/choose
     about: React related issues should be reported on the vite-plugin-react repository.


### PR DESCRIPTION
Removes this:
<img width="993" height="750" alt="image" src="https://github.com/user-attachments/assets/68c70620-8d1a-45ab-bf93-25a739d34caf" />
