### PR TITLE
test: reduce fs-serve flaky failure

### DIFF
--- a/playground/fs-serve/root/vite.config-base.js
+++ b/playground/fs-serve/root/vite.config-base.js
@@ -12,6 +12,7 @@ export default defineConfig({
         main: path.resolve(import.meta.dirname, 'src/index.html'),
       },
     },
+    outDir: 'dist/base',
   },
   server: {
     fs: {

--- a/playground/fs-serve/root/vite.config-deny.js
+++ b/playground/fs-serve/root/vite.config-deny.js
@@ -9,6 +9,7 @@ export default defineConfig({
         main: path.resolve(import.meta.dirname, 'src/index.html'),
       },
     },
+    outDir: 'dist/deny',
   },
   server: {
     fs: {

--- a/playground/fs-serve/root/vite.config.js
+++ b/playground/fs-serve/root/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
         main: path.resolve(import.meta.dirname, 'src/index.html'),
       },
     },
+    outDir: 'dist/main',
   },
   server: {
     fs: {


### PR DESCRIPTION
The builds were overwriting each other.

Fixes flaky failures like https://github.com/vitejs/vite/actions/runs/23436193532/job/68174750434#step:13:26
