### PR TITLE
fix(vite): scan is not resolving sub path import if used in a glob import

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/index.html
+++ b/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "scan-subpath-import-glob",
+  "private": true,
+  "imports": {
+    "#src/*": "./src/*"
+  }
+}

--- a/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/entry.ts
+++ b/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/entry.ts
@@ -1,0 +1,1 @@
+export const modules = import.meta.glob('#src/foo/*.ts')

--- a/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/foo/a.ts
+++ b/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/foo/a.ts
@@ -1,0 +1,1 @@
+export const value = 'a'

--- a/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/main.ts
+++ b/packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob/src/main.ts
@@ -1,0 +1,1 @@
+import './entry'

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -179,7 +179,11 @@ test('scan import.meta.glob package imports patterns', async (ctx) => {
   const server = await createServer({
     configFile: false,
     logLevel: 'error',
-    root: path.join(import.meta.dirname, 'fixtures', 'scan-subpath-import-glob'),
+    root: path.join(
+      import.meta.dirname,
+      'fixtures',
+      'scan-subpath-import-glob',
+    ),
     optimizeDeps: {
       entries: ['./index.html'],
       force: true,

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -1,6 +1,12 @@
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { commentRE, importsRE, scriptRE } from '../optimizer/scan'
+import {
+  commentRE,
+  devToScanEnvironment,
+  importsRE,
+  scanImports,
+  scriptRE,
+} from '../optimizer/scan'
 import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
 import { createServer, createServerModuleRunner } from '..'
 
@@ -167,4 +173,26 @@ test('scan jsx-runtime', async (ctx) => {
   const mod2 = await runner.import('./entry-jsx.js')
   expect((globalThis as any).__test_scan_jsx_runtime).toBe(1)
   expect(mod1).toBe(mod2)
+})
+
+test('scan import.meta.glob package imports patterns', async (ctx) => {
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'error',
+    root: path.join(import.meta.dirname, 'fixtures', 'scan-subpath-import-glob'),
+    optimizeDeps: {
+      entries: ['./index.html'],
+      force: true,
+      noDiscovery: false,
+    },
+  })
+
+  ctx.onTestFinished(() => server.close())
+
+  const { cancel, result } = scanImports(
+    devToScanEnvironment(server.environments.client),
+  )
+  ctx.onTestFinished(cancel)
+
+  await expect(result).resolves.toEqual({ deps: {}, missing: {} })
 })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -348,19 +348,28 @@ function rolldownScanPlugin(
   async function resolveId(
     id: string,
     importer?: string,
+    options?: Parameters<EnvironmentPluginContainer['resolveId']>[2],
   ): Promise<PartialResolvedId | null> {
     return environment.pluginContainer.resolveId(
       id,
       importer && normalizePath(importer),
-      { scan: true },
+      { scan: true, ...options },
     )
   }
-  const resolve = async (id: string, importer?: string) => {
-    const key = id + (importer && path.dirname(importer))
+  const resolve = async (
+    id: string,
+    importer?: string,
+    options?: Parameters<typeof resolveId>[2],
+  ) => {
+    const key = JSON.stringify([
+      id,
+      importer && path.dirname(importer),
+      options?.custom ?? null,
+    ])
     if (seen.has(key)) {
       return seen.get(key)
     }
-    const resolved = await resolveId(id, importer)
+    const resolved = await resolveId(id, importer, options)
     const res = resolved?.id
     seen.set(key, res)
     return res

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/file-url: {}
 
+  packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob: {}
+
   packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}
 
   packages/vite/src/node/__tests__/fixtures/watch-rebuild-manifest: {}


### PR DESCRIPTION
fixes #22005 

I did use AI pretty heavily for this to find  issue, make test case and fix. I have reviewed everything myself and looks fine to me. I am not entirely sure why this fixes it though, guessing things are passing in a 3rd parameter but this one case wasnt using it?
