### PR TITLE
types: disallow unsupported sourcemapFileNames output option

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -251,6 +251,42 @@ describe('build', () => {
     ) as OutputChunk
     expect(foo.code).not.contains('import "external"')
   })
+
+  test('warns when sourcemapFileNames is configured', async () => {
+    const logger = createLogger('silent')
+    const warnSpy = vi.spyOn(logger, 'warnOnce').mockImplementation(() => {})
+
+    await build({
+      root: resolve(dirname, 'fixtures/emit-assets'),
+      logLevel: 'silent',
+      customLogger: logger,
+      build: {
+        write: false,
+        sourcemap: true,
+        rollupOptions: {
+          input: {
+            index: '/entry',
+          },
+          output: {
+            sourcemapFileNames: 'maps/[name]-[hash].map',
+          } as OutputOptions,
+        },
+      },
+    })
+
+    const logs = warnSpy.mock.calls.map((args) =>
+      stripVTControlCharacters(args[0]),
+    )
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Vite does not support "rollupOptions.output.sourcemapFileNames"',
+        ),
+      ]),
+    )
+    expect(logs.join('\n')).not.toContain('Invalid output options')
+  })
 })
 
 const baseLibOptions: LibraryOptions = {

--- a/packages/vite/src/node/__tests_dts__/config.ts
+++ b/packages/vite/src/node/__tests_dts__/config.ts
@@ -47,6 +47,37 @@ defineConfig({
   unknownProperty: 1,
 })
 
+defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        // @ts-expect-error --- unsupported by Vite's Rolldown-backed build
+        sourcemapFileNames: '[name]-[hash].js.map',
+      },
+    },
+    rolldownOptions: {
+      output: {
+        // @ts-expect-error --- unsupported by Vite's Rolldown-backed build
+        sourcemapFileNames: '[name]-[hash].js.map',
+      },
+    },
+  },
+  worker: {
+    rollupOptions: {
+      output: {
+        // @ts-expect-error --- unsupported by Vite's Rolldown-backed worker build
+        sourcemapFileNames: '[name]-[hash].js.map',
+      },
+    },
+    rolldownOptions: {
+      output: {
+        // @ts-expect-error --- unsupported by Vite's Rolldown-backed worker build
+        sourcemapFileNames: '[name]-[hash].js.map',
+      },
+    },
+  },
+})
+
 defineConfig(() => ({
   base: '',
   build: {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -191,12 +191,12 @@ export interface BuildEnvironmentOptions {
    * Alias to `rolldownOptions`
    * @deprecated Use `rolldownOptions` instead.
    */
-  rollupOptions?: RolldownOptions
+  rollupOptions?: ViteRolldownOptions
   /**
    * Will be merged with internal rolldown options.
    * https://rolldown.rs/reference/config-options
    */
-  rolldownOptions?: RolldownOptions
+  rolldownOptions?: ViteRolldownOptions
   /**
    * Options to pass on to `@rollup/plugin-commonjs`
    * @deprecated This option is no-op and will be removed in future versions.
@@ -303,6 +303,12 @@ export interface BuildEnvironmentOptions {
 }
 
 export type BuildOptions = BuildEnvironmentOptions
+
+export type ViteOutputOptions = Omit<OutputOptions, 'sourcemapFileNames'>
+
+export type ViteRolldownOptions = Omit<RolldownOptions, 'output'> & {
+  output?: ViteOutputOptions | ViteOutputOptions[]
+}
 
 export interface LibraryOptions {
   /**

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -661,21 +661,33 @@ export function resolveRolldownOptions(
     environment.getTopLevelConfig().ssr?.target === 'webworker'
 
   const buildOutputOptions = (output: OutputOptions = {}): OutputOptions => {
+    const { sourcemapFileNames, ...outputOptions } = output as OutputOptions & {
+      sourcemapFileNames?: string
+    }
+    if (sourcemapFileNames !== undefined) {
+      logger.warnOnce(
+        colors.yellow(
+          `Vite does not support "rollupOptions.output.sourcemapFileNames". ` +
+            `Rolldown doesn't support customizing sourcemap filenames yet, so this option is ignored.`,
+        ),
+      )
+    }
+
     // @ts-expect-error See https://github.com/vitejs/vite/issues/5812#issuecomment-984345618
-    if (output.output) {
+    if (outputOptions.output) {
       logger.warn(
         `You've set "rollupOptions.output.output" in your config. ` +
           `This is deprecated and will override all Vite.js default output options. ` +
           `Please use "rollupOptions.output" instead.`,
       )
     }
-    if (output.file) {
+    if (outputOptions.file) {
       throw new Error(
         `Vite does not support "rollupOptions.output.file". ` +
           `Please use "rollupOptions.output.dir" and "rollupOptions.output.entryFileNames" instead.`,
       )
     }
-    if (output.sourcemap) {
+    if (outputOptions.sourcemap) {
       logger.warnOnce(
         colors.yellow(
           `Vite does not support "rollupOptions.output.sourcemap". ` +
@@ -684,7 +696,7 @@ export function resolveRolldownOptions(
       )
     }
 
-    const format = output.format || 'es'
+    const format = outputOptions.format || 'es'
     const jsExt =
       (ssr && !isSsrTargetWebworkerEnvironment) || libOptions
         ? resolveOutputJsExtension(
@@ -726,16 +738,16 @@ export function resolveRolldownOptions(
         ? `[name].[ext]`
         : path.posix.join(options.assetsDir, `[name]-[hash].[ext]`),
       codeSplitting:
-        output.codeSplitting ??
-        (output.format === 'umd' ||
-        output.format === 'iife' ||
+        outputOptions.codeSplitting ??
+        (outputOptions.format === 'umd' ||
+        outputOptions.format === 'iife' ||
         (isSsrTargetWebworkerEnvironment &&
           (typeof input === 'string' || Object.keys(input).length === 1))
           ? false
           : undefined),
       comments:
-        typeof output.comments === 'boolean'
-          ? output.comments
+        typeof outputOptions.comments === 'boolean'
+          ? outputOptions.comments
           : {
               // Do not minify whitespace for ES lib output since that would remove
               // pure annotations and break tree-shaking
@@ -744,7 +756,7 @@ export function resolveRolldownOptions(
                 (libOptions && (format === 'es' || format === 'esm')),
               jsdoc: !options.minify,
               legal: !options.minify,
-              ...output.comments,
+              ...outputOptions.comments,
             },
       minify:
         options.minify === 'oxc'
@@ -761,7 +773,7 @@ export function resolveRolldownOptions(
             ? 'dce-only'
             : false,
       topLevelVar: true,
-      ...output,
+      ...outputOptions,
     }
   }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -55,6 +55,7 @@ import type {
   ResolvedBuildEnvironmentOptions,
   ResolvedBuildOptions,
   ResolvedBuilderOptions,
+  ViteRolldownOptions,
 } from './build'
 import {
   buildEnvironmentOptionsDefaults,
@@ -480,14 +481,14 @@ export interface UserConfig extends DefaultEnvironmentOptions {
      * @deprecated Use `rolldownOptions` instead.
      */
     rollupOptions?: Omit<
-      RolldownOptions,
+      ViteRolldownOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
     /**
      * Rolldown options to build worker bundle
      */
     rolldownOptions?: Omit<
-      RolldownOptions,
+      ViteRolldownOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
   }
@@ -608,8 +609,8 @@ export interface ResolvedWorkerOptions {
   /**
    * @deprecated Use `rolldownOptions` instead.
    */
-  rollupOptions: RolldownOptions
-  rolldownOptions: RolldownOptions
+  rollupOptions: ViteRolldownOptions
+  rolldownOptions: ViteRolldownOptions
 }
 
 export interface InlineConfig extends UserConfig {


### PR DESCRIPTION
Type-only fix: narrow Vite public build and worker rolldown option types so output.sourcemapFileNames is rejected, keeping runtime behavior unchanged and aligning the type surface with the current Rolldown-backed limitation. Added DTS regression coverage for both rollupOptions and rolldownOptions. Validation: corepack pnpm --filter vite exec tsc -p src/node; corepack pnpm --filter vite exec premove dist; corepack pnpm --filter vite exec rolldown --config rolldown.config.ts; corepack pnpm --filter vite exec rolldown --config rolldown.dts.config.ts; corepack pnpm --filter vite exec tsc --project tsconfig.check.json; corepack pnpm --filter vite exec tsc -p src/node/__tests_dts__; corepack pnpm exec prettier --check packages/vite/src/node/build.ts packages/vite/src/node/config.ts packages/vite/src/node/__tests_dts__/config.ts; corepack pnpm exec eslint packages/vite/src/node/build.ts packages/vite/src/node/config.ts; git diff --check.