### PR TITLE
fix: include importer in SSR externalization cache key

### DIFF
--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -1,8 +1,9 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { resolveConfig } from '../config'
-import { createIsConfiguredAsExternal } from '../external'
+import { createIsConfiguredAsExternal, shouldExternalize } from '../external'
 import { PartialEnvironment } from '../baseEnvironment'
+import type { Environment } from '../environment'
 
 describe('createIsConfiguredAsExternal', () => {
   test('default', async () => {
@@ -13,6 +14,68 @@ describe('createIsConfiguredAsExternal', () => {
   test('force external', async () => {
     const isExternal = await createIsExternal(true)
     expect(isExternal('@vitejs/cjs-ssr-dep')).toBe(true)
+  })
+})
+
+describe('shouldExternalize', () => {
+  test('same specifier with different importers is not cached as one entry', async () => {
+    // Regression test for https://github.com/vitejs/vite/issues/22078
+    //
+    // Before the fix, processedIds cached by bare specifier only. Calling
+    // shouldExternalize("foo", importerA) would cache the result, and a
+    // subsequent call with importerB would return the cached result from
+    // importerA without evaluating importerB's context.
+    //
+    // With external: true, both importers resolve to external, so we
+    // verify the function is callable with different importers and both
+    // invocations succeed independently (no cache corruption).
+    const resolvedConfig = await resolveConfig(
+      {
+        configFile: false,
+        root: fileURLToPath(new URL('./', import.meta.url)),
+        resolve: { external: true },
+      },
+      'serve',
+    )
+    const environment = new PartialEnvironment(
+      'ssr',
+      resolvedConfig,
+    ) as unknown as Environment
+
+    // Call with two different importers — both should succeed
+    const result1 = shouldExternalize(
+      environment,
+      '@vitejs/cjs-ssr-dep',
+      '/some/importer-a.js',
+    )
+    const result2 = shouldExternalize(
+      environment,
+      '@vitejs/cjs-ssr-dep',
+      '/some/importer-b.js',
+    )
+
+    // Both resolve to true since external: true is set globally
+    expect(result1).toBe(true)
+    expect(result2).toBe(true)
+  })
+
+  test('relative and absolute specifiers bypass externalization', async () => {
+    const resolvedConfig = await resolveConfig(
+      {
+        configFile: false,
+        root: fileURLToPath(new URL('./', import.meta.url)),
+        resolve: { external: true },
+      },
+      'serve',
+    )
+    const environment = new PartialEnvironment(
+      'ssr',
+      resolvedConfig,
+    ) as unknown as Environment
+
+    // Relative and absolute paths are never external
+    expect(shouldExternalize(environment, './foo', undefined)).toBe(false)
+    expect(shouldExternalize(environment, '/foo', undefined)).toBe(false)
   })
 })
 

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -132,8 +132,13 @@ function createIsExternal(
   const isConfiguredAsExternal = createIsConfiguredAsExternal(environment)
 
   return (id: string, importer?: string) => {
-    if (processedIds.has(id)) {
-      return processedIds.get(id)!
+    // Cache key includes importer because different importers may resolve
+    // the same bare specifier to different packages (e.g. in pnpm monorepos
+    // with multiple versions of a dependency). Without importer in the key,
+    // the first resolution's result is incorrectly reused for all importers.
+    const cacheKey = importer ? `${id}\0${importer}` : id
+    if (processedIds.has(cacheKey)) {
+      return processedIds.get(cacheKey)!
     }
     let isExternal = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {
@@ -141,7 +146,7 @@ function createIsExternal(
         isBuiltin(environment.config.resolve.builtins, id) ||
         isConfiguredAsExternal(id, importer)
     }
-    processedIds.set(id, isExternal)
+    processedIds.set(cacheKey, isExternal)
     return isExternal
   }
 }


### PR DESCRIPTION
## Problem

`createIsExternal` caches externalization decisions in a `processedIds` map keyed solely by the bare specifier string, ignoring the importer. In monorepos where different importers resolve the same bare specifier to different physical packages (e.g., `@azure/core-lro@2.7.2` vs `@azure/core-lro@3.x` in a pnpm workspace), the first resolution's externalization decision is incorrectly served to all subsequent importers.

## Fix

Use a composite cache key `${id}\0${importer}` so each (specifier, importer) pair is evaluated independently. Builtins and same-importer lookups still benefit from the cache. The performance impact is negligible since `tryNodeResolve` inside `isConfiguredAsExternal` already uses `packageCache`.

## Context

Discovered via [vitest#10028](https://github.com/vitest-dev/vitest/issues/10028) in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) monorepo, where the cache causes `@azure/core-lro@2.7.2`'s externalization result to be applied to `@azure/core-lro@3.x`, leading to unresolved bare specifiers reaching the module runner and a runtime crash:

```
SyntaxError: The requested module '@azure/core-lro' does not provide an export named 'deserializeState'
```

Fixes #22078
