### PR TITLE
fix: always strip trailing slash from alias replacement

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1460,12 +1460,10 @@ function normalizeSingleAlias({
   replacement,
   customResolver,
 }: Alias): Alias {
-  if (
-    typeof find === 'string' &&
-    find.endsWith('/') &&
-    replacement.endsWith('/')
-  ) {
-    find = find.slice(0, find.length - 1)
+  if (typeof find === 'string' && replacement.endsWith('/')) {
+    if (find.endsWith('/')) {
+      find = find.slice(0, find.length - 1)
+    }
     replacement = replacement.slice(0, replacement.length - 1)
   }
 

--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -57,3 +57,9 @@ test('custom resolver', async () => {
     '[success] alias to custom-resolver path',
   )
 })
+
+test('trailing slash on replacement', async () => {
+  expect(await page.textContent('.trailing-slash')).toMatch(
+    '[success] alias with trailing slash',
+  )
+})

--- a/playground/alias/dir/trailing-slash.js
+++ b/playground/alias/dir/trailing-slash.js
@@ -1,0 +1,1 @@
+export const msg = `[success] alias with trailing slash`

--- a/playground/alias/index.html
+++ b/playground/alias/index.html
@@ -8,6 +8,7 @@
 <p class="url-conflict"></p>
 <p class="aliased-module"></p>
 <p class="custom-resolver"></p>
+<p class="trailing-slash"></p>
 
 <div class="optimized"></div>
 
@@ -20,6 +21,7 @@
   import { msg as moduleMsg } from 'aliased-module/index.js'
   import { msg as urlConflictMsg } from '//url_conflict.js'
   import { msg as customResolverMsg } from 'custom-resolver'
+  import { msg as trailingSlashMsg } from '#dir/trailing-slash'
 
   function text(el, text) {
     document.querySelector(el).textContent = text
@@ -32,6 +34,7 @@
   text('.aliased-module', moduleMsg)
   text('.url-conflict', urlConflictMsg)
   text('.custom-resolver', customResolverMsg)
+  text('.trailing-slash', trailingSlashMsg)
 
   import { createApp } from 'vue'
   import { ref } from 'foo'

--- a/playground/alias/vite.config.js
+++ b/playground/alias/vite.config.js
@@ -33,6 +33,11 @@ export default defineConfig({
           return id.replace('test.js', 'customResolver.js')
         },
       },
+      // trailing slash on replacement only (directory alias without trailing slash on find)
+      {
+        find: '#dir',
+        replacement: path.resolve(import.meta.dirname, 'dir') + '/',
+      },
     ],
   },
   build: {


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

spotted in https://github.com/nuxt/nuxt/actions/runs/23111442844/job/67147979460
related: https://github.com/nuxt/nuxt/pull/34594

this PR strips the trailing slash from alias `replacement` when `find` is a string, even if `find` itself doesn't end with a trailing slash (previously this only happened when both `find` and `replacement` ended with a trailing slash)

the issue is that, when only `replacement` has a trailing slash, the alias plugin's string replacement can produce double-slash paths (e.g. `#build/foo` → `/path/.nuxt//foo`), which are not normalized by rolldown's native resolver

in most cases that's probably fine, but in Nuxt's case, these are virtual files which don't match the expected pattern.