### PR TITLE
docs: change "rollup worker" to "rolldown worker" in the description for the worker.plugins configuration item.

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -14,7 +14,7 @@ Output format for worker bundle.
 - **Type:** [`() => (Plugin | Plugin[])[]`](./shared-options#plugins)
 
 Vite plugins that apply to the worker bundles. Note that [config.plugins](./shared-options#plugins) only applies to workers in dev, it should be configured here instead for build.
-The function should return new plugin instances as they are used in parallel rollup worker builds. As such, modifying `config.worker` options in the `config` hook will be ignored.
+The function should return new plugin instances as they are used in parallel rolldown worker builds. As such, modifying `config.worker` options in the `config` hook will be ignored.
 
 ## worker.rolldownOptions
 


### PR DESCRIPTION
It seems that "rollup worker" in the description of the `worker.plugins` configuration item was not updated to "rolldown worker".

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
