### PR TITLE
docs: fix incorrect article "a" → "an" in migration guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -19,7 +19,7 @@ Vite 8 uses [Rolldown](https://rolldown.rs/) and [Oxc](https://oxc.rs/) based to
 
 ### Gradual Migration
 
-The `rolldown-vite` package implements Vite 7 with Rolldown, without other Vite 8 changes. This can be used as a intermediate step to migrate to Vite 8. See [the Rolldown Integration guide](https://v7.vite.dev/guide/rolldown) in the Vite 7 docs to switch to `rolldown-vite` from Vite 7.
+The `rolldown-vite` package implements Vite 7 with Rolldown, without other Vite 8 changes. This can be used as an intermediate step to migrate to Vite 8. See [the Rolldown Integration guide](https://v7.vite.dev/guide/rolldown) in the Vite 7 docs to switch to `rolldown-vite` from Vite 7.
 
 For users migrating from `rolldown-vite` to Vite 8, you can undo the dependency changes in `package.json` and update to Vite 8:
 


### PR DESCRIPTION
## Summary

Fix a grammatical error in the v8 migration guide.

In the "Gradual Migration" section, `a intermediate` should be `an intermediate` (the indefinite article "an" is required before a vowel sound).

## Change
```diff
- This can be used as a intermediate step to migrate to Vite 8.
+ This can be used as an intermediate step to migrate to Vite 8.
```

**File:** `docs/guide/migration.md`