### PR TITLE
fix: improve `no-cors` request block error

### DIFF
--- a/packages/vite/src/node/server/middlewares/rejectNoCorsRequest.ts
+++ b/packages/vite/src/node/server/middlewares/rejectNoCorsRequest.ts
@@ -25,9 +25,15 @@ export function rejectNoCorsRequestMiddleware(): Connect.NextHandleFunction {
       // we only need to block classic script requests
       req.headers['sec-fetch-dest'] === 'script'
     ) {
-      res.statusCode = 403
+      // Send a JavaScript code instead of 403 so that the error is shown in the devtools
+      // If we send 403, the browser will avoid loading the body of the response
+      // and just show "Failed to load" error without the detailed message.
+      res.setHeader('Content-Type', 'text/javascript')
       res.end(
-        'Cross-origin requests for classic scripts must be made with CORS mode enabled. Make sure to set the "crossorigin" attribute on your <script> tag.',
+        `throw new Error(${JSON.stringify(
+          '[Vite] Cross-origin requests for classic scripts must be made with CORS mode enabled.' +
+            ' Make sure to set the "crossorigin" attribute on your <script> tag.',
+        )});`,
       )
       return
     }

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -495,7 +495,7 @@ test.runIf(isServe)(
           reject(e)
         })
     })
-    expect(res.statusCode).toBe(403)
+    expect(res.statusCode).toBe(200)
     const body = Buffer.concat(await ArrayFromAsync(res)).toString()
     expect(body).toContain(
       'Cross-origin requests for classic scripts must be made with CORS mode enabled.',
@@ -531,6 +531,10 @@ test.runIf(isServe)(
         })
     })
     expect(res.statusCode).not.toBe(403)
+    const body = Buffer.concat(await ArrayFromAsync(res)).toString()
+    expect(body).not.toContain(
+      'Cross-origin requests for classic scripts must be made with CORS mode enabled.',
+    )
   },
 )
 


### PR DESCRIPTION
#21235 added a middleware to block no-CORS script requests mainly to prevent HMR scripts for bunded dev to be executed from untrusted origins. That middleware returns 403 when blocking the request, but it seems browsers avoid loading the body of the response in such case. This PR changes that middleware to return 200 with a custom error. It will now show the following error:

> Uncaught Error: [Vite] Cross-origin requests for classic scripts must be made with CORS mode enabled. Make sure to set the "crossorigin" attribute on your <script> tag.

refs #21849 
