### PR TITLE
test: remove stale resolve sniffing test

### DIFF
--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -101,12 +101,6 @@ test("don't add extension to directory name (./dir-with-ext.js/index.js)", async
   expect(await page.textContent('.dir-with-ext')).toMatch('[success]')
 })
 
-test('do not resolve to the `module` field if the importer is a `require` call', async () => {
-  expect(await page.textContent('.require-pkg-with-module-field')).toMatch(
-    '[success]',
-  )
-})
-
 test('a ts module can import another ts module using its corresponding js file name', async () => {
   expect(await page.textContent('.ts-extension')).toMatch('[success]')
 })

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -140,9 +140,6 @@
 <h2>Resolve browser field even if module field exists</h2>
 <p class="browser-module1">fail</p>
 
-<h2>Don't resolve to the `module` field if the importer is a `require` call</h2>
-<p class="require-pkg-with-module-field">fail</p>
-
 <h2>CSS Entry</h2>
 <p class="css"></p>
 
@@ -361,9 +358,6 @@
 
   import browserModule1 from '@vitejs/test-resolve-browser-module-field1'
   text('.browser-module1', browserModule1)
-
-  import { msg as requireButWithModuleFieldMsg } from '@vitejs/test-require-pkg-with-module-field'
-  text('.require-pkg-with-module-field', requireButWithModuleFieldMsg)
 
   import { msg as customExtMsg } from './custom-ext'
   text('.custom-ext', customExtMsg)

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@babel/runtime": "^7.28.6",
     "normalize.css": "^8.0.1",
-    "@vitejs/test-require-pkg-with-module-field": "link:./require-pkg-with-module-field",
     "@vitejs/test-resolve-browser-field": "link:./browser-field",
     "@vitejs/test-resolve-browser-module-field1": "link:./browser-module-field1",
     "@vitejs/test-resolve-custom-condition": "link:./custom-condition",

--- a/playground/resolve/require-pkg-with-module-field/dep.cjs
+++ b/playground/resolve/require-pkg-with-module-field/dep.cjs
@@ -1,5 +1,0 @@
-const BigNumber = require('bignumber.js')
-
-const x = new BigNumber('1111222233334444555566')
-
-module.exports = x.toString()

--- a/playground/resolve/require-pkg-with-module-field/index.cjs
+++ b/playground/resolve/require-pkg-with-module-field/index.cjs
@@ -1,8 +1,0 @@
-const dep = require('./dep.cjs')
-
-const msg =
-  dep === '1.111222233334444555566e+21'
-    ? '[success] require-pkg-with-module-field'
-    : '[failed] require-pkg-with-module-field'
-
-exports.msg = msg

--- a/playground/resolve/require-pkg-with-module-field/package.json
+++ b/playground/resolve/require-pkg-with-module-field/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "@vitejs/test-require-pkg-with-module-field",
-  "private": true,
-  "version": "1.0.0",
-  "main": "./index.cjs",
-  "dependencies": {
-    "bignumber.js": "9.3.1"
-  }
-}

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -161,7 +161,6 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@vitejs/test-resolve-exports-with-module-condition-required',
-      '@vitejs/test-require-pkg-with-module-field',
       '@vitejs/test-resolve-sharp-dir',
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1329,9 +1329,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.28.6
         version: 7.28.6
-      '@vitejs/test-require-pkg-with-module-field':
-        specifier: link:./require-pkg-with-module-field
-        version: link:require-pkg-with-module-field
       '@vitejs/test-resolve-browser-field':
         specifier: link:./browser-field
         version: link:browser-field
@@ -1447,12 +1444,6 @@ importers:
   playground/resolve/imports-path/other-pkg: {}
 
   playground/resolve/inline-package: {}
-
-  playground/resolve/require-pkg-with-module-field:
-    dependencies:
-      bignumber.js:
-        specifier: 9.3.1
-        version: 9.3.1
 
   playground/resolve/sharp-dir:
     dependencies:
@@ -4710,9 +4701,6 @@ packages:
     resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -10817,8 +10805,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.0: {}
-
-  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 


### PR DESCRIPTION
This test was added by #7438, #7582, #7737. But the related behavior was removed in v8 and we don't need this test any more.
https://v8.vite.dev/guide/migration#removed-module-resolution-using-format-sniffing
