### PR TITLE
fix: respect server.cors config in no-cors request rejection

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -923,7 +923,7 @@ export async function _createServer(
   }
 
   middlewares.use(rejectInvalidRequestMiddleware())
-  middlewares.use(rejectNoCorsRequestMiddleware())
+  middlewares.use(rejectNoCorsRequestMiddleware(serverConfig.cors ?? false))
 
   // cors
   const { cors } = serverConfig

--- a/packages/vite/src/node/server/middlewares/rejectNoCorsRequest.ts
+++ b/packages/vite/src/node/server/middlewares/rejectNoCorsRequest.ts
@@ -1,4 +1,5 @@
 import type { Connect } from '#dep-types/connect'
+import type { CorsOptions } from '../../http'
 
 /**
  * A middleware that rejects no-cors mode requests that are not same-origin.
@@ -14,7 +15,9 @@ import type { Connect } from '#dep-types/connect'
  * https://green.sapphi.red/blog/local-server-security-best-practices#_2-using-xssi-and-modifying-the-prototype
  * https://green.sapphi.red/blog/local-server-security-best-practices#properly-check-the-request-origin
  */
-export function rejectNoCorsRequestMiddleware(): Connect.NextHandleFunction {
+export function rejectNoCorsRequestMiddleware(
+  cors: CorsOptions | boolean,
+): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteRejectNoCorsRequestMiddleware(req, res, next) {
     // While we can set Cross-Origin-Resource-Policy header instead of rejecting requests,
@@ -25,6 +28,11 @@ export function rejectNoCorsRequestMiddleware(): Connect.NextHandleFunction {
       // we only need to block classic script requests
       req.headers['sec-fetch-dest'] === 'script'
     ) {
+      // If the CORS config allows this origin, let the request through
+      if (isOriginAllowedByCors(req.headers.origin, cors)) {
+        return next()
+      }
+
       res.statusCode = 403
       res.end(
         'Cross-origin requests for classic scripts must be made with CORS mode enabled. Make sure to set the "crossorigin" attribute on your <script> tag.',
@@ -33,4 +41,38 @@ export function rejectNoCorsRequestMiddleware(): Connect.NextHandleFunction {
     }
     return next()
   }
+}
+
+function isOriginAllowedByCors(
+  origin: string | undefined,
+  cors: CorsOptions | boolean,
+): boolean {
+  if (cors === false) return false
+  // cors: true translates to corsMiddleware({}) which allows all origins
+  if (cors === true) return true
+
+  const configuredOrigin = cors.origin
+  // No origin configured means cors npm package defaults to '*' (allow all)
+  if (configuredOrigin === undefined || configuredOrigin === true) return true
+  if (configuredOrigin === false) return false
+
+  // Can't verify without an Origin header
+  if (!origin) return false
+
+  if (typeof configuredOrigin === 'string') {
+    return configuredOrigin === '*' || configuredOrigin === origin
+  }
+  if (configuredOrigin instanceof RegExp) {
+    return configuredOrigin.test(origin)
+  }
+  if (Array.isArray(configuredOrigin)) {
+    return configuredOrigin.some((o) =>
+      typeof o === 'string' ? o === origin : o.test(origin),
+    )
+  }
+  // origin is a callback function — user has explicitly configured custom logic,
+  // so we trust their intent and allow the request through
+  if (typeof configuredOrigin === 'function') return true
+
+  return false
 }


### PR DESCRIPTION
## Summary

- The `rejectNoCorsRequestMiddleware` (added in Vite 8 for [GHSA-4v9v-hfq4-rm2v](https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-4v9v-hfq4-rm2v) protection) unconditionally blocks all cross-origin classic script requests with a 403 — **before** the CORS middleware or static file serving middleware ever run
- This causes `server.cors` and `server.headers` to never be applied to static JS files loaded cross-origin via `<script>` tags, even when the CORS config would allow the requesting origin
- This fix makes the middleware check the request's `Origin` header against the resolved `server.cors` configuration before rejecting. Requests from allowed origins (including localhost origins allowed by the default config) now pass through to the normal middleware chain

Fixes #21893
Closes #21849

## How it works

The `isOriginAllowedByCors` function mirrors the origin-matching logic of the `cors` npm package:
- `cors: false` → always reject
- `cors: true` / `cors: {}` → allow all origins
- `cors: { origin: RegExp }` → test against the regex (**default** — `defaultAllowedOrigins` matches localhost, so localhost↔localhost requests now work out of the box)
- `cors: { origin: string }` → exact match or `'*'`
- `cors: { origin: (string|RegExp)[] }` → match any element
- `cors: { origin: function }` → trust user's custom callback

## Test plan

- [x] All 730 unit tests pass
- [x] Build succeeds
- [x] Pre-commit hooks (prettier + eslint) pass
- [ ] Existing e2e test `'load script with no-cors mode from a different origin'` in `playground/fs-serve` should still pass (sends `Origin: http://vite.dev` which doesn't match `defaultAllowedOrigins` → still rejected with 403)
- [ ] Manual test: two Vite projects on `localhost:5173` and `localhost:5174` — cross-origin `<script>` loading now works with default config since both origins match `defaultAllowedOrigins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)