### PR TITLE
docs: remove reference to react swc templates

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -106,7 +106,7 @@ $ deno init --npm vite my-vue-app --template vue
 
 :::
 
-See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
+See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
 
 You can use `.` for the project name to scaffold in the current directory.
 

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -64,8 +64,6 @@ Currently supported template presets include:
 - `vue-ts`
 - `react`
 - `react-ts`
-- `react-swc`
-- `react-swc-ts`
 - `preact`
 - `preact-ts`
 - `lit`


### PR DESCRIPTION
templates were removed in https://github.com/vitejs/vite/pull/21633 but not in the docs