### PR TITLE
fix: sort polyfill imports for deterministic chunk hashes

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -946,7 +946,7 @@ function polyfillsPlugin(
     load(id) {
       if (id === polyfillId) {
         return (
-          [...imports].map((i) => `import ${JSON.stringify(i)};`).join('') +
+          [...imports].sort().map((i) => `import ${JSON.stringify(i)};`).join('') +
           (excludeSystemJS ? '' : `import "systemjs/dist/s.min.js";`)
         )
       }


### PR DESCRIPTION
## Summary
- `@vitejs/plugin-legacy` produces non-deterministic polyfill chunk hashes across builds
- The polyfill import order varies because `Set` iteration depends on insertion order from parallel `renderChunk` calls

## Root Cause
In `polyfillsPlugin.load()`, the `imports` Set is spread into an array with `[...imports].map(...)`. Since `renderChunk` hooks run in parallel, polyfills are added to the Set in non-deterministic order, producing different import sequences and thus different chunk content hashes.

## Fix
Sort the imports array before generating the polyfill code: `[...imports].sort().map(...)`. This ensures identical import order regardless of `renderChunk` execution order.

## Testing
- Verified the sort produces stable, alphabetical import order
- No behavior change — only the order of imports in the generated polyfill chunk is stabilized

Fixes #21905

Made with [Cursor](https://cursor.com)