### PR TITLE
fix: avoid unhandled rejection error for missing properties

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -294,7 +294,22 @@ export function createWebSocketServer(
 
     const client = getSocketClient(socket)
     for (const listener of listeners) {
-      listener(data, client)
+      const result: unknown = listener(data, client)
+      if (
+        result &&
+        typeof result === 'object' &&
+        'catch' in result &&
+        typeof result.catch === 'function'
+      ) {
+        result.catch((err: unknown) => {
+          config.logger.error(
+            `${colors.red(`ws custom listener error:`)}\n${err}`,
+            {
+              timestamp: true,
+            },
+          )
+        })
+      }
     }
   }
 

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -1,6 +1,7 @@
 import { stripVTControlCharacters } from 'node:util'
 import { beforeAll, describe, expect, it, test } from 'vitest'
 import type { Page } from 'playwright-chromium'
+import WebSocket from 'ws'
 import {
   addFile,
   browser,
@@ -9,6 +10,7 @@ import {
   getBg,
   getColor,
   isBuild,
+  isServe,
   page,
   readFile,
   removeFile,
@@ -1160,3 +1162,40 @@ if (!isBuild) {
     await expect.poll(() => getColor('.test-css-link')).toBe('black')
   })
 }
+
+describe.runIf(isServe)('malformed vite:invoke', () => {
+  function connectClient(
+    url: string,
+  ): Promise<{ send: WebSocket['send']; [Symbol.dispose](): void }> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url, 'vite-hmr')
+      ws.on('open', () => {
+        // Wait for the { type: 'connected' } message before resolving
+        ws.once('message', () => {
+          resolve({
+            send: ws.send.bind(ws),
+            [Symbol.dispose]() {
+              ws.close()
+            },
+          })
+        })
+      })
+      ws.on('error', reject)
+    })
+  }
+
+  it('does not throw unhandled promise rejection for missing properties', async () => {
+    serverLogs.length = 0
+    const wsUrl = viteTestUrl.replace(/^http/, 'ws')
+    using ws = await connectClient(wsUrl)
+    ws.send(
+      JSON.stringify({
+        type: 'custom',
+        event: 'vite:invoke',
+      }),
+    )
+    await expect
+      .poll(() => serverLogs)
+      .toContainEqual(expect.stringContaining('ws custom listener error'))
+  })
+})

--- a/playground/hmr/package.json
+++ b/playground/hmr/package.json
@@ -8,5 +8,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
+  },
+  "devDependencies": {
+    "ws": "^8.20.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -861,7 +861,11 @@ importers:
 
   playground/glob-import/import-meta-glob-pkg: {}
 
-  playground/hmr: {}
+  playground/hmr:
+    devDependencies:
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   playground/hmr-full-bundle-mode: {}
 


### PR DESCRIPTION
unhandled rejection error happened when accessing `.id` here if the `id` property was missing.
https://github.com/vitejs/vite/blob/f261dc9383e505cb6df75df46854c0802eb4eed9/packages/vite/src/node/server/hmr.ts#L285