### PR TITLE
fix: add types for `vite/modulepreload-polyfill`

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -1,5 +1,8 @@
 /// <reference path="./types/importMeta.d.ts" />
 
+// virtual modules
+declare module 'vite/modulepreload-polyfill'
+
 // CSS modules
 type CSSModuleClasses = { readonly [key: string]: string }
 

--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -1,7 +1,7 @@
 /// <reference path="./types/importMeta.d.ts" />
 
 // virtual modules
-declare module 'vite/modulepreload-polyfill'
+declare module 'vite/modulepreload-polyfill' {}
 
 // CSS modules
 type CSSModuleClasses = { readonly [key: string]: string }

--- a/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error virtual module (TODO: investigate typing this)
 import 'vite/modulepreload-polyfill'
 import cssUrl from '../styles/url.css?url'
 import waterContainer from './water-container.svg'


### PR DESCRIPTION
Previously there was no typing error because `noUncheckedSideEffectImports` is false by default. Now it's true by default in TypeScript 6.

Follow-up to https://github.com/vitejs/vite/pull/22110#discussion_r3029074497