### PR TITLE
fix(server): add realpath of symlinked dirs to fs.allow (fix #16257)

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1240,26 +1240,13 @@ export async function resolveServerOptions(
 
   allowDirs = allowDirs.map((i) => resolvedAllowDir(root, i))
 
-  // Also add realpath-resolved versions to handle symlinked project roots.
-  // When the project root is a symlink, resolved module IDs point to real paths
+  // If the project root is a symlink, resolved module IDs point to the real path,
   // which would otherwise fail the fs.allow check.
   // See https://github.com/vitejs/vite/issues/16440
-  const realpathAllowDirs: string[] = []
-  for (const dir of allowDirs) {
-    try {
-      const realpathDir = normalizePath(safeRealpathSync(dir))
-      if (
-        realpathDir !== dir &&
-        !allowDirs.includes(realpathDir) &&
-        !realpathAllowDirs.includes(realpathDir)
-      ) {
-        realpathAllowDirs.push(realpathDir)
-      }
-    } catch {
-      // ignore if dir doesn't exist (e.g., user manually specified a non-existent path)
-    }
+  const realpathRoot = normalizePath(safeRealpathSync(root))
+  if (realpathRoot !== root && !allowDirs.includes(realpathRoot)) {
+    allowDirs.push(realpathRoot)
   }
-  allowDirs = [...allowDirs, ...realpathAllowDirs]
 
   // only push client dir when vite itself is outside-of-root
   const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1243,9 +1243,13 @@ export async function resolveServerOptions(
   // If the project root is a symlink, resolved module IDs point to the real path,
   // which would otherwise fail the fs.allow check.
   // See https://github.com/vitejs/vite/issues/16440
-  const realpathRoot = normalizePath(safeRealpathSync(root))
-  if (realpathRoot !== root && !allowDirs.includes(realpathRoot)) {
-    allowDirs.push(realpathRoot)
+  try {
+    const realpathRoot = normalizePath(safeRealpathSync(root))
+    if (realpathRoot !== root && !allowDirs.includes(realpathRoot)) {
+      allowDirs.push(realpathRoot)
+    }
+  } catch {
+    // root may not exist on disk (e.g. paths with special characters in tests)
   }
 
   // only push client dir when vite itself is outside-of-root

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -42,6 +42,7 @@ import {
   normalizePath,
   resolveHostname,
   resolveServerUrls,
+  safeRealpathSync,
   setupSIGTERMListener,
   teardownSIGTERMListener,
 } from '../utils'
@@ -1238,6 +1239,27 @@ export async function resolveServerOptions(
   }
 
   allowDirs = allowDirs.map((i) => resolvedAllowDir(root, i))
+
+  // Also add realpath-resolved versions to handle symlinked project roots.
+  // When the project root is a symlink, resolved module IDs point to real paths
+  // which would otherwise fail the fs.allow check.
+  // See https://github.com/vitejs/vite/issues/16440
+  const realpathAllowDirs: string[] = []
+  for (const dir of allowDirs) {
+    try {
+      const realpathDir = normalizePath(safeRealpathSync(dir))
+      if (
+        realpathDir !== dir &&
+        !allowDirs.includes(realpathDir) &&
+        !realpathAllowDirs.includes(realpathDir)
+      ) {
+        realpathAllowDirs.push(realpathDir)
+      }
+    } catch {
+      // ignore if dir doesn't exist (e.g., user manually specified a non-existent path)
+    }
+  }
+  allowDirs = [...allowDirs, ...realpathAllowDirs]
 
   // only push client dir when vite itself is outside-of-root
   const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -32,7 +32,7 @@ import {
   extractSourcemapFromFile,
   injectSourcesContent,
 } from './sourcemap'
-import { isFileLoadingAllowed } from './middlewares/static'
+import { checkLoadingAccess, isFileLoadingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
 import type { DevEnvironment } from './environment'
 
@@ -323,7 +323,11 @@ async function loadAndTransform(
         `build without going through the plugin transforms, and therefore ` +
         `should not be imported from source code. It can only be referenced ` +
         `via HTML tags.`
-      : `Does the file exist?`
+      : checkLoadingAccess(environment.getTopLevelConfig(), cleanUrl(id)) ===
+          'denied'
+        ? `The file exists but cannot be served. Is it outside of Vite's ` +
+          `server root? If so, add it to server.fs.allow in your Vite config.`
+        : `Does the file exist?`
     const importerMod: EnvironmentModuleNode | undefined =
       moduleGraph.idToModuleMap.get(id)?.importers.values().next().value
     const importer = importerMod?.file || importerMod?.url


### PR DESCRIPTION
What is this PR solving?

When a user runs Vite from a symlinked project root (for example, created via `New-Item -ItemType SymbolicLink` on Windows or `ln -s` on Linux), the dev server throws:

[vite] Pre-transform error: Failed to load url /src/main.ts (resolved id: C:/real/path/src/main.ts). Does the file exist?

Root cause: `server.fs.allow` contains the symlinked project root path, while resolved module IDs may point to the real (post-symlink) path. The `isFileLoadingAllowed` check then compares the real file path against the symlinked allow dir, so the file read is denied and the error is thrown.

Fixes #16257.

Changes
- `server/index.ts`: After `allowDirs` is normalized, resolve the project root to its real path via `safeRealpathSync`. If the real path differs and isn't already in the list, append it. This allows files under the real project root path to pass `isFileLoadingAllowed` when the root itself is symlinked, without implicitly expanding all entries in `server.fs.allow`.
- `server/transformRequest.ts`: Improve the error message when a file is blocked by `isFileLoadingAllowed`. Previously it said "Does the file exist?" which is misleading in the denied case. Now it reports that the file exists but cannot be served and suggests adding the path to `server.fs.allow` if needed.