### PR TITLE
fix: preserve manifest metadata for same-basename CSS entries

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1160,6 +1160,63 @@ test('watch rebuild manifest', async (ctx) => {
   `)
 })
 
+test('manifest keeps same-basename css entries independent', async () => {
+  const root = resolve(dirname, 'fixtures/manifest-css-entry-same-basename')
+  const output = (await build({
+    root,
+    logLevel: 'silent',
+    build: {
+      write: false,
+      manifest: true,
+      rollupOptions: {
+        input: [
+          resolve(
+            root,
+            'resources/assets/css/store/skins/store_skin_85535.css',
+          ),
+          resolve(
+            root,
+            'resources/assets/css/store3/skins/store_skin_85535.css',
+          ),
+        ],
+      },
+    },
+  })) as RolldownOutput
+
+  const manifestAsset = output.output.find(
+    (item) => item.fileName === '.vite/manifest.json',
+  )
+  expect(manifestAsset?.type).toBe('asset')
+
+  const manifest = JSON.parse(
+    manifestAsset!.type === 'asset' ? manifestAsset.source.toString() : '{}',
+  ) as Record<
+    string,
+    { css?: string[]; file: string; isEntry?: boolean; src?: string }
+  >
+
+  const firstKey = 'resources/assets/css/store/skins/store_skin_85535.css'
+  const secondKey = 'resources/assets/css/store3/skins/store_skin_85535.css'
+
+  expect(manifest[firstKey]).toMatchObject({
+    isEntry: true,
+    src: firstKey,
+  })
+  expect(manifest[secondKey]).toMatchObject({
+    isEntry: true,
+    src: secondKey,
+  })
+  expect(manifest[firstKey].file).toMatch(
+    /^assets\/store_skin_85535-[\w-]+\.css$/,
+  )
+  expect(manifest[secondKey].file).toMatch(
+    /^assets\/store_skin_85535-[\w-]+\.css$/,
+  )
+  expect(manifest[firstKey].file).not.toBe(manifest[secondKey].file)
+  expect(manifest[firstKey].css).toBeUndefined()
+  expect(manifest[secondKey].css).toBeUndefined()
+})
+
 /**
  * for each chunks in output1, if there's a chunk in output2 with the same fileName,
  * ensure that the chunk code is the same. if not, the chunk hash should have changed.

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1192,7 +1192,13 @@ test('manifest keeps same-basename css entries independent', async () => {
     manifestAsset!.type === 'asset' ? manifestAsset.source.toString() : '{}',
   ) as Record<
     string,
-    { css?: string[]; file: string; isEntry?: boolean; src?: string }
+    {
+      css?: string[]
+      file: string
+      isEntry?: boolean
+      name?: string
+      src?: string
+    }
   >
 
   const firstKey = 'resources/assets/css/store/skins/store_skin_85535.css'
@@ -1215,6 +1221,55 @@ test('manifest keeps same-basename css entries independent', async () => {
   expect(manifest[firstKey].file).not.toBe(manifest[secondKey].file)
   expect(manifest[firstKey].css).toBeUndefined()
   expect(manifest[secondKey].css).toBeUndefined()
+})
+
+test('manifest preserves explicit css entry aliases for same-basename files', async () => {
+  const root = resolve(dirname, 'fixtures/manifest-css-entry-same-basename')
+  const firstKey = 'resources/assets/css/store/skins/store_skin_85535.css'
+  const secondKey = 'resources/assets/css/store3/skins/store_skin_85535.css'
+
+  const output = (await build({
+    root,
+    logLevel: 'silent',
+    build: {
+      write: false,
+      manifest: true,
+      rollupOptions: {
+        input: {
+          'bar.css': resolve(root, firstKey),
+          'bar.custom': resolve(root, secondKey),
+        },
+      },
+    },
+  })) as RolldownOutput
+
+  const manifestAsset = output.output.find(
+    (item) => item.fileName === '.vite/manifest.json',
+  )
+  expect(manifestAsset?.type).toBe('asset')
+
+  const manifest = JSON.parse(
+    manifestAsset!.type === 'asset' ? manifestAsset.source.toString() : '{}',
+  ) as Record<
+    string,
+    {
+      file: string
+      isEntry?: boolean
+      name?: string
+      src?: string
+    }
+  >
+
+  expect(manifest[firstKey]).toMatchObject({
+    isEntry: true,
+    name: 'bar.css',
+    src: firstKey,
+  })
+  expect(manifest[secondKey]).toMatchObject({
+    isEntry: true,
+    name: 'bar.custom',
+    src: secondKey,
+  })
 })
 
 /**

--- a/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/resources/assets/css/store/skins/store_skin_85535.css
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/resources/assets/css/store/skins/store_skin_85535.css
@@ -1,0 +1,3 @@
+.button {
+  color: #f75a38;
+}

--- a/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/resources/assets/css/store3/skins/store_skin_85535.css
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename/resources/assets/css/store3/skins/store_skin_85535.css
@@ -1,0 +1,3 @@
+.button {
+  color: #ffffff;
+}

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -53,8 +53,14 @@ export const inlineRE: RegExp = /[?&]inline\b/
 
 const assetCache = new WeakMap<Environment, Map<string, string>>()
 
-/** a set of referenceId for entry CSS assets for each environment */
+/** manifest name -> referenceId for entry CSS assets for each environment */
 export const cssEntriesMap: WeakMap<
+  Environment,
+  Map<string, string>
+> = new WeakMap()
+
+/** placeholder preliminary file name -> referenceId for pure CSS entry assets */
+export const cssEntryReferenceIdsMap: WeakMap<
   Environment,
   Map<string, string>
 > = new WeakMap()
@@ -160,6 +166,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     buildStart() {
       assetCache.set(this.environment, new Map())
       cssEntriesMap.set(this.environment, new Map())
+      cssEntryReferenceIdsMap.set(this.environment, new Map())
     },
 
     resolveId: {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -98,6 +98,7 @@ import { addToHTMLProxyTransformResult } from './html'
 import {
   assetUrlRE,
   cssEntriesMap,
+  cssEntryReferenceIdsMap,
   fileToUrl,
   publicAssetUrlCache,
   publicAssetUrlRE,
@@ -276,12 +277,32 @@ export const removedPureCssFilesCache: WeakMap<
   Map<string, RenderedChunk>
 > = new WeakMap()
 
-function getCssEntryKey(
+function getCssEntryManifestName(
   chunk: OutputChunk | RenderedChunk,
-  root: string,
+  config: ResolvedConfig,
   isLegacy: boolean,
 ): string {
-  return getChunkOriginalFileName(chunk, root, isLegacy) ?? chunk.name
+  if (chunk.facadeModuleId) {
+    const input = config.build.rollupOptions.input
+    if (input && !Array.isArray(input) && typeof input === 'object') {
+      const normalizedFacadeModuleId = normalizePath(chunk.facadeModuleId)
+      for (const [name, entry] of Object.entries(input)) {
+        const resolvedEntry = normalizePath(
+          path.isAbsolute(entry) ? entry : path.resolve(config.root, entry),
+        )
+        if (resolvedEntry === normalizedFacadeModuleId) {
+          if (isLegacy && !name.includes('-legacy')) {
+            const ext = path.extname(name)
+            const endPos = ext.length !== 0 ? -ext.length : undefined
+            return `${name.slice(0, endPos)}-legacy${ext}`
+          }
+          return name
+        }
+      }
+    }
+  }
+
+  return getChunkOriginalFileName(chunk, config.root, isLegacy) ?? chunk.name
 }
 
 // Used only if the config doesn't code-split CSS (builds a single CSS file)
@@ -925,9 +946,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                     cssEntriesMap
                       .get(this.environment)!
                       .set(
-                        getCssEntryKey(chunk, config.root, isLegacyChunk),
+                        getCssEntryManifestName(chunk, config, isLegacyChunk),
                         referenceId,
                       )
+                    cssEntryReferenceIdsMap
+                      .get(this.environment)!
+                      .set(chunk.preliminaryFileName, referenceId)
                   }
                   chunk.viteMetadata!.importedCss.add(
                     this.getFileName(referenceId),
@@ -1126,9 +1150,18 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             const cssReferenceId = cssEntriesMap
               .get(this.environment)!
               .get(
-                getCssEntryKey(emptyJsPlaceholder, config.root, isLegacyChunk),
+                getCssEntryManifestName(
+                  emptyJsPlaceholder,
+                  config,
+                  isLegacyChunk,
+                ),
               )!
-            const realCssEntryName = this.getFileName(cssReferenceId)
+            const cssReferenceIdByPlaceholder = cssEntryReferenceIdsMap
+              .get(this.environment)!
+              .get(emptyJsPlaceholder.preliminaryFileName)
+            const realCssEntryName = this.getFileName(
+              cssReferenceIdByPlaceholder ?? cssReferenceId,
+            )
             const realCssEntry = bundle[realCssEntryName]!
             importedCss.delete(realCssEntryName)
             if (importedAssets.size) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -951,7 +951,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                       )
                     cssEntryReferenceIdsMap
                       .get(this.environment)!
-                      .set(chunk.preliminaryFileName, referenceId)
+                      .set(
+                        ('preliminaryFileName' in chunk
+                          ? chunk.preliminaryFileName
+                          : chunk.fileName) as string,
+                        referenceId,
+                      )
                   }
                   chunk.viteMetadata!.importedCss.add(
                     this.getFileName(referenceId),
@@ -1158,7 +1163,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               )!
             const cssReferenceIdByPlaceholder = cssEntryReferenceIdsMap
               .get(this.environment)!
-              .get(emptyJsPlaceholder.preliminaryFileName)
+              .get(
+                ('preliminaryFileName' in emptyJsPlaceholder
+                  ? emptyJsPlaceholder.preliminaryFileName
+                  : emptyJsPlaceholder.fileName) as string,
+              )
             const realCssEntryName = this.getFileName(
               cssReferenceIdByPlaceholder ?? cssReferenceId,
             )

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -276,6 +276,14 @@ export const removedPureCssFilesCache: WeakMap<
   Map<string, RenderedChunk>
 > = new WeakMap()
 
+function getCssEntryKey(
+  chunk: OutputChunk | RenderedChunk,
+  root: string,
+  isLegacy: boolean,
+): string {
+  return getChunkOriginalFileName(chunk, root, isLegacy) ?? chunk.name
+}
+
 // Used only if the config doesn't code-split CSS (builds a single CSS file)
 export const cssBundleNameCache: WeakMap<ResolvedConfig, string> = new WeakMap()
 
@@ -874,6 +882,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   (opts.format === 'es' || opts.format === 'cjs') &&
                   !chunk.fileName.includes('-legacy')
                 ) {
+                  const isLegacyChunk =
+                    this.environment.config.isOutputOptionsForLegacyChunks?.(
+                      opts,
+                    ) ?? false
                   const isEntry = chunk.isEntry && isPureCssChunk
                   const cssFullAssetName = ensureFileExt(chunk.name, '.css')
                   // if facadeModuleId doesn't exist or doesn't have a CSS extension,
@@ -888,9 +900,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   const originalFileName = getChunkOriginalFileName(
                     chunk,
                     config.root,
-                    this.environment.config.isOutputOptionsForLegacyChunks?.(
-                      opts,
-                    ) ?? false,
+                    isLegacyChunk,
                   )
 
                   chunkCSS = resolveAssetUrlsInCss(
@@ -914,7 +924,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   if (isEntry) {
                     cssEntriesMap
                       .get(this.environment)!
-                      .set(chunk.name, referenceId)
+                      .set(
+                        getCssEntryKey(chunk, config.root, isLegacyChunk),
+                        referenceId,
+                      )
                   }
                   chunk.viteMetadata!.importedCss.add(
                     this.getFileName(referenceId),
@@ -1107,9 +1120,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           if (emptyJsPlaceholder.isEntry) {
             const { importedAssets, importedCss } =
               emptyJsPlaceholder.viteMetadata!
+            const isLegacyChunk =
+              this.environment.config.isOutputOptionsForLegacyChunks?.(opts) ??
+              false
             const cssReferenceId = cssEntriesMap
               .get(this.environment)!
-              .get(emptyJsPlaceholder.name)!
+              .get(
+                getCssEntryKey(emptyJsPlaceholder, config.root, isLegacyChunk),
+              )!
             const realCssEntryName = this.getFileName(cssReferenceId)
             const realCssEntry = bundle[realCssEntryName]!
             importedCss.delete(realCssEntryName)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/file-url: {}
 
+  packages/vite/src/node/__tests__/fixtures/manifest-css-entry-same-basename: {}
+
   packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob: {}
 
   packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}


### PR DESCRIPTION
## Summary
- key emitted CSS entry metadata by the original entry path when available instead of the lossy chunk basename
- reuse the same key when replacing pure CSS entry placeholders so manifest bookkeeping resolves the right emitted asset
- add a build regression for two CSS entry points with the same basename in different directories

Fixes #22013.

## Testing
- `corepack pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts -t "manifest keeps same-basename css entries independent"`
- `corepack pnpm exec eslint packages/vite/src/node/plugins/css.ts packages/vite/src/node/__tests__/build.spec.ts`
- `git diff --check`