### PR TITLE
docs(create-vite): fix qwik template typo

### DIFF
--- a/packages/create-vite/template-qwik-ts/README.md
+++ b/packages/create-vite/template-qwik-ts/README.md
@@ -14,7 +14,7 @@ export default defineConfig({
 })
 ```
 
-Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframwork.
+Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframework.
 
 ## Usage
 

--- a/packages/create-vite/template-qwik-ts/README.md
+++ b/packages/create-vite/template-qwik-ts/README.md
@@ -14,7 +14,7 @@ export default defineConfig({
 })
 ```
 
-Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframework.
+Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side meta-framework.
 
 ## Usage
 

--- a/packages/create-vite/template-qwik/README.md
+++ b/packages/create-vite/template-qwik/README.md
@@ -14,7 +14,7 @@ export default defineConfig({
 })
 ```
 
-Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframwork.
+Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframework.
 
 ## Usage
 

--- a/packages/create-vite/template-qwik/README.md
+++ b/packages/create-vite/template-qwik/README.md
@@ -14,7 +14,7 @@ export default defineConfig({
 })
 ```
 
-Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side metaframework.
+Use `npm create qwik@latest` to create a full production ready Qwik application, using SSR and [QwikCity](https://qwik.dev/docs/qwikcity/), our server-side meta-framework.
 
 ## Usage
 


### PR DESCRIPTION
1. This fixes a typo in the Qwik `create-vite` template READMEs.

`metaframwork` is corrected to `metaframework` in:

- `packages/create-vite/template-qwik/README.md`
- `packages/create-vite/template-qwik-ts/README.md`

2. Related issue

No linked issue.

3. Alternatives explored

No alternative implementation was needed since this is a straightforward docs typo fix.

## Notes for reviewers

This is a docs-only change in template README files.

## Tests

No tests were added because this change only updates README text and does not affect runtime behavior.
