### PR TITLE
feat: add warning to discourage Vite with yarn pnp

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1480,6 +1480,15 @@ export async function resolveConfig(
     )
   }
 
+  if (process.versions.pnp) {
+    logger.warnOnce(
+      colors.yellow(
+        `Using Yarn PnP with Vite is discouraged and PnP-specific bugs will no longer be actively worked on. ` +
+          `Please switch to a different ${colors.bold('nodeLinker')} mode or to a different package manager.`,
+      ),
+    )
+  }
+
   // resolve root
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),


### PR DESCRIPTION
Adding the following message to discourage people from using yarn pnp with Vite: 

> Using Yarn PnP with Vite is discouraged and PnP-specific bugs will no longer be actively worked on.
> Please switch to a different **'nodeLinker'** mode or to a different package manager.

While yarn defaults to yarn pnp when running `yarn set version stable`, maintaining a dedicated code path to support it has been a consistent maintenance overhead for the Vite team. Given that users can easily opt out of PnP by setting `nodeLinker: node-modules` in their `.yarnrc.yml`, I think it is the right call to discourage its use and allocate time on the other areas.

If someone is willing to maintain the yarn pnp support in Vite including all the upstream dependencies and also fixes, https://github.com/vitejs/vite/issues/15809, we can remove this warning.
