### PR TITLE
fix: handle rolldown and rollup in resolveRolldownOptions

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -256,7 +256,7 @@ export interface BuildEnvironmentOptions {
   lib?: LibraryOptions | false
   /**
    * Produce SSR oriented build. Note this requires specifying SSR entry via
-   * `rollupOptions.input`.
+   * `rolldownOptions.input`.
    * @default false
    */
   ssr?: boolean | string
@@ -288,8 +288,8 @@ export interface BuildEnvironmentOptions {
    */
   chunkSizeWarningLimit?: number
   /**
-   * Rollup watch options
-   * https://rollupjs.org/configuration-options/#watch
+   * Rolldown watch options
+   * https://rolldown.rs/reference/InputOptions.watch
    * @default null
    */
   watch?: WatcherOptions | null
@@ -510,7 +510,10 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
         async (environment) =>
           (
             await asyncFlatten(
-              arraify(environment.config.build.rollupOptions.plugins),
+              arraify(
+                environment.config.build.rolldownOptions.plugins ||
+                  environment.config.build.rollupOptions.plugins,
+              ),
             )
           ).filter(Boolean) as Plugin[],
       ),
@@ -573,7 +576,8 @@ export function resolveRolldownOptions(
 
   const resolve = (p: string) => path.resolve(root, p)
   const input = libOptions
-    ? options.rollupOptions.input ||
+    ? options.rolldownOptions.input ||
+      options.rollupOptions.input ||
       (typeof libOptions.entry === 'string'
         ? resolve(libOptions.entry)
         : Array.isArray(libOptions.entry)
@@ -586,7 +590,9 @@ export function resolveRolldownOptions(
             ))
     : typeof options.ssr === 'string'
       ? resolve(options.ssr)
-      : options.rollupOptions.input || resolve('index.html')
+      : options.rolldownOptions.input ||
+        options.rollupOptions.input ||
+        resolve('index.html')
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(
@@ -615,7 +621,7 @@ export function resolveRolldownOptions(
     injectEnvironmentToHooks(environment, chunkMetadataMap, p),
   )
 
-  const rollupOptions: RolldownOptions = {
+  const rolldownOptions: RolldownOptions = {
     preserveEntrySignatures: ssr
       ? 'allow-extension'
       : libOptions
@@ -623,18 +629,19 @@ export function resolveRolldownOptions(
         : false,
     // cache: options.watch ? undefined : false,
     ...options.rollupOptions,
-    output: options.rollupOptions.output,
+    ...options.rolldownOptions,
     input,
     plugins,
-    external: options.rollupOptions.external,
     onLog(level, log) {
       onRollupLog(level, log, environment)
     },
     transform: {
       target: options.target === false ? undefined : options.target,
       ...options.rollupOptions.transform,
+      ...options.rolldownOptions.transform,
       define: {
         ...options.rollupOptions.transform?.define,
+        ...options.rolldownOptions.transform?.define,
         // disable builtin process.env.NODE_ENV replacement as it is handled by the define plugin
         'process.env.NODE_ENV': 'process.env.NODE_ENV',
       },
@@ -642,10 +649,12 @@ export function resolveRolldownOptions(
     // TODO: remove this and enable rolldown's CSS support later
     moduleTypes: {
       ...options.rollupOptions.moduleTypes,
+      ...options.rolldownOptions.moduleTypes,
       '.css': 'js',
     },
     experimental: {
       ...options.rollupOptions.experimental,
+      ...options.rolldownOptions.experimental,
       viteMode: true,
     },
   }
@@ -761,18 +770,18 @@ export function resolveRolldownOptions(
 
   // resolve lib mode outputs
   const outputs = resolveBuildOutputs(
-    options.rollupOptions.output,
+    options.rolldownOptions.output || options.rollupOptions.output,
     libOptions,
     logger,
   )
 
   if (Array.isArray(outputs)) {
-    rollupOptions.output = outputs.map(buildOutputOptions)
+    rolldownOptions.output = outputs.map(buildOutputOptions)
   } else {
-    rollupOptions.output = buildOutputOptions(outputs)
+    rolldownOptions.output = buildOutputOptions(outputs)
   }
 
-  return rollupOptions
+  return rolldownOptions
 }
 
 /**
@@ -796,7 +805,10 @@ async function buildEnvironment(
   let startTime: number | undefined
   try {
     const chunkMetadataMap = new ChunkMetadataMap()
-    const rollupOptions = resolveRolldownOptions(environment, chunkMetadataMap)
+    const rolldownOptions = resolveRolldownOptions(
+      environment,
+      chunkMetadataMap,
+    )
 
     // watch file changes with rollup
     if (options.watch) {
@@ -805,7 +817,7 @@ async function buildEnvironment(
       const resolvedOutDirs = getResolvedOutDirs(
         root,
         options.outDir,
-        options.rollupOptions.output,
+        options.rolldownOptions.output || options.rollupOptions.output,
       )
       const emptyOutDir = resolveEmptyOutDir(
         options.emptyOutDir,
@@ -816,7 +828,7 @@ async function buildEnvironment(
       const resolvedChokidarOptions = resolveChokidarOptions(
         {
           // @ts-expect-error chokidar option does not exist in rolldown but used for backward compat
-          ...(rollupOptions.watch || {}).chokidar,
+          ...(rolldownOptions.watch || {}).chokidar,
           // @ts-expect-error chokidar option does not exist in rolldown but used for backward compat
           ...options.watch.chokidar,
         },
@@ -827,9 +839,9 @@ async function buildEnvironment(
 
       const { watch } = await import('rolldown')
       const watcher = watch({
-        ...rollupOptions,
+        ...rolldownOptions,
         watch: {
-          ...rollupOptions.watch,
+          ...rolldownOptions.watch,
           ...options.watch,
           watcher: convertToWatcherOptions(resolvedChokidarOptions),
         },
@@ -856,10 +868,10 @@ async function buildEnvironment(
     // write or generate files with rolldown
     const { rolldown } = await import('rolldown')
     startTime = Date.now()
-    bundle = await rolldown(rollupOptions)
+    bundle = await rolldown(rolldownOptions)
 
     const res: RolldownOutput[] = []
-    for (const output of arraify(rollupOptions.output!)) {
+    for (const output of arraify(rolldownOptions.output!)) {
       res.push(await bundle[options.write ? 'write' : 'generate'](output))
     }
     for (const output of res) {
@@ -870,7 +882,7 @@ async function buildEnvironment(
     logger.info(
       `${colors.green(`✓ built in ${displayTime(Date.now() - startTime)}`)}`,
     )
-    return Array.isArray(rollupOptions.output) ? res : res[0]
+    return Array.isArray(rolldownOptions.output) ? res : res[0]
   } catch (e) {
     enhanceRollupError(e)
     clearLine()
@@ -1127,8 +1139,12 @@ export function onRollupLog(
   }
 
   clearLine()
-  const userOnLog = environment.config.build.rollupOptions?.onLog
-  const userOnWarn = environment.config.build.rollupOptions?.onwarn
+  const userOnLog =
+    environment.config.build.rolldownOptions?.onLog ||
+    environment.config.build.rollupOptions?.onLog
+  const userOnWarn =
+    environment.config.build.rolldownOptions?.onwarn ||
+    environment.config.build.rollupOptions?.onwarn
   if (userOnLog) {
     if (userOnWarn) {
       const normalizedUserOnWarn = normalizeUserOnWarn(userOnWarn, viteLog)


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

- Fixing a case where `rolldownOptions` would not be used to resolve some options during the build, unlike `rollupOptions`. This PR updates the logic so it first uses `rolldownOptions` and fallbacks to `rollupOptions`
- Closes #22033
- Where should I test this change? `resolveRolldownOptions` is not tested currently