### PR TITLE
fix: align sourcemapFileNames build config typing with rolldown

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -251,6 +251,42 @@ describe('build', () => {
     ) as OutputChunk
     expect(foo.code).not.contains('import "external"')
   })
+
+  test('warns when sourcemapFileNames is configured', async () => {
+    const logger = createLogger('silent')
+    const warnSpy = vi.spyOn(logger, 'warnOnce').mockImplementation(() => {})
+
+    await build({
+      root: resolve(dirname, 'fixtures/emit-assets'),
+      logLevel: 'silent',
+      customLogger: logger,
+      build: {
+        write: false,
+        sourcemap: true,
+        rollupOptions: {
+          input: {
+            index: '/entry',
+          },
+          output: {
+            sourcemapFileNames: 'maps/[name]-[hash].map',
+          } as OutputOptions,
+        },
+      },
+    })
+
+    const logs = warnSpy.mock.calls.map((args) =>
+      stripVTControlCharacters(args[0]),
+    )
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Vite does not support "rollupOptions.output.sourcemapFileNames"',
+        ),
+      ]),
+    )
+    expect(logs.join('\n')).not.toContain('Invalid output options')
+  })
 })
 
 const baseLibOptions: LibraryOptions = {

--- a/packages/vite/src/node/__tests_dts__/config.ts
+++ b/packages/vite/src/node/__tests_dts__/config.ts
@@ -93,6 +93,17 @@ defineConfig(async () => ({
   },
 }))
 
+defineConfig({
+  build: {
+    rollupOptions: {
+      // @ts-expect-error --- Rolldown does not support this output option yet
+      output: {
+        sourcemapFileNames: 'maps/[name]-[hash].map',
+      },
+    },
+  },
+})
+
 mergeConfig(defineConfig({}), defineConfig({}))
 mergeConfig(
   // @ts-expect-error

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -88,6 +88,24 @@ import {
 import { prepareOutDirPlugin } from './plugins/prepareOutDir'
 import type { Environment } from './environment'
 
+interface UnsupportedBuildOutputOptions {
+  /**
+   * Rolldown doesn't support customizing sourcemap output filenames yet.
+   * Keep this typed as `never` so Vite's config types match build-time behavior.
+   */
+  sourcemapFileNames?: never
+}
+
+export type BuildOutputOptions = Omit<
+  OutputOptions,
+  keyof UnsupportedBuildOutputOptions
+> &
+  UnsupportedBuildOutputOptions
+
+export type BuildRolldownOptions = Omit<RolldownOptions, 'output'> & {
+  output?: BuildOutputOptions | BuildOutputOptions[]
+}
+
 export interface BuildEnvironmentOptions {
   /**
    * Compatibility transform target. The transform is performed with esbuild
@@ -191,12 +209,12 @@ export interface BuildEnvironmentOptions {
    * Alias to `rolldownOptions`
    * @deprecated Use `rolldownOptions` instead.
    */
-  rollupOptions?: RolldownOptions
+  rollupOptions?: BuildRolldownOptions
   /**
    * Will be merged with internal rolldown options.
    * https://rolldown.rs/reference/config-options
    */
-  rolldownOptions?: RolldownOptions
+  rolldownOptions?: BuildRolldownOptions
   /**
    * Options to pass on to `@rollup/plugin-commonjs`
    * @deprecated This option is no-op and will be removed in future versions.
@@ -655,21 +673,33 @@ export function resolveRolldownOptions(
     environment.getTopLevelConfig().ssr?.target === 'webworker'
 
   const buildOutputOptions = (output: OutputOptions = {}): OutputOptions => {
+    const { sourcemapFileNames, ...outputOptions } = output as OutputOptions & {
+      sourcemapFileNames?: string
+    }
+    if (sourcemapFileNames !== undefined) {
+      logger.warnOnce(
+        colors.yellow(
+          `Vite does not support "rollupOptions.output.sourcemapFileNames". ` +
+            `Rolldown doesn't support customizing sourcemap filenames yet, so this option is ignored.`,
+        ),
+      )
+    }
+
     // @ts-expect-error See https://github.com/vitejs/vite/issues/5812#issuecomment-984345618
-    if (output.output) {
+    if (outputOptions.output) {
       logger.warn(
         `You've set "rollupOptions.output.output" in your config. ` +
           `This is deprecated and will override all Vite.js default output options. ` +
           `Please use "rollupOptions.output" instead.`,
       )
     }
-    if (output.file) {
+    if (outputOptions.file) {
       throw new Error(
         `Vite does not support "rollupOptions.output.file". ` +
           `Please use "rollupOptions.output.dir" and "rollupOptions.output.entryFileNames" instead.`,
       )
     }
-    if (output.sourcemap) {
+    if (outputOptions.sourcemap) {
       logger.warnOnce(
         colors.yellow(
           `Vite does not support "rollupOptions.output.sourcemap". ` +
@@ -678,7 +708,7 @@ export function resolveRolldownOptions(
       )
     }
 
-    const format = output.format || 'es'
+    const format = outputOptions.format || 'es'
     const jsExt =
       (ssr && !isSsrTargetWebworkerEnvironment) || libOptions
         ? resolveOutputJsExtension(
@@ -720,16 +750,16 @@ export function resolveRolldownOptions(
         ? `[name].[ext]`
         : path.posix.join(options.assetsDir, `[name]-[hash].[ext]`),
       codeSplitting:
-        output.codeSplitting ??
-        (output.format === 'umd' ||
-        output.format === 'iife' ||
+        outputOptions.codeSplitting ??
+        (outputOptions.format === 'umd' ||
+        outputOptions.format === 'iife' ||
         (isSsrTargetWebworkerEnvironment &&
           (typeof input === 'string' || Object.keys(input).length === 1))
           ? false
           : undefined),
       comments:
-        typeof output.comments === 'boolean'
-          ? output.comments
+        typeof outputOptions.comments === 'boolean'
+          ? outputOptions.comments
           : {
               // Do not minify whitespace for ES lib output since that would remove
               // pure annotations and break tree-shaking
@@ -738,7 +768,7 @@ export function resolveRolldownOptions(
                 (libOptions && (format === 'es' || format === 'esm')),
               jsdoc: !options.minify,
               legal: !options.minify,
-              ...output.comments,
+              ...outputOptions.comments,
             },
       minify:
         options.minify === 'oxc'
@@ -755,7 +785,7 @@ export function resolveRolldownOptions(
             ? 'dce-only'
             : false,
       topLevelVar: true,
-      ...output,
+      ...outputOptions,
     }
   }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -50,6 +50,7 @@ import type {
 } from './plugin'
 import type {
   BuildEnvironmentOptions,
+  BuildRolldownOptions,
   BuilderOptions,
   RenderBuiltAssetUrl,
   ResolvedBuildEnvironmentOptions,
@@ -480,14 +481,14 @@ export interface UserConfig extends DefaultEnvironmentOptions {
      * @deprecated Use `rolldownOptions` instead.
      */
     rollupOptions?: Omit<
-      RolldownOptions,
+      BuildRolldownOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
     /**
      * Rolldown options to build worker bundle
      */
     rolldownOptions?: Omit<
-      RolldownOptions,
+      BuildRolldownOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
   }


### PR DESCRIPTION
Closes #22010.

## Summary
- reject `build.rollupOptions.output.sourcemapFileNames` in Vite's build config types so TypeScript matches current Rolldown behavior
- strip that unsupported key before invoking Rolldown and emit a targeted Vite warning instead of the generic invalid-output-options warning
- add both a dts regression and a build test for the warning path

## Testing
- `corepack pnpm --filter vite exec vitest run src/node/__tests__/build.spec.ts -t "warns when sourcemapFileNames is configured"`
- `corepack pnpm --filter vite exec tsc -p src/node`
- `corepack pnpm --filter vite exec tsc -p src/node/__tests_dts__/tsconfig.json`
- `corepack pnpm --filter vite exec eslint src/node/build.ts src/node/config.ts src/node/__tests__/build.spec.ts`
- `git diff --check`