### PR TITLE
fix(moduleRunner): use optional chaining for WebSocket send method

### DIFF
--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -321,7 +321,7 @@ export const createWebSocketModuleRunnerTransport = (options: {
       ws?.close()
     },
     send(data) {
-      ws!.send(JSON.stringify(data))
+      ws?.send(JSON.stringify(data))
     },
   }
 }


### PR DESCRIPTION
## PR Description

### What does this PR solve?

Fixes a `TypeError` thrown in the browser console when `server.ws: false` is set in the Vite config.

### Root Cause

When `server.ws: false` is configured:

1. **Server side** (`ws.ts`): Correctly returns a noop implementation that doesn't listen on any port ✅
2. **Client side** (`client.ts`): Still attempts to create a WebSocket connection
3. Connection fails silently (server not listening), `ws` variable remains `undefined`
4. `send()` method uses non-null assertion `ws!.send()` → crashes with `TypeError` ❌

### The Fix

Change the non-null assertion to optional chaining in `packages/vite/src/shared/moduleRunnerTransport.ts:323-325`:

```diff
- ws!.send(JSON.stringify(data))
+ ws?.send(JSON.stringify(data))