### PR TITLE
docs: add experimentalMinChunkSize to migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -304,7 +304,7 @@ The object form `output.manualChunks` option is not supported anymore. The funct
 
 ### Removed `build.rollupOptions.output.experimentalMinChunkSize` option
 
-The `build.rollupOptions.output.experimentalMinChunkSize` option was removed. Rolldown has the [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option with `groups` and `minSize`, but note that `minSize` only takes effect when `groups` are defined. See Rolldown's docs for more details: [Manual Code Splitting - Rolldown](https://rolldown.rs/in-depth/manual-code-splitting).
+The `build.rollupOptions.output.experimentalMinChunkSize` option was removed as there is no direct equivalent in Rolldown. See the [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option for Rolldown's approach to controlling chunk splitting.
 
 ### `build()` Throws `BundleError`
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -302,6 +302,10 @@ The `build.rollupOptions.watch.chokidar` option was removed. Please migrate to t
 
 The object form `output.manualChunks` option is not supported anymore. The function form `output.manualChunks` is deprecated. Rolldown has the more flexible [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option. See Rolldown's docs for more details about `codeSplitting`: [Manual Code Splitting - Rolldown](https://rolldown.rs/in-depth/manual-code-splitting).
 
+### Removed `build.rollupOptions.output.experimentalMinChunkSize` option
+
+The `build.rollupOptions.output.experimentalMinChunkSize` option was removed. Please migrate to the [`build.rolldownOptions.output.codeSplitting.minSize`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option.
+
 ### `build()` Throws `BundleError`
 
 _This change only affects JS API users._

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -304,7 +304,7 @@ The object form `output.manualChunks` option is not supported anymore. The funct
 
 ### Removed `build.rollupOptions.output.experimentalMinChunkSize` option
 
-The `build.rollupOptions.output.experimentalMinChunkSize` option was removed. Please migrate to the [`build.rolldownOptions.output.codeSplitting.minSize`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option.
+The `build.rollupOptions.output.experimentalMinChunkSize` option was removed. Rolldown has the [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option with `groups` and `minSize`, but note that `minSize` only takes effect when `groups` are defined. See Rolldown's docs for more details: [Manual Code Splitting - Rolldown](https://rolldown.rs/in-depth/manual-code-splitting).
 
 ### `build()` Throws `BundleError`
 


### PR DESCRIPTION
This is a docs-only change with no runtime impact.

## Summary

Add `build.rollupOptions.output.experimentalMinChunkSize` to the v7 → v8 migration guide, noting its removal and that there is no direct equivalent in Rolldown. Points to the `codeSplitting` option as the general area for controlling chunk splitting.

Placed after the `manualChunks` section, as both are Rollup `output` → Rolldown `codeSplitting` migrations.

## What I confirmed

- [x] `pnpm run docs-build` passes
- [x] The new section renders correctly in the built docs
- [x] The link to the Rolldown `codeSplitting` API reference resolves correctly
- [x] `codeSplitting.minSize` without `groups` has no effect (Rolldown emits a warning)
- [x] `codeSplitting` with `groups` is not a direct 1:1 replacement for `experimentalMinChunkSize`

Fixes #21844