### PR TITLE
fix: avoid browser-external proxy in NODE_ENV=development builds

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/browser-false-cjs/index.html
+++ b/packages/vite/src/node/__tests__/fixtures/browser-false-cjs/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/packages/vite/src/node/__tests__/fixtures/browser-false-cjs/main.js
+++ b/packages/vite/src/node/__tests__/fixtures/browser-false-cjs/main.js
@@ -1,0 +1,3 @@
+import inspectResult from 'browser-false-cjs-dep'
+
+window.__INSPECT_RESULT__ = inspectResult

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../server'
@@ -309,5 +310,39 @@ describe('file url', () => {
       join(import.meta.dirname, 'fixtures/file-url/dist/virtual/index.js')
     )
     expect(mod2.default.default).toBe('ok')
+  })
+})
+
+describe('browser: false build output', () => {
+  test('build keeps browser-disabled CJS deep imports inert when NODE_ENV=development', async () => {
+    const root = join(import.meta.dirname, 'fixtures/browser-false-cjs')
+    const outDir = 'dist-dev'
+    const previousNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    onTestFinished(() => {
+      process.env.NODE_ENV = previousNodeEnv
+      fs.rmSync(join(root, outDir), { recursive: true, force: true })
+    })
+
+    await build({
+      configFile: false,
+      root,
+      logLevel: 'error',
+      build: {
+        minify: false,
+        outDir,
+      },
+    })
+
+    const bundleDir = join(root, outDir, 'assets')
+    const bundleFile = fs
+      .readdirSync(bundleDir)
+      .find((file) => file.endsWith('.js'))
+    expect(bundleFile).toBeDefined()
+
+    const output = fs.readFileSync(join(bundleDir, bundleFile!), 'utf-8')
+    expect(output).toContain('module.exports = {}')
+    expect(output).not.toContain('externalized for browser compatibility')
   })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -518,6 +518,9 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
     ],
     post: [
       ...(isBuild ? buildImportAnalysisPlugin(config) : []),
+      ...(isBuild && process.env.NODE_ENV !== 'production'
+        ? [buildBrowserExternalRewritePlugin()]
+        : []),
       ...(config.build.minify === 'esbuild' ? [buildEsbuildPlugin()] : []),
       ...(isBuild ? [terserPlugin(config)] : []),
       ...(isBuild && !config.isWorker
@@ -530,6 +533,26 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
         : []),
       nativeLoadFallbackPlugin(),
     ],
+  }
+}
+
+const browserExternalWarningStubRE =
+  /module\.exports = Object\.create\(new Proxy\(\{\}, \{ get\(_, key\) \{\s*if \(key !== "__esModule" && key !== "__proto__" && key !== "constructor" && key !== "splice"\) throw new Error\(`Module "[^`]*" has been externalized for browser compatibility\. Cannot access "[^`]*\.\$\{key\}" in client code\.\s+See https:\/\/vite\.dev\/guide\/troubleshooting\.html#module-externalized-for-browser-compatibility for more details\.`\);\s*\} \}\)\);/g
+
+function buildBrowserExternalRewritePlugin(): Plugin {
+  return {
+    name: 'vite:build-browser-external-rewrite',
+    renderChunk(code) {
+      const rewritten = code.replace(
+        browserExternalWarningStubRE,
+        'module.exports = {}',
+      )
+      if (rewritten === code) return null
+      return {
+        code: rewritten,
+        map: null,
+      }
+    },
   }
 }
 


### PR DESCRIPTION
Fixes #22022.

## Summary
- rewrite the internal `__vite-browser-external` CommonJS proxy back to an inert stub during `vite build` runs where `NODE_ENV` is not `production`
- keep the behavior scoped to build output so dev-server browser-external warnings stay unchanged
- add a regression fixture that reproduces the `browser: false` CommonJS deep-import case from the issue

## Validation
- `corepack pnpm exec vitest run packages/vite/src/node/__tests__/resolve.spec.ts packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts`
- `corepack pnpm exec eslint packages/vite/src/node/build.ts packages/vite/src/node/__tests__/resolve.spec.ts`
- rebuilt `packages/vite` locally and verified the public repro from #22022 now emits `module.exports = {}` instead of the throwing browser-external proxy when built with `NODE_ENV=development`