### PR TITLE
fix(html): cache unfiltered CSS list to prevent missing styles across entries

### DIFF
--- a/packages/vite/src/node/__tests__/html.spec.ts
+++ b/packages/vite/src/node/__tests__/html.spec.ts
@@ -161,6 +161,74 @@ describe('getCssFilesForChunk', () => {
     ])
   })
 
+  test('cached chunk does not lose CSS that was already in seenCss during first entry (#21298)', () => {
+    // entry  → chunk1 (chunk1.css, chunk-shared.css)
+    //        → chunk2 (chunk2.css, chunk-shared.css)
+    // entry2 → chunk2
+    const chunk1 = createChunk(
+      'chunk1.js',
+      [],
+      ['chunk1.css', 'chunk-shared.css'],
+    )
+    const chunk2 = createChunk(
+      'chunk2.js',
+      [],
+      ['chunk2.css', 'chunk-shared.css'],
+    )
+    const entry = createChunk(
+      'entry.js',
+      ['chunk1.js', 'chunk2.js'],
+      ['entry.css'],
+    )
+    const entry2 = createChunk('entry2.js', ['chunk2.js'], ['entry2.css'])
+    const bundle = createBundle(entry, entry2, chunk1, chunk2)
+    const cache = new Map<OutputChunk, string[]>()
+
+    expect(getCssFilesForChunk(entry, bundle, cache)).toStrictEqual([
+      'chunk1.css',
+      'chunk-shared.css',
+      'chunk2.css',
+      'entry.css',
+    ])
+    expect(getCssFilesForChunk(entry2, bundle, cache)).toStrictEqual([
+      'chunk2.css',
+      'chunk-shared.css',
+      'entry2.css',
+    ])
+  })
+
+  test('dirty leaf chunk CSS is not lost through cached parent (#21298 edge case)', () => {
+    //  entry1 → other (shared.css)
+    //         → mid   → leaf (shared.css, leaf.css)
+    //  entry2 → mid   → leaf (shared.css, leaf.css)
+    const leaf = createChunk('leaf.js', [], ['shared.css', 'leaf.css'])
+    const mid = createChunk('mid.js', ['leaf.js'], ['mid.css'])
+    const other = createChunk('other.js', [], ['shared.css'])
+    const entry1 = createChunk(
+      'entry1.js',
+      ['other.js', 'mid.js'],
+      ['entry1.css'],
+    )
+    const entry2 = createChunk('entry2.js', ['mid.js'], ['entry2.css'])
+    const bundle = createBundle(entry1, entry2, other, mid, leaf)
+    const cache = new Map<OutputChunk, string[]>()
+
+    expect(getCssFilesForChunk(entry1, bundle, cache)).toStrictEqual([
+      'shared.css',
+      'leaf.css',
+      'mid.css',
+      'entry1.css',
+    ])
+    // entry2 must still get shared.css via leaf, even though mid's cache
+    // was built while shared.css was already seen
+    expect(getCssFilesForChunk(entry2, bundle, cache)).toStrictEqual([
+      'shared.css',
+      'leaf.css',
+      'mid.css',
+      'entry2.css',
+    ])
+  })
+
   test('circular imports do not cause infinite loop', () => {
     const a = createChunk('a.js', ['b.js'], ['a.css'])
     const b = createChunk('b.js', ['a.js'], ['b.css'])

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -370,31 +370,40 @@ export function getCssFilesForChunk(
     return additionals
   }
 
-  const files: string[] = []
+  // Collect all CSS from imports (unfiltered for caching, filtered for return)
+  const allFiles: string[] = []
+  const filteredFiles: string[] = []
   chunk.imports.forEach((file) => {
     const importee = bundle[file]
     if (importee?.type === 'chunk') {
-      files.push(
-        ...getCssFilesForChunk(
-          importee,
-          bundle,
-          analyzedImportedCssFiles,
-          seenChunks,
-          seenCss,
-        ),
+      const importeeCss = getCssFilesForChunk(
+        importee,
+        bundle,
+        analyzedImportedCssFiles,
+        seenChunks,
+        seenCss,
       )
+      filteredFiles.push(...importeeCss)
+      // For cache: use the importee's full cached list
+      if (analyzedImportedCssFiles.has(importee)) {
+        allFiles.push(...analyzedImportedCssFiles.get(importee)!)
+      } else {
+        allFiles.push(...importeeCss)
+      }
     }
   })
-  analyzedImportedCssFiles.set(chunk, files)
 
   chunk.viteMetadata!.importedCss.forEach((file) => {
+    allFiles.push(file)
     if (!seenCss.has(file)) {
       seenCss.add(file)
-      files.push(file)
+      filteredFiles.push(file)
     }
   })
 
-  return files
+  analyzedImportedCssFiles.set(chunk, unique(allFiles))
+
+  return filteredFiles
 }
 
 /**


### PR DESCRIPTION
Updated version of #21298

I added a test for #21298 and also added a test case that fails with #21298. I fixed the bug in the implementation of #21298

This bug was one of the reason of the flaky failure: https://github.com/vitejs/vite/actions/runs/23434192835/job/68171680224?pr=21998#step:13:26
```
 FAIL  playground/html/__tests__/html.spec.ts > nested > css
 FAIL  playground/html/__tests__/html.spec.ts > nested w/ query > css
AssertionError: expected 'black' to be 'grey' // Object.is equality

Expected: "grey"
Received: "black"

 ❯ playground/html/__tests__/html.spec.ts:84:33
     82|   test('css', async () => {
     83|     expect(await getColor('h1')).toBe(isNested ? 'red' : 'blue')
     84|     expect(await getColor('p')).toBe('grey')
       |                                 ^
     85|   })
     86|
```

close #21298
refs https://github.com/rolldown/rolldown/issues/8834

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
