### PR TITLE
fix: `hasBothRollupOptionsAndRolldownOptions` should return `false` for proxy case

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -6,7 +6,7 @@ import type { InlineConfig, PluginOption } from '..'
 import type { UserConfig, UserConfigExport } from '../config'
 import { defineConfig, loadConfigFromFile, resolveConfig } from '../config'
 import { resolveEnvPrefix } from '../env'
-import { mergeConfig } from '../utils'
+import { hasBothRollupOptionsAndRolldownOptions, mergeConfig } from '../utils'
 import { createLogger } from '../logger'
 
 describe('mergeConfig', () => {
@@ -558,6 +558,55 @@ describe('mergeConfig', () => {
     upOutput.hashCharacters = 'base36'
     expect(upOutput.hashCharacters).toBe('base36')
     expect(downOutput.hashCharacters).toBe('base36')
+  })
+
+  test('hasBothRollupOptionsAndRolldownOptions returns false when only rollupOptions is set (proxy case)', () => {
+    // When mergeConfig is called with only rollupOptions in the override,
+    // setupRollupOptionCompat creates a proxy where rollupOptions === rolldownOptions.
+    // hasBothRollupOptionsAndRolldownOptions should return false in this case
+    // to avoid false positive warnings.
+    const baseConfig = defineConfig({
+      build: {}, // Need existing build object for recursive merge to happen
+    })
+
+    const newConfig = defineConfig({
+      build: {
+        rollupOptions: {
+          treeshake: false,
+        },
+      },
+    })
+
+    const mergedConfig = mergeConfig(baseConfig, newConfig) as UserConfig
+
+    // After merge, both rollupOptions and rolldownOptions exist,
+    // but they point to the same object (proxy relationship)
+    expect(mergedConfig.build!.rollupOptions).toBeDefined()
+    expect(mergedConfig.build!.rolldownOptions).toBeDefined()
+    expect(mergedConfig.build!.rollupOptions).toBe(
+      mergedConfig.build!.rolldownOptions,
+    )
+
+    // hasBothRollupOptionsAndRolldownOptions should return false
+    // because they are the same object (proxy)
+    expect(hasBothRollupOptionsAndRolldownOptions(mergedConfig)).toBe(false)
+  })
+
+  test('hasBothRollupOptionsAndRolldownOptions returns true when both are explicitly set to different values', () => {
+    // When both rollupOptions and rolldownOptions are explicitly set to different values,
+    // hasBothRollupOptionsAndRolldownOptions should return true
+    const config = defineConfig({
+      build: {
+        rollupOptions: {
+          treeshake: false,
+        },
+        rolldownOptions: {
+          platform: 'neutral',
+        },
+      },
+    })
+
+    expect(hasBothRollupOptionsAndRolldownOptions(config)).toBe(true)
   })
 
   test('rollupOptions/rolldownOptions.platform', async () => {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -560,7 +560,7 @@ describe('mergeConfig', () => {
     expect(downOutput.hashCharacters).toBe('base36')
   })
 
-  test('hasBothRollupOptionsAndRolldownOptions returns false when only rollupOptions is set (proxy case)', () => {
+  test('hasBothRollupOptionsAndRolldownOptions returns false when only rollupOptions is set', () => {
     // When mergeConfig is called with only rollupOptions in the override,
     // setupRollupOptionCompat creates a proxy where rollupOptions === rolldownOptions.
     // hasBothRollupOptionsAndRolldownOptions should return false in this case
@@ -568,7 +568,6 @@ describe('mergeConfig', () => {
     const baseConfig = defineConfig({
       build: {}, // Need existing build object for recursive merge to happen
     })
-
     const newConfig = defineConfig({
       build: {
         rollupOptions: {
@@ -576,25 +575,18 @@ describe('mergeConfig', () => {
         },
       },
     })
+    const mergedConfig: UserConfig = mergeConfig(baseConfig, newConfig)
 
-    const mergedConfig = mergeConfig(baseConfig, newConfig) as UserConfig
-
-    // After merge, both rollupOptions and rolldownOptions exist,
-    // but they point to the same object (proxy relationship)
     expect(mergedConfig.build!.rollupOptions).toBeDefined()
     expect(mergedConfig.build!.rolldownOptions).toBeDefined()
     expect(mergedConfig.build!.rollupOptions).toBe(
       mergedConfig.build!.rolldownOptions,
     )
 
-    // hasBothRollupOptionsAndRolldownOptions should return false
-    // because they are the same object (proxy)
     expect(hasBothRollupOptionsAndRolldownOptions(mergedConfig)).toBe(false)
   })
 
   test('hasBothRollupOptionsAndRolldownOptions returns true when both are explicitly set to different values', () => {
-    // When both rollupOptions and rolldownOptions are explicitly set to different values,
-    // hasBothRollupOptionsAndRolldownOptions should return true
     const config = defineConfig({
       build: {
         rollupOptions: {
@@ -605,7 +597,6 @@ describe('mergeConfig', () => {
         },
       },
     })
-
     expect(hasBothRollupOptionsAndRolldownOptions(config)).toBe(true)
   })
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1317,7 +1317,10 @@ export function hasBothRollupOptionsAndRolldownOptions(
     if (
       opt != null &&
       opt.rollupOptions != null &&
-      opt.rolldownOptions != null
+      opt.rolldownOptions != null &&
+      // Check that they are actually different objects
+      // (not just a proxy relationship created by setupRollupOptionCompat)
+      opt.rollupOptions !== opt.rolldownOptions
     ) {
       return true
     }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1318,8 +1318,7 @@ export function hasBothRollupOptionsAndRolldownOptions(
       opt != null &&
       opt.rollupOptions != null &&
       opt.rolldownOptions != null &&
-      // Check that they are actually different objects
-      // (not just a proxy relationship created by setupRollupOptionCompat)
+      // Check they are not just proxy values created by setupRollupOptionCompat
       opt.rollupOptions !== opt.rolldownOptions
     ) {
       return true


### PR DESCRIPTION
## Description

When mergeConfig is called with only rollupOptions, the function setupRollupOptionCompat creates a proxy where rollupOptions points to rolldownOptions. Both properties exist but they reference the same object.

The function hasBothRollupOptionsAndRolldownOptions was incorrectly returning true in this case, causing false positive warnings.

This fix adds a check to ensure both properties are actually different objects before returning true.

## Related Issue
refs #22040