### PR TITLE
chore: inline single-use renameFiles mapping

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -387,10 +387,6 @@ const TEMPLATES = FRAMEWORKS.map((f) => f.variants.map((v) => v.name)).reduce(
   [],
 )
 
-const renameFiles: Record<string, string | undefined> = {
-  _gitignore: '.gitignore',
-}
-
 const defaultTargetDir = 'vite-project'
 
 function run([command, ...args]: string[], options?: SpawnOptions) {
@@ -646,7 +642,10 @@ async function init() {
   )
 
   const write = (file: string, content?: string) => {
-    const targetPath = path.join(root, renameFiles[file] ?? file)
+    const targetPath = path.join(
+      root,
+      file === '_gitignore' ? '.gitignore' : file
+    )
     if (content) {
       fs.writeFileSync(targetPath, content)
     } else if (file === 'index.html') {

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -644,7 +644,7 @@ async function init() {
   const write = (file: string, content?: string) => {
     const targetPath = path.join(
       root,
-      file === '_gitignore' ? '.gitignore' : file
+      file === '_gitignore' ? '.gitignore' : file,
     )
     if (content) {
       fs.writeFileSync(targetPath, content)


### PR DESCRIPTION
Inline the single-use renameFiles mapping to simplify the code and remove unnecessary indirection.