### PR TITLE
docs: use rolldownOptions in library mode multiple entries example

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -185,7 +185,7 @@ export default defineConfig({
       },
       name: 'MyLib',
     },
-    rollupOptions: {
+    rolldownOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
       external: ['vue'],


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
The multiple entries tab in the Library Mode section of the
"Building for Production" docs still references `rollupOptions`
instead of `rolldownOptions`.

The single entry tab and all other examples on the same page
already use the correct `rolldownOptions` name.

Fixes #21915