### PR TITLE
fix: verify module identity in cache protocol to prevent stale modules

### DIFF
--- a/packages/vite/src/module-runner/__tests__/evaluatedModules.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/evaluatedModules.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest'
+import { EvaluatedModules } from '../evaluatedModules'
+
+describe('EvaluatedModules', () => {
+  test('ensureModule creates a new module and indexes by id and url', () => {
+    const modules = new EvaluatedModules()
+    const mod = modules.ensureModule('/path/to/module.js', '/url/module.js')
+
+    expect(mod.id).toBe('/path/to/module.js')
+    expect(mod.url).toBe('/url/module.js')
+    expect(modules.getModuleById('/path/to/module.js')).toBe(mod)
+    expect(modules.getModuleByUrl('/url/module.js')).toBe(mod)
+  })
+
+  test('ensureModule returns existing module when id matches', () => {
+    const modules = new EvaluatedModules()
+    const mod1 = modules.ensureModule('/path/to/module.js', '/url/v1')
+    const mod2 = modules.ensureModule('/path/to/module.js', '/url/v2')
+
+    expect(mod1).toBe(mod2)
+    // New url should also map to the same module
+    expect(modules.getModuleByUrl('/url/v2')).toBe(mod1)
+  })
+
+  test('different ids with same url creates separate modules but url maps to latest', () => {
+    const modules = new EvaluatedModules()
+    const mod1 = modules.ensureModule('/path/v1/index.js', 'shared-dep')
+    const mod2 = modules.ensureModule('/path/v2/index.js', 'shared-dep')
+
+    // They should be different module nodes
+    expect(mod1).not.toBe(mod2)
+    expect(mod1.id).toBe('/path/v1/index.js')
+    expect(mod2.id).toBe('/path/v2/index.js')
+
+    // The url 'shared-dep' should map to whichever was registered last
+    // This is the bug scenario: bare specifier URL maps to wrong module
+    expect(modules.getModuleByUrl('shared-dep')).toBe(mod2)
+
+    // But id-based lookups remain correct
+    expect(modules.getModuleById('/path/v1/index.js')).toBe(mod1)
+    expect(modules.getModuleById('/path/v2/index.js')).toBe(mod2)
+  })
+})

--- a/packages/vite/src/module-runner/__tests__/runner-cache.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/runner-cache.spec.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'vitest'
+import type { HotPayload } from '#types/hot'
+import type {
+  CachedFetchResult,
+  ExternalFetchResult,
+  FetchResult,
+  ViteFetchResult,
+} from '../../shared/invokeMethods'
+import { ModuleRunner } from '../runner'
+import type { ModuleEvaluator, ModuleRunnerContext } from '../types'
+
+// Minimal evaluator that resolves without executing code
+class MockEvaluator implements ModuleEvaluator {
+  startOffset = 0
+  async runInlinedModule(_context: ModuleRunnerContext): Promise<any> {
+    // no-op
+  }
+  async runExternalModule(_file: string): Promise<any> {
+    return { __esModule: true, version: 'mock' }
+  }
+}
+
+function createMockTransport(
+  handler: (
+    url: string,
+    importer: string | undefined,
+    options: any,
+  ) => Promise<FetchResult> | FetchResult,
+) {
+  return {
+    invoke: async (data: HotPayload): Promise<{ result: any }> => {
+      const payload = data as any
+      if (payload.data?.name === 'fetchModule') {
+        const [url, importer, options] = payload.data.data
+        const result = await handler(url, importer, options)
+        return { result }
+      }
+      if (payload.data?.name === 'getBuiltins') {
+        return { result: [] }
+      }
+      return { result: undefined }
+    },
+  }
+}
+
+describe('module runner cache identity verification', () => {
+  // Regression tests for https://github.com/vitejs/vite/issues/22079
+  //
+  // When a bare specifier (e.g., "@azure/core-lro") is externalized,
+  // the module runner caches it by the bare specifier URL. If a second
+  // import of the same specifier should resolve to a different physical
+  // module, the cache returns the wrong one. The server's { cache: true }
+  // response now includes the resolved module ID so the client can detect
+  // and recover from this mismatch.
+
+  test('refetches when server cache response has different module id', async () => {
+    const fetchCalls: { url: string; cached: boolean }[] = []
+    let callCount = 0
+
+    // Simulate: first resolution externalizes to v1, second should be v2
+    const externalV1: ExternalFetchResult = {
+      externalize: 'file:///path/to/dep-v1/index.js',
+      type: 'module',
+    }
+    const moduleV2: ViteFetchResult = {
+      code: 'export const version = "v2"; export const extraExport = "only-in-v2"',
+      file: '/path/to/dep-v2/index.js',
+      id: '/path/to/dep-v2/index.js',
+      url: '/dep-v2/index.js',
+      invalidate: false,
+    }
+
+    const runner = new ModuleRunner(
+      {
+        transport: createMockTransport((url, _importer, options) => {
+          callCount++
+          fetchCalls.push({
+            url,
+            cached: !!options?.cached,
+          })
+
+          if (callCount === 1) {
+            // First fetch: externalize to v1
+            return externalV1
+          }
+          if (callCount === 2) {
+            // Server resolved to v2 (different module id), but client
+            // has v1 cached. Return cache with server's resolved id.
+            return {
+              cache: true,
+              id: moduleV2.id,
+            } as CachedFetchResult
+          }
+          // Third: client detected mismatch, refetches without cache flag
+          return moduleV2
+        }),
+        hmr: false,
+        sourcemapInterceptor: false,
+      },
+      new MockEvaluator(),
+    )
+
+    // First import: resolves to v1 (externalized), cached by bare specifier
+    await runner.import('shared-dep')
+    expect(fetchCalls).toHaveLength(1)
+
+    // Verify v1 is cached under the bare specifier URL
+    const cachedMod = runner.evaluatedModules.getModuleByUrl('shared-dep')
+    expect(cachedMod).toBeDefined()
+    expect(cachedMod!.id).toContain('dep-v1')
+
+    // Second import: client sends cached: true, server returns
+    // { cache: true, id: '/path/to/dep-v2/index.js' } — mismatch!
+    // Runner should refetch and get v2.
+    await runner.import('shared-dep')
+
+    expect(fetchCalls).toHaveLength(3)
+    expect(fetchCalls[1]).toEqual({ url: 'shared-dep', cached: true })
+    expect(fetchCalls[2]).toEqual({ url: 'shared-dep', cached: false })
+
+    await runner.close()
+  })
+
+  test('uses cache when server response has matching module id', async () => {
+    const fetchCalls: { url: string; cached: boolean }[] = []
+    let callCount = 0
+
+    const externalV1: ExternalFetchResult = {
+      externalize: 'file:///path/to/dep-v1/index.js',
+      type: 'module',
+    }
+
+    const runner = new ModuleRunner(
+      {
+        transport: createMockTransport((url, _importer, options) => {
+          callCount++
+          fetchCalls.push({
+            url,
+            cached: !!options?.cached,
+          })
+
+          if (callCount === 1) {
+            return externalV1
+          }
+          // Server confirms same module id — cache is valid
+          return {
+            cache: true,
+            id: externalV1.externalize,
+          } as CachedFetchResult
+        }),
+        hmr: false,
+        sourcemapInterceptor: false,
+      },
+      new MockEvaluator(),
+    )
+
+    await runner.import('shared-dep')
+    await runner.import('shared-dep')
+
+    // Only 2 calls: fetch + cache confirmation (no refetch)
+    expect(fetchCalls).toHaveLength(2)
+    expect(fetchCalls[1]).toEqual({ url: 'shared-dep', cached: true })
+
+    await runner.close()
+  })
+
+  test('uses cache when server response omits id (backward compat)', async () => {
+    const fetchCalls: { url: string; cached: boolean }[] = []
+    let callCount = 0
+
+    const externalV1: ExternalFetchResult = {
+      externalize: 'file:///path/to/dep-v1/index.js',
+      type: 'module',
+    }
+
+    const runner = new ModuleRunner(
+      {
+        transport: createMockTransport((url, _importer, options) => {
+          callCount++
+          fetchCalls.push({
+            url,
+            cached: !!options?.cached,
+          })
+
+          if (callCount === 1) {
+            return externalV1
+          }
+          // Old-style cache response without id
+          return { cache: true } as FetchResult
+        }),
+        hmr: false,
+        sourcemapInterceptor: false,
+      },
+      new MockEvaluator(),
+    )
+
+    await runner.import('shared-dep')
+    await runner.import('shared-dep')
+
+    // Only 2 calls: backward compatible, no refetch
+    expect(fetchCalls).toHaveLength(2)
+    expect(fetchCalls[1]).toEqual({ url: 'shared-dep', cached: true })
+
+    await runner.close()
+  })
+})

--- a/packages/vite/src/module-runner/__tests__/runner-cache.spec.ts
+++ b/packages/vite/src/module-runner/__tests__/runner-cache.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import type { HotPayload } from '#types/hot'
+import type { HotPayload } from 'vite'
 import type {
   CachedFetchResult,
   ExternalFetchResult,

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -8,7 +8,7 @@ import {
 } from '../shared/moduleRunnerTransport'
 import { createIsBuiltin } from '../shared/builtin'
 import type { EvaluatedModuleNode } from './evaluatedModules'
-import { EvaluatedModules } from './evaluatedModules'
+import { EvaluatedModules, normalizeModuleId } from './evaluatedModules'
 import type {
   ModuleEvaluator,
   ModuleRunnerContext,
@@ -308,6 +308,25 @@ export class ModuleRunner {
         throw new Error(
           `Module "${url}" was mistakenly invalidated during fetch phase.`,
         )
+      }
+      // Verify the server resolved to the same module we have cached.
+      // When a bare specifier maps to different physical packages for
+      // different importers (e.g. monorepos with duplicate deps), the
+      // urlToIdModuleMap may hold a stale entry. If the server resolved
+      // to a different module, refetch without the cache flag.
+      if (
+        fetchedModule.id &&
+        cachedModule.id !== normalizeModuleId(fetchedModule.id)
+      ) {
+        this.debug?.(
+          '[module runner] cache identity mismatch for',
+          url,
+          '- cached:',
+          cachedModule.id,
+          'server:',
+          fetchedModule.id,
+        )
+        return this.getModuleInformation(url, importer, undefined)
       }
       return cachedModule
     }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -85,7 +85,7 @@ export async function fetchModule(
 
   // if url is already cached, we can just confirm it's also cached on the server
   if (options.cached && cached) {
-    return { cache: true }
+    return { cache: true, id: mod.id }
   }
 
   let result = await environment.transformRequest(url)

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -85,7 +85,7 @@ export async function fetchModule(
 
   // if url is already cached, we can just confirm it's also cached on the server
   if (options.cached && cached) {
-    return { cache: true, id: mod.id }
+    return { cache: true, id: mod.id ?? undefined }
   }
 
   let result = await environment.transformRequest(url)

--- a/packages/vite/src/shared/invokeMethods.ts
+++ b/packages/vite/src/shared/invokeMethods.ts
@@ -14,6 +14,13 @@ export interface CachedFetchResult {
    * it wasn't invalidated on the server side.
    */
   cache: true
+  /**
+   * The resolved module ID on the server. The client uses this to verify
+   * that its cached module matches what the server resolved. When a bare
+   * specifier maps to different physical packages for different importers,
+   * the client's cache may hold the wrong version.
+   */
+  id?: string
 }
 
 export interface ExternalFetchResult {


### PR DESCRIPTION
## Problem

Two related bugs in the module runner cause stale modules to be served when multiple versions of a dependency exist in a monorepo:

1. **`urlToIdModuleMap` keyed by bare specifier**: When a bare specifier like `@azure/core-lro` is used as the URL (because import analysis treated it as external and didn't resolve it), the first resolved version is cached and served to all subsequent importers.

2. **`{ cache: true }` protocol lacks identity verification**: When the client sends `{ cached: true }`, the server confirms the module was transformed and returns `{ cache: true }`. But the server may have resolved the URL to a *different* physical package than what the client has cached. The client blindly uses its stale module.

Together, these cause silent data corruption where imports get the wrong version of a dependency.

## Fix

- **Server**: Include the resolved module ID (`mod.id`) in `CachedFetchResult` via a new optional `id` field.
- **Client**: When receiving `{ cache: true, id }`, verify that the cached module's normalized ID matches the server's. On mismatch, refetch the module without the cache flag.

The `id` field is optional for backward compatibility — existing transports that don't include it continue working as before.

## Context

Discovered via [vitest#10028](https://github.com/vitest-dev/vitest/issues/10028) in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) monorepo. Related to but independent from #22080 (SSR externalization cache). Both are needed for full correctness, but each fixes a distinct bug.

Fixes #22079
