### PR TITLE
fix(css): lightningcss minify failed when `build.target: 'es6'`

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -274,6 +274,10 @@ describe('convertTargets', () => {
       safari: 852224,
     })
   })
+
+  test('supports es6 as an alias of es2015', () => {
+    expect(convertTargets('es6')).toStrictEqual(convertTargets('es2015'))
+  })
 })
 
 describe('getEmptyChunkReplacer', () => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3479,7 +3479,7 @@ const esMap: Record<number, string[]> = {
   ],
 }
 
-const esRE = /es(\d{4})/
+const esRE = /es(6|\d{4})/
 const versionRE = /\d/
 
 const convertTargetsCache = new Map<
@@ -3497,7 +3497,7 @@ export const convertTargets = (
   const entriesWithoutES = arraify(esbuildTarget).flatMap((e) => {
     const match = esRE.exec(e)
     if (!match) return e
-    const year = Number(match[1])
+    const year = match[1] === '6' ? 2015 : Number(match[1])
     if (!esMap[year]) throw new Error(`Unsupported target "${e}"`)
     return esMap[year]
   })


### PR DESCRIPTION
## Repro

Running the following commands:

```sh
npx -y create-vite@latest -t vanilla --no-interactive
cd vite-project
npm i
echo 'export default { build: { target: "es6" } }' > vite.config.js
npm run build
```

will produce the following output:

```log
> vite-project@0.0.0 build
> vite build

vite v8.0.0 building client environment for production...
✓ 9 modules transformed.
✗ Build failed in 76ms
error during build:
Build failed with 1 error:

[plugin vite:css-post]
Error: [lightningcss minify] Unsupported target "es6"
    at convertTargets (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:21916:9)
    at minifyCSS (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:21172:13)
    at async finalizeCss (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:21016:36)
    at async Promise.all (index 1)
    at async Object.run (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:2437:22)
    at async PluginContextImpl.renderChunk (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:20555:19)
    at async plugin (file:///D:/a/vite-project/node_modules/rolldown/dist/shared/bindingify-input-options-Cu7pt6SZ.mjs:1211:16)
    at async plugin.<computed> (file:///D:/a/vite-project/node_modules/rolldown/dist/shared/bindingify-input-options-Cu7pt6SZ.mjs:1570:12)
    at aggregateBindingErrorsIntoJsError (file:///D:/a/vite-project/node_modules/rolldown/dist/shared/error-CP8smW_P.mjs:48:18)
    at unwrapBindingResult (file:///D:/a/vite-project/node_modules/rolldown/dist/shared/error-CP8smW_P.mjs:18:128)
    at #build (file:///D:/a/vite-project/node_modules/rolldown/dist/shared/rolldown-build-4YnQkA76.mjs:3311:34)
    at async buildEnvironment (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:32794:64)
    at async Object.build (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:33216:19)
    at async Object.buildApp (file:///D:/a/vite-project/node_modules/vite/dist/node/chunks/node.js:33213:153)
    at async CAC.<anonymous> (file:///D:/a/vite-project/node_modules/vite/dist/node/cli.js:778:3) {
  errors: [Getter/Setter]
}
```

This only occurs when `config.build.target` is `es6`. It will not occur with `es2015`.

The reason js bundling works correctly is that oxc specifically supports the string `es6` along with `es2015`:

https://github.com/oxc-project/oxc/blob/c481b2fc7423cbeaff7cfbded4e569618e3e4bda/crates/oxc_syntax/src/es_target.rs#L31

```diff
  fn from_str(s: &str) -> Result<Self, Self::Err> {
      match s.cow_to_ascii_lowercase().as_ref() {
          "es5" => Err(String::from("ES5 is not yet supported.")),
+         "es6" | "es2015" => Ok(Self::ES2015),
          "es2016" => Ok(Self::ES2016),
```

Using `target: 'es6', cssMinify: 'lightningcss'` in vite 7 also produces the same error. And since `cssMinify: 'lightningcss'` is the default behavior in vite 8, to reduce migration regressions, I suggest supporting `es6` as an alias of `es2015` for the `convertTargets()` method of plugin css.

This patch can also be safely backported to vite 7.
