### PR TITLE
docs: clarify Environment API externalization options

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -13,6 +13,10 @@ If `true`, all dependencies including linked dependencies are externalized.
 
 Note that the explicitly listed dependencies (using `string[]` type) will always take priority if they're also listed in `ssr.noExternal` (using any type).
 
+When using the Environment API, configure the same behavior with
+`environments.<name>.resolve.external`. `ssr.external` is the backward-compatible alias for
+the default `ssr` environment.
+
 ## ssr.noExternal
 
 - **Type:** `string | RegExp | (string | RegExp)[] | true`
@@ -23,6 +27,10 @@ Prevent listed dependencies from being externalized for SSR, which they will get
 If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized. If `ssr.target: 'node'` is set, Node.js built-ins will also be externalized by default.
 
 Note that if both `ssr.noExternal: true` and `ssr.external: true` are configured, `ssr.noExternal` takes priority and no dependencies are externalized.
+
+When using the Environment API, configure the same behavior with
+`environments.<name>.resolve.noExternal`. `ssr.noExternal` is the backward-compatible alias
+for the default `ssr` environment.
 
 ## ssr.target
 

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -94,6 +94,11 @@ interface UserConfig extends EnvironmentOptions {
 }
 ```
 
+For server environments, dependency externalization is configured under `resolve`, not `build`.
+Use `environments.<name>.resolve.noExternal` and `environments.<name>.resolve.external`
+for custom environments. The top-level `ssr.noExternal` and `ssr.external` options are the
+backward-compatible aliases for the default `ssr` environment.
+
 Note that the `ssr` top-level property is going to be deprecated once the Environment API is stable. This option has the same role as `environments`, but for the default `ssr` environment and only allowed configuring of a small set of options.
 
 ## Custom Environment Instances


### PR DESCRIPTION
Fixes #20098

Summary:
- clarify in the Environment API guide that dependency externalization for server environments is configured under resolve, not build
- document that environments.<name>.resolve.external and environments.<name>.resolve.noExternal are the Environment API equivalents of the top-level ssr.external and ssr.noExternal options
- note that the top-level ssr.* options remain the backward-compatible alias for the default ssr environment

Verification:
- git diff --check
- npx prettier@3.8.1 --check docs/guide/api-environment.md docs/config/ssr-options.md