### PR TITLE
chore(deps): bump required `@vitejs/devtools` version to 0.1+

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -141,7 +141,7 @@
   },
   "peerDependencies": {
     "@types/node": "^20.19.0 || >=22.12.0",
-    "@vitejs/devtools": "^0.0.0-alpha.31",
+    "@vitejs/devtools": "^0.1.0",
     "esbuild": "^0.27.0",
     "jiti": ">=1.21.0",
     "less": "^4.0.0",


### PR DESCRIPTION
close #21921