### PR TITLE
fix(docs): preserve cross-origin docsearch hits

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -560,6 +560,18 @@ const config = defineConfig({
     },
   },
   vite: {
+    resolve: {
+      alias: [
+        {
+          // Preserve old-version doc search hits as cross-origin navigations.
+          find: /^.*\/vitepress-default\/VPAlgoliaSearchBox\.vue$/,
+          replacement: path.resolve(
+            import.meta.dirname,
+            './theme/components/ViteDocSearchBox.vue',
+          ),
+        },
+      ],
+    },
     plugins: [
       groupIconVitePlugin({
         customIcon: {

--- a/docs/.vitepress/theme/components/ViteDocSearchBox.vue
+++ b/docs/.vitepress/theme/components/ViteDocSearchBox.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import type { DocSearchInstance, DocSearchProps } from '@docsearch/js'
+import type { SidepanelInstance, SidepanelProps } from '@docsearch/sidepanel-js'
+import { inBrowser, useData, useRouter } from 'vitepress'
+import type { DefaultTheme } from 'vitepress/theme'
+import { nextTick, onUnmounted, watch } from 'vue'
+import type { DocSearchAskAi } from '@voidzero-dev/vitepress-theme/src/types/docsearch'
+import {
+  resolveMode,
+  validateCredentials,
+} from '@voidzero-dev/vitepress-theme/src/support/vitepress-default/docsearch'
+import {
+  resolveDocSearchNavigationTarget,
+  resolveDocSearchResultUrl,
+} from '../composables/docsearchResultUrl'
+
+import '@voidzero-dev/vitepress-theme/src/styles/vitepress-default/docsearch.css'
+
+const props = defineProps<{
+  algoliaOptions: DefaultTheme.AlgoliaSearchOptions
+  openRequest?: {
+    target: 'search' | 'askAi' | 'toggleAskAi'
+    nonce: number
+  } | null
+}>()
+
+const router = useRouter()
+const { site } = useData()
+
+let cleanup = () => {}
+let docsearchInstance: DocSearchInstance | undefined
+let sidepanelInstance: SidepanelInstance | undefined
+let openOnReady: 'search' | 'askAi' | null = null
+let initializeCount = 0
+let docsearchLoader: Promise<typeof import('@docsearch/js')> | undefined
+let sidepanelLoader:
+  | Promise<typeof import('@docsearch/sidepanel-js')>
+  | undefined
+let lastFocusedElement: HTMLElement | null = null
+let skipEventDocsearch = false
+let skipEventSidepanel = false
+
+watch(() => props.algoliaOptions, update, { immediate: true })
+onUnmounted(cleanup)
+
+watch(
+  () => props.openRequest?.nonce,
+  () => {
+    const req = props.openRequest
+    if (!req) return
+    if (req.target === 'search') {
+      if (docsearchInstance?.isReady) {
+        onBeforeOpen('docsearch', () => docsearchInstance?.open())
+      } else {
+        openOnReady = 'search'
+      }
+    } else if (req.target === 'toggleAskAi') {
+      if (sidepanelInstance?.isOpen) {
+        sidepanelInstance.close()
+      } else {
+        onBeforeOpen('sidepanel', () => sidepanelInstance?.open())
+      }
+    } else {
+      if (sidepanelInstance?.isReady) {
+        onBeforeOpen('sidepanel', () => sidepanelInstance?.open())
+      } else if (sidepanelInstance) {
+        openOnReady = 'askAi'
+      } else if (docsearchInstance?.isReady) {
+        onBeforeOpen('docsearch', () => docsearchInstance?.openAskAi())
+      } else {
+        openOnReady = 'askAi'
+      }
+    }
+  },
+  { immediate: true },
+)
+
+async function update(options: DefaultTheme.AlgoliaSearchOptions) {
+  if (!inBrowser) return
+  await nextTick()
+
+  const askAi = options.askAi as DocSearchAskAi | undefined
+
+  const { valid, ...credentials } = validateCredentials({
+    appId: options.appId ?? askAi?.appId,
+    apiKey: options.apiKey ?? askAi?.apiKey,
+    indexName: options.indexName ?? askAi?.indexName,
+  })
+
+  if (!valid) {
+    console.warn(
+      '[vitepress] Algolia search cannot be initialized: missing appId/apiKey/indexName.',
+    )
+    return
+  }
+
+  await initialize({ ...options, ...credentials })
+}
+
+async function initialize(userOptions: DefaultTheme.AlgoliaSearchOptions) {
+  const currentInitialize = ++initializeCount
+
+  cleanup()
+
+  const { useSidePanel } = resolveMode(userOptions)
+  const askAi = userOptions.askAi as DocSearchAskAi | undefined
+
+  const { default: docsearch } = await loadDocsearch()
+  if (currentInitialize !== initializeCount) return
+
+  if (useSidePanel && askAi?.sidePanel) {
+    const { default: sidepanel } = await loadSidepanel()
+    if (currentInitialize !== initializeCount) return
+
+    sidepanelInstance = sidepanel({
+      ...(askAi.sidePanel === true ? {} : askAi.sidePanel),
+      container: '#vp-docsearch-sidepanel',
+      indexName: askAi.indexName ?? userOptions.indexName,
+      appId: askAi.appId ?? userOptions.appId,
+      apiKey: askAi.apiKey ?? userOptions.apiKey,
+      assistantId: askAi.assistantId,
+      onOpen: focusInput,
+      onClose: onClose.bind(null, 'sidepanel'),
+      onReady: () => {
+        if (openOnReady === 'askAi') {
+          openOnReady = null
+          onBeforeOpen('sidepanel', () => sidepanelInstance?.open())
+        }
+      },
+      keyboardShortcuts: {
+        'Ctrl/Cmd+I': false,
+      },
+    } as SidepanelProps)
+  }
+
+  const options = {
+    ...userOptions,
+    container: '#vp-docsearch',
+    navigator: {
+      navigate(item) {
+        const target = resolveDocSearchNavigationTarget(
+          item.itemUrl,
+          location.origin,
+          site.value.cleanUrls,
+        )
+
+        if (target.external) {
+          window.location.assign(target.url)
+        } else {
+          router.go(target.url)
+        }
+      },
+    },
+    transformItems: (items) =>
+      items.map((item) => ({
+        ...item,
+        url: resolveDocSearchResultUrl(
+          item.url,
+          location.origin,
+          site.value.cleanUrls,
+        ),
+      })),
+    ...(useSidePanel &&
+      sidepanelInstance && {
+        interceptAskAiEvent: (initialMessage) => {
+          onBeforeOpen('sidepanel', () =>
+            sidepanelInstance?.open(initialMessage),
+          )
+          return true
+        },
+      }),
+    onOpen: focusInput,
+    onClose: onClose.bind(null, 'docsearch'),
+    onReady: () => {
+      if (openOnReady === 'search') {
+        openOnReady = null
+        onBeforeOpen('docsearch', () => docsearchInstance?.open())
+      } else if (openOnReady === 'askAi' && !sidepanelInstance) {
+        openOnReady = null
+        onBeforeOpen('docsearch', () => docsearchInstance?.openAskAi())
+      }
+    },
+    keyboardShortcuts: {
+      '/': false,
+      'Ctrl/Cmd+K': false,
+    },
+  } as DocSearchProps
+
+  docsearchInstance = docsearch(options)
+
+  cleanup = () => {
+    docsearchInstance?.destroy()
+    sidepanelInstance?.destroy()
+    docsearchInstance = undefined
+    sidepanelInstance = undefined
+    openOnReady = null
+    lastFocusedElement = null
+  }
+}
+
+function focusInput() {
+  requestAnimationFrame(() => {
+    const input =
+      document.querySelector<HTMLInputElement>('#docsearch-input') ||
+      document.querySelector<HTMLInputElement>('#docsearch-sidepanel textarea')
+    input?.focus()
+  })
+}
+
+function onBeforeOpen(target: 'docsearch' | 'sidepanel', cb: () => void) {
+  if (target === 'docsearch') {
+    if (sidepanelInstance?.isOpen) {
+      skipEventSidepanel = true
+      sidepanelInstance.close()
+    } else if (!docsearchInstance?.isOpen) {
+      if (document.activeElement instanceof HTMLElement) {
+        lastFocusedElement = document.activeElement
+      }
+    }
+  } else if (target === 'sidepanel') {
+    if (docsearchInstance?.isOpen) {
+      skipEventDocsearch = true
+      docsearchInstance.close()
+    } else if (!sidepanelInstance?.isOpen) {
+      if (document.activeElement instanceof HTMLElement) {
+        lastFocusedElement = document.activeElement
+      }
+    }
+  }
+  setTimeout(cb, 0)
+}
+
+function onClose(target: 'docsearch' | 'sidepanel') {
+  if (target === 'docsearch') {
+    if (skipEventDocsearch) {
+      skipEventDocsearch = false
+      return
+    }
+  } else if (target === 'sidepanel') {
+    if (skipEventSidepanel) {
+      skipEventSidepanel = false
+      return
+    }
+  }
+  if (lastFocusedElement) {
+    lastFocusedElement.focus()
+    lastFocusedElement = null
+  }
+}
+
+function loadDocsearch() {
+  if (!docsearchLoader) {
+    docsearchLoader = import('@docsearch/js')
+  }
+  return docsearchLoader
+}
+
+function loadSidepanel() {
+  if (!sidepanelLoader) {
+    sidepanelLoader = import('@docsearch/sidepanel-js')
+  }
+  return sidepanelLoader
+}
+</script>
+
+<template>
+  <div id="vp-docsearch" />
+  <div id="vp-docsearch-sidepanel" />
+</template>

--- a/docs/.vitepress/theme/composables/__tests__/docsearchResultUrl.spec.ts
+++ b/docs/.vitepress/theme/composables/__tests__/docsearchResultUrl.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+import {
+  resolveDocSearchNavigationTarget,
+  resolveDocSearchResultUrl,
+} from '../docsearchResultUrl'
+
+describe('resolveDocSearchNavigationTarget', () => {
+  test('normalizes same-origin result urls for client-side routing', () => {
+    expect(
+      resolveDocSearchNavigationTarget(
+        'https://vite.dev/guide/why.html?foo=bar#intro',
+        'https://vite.dev',
+        true,
+      ),
+    ).toEqual({
+      external: false,
+      url: '/guide/why?foo=bar#intro',
+    })
+  })
+
+  test('preserves cross-origin result urls for old docs versions', () => {
+    expect(
+      resolveDocSearchNavigationTarget(
+        'https://v7.vite.dev/guide/rolldown.html#usage',
+        'https://vite.dev',
+        true,
+      ),
+    ).toEqual({
+      external: true,
+      url: 'https://v7.vite.dev/guide/rolldown.html#usage',
+    })
+  })
+})
+
+describe('resolveDocSearchResultUrl', () => {
+  test('keeps .html urls when cleanUrls is disabled', () => {
+    expect(
+      resolveDocSearchResultUrl(
+        '/guide/why.html?foo=bar#intro',
+        'https://vite.dev',
+        false,
+      ),
+    ).toBe('/guide/why.html?foo=bar#intro')
+  })
+})

--- a/docs/.vitepress/theme/composables/docsearchResultUrl.ts
+++ b/docs/.vitepress/theme/composables/docsearchResultUrl.ts
@@ -1,0 +1,32 @@
+export interface DocSearchNavigationTarget {
+  external: boolean
+  url: string
+}
+
+export function resolveDocSearchNavigationTarget(
+  url: string,
+  origin: string,
+  cleanUrls: boolean,
+): DocSearchNavigationTarget {
+  const resolvedUrl = new URL(url, origin)
+  const external = resolvedUrl.origin !== origin
+
+  return {
+    external,
+    url: external
+      ? resolvedUrl.href
+      : `${cleanPathname(resolvedUrl.pathname, cleanUrls)}${resolvedUrl.search}${resolvedUrl.hash}`,
+  }
+}
+
+export function resolveDocSearchResultUrl(
+  url: string,
+  origin: string,
+  cleanUrls: boolean,
+): string {
+  return resolveDocSearchNavigationTarget(url, origin, cleanUrls).url
+}
+
+function cleanPathname(pathname: string, cleanUrls: boolean): string {
+  return cleanUrls ? pathname.replace(/\.html$/, '') : pathname
+}


### PR DESCRIPTION
## Summary
- preserve cross-origin Algolia docsearch hits instead of collapsing them into same-origin SPA routes
- override the docs theme search box used by the Vite docs site so old-version results navigate with a full page load
- add a focused unit test for the URL normalization and navigation target logic

## Reproduction
- search for a result that points to an older docs host such as `v7.vite.dev`
- click the result from the docs search modal on `vite.dev`
- before this change, the docs SPA rewrote it into a same-origin route and bypassed the server redirect

Closes #22049

## Testing
- `corepack pnpm --filter vite build`
- `corepack pnpm exec vitest run docs/.vitepress/theme/composables/__tests__/docsearchResultUrl.spec.ts`
- `corepack pnpm --filter=./docs run docs-build`