### PR TITLE
fix: use environment config for tsconfigPaths in fetchModule

### DIFF
--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -57,7 +57,7 @@ export async function fetchModule(
       extensions: ['.js', '.cjs', '.json'],
       dedupe,
       preserveSymlinks,
-      tsconfigPaths: false,
+      tsconfigPaths: environment.config.resolve.tsconfigPaths ?? false,
       isBuild: false,
       isProduction,
       root,


### PR DESCRIPTION
## Summary
- `fetchModule` hardcodes `tsconfigPaths: false` when calling `tryNodeResolve`, ignoring the user's `resolve.tsconfigPaths` configuration
- This breaks SSR path resolution for projects that rely on TypeScript path aliases

## Root Cause
Line 60 in `packages/vite/src/node/ssr/fetchModule.ts` passes `tsconfigPaths: false` instead of reading from `environment.config.resolve.tsconfigPaths`.

## Fix
Read `tsconfigPaths` from `environment.config.resolve.tsconfigPaths` with a fallback to `false` for backward compatibility.

## Testing
- Verified the change is a single-line config propagation
- No behavior change for projects without tsconfig paths configured (falls back to `false`)

Fixes #21895

Made with [Cursor](https://cursor.com)