### PR TITLE
fix(worker): adjust format error message for rolldown

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -931,10 +931,13 @@ test('sharedConfigBuild and emitAssets', async () => {
   ])
 })
 
-test.skip('adjust worker build error for worker.format', async () => {
+test('adjust worker build error for worker.format', async () => {
   try {
     await build({
       root: resolve(dirname, 'fixtures/worker-dynamic'),
+      worker: {
+        format: 'invalid' as any,
+      },
       build: {
         rollupOptions: {
           input: {
@@ -944,7 +947,7 @@ test.skip('adjust worker build error for worker.format', async () => {
       },
       logLevel: 'silent',
     })
-  } catch (e) {
+  } catch (e: any) {
     expect(e.message).toContain('worker.format')
     expect(e.message).not.toContain('output.format')
     return

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import MagicString from 'magic-string'
-import type { RolldownOutput, RollupError } from 'rolldown'
+import type { RolldownOutput } from 'rolldown'
 import colors from 'picocolors'
 import { type ImportSpecifier, init, parse } from 'es-module-lexer'
 import { viteWebWorkerPostPlugin as nativeWebWorkerPostPlugin } from 'rolldown/experimental'
@@ -242,14 +242,9 @@ async function bundleWorkerEntry(
       sourcemap: workerEnvironment.config.build.sourcemap,
     })
     watchedFiles = (await bundle.watchFiles).map((f) => normalizePath(f))
-  } catch (e) {
-    // adjust rollup format error
-    if (
-      e instanceof Error &&
-      e.name === 'RollupError' &&
-      (e as RollupError).code === 'INVALID_OPTION' &&
-      e.message.includes('"output.format"')
-    ) {
+  } catch (e: any) {
+    // adjust rollup/rolldown format error
+    if (e instanceof Error && e.message.includes('output.format')) {
       e.message = e.message.replace('output.format', 'worker.format')
     }
     throw e


### PR DESCRIPTION

This PR fixes a small regression when using Rolldown in Vite 6, where an invalid worker format error message still uses the internal output.format instead of worker.format (which is the Vite configuration option).

Previously, this was handled only for RollupError with a specific code and message format. Rolldown errors in some cases (like invalid formats in RC.12) are thrown as generic Errors with a different message structure. This PR simplifies the check and ensures any output.format error during worker bundling is correctly adjusted in the message.

I have also unskipped and updated the related unit test adjust worker build error for worker.format to explicitly trigger an invalid format error and verify the adjustment.

Also, please make sure you do the following:

 Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
 Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
 Update the corresponding documentation if needed. (N/A for internally adjusted error messages)
 Include relevant tests that fail without this PR but pass with it.


Files Changed:
packages/vite/src/node/plugins/worker.ts: Improved error adjustment in bundleWorkerEntry.
packages/vite/src/node/__tests__/build.spec.ts: Unskipped and improved the adjust worker build error... unit test.

Final Checks:
Verified with pnpm run test-unit -t "adjust worker build error for worker.format".
Ran pnpm run format and pnpm run lint.