### PR TITLE
fix: respect runtime rolldownOptions.input mutations in builder

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -864,6 +864,34 @@ test.for([true, false])(
   },
 )
 
+test('builder respects runtime rolldownOptions.input mutations', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/minify')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          write: false,
+          outDir: './dist/client',
+        },
+      },
+    },
+  })
+
+  builder.environments.client.config.build.rolldownOptions = {
+    input: '/entry.js',
+    output: {
+      entryFileNames: '__test__.js',
+    },
+  }
+
+  const result = await builder.build(builder.environments.client)
+  expect((result as RolldownOutput).output[0].fileName).toMatch(
+    /assets\/entry-[-\w]{8}\.js/,
+  )
+})
+
 test('sharedConfigBuild and emitAssets', async () => {
   const root = resolve(dirname, 'fixtures/shared-config-build/emitAssets')
   const builder = await createBuilder({

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -570,10 +570,11 @@ export function resolveRolldownOptions(
   const libOptions = options.lib
   const { logger } = environment
   const ssr = environment.config.consumer === 'server'
+  const rolldownInput = options.rolldownOptions.input
 
   const resolve = (p: string) => path.resolve(root, p)
   const input = libOptions
-    ? options.rollupOptions.input ||
+    ? rolldownInput ||
       (typeof libOptions.entry === 'string'
         ? resolve(libOptions.entry)
         : Array.isArray(libOptions.entry)
@@ -586,7 +587,7 @@ export function resolveRolldownOptions(
             ))
     : typeof options.ssr === 'string'
       ? resolve(options.ssr)
-      : options.rollupOptions.input || resolve('index.html')
+      : rolldownInput || resolve('index.html')
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(


### PR DESCRIPTION
## Summary
- read the build entry from `rolldownOptions.input` when resolving Rolldown build inputs
- keep the existing `index.html` fallback only when no runtime input override is present
- add a regression covering `builder.environments.client.config.build.rolldownOptions` mutations before `builder.build(...)`

## Validation
- `corepack pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts -t "builder respects runtime rolldownOptions.input mutations"`
- `corepack pnpm --filter vite build`