### PR TITLE
fix: preserve browser:false relative ids

### DIFF
--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -61,7 +61,9 @@ describe('browser field', () => {
   test('preserves relative ids for browser:false mappings', async () => {
     const root = mkdtempSync(join(tmpdir(), 'vite-browser-field-'))
     const pkgDir = join(root, 'node_modules', 'object-inspect')
+    const nestedDir = join(pkgDir, 'nested')
     mkdirSync(pkgDir, { recursive: true })
+    mkdirSync(nestedDir, { recursive: true })
     writeFileSync(
       join(pkgDir, 'package.json'),
       JSON.stringify(
@@ -71,6 +73,7 @@ describe('browser field', () => {
           main: 'index.js',
           browser: {
             './util.inspect.js': false,
+            './nested/util.inspect.js': false,
           },
         },
         null,
@@ -80,6 +83,10 @@ describe('browser field', () => {
     writeFileSync(
       join(pkgDir, 'index.js'),
       "var utilInspect = require('./util.inspect');\nmodule.exports = utilInspect;\n",
+    )
+    writeFileSync(
+      join(pkgDir, 'nested.js'),
+      "var utilInspect = require('./nested/util.inspect');\nmodule.exports = utilInspect;\n",
     )
 
     const server = await createServer({
@@ -100,8 +107,16 @@ describe('browser field', () => {
       './util.inspect',
       join(pkgDir, 'index.js'),
     )
+    const nestedResolved =
+      await server.environments.client.pluginContainer.resolveId(
+        './nested/util.inspect',
+        join(pkgDir, 'nested.js'),
+      )
 
     expect(resolved?.id).toBe('__vite-browser-external:./util.inspect')
+    expect(nestedResolved?.id).toBe(
+      '__vite-browser-external:./nested/util.inspect',
+    )
   })
 })
 

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -1,4 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../server'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
@@ -52,6 +54,54 @@ describe('import and resolveId', () => {
       'dir/index.default.js',
       expect.stringContaining('dir/index.module.js'),
     ])
+  })
+})
+
+describe('browser field', () => {
+  test('preserves relative ids for browser:false mappings', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vite-browser-field-'))
+    const pkgDir = join(root, 'node_modules', 'object-inspect')
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'object-inspect',
+          version: '1.0.0',
+          main: 'index.js',
+          browser: {
+            './util.inspect.js': false,
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    writeFileSync(
+      join(pkgDir, 'index.js'),
+      "var utilInspect = require('./util.inspect');\nmodule.exports = utilInspect;\n",
+    )
+
+    const server = await createServer({
+      configFile: false,
+      root,
+      logLevel: 'error',
+      server: {
+        middlewareMode: true,
+        ws: false,
+      },
+    })
+    onTestFinished(() => {
+      server.close()
+      rmSync(root, { recursive: true, force: true })
+    })
+
+    const resolved = await server.environments.client.pluginContainer.resolveId(
+      './util.inspect',
+      join(pkgDir, 'index.js'),
+    )
+
+    expect(resolved?.id).toBe('__vite-browser-external:./util.inspect')
   })
 })
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -446,6 +446,19 @@ function optimizerResolvePlugin(
             const basedir = importer ? path.dirname(importer) : root
             const fsPath = path.resolve(basedir, id)
             // handle browser field mapping for relative imports
+            if (options.mainFields.includes('browser')) {
+              const pkgData = findNearestPackageData(basedir, options.packageCache)
+              const browserField = pkgData?.data.browser
+              if (pkgData && isObject(browserField)) {
+                const mapped = mapWithBrowserField(
+                  `./${path.relative(pkgData.dir, fsPath)}`,
+                  browserField,
+                )
+                if (mapped === false) {
+                  return `${browserExternalId}:${id}`
+                }
+              }
+            }
 
             const normalizedFsPath = normalizePath(fsPath)
 
@@ -1087,8 +1100,9 @@ function resolveDeepImport(
     if (mapped) {
       relativeId = mapped + postfix
     } else if (mapped === false) {
-      setResolvedCache(id, browserExternalId, options)
-      return browserExternalId
+      const browserExternal = `${browserExternalId}:${id}`
+      setResolvedCache(id, browserExternal, options)
+      return browserExternal
     }
   }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -454,7 +454,7 @@ function optimizerResolvePlugin(
               const browserField = pkgData?.data.browser
               if (pkgData && isObject(browserField)) {
                 const mapped = mapWithBrowserField(
-                  `./${path.relative(pkgData.dir, fsPath)}`,
+                  `./${normalizePath(path.relative(pkgData.dir, fsPath))}`,
                   browserField,
                 )
                 if (mapped === false) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -447,7 +447,10 @@ function optimizerResolvePlugin(
             const fsPath = path.resolve(basedir, id)
             // handle browser field mapping for relative imports
             if (options.mainFields.includes('browser')) {
-              const pkgData = findNearestPackageData(basedir, options.packageCache)
+              const pkgData = findNearestPackageData(
+                basedir,
+                options.packageCache,
+              )
               const browserField = pkgData?.data.browser
               if (pkgData && isObject(browserField)) {
                 const mapped = mapWithBrowserField(


### PR DESCRIPTION
Fixes #22022.

Summary:
- Preserve relative specifiers when `browser:false` mappings externalize them, so the original request stays visible in the external id.
- Keep both the nearest package browser-map path and the deep-import path emitting `__vite-browser-external:<id>`.

Validation:
- `corepack pnpm exec vitest run packages/vite/src/node/__tests__/resolve.spec.ts -t "preserves relative ids for browser:false mappings"`
- `corepack pnpm exec rolldown --config rolldown.config.ts` in `packages/vite`
- `$env:NODE_ENV='development'; node ..\repo-vite-22022\packages\vite\bin\vite.js build` in the repro app
- `rg -n -F 'Module "" has been externalized' dist` with no matches

Manual risk:
- The change is backed by a focused resolver regression plus the repro build, but normal upstream review and CI are still the final gate.