### PR TITLE
fix: prebundle workspace dependencies in monorepos

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -109,7 +109,7 @@ export const JS_TYPES_RE: RegExp = /\.(?:j|t)sx?$|\.mjs$/
 export const CSS_LANGS_RE: RegExp =
   /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/
 
-export const OPTIMIZABLE_ENTRY_RE: RegExp = /\.[cm]?[jt]s$/
+export const OPTIMIZABLE_ENTRY_RE: RegExp = /\.[cm]?[jt]sx?$/
 
 export const SPECIAL_QUERY_RE: RegExp = /[?&](?:worker|sharedworker|raw|url)\b/
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -607,6 +607,15 @@ function rolldownScanPlugin(
               return externalUnlessEntry({ path: id })
             } else if (isScannable(resolved, optimizeDepsOptions.extensions)) {
               // linked package, keep crawling
+              // If it's a workspace package (not the app itself), add to depImports
+              // for prebundling so users don't need to manually add to optimizeDeps.include
+              if (
+                !entries.some((entry) =>
+                  resolved!.startsWith(path.dirname(entry) + path.sep),
+                )
+              ) {
+                depImports[id] = resolved
+              }
               return path.resolve(resolved)
             } else {
               return externalUnlessEntry({ path: id })


### PR DESCRIPTION
## Description

Prevents performance issues in large monorepos where workspace packages are not prebundled, causing many individual modules to be served to the browser.

### Changes

1. **Scanner (scan.ts)**: Workspace packages (non-node_modules scannable packages) are now added to `depImports` for prebundling, in addition to being crawled for their internal exports. Workspace packages are identified as scannable packages outside node_modules that are not part of the app's entry point directories.

2. **OPTIMIZABLE_ENTRY_RE (constants.ts)**: Extended to include `.jsx` and `.tsx` files, allowing packages with JSX/TSX entry points to be prebundled by esbuild.

### Why this helps

Previously, workspace packages in monorepos were treated as "linked packages" - they were crawled for their internal imports but NOT prebundled. This meant that importing a workspace package with 50 files would result in 50 individual HTTP requests during development. With this fix, workspace packages are prebundled like regular dependencies, reducing the number of modules served to the browser.

### Example

Before: A monorepo with 10 workspace packages each having 20 source files = 200+ individual modules served
After: Same monorepo = 10 bundled workspace packages (each as a single module)

---

**Related Issues:**
- Fixes #2241 (Prebundle workspace dependencies)
- Related to #8175 (improve DX for linked packages)
