### PR TITLE
fix(hmr): resolve virtual module URLs correctly for HMR updates and invalidation

### DIFF
--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -16,7 +16,7 @@ import {
   createExplicitDepsOptimizer,
 } from '../optimizer/optimizer'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
-import { promiseWithResolvers } from '../../shared/utils'
+import { promiseWithResolvers, unwrapId } from '../../shared/utils'
 import type { ViteDevServer } from '../server'
 import { EnvironmentModuleGraph } from './moduleGraph'
 import type { EnvironmentModuleNode } from './moduleGraph'
@@ -265,7 +265,12 @@ export class DevEnvironment extends BaseEnvironment {
     },
     _client: NormalizedHotChannelClient,
   ): void {
-    const mod = this.moduleGraph.urlToModuleMap.get(m.path)
+    // Try direct URL lookup first (fast path for regular modules), then
+    // fall back to ID lookup via unwrapId (handles virtual modules whose
+    // client-side URL /@id/__x00__... differs from the stored URL)
+    const mod =
+      this.moduleGraph.urlToModuleMap.get(m.path) ??
+      this.moduleGraph.idToModuleMap.get(unwrapId(m.path))
     if (
       mod &&
       mod.isSelfAccepting &&

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -681,8 +681,12 @@ export function updateModules(
         ({ boundary, acceptedVia, isWithinCircularImport }) => ({
           type: `${boundary.type}-update` as const,
           timestamp,
-          path: normalizeHmrUrl(boundary.url),
-          acceptedPath: normalizeHmrUrl(acceptedVia.url),
+          path: normalizeHmrUrl(
+            boundary.id?.includes('\0') ? boundary.id : boundary.url,
+          ),
+          acceptedPath: normalizeHmrUrl(
+            acceptedVia.id?.includes('\0') ? acceptedVia.id : acceptedVia.url,
+          ),
           explicitImportRequired:
             boundary.type === 'js'
               ? isExplicitImportRequired(acceptedVia.url)

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -227,6 +227,20 @@ if (!isBuild) {
     }
   })
 
+  test('invalidate virtual module propagates to importers', async () => {
+    const el = await page.$('.virtual-invalidation-parent')
+    await expect.poll(() => el.textContent()).toBe('initial')
+
+    // Edit the real dep file — Vite detects the change and sends
+    // js-update to the virtual module.  The virtual module accepts
+    // then invalidates, which should propagate to parent.js.
+    editFile('virtual-invalidation/dep.js', (code) =>
+      code.replace('initial', 'updated'),
+    )
+
+    await expect.poll(() => el.textContent()).toBe('updated')
+  })
+
   test('invalidate on root triggers page reload', async () => {
     editFile('invalidation/root.js', (code) => code.replace('Init', 'Updated'))
     await page.waitForEvent('load')

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -28,6 +28,8 @@
 <div class="virtual-dep"></div>
 <div class="soft-invalidation"></div>
 <div class="invalidation-parent"></div>
+<div class="virtual-invalidation-parent"></div>
+<script type="module" src="./virtual-invalidation/parent.js"></script>
 <div class="invalidation-root"></div>
 <div class="invalidation-circular-deps"></div>
 <div class="invalidation-circular-deps-handled"></div>

--- a/playground/hmr/virtual-invalidation/dep.js
+++ b/playground/hmr/virtual-invalidation/dep.js
@@ -1,0 +1,1 @@
+export const depValue = 'initial'

--- a/playground/hmr/virtual-invalidation/parent.js
+++ b/playground/hmr/virtual-invalidation/parent.js
@@ -1,0 +1,7 @@
+import { value } from 'virtual:invalidation-file'
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}
+
+document.querySelector('.virtual-invalidation-parent').innerHTML = value

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -54,12 +54,41 @@ export default defineConfig(({ command }) => ({
       },
     },
     virtualPlugin(),
+    virtualInvalidationPlugin(),
     transformCountPlugin(),
     watchCssDepsPlugin(),
     TestCssLinkPlugin(),
     hotEventsPlugin(),
   ],
 }))
+
+// Virtual module that supports invalidate() — tests that invalidate()
+// correctly resolves virtual module URLs (/@id/__x00__... → \0...)
+function virtualInvalidationPlugin(): Plugin {
+  return {
+    name: 'virtual-invalidation-file',
+    resolveId(id) {
+      if (id === 'virtual:invalidation-file') {
+        return '\0virtual:invalidation-file'
+      }
+    },
+    load(id) {
+      if (id === '\0virtual:invalidation-file') {
+        // Import a real file so editing it triggers Vite's HMR pipeline.
+        // The virtual module accepts and immediately invalidates,
+        // which should propagate to its importers.
+        return `\
+import { depValue } from '/virtual-invalidation/dep.js';
+export const value = depValue;
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {
+    import.meta.hot.invalidate()
+  })
+}`
+      }
+    },
+  }
+}
 
 function virtualPlugin(): Plugin {
   let num = 0


### PR DESCRIPTION
`import.meta.hot.invalidate()` and HMR `js-update` silently fail for virtual modules.

### Root cause

Virtual modules have a URL mismatch between client and server:

| Location | URL format |
|----------|-----------|
| Browser (client) | `/@id/__x00__virtual:my-module` |
| `mod.url` (server) | `virtual:my-module` |

This is because `mod.url` doesn't contain the `\0` prefix — it stores the bare specifier. When `normalizeHmrUrl(mod.url)` runs `wrapId()`, it produces `/@id/virtual:my-module` (missing `__x00__`), which doesn't match the browser-side URL.

This breaks two things:
1. `js-update` for virtual module HMR boundaries — `accept()` callback never fires
2. `invalidate()` — server can't find the module in `urlToModuleMap`

### Fix

- **`hmr.ts`**: Use `mod.id` (which has `\0`) instead of `mod.url` for virtual modules, so `wrapId` generates the correct `/@id/__x00__...` path.
- **`environment.ts`**: Fall back to `idToModuleMap.get(unwrapId(path))` in `invalidateModule`.

### Test

Added `'invalidate virtual module propagates to importers'` in `playground/hmr` — a virtual module that `accept()`s then `invalidate()`s. Fails without fix, passes with it.
