### PR TITLE
docs: fix typo in worker-options.md

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -20,7 +20,7 @@ The function should return new plugin instances as they are used in parallel rol
 
 - **Type:** [`RolldownOptions`](https://rolldown.rs/reference/)
 
-Rollup options to build worker bundle.
+Rolldown options to build worker bundle.
 
 ## worker.rollupOptions
 


### PR DESCRIPTION
docs: In the description of the worker.rolldownOptions configuration item, Rollup should be changed to Rolldown.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
