### PR TITLE
fix: disallow referencing files outside the package from sourcemap

### DIFF
--- a/packages/vite/src/node/plugins/forwardConsole.ts
+++ b/packages/vite/src/node/plugins/forwardConsole.ts
@@ -92,7 +92,11 @@ function formatError(
       if (result && !result.map) {
         try {
           const filePath = id.split('?')[0]
-          const extracted = extractSourcemapFromFile(result.code, filePath)
+          const extracted = extractSourcemapFromFile(
+            result.code,
+            filePath,
+            environment.config.logger,
+          )
           sourceMapCache.set(id, extracted?.map)
           return extracted?.map
         } catch {

--- a/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
+++ b/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest'
+import { getNodeModulesPackageRoot } from '../sourcemap'
+import { isWindows } from '../../../shared/utils'
+
+describe('getNodeModulesPackageRoot', () => {
+  const cases = [
+    {
+      name: 'returns undefined for path outside node_modules',
+      input: '/project/src/foo.ts',
+      expected: undefined,
+    },
+    {
+      name: 'returns undefined for plain filename',
+      input: 'foo.js',
+      expected: undefined,
+    },
+    {
+      name: 'unscoped package',
+      input: '/project/node_modules/foo/index.js',
+      expected: '/project/node_modules/foo',
+    },
+    {
+      name: 'unscoped package in nested directory',
+      input: '/project/node_modules/foo/dist/bar.js',
+      expected: '/project/node_modules/foo',
+    },
+    {
+      name: 'scoped package',
+      input: '/project/node_modules/@scope/pkg/dist/foo.js',
+      expected: '/project/node_modules/@scope/pkg',
+    },
+    {
+      name: 'scoped package at root level',
+      input: '/project/node_modules/@scope/pkg/index.js',
+      expected: '/project/node_modules/@scope/pkg',
+    },
+    {
+      name: 'nested node_modules uses the last segment',
+      input: '/project/node_modules/foo/node_modules/bar/index.js',
+      expected: '/project/node_modules/foo/node_modules/bar',
+    },
+    {
+      name: 'Windows-style path',
+      input: 'D:\\project\\node_modules\\foo\\dist\\bar.js',
+      expected: 'D:/project/node_modules/foo',
+      skip: isWindows,
+    },
+    {
+      name: 'Windows-style path with scoped package',
+      input: 'D:\\project\\node_modules\\@scope\\pkg\\index.js',
+      expected: 'D:/project/node_modules/@scope/pkg',
+      skip: isWindows,
+    },
+    {
+      name: 'package name without subdirectory',
+      input: '/project/node_modules/foo',
+      expected: '/project/node_modules/foo',
+    },
+    {
+      name: 'scoped package name without subdirectory',
+      input: '/project/node_modules/@scope/pkg',
+      expected: '/project/node_modules/@scope/pkg',
+    },
+  ]
+
+  for (const { name, input, expected, skip } of cases) {
+    test.skipIf(skip)(name, () => {
+      expect(getNodeModulesPackageRoot(input)).toBe(expected)
+    })
+  }
+})

--- a/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
+++ b/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
@@ -43,13 +43,13 @@ describe('getNodeModulesPackageRoot', () => {
       name: 'Windows-style path',
       input: 'D:\\project\\node_modules\\foo\\dist\\bar.js',
       expected: 'D:/project/node_modules/foo',
-      skip: isWindows,
+      skip: !isWindows,
     },
     {
       name: 'Windows-style path with scoped package',
       input: 'D:\\project\\node_modules\\@scope\\pkg\\index.js',
       expected: 'D:/project/node_modules/@scope/pkg',
-      skip: isWindows,
+      skip: !isWindows,
     },
     {
       name: 'package name without subdirectory',

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -3,13 +3,46 @@ import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import convertSourceMap from 'convert-source-map'
 import type { ExistingRawSourceMap, SourceMap } from 'rolldown'
+import colors from 'picocolors'
 import type { Logger } from '../logger'
-import { blankReplacer, createDebugger } from '../utils'
+import {
+  blankReplacer,
+  createDebugger,
+  isParentDirectory,
+  normalizePath,
+} from '../utils'
 import { cleanUrl } from '../../shared/utils'
 
 const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true,
 })
+
+/**
+ * Given a file path inside node_modules, returns the package root directory.
+ * For scoped packages like `node_modules/@scope/pkg/dist/foo.js`, returns `node_modules/@scope/pkg`.
+ * Returns `undefined` if the file is not inside node_modules.
+ */
+export function getNodeModulesPackageRoot(
+  filePath: string,
+): string | undefined {
+  const normalized = normalizePath(filePath)
+  const nodeModulesIndex = normalized.lastIndexOf('/node_modules/')
+  if (nodeModulesIndex === -1) return undefined
+
+  const packageStart = nodeModulesIndex + '/node_modules/'.length
+  const rest = normalized.slice(packageStart)
+  const firstSlash = rest.indexOf('/')
+
+  let packageName: string
+  if (rest.startsWith('@')) {
+    // scoped package: @scope/pkg
+    const secondSlash = rest.indexOf('/', firstSlash + 1)
+    packageName = secondSlash === -1 ? rest : rest.slice(0, secondSlash)
+  } else {
+    packageName = firstSlash === -1 ? rest : rest.slice(0, firstSlash)
+  }
+  return normalized.slice(0, packageStart) + packageName
+}
 
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
@@ -40,6 +73,7 @@ export async function injectSourcesContent(
 ): Promise<void> {
   let sourceRootPromise: Promise<string | undefined>
 
+  const packageRoot = getNodeModulesPackageRoot(file)
   const missingSources: string[] = []
   const sourcesContent = map.sourcesContent || []
   const sourcesContentPromises: Promise<void>[] = []
@@ -59,7 +93,22 @@ export async function injectSourcesContent(
           if (sourceRoot) {
             resolvedSourcePath = path.resolve(sourceRoot, resolvedSourcePath)
           }
-
+          // Block path traversal outside the package boundary for node_modules
+          // A malicious package may point to a sensitive file
+          if (packageRoot) {
+            const resolvedSourcePathNormalized = normalizePath(
+              path.resolve(resolvedSourcePath),
+            )
+            if (!isParentDirectory(packageRoot, resolvedSourcePathNormalized)) {
+              sourcesContent[index] = null
+              logger.warnOnce(
+                colors.yellow(
+                  `Sourcemap for ${JSON.stringify(file)} points to a source file outside its package: ${JSON.stringify(resolvedSourcePathNormalized)}`,
+                ),
+              )
+              return
+            }
+          }
           sourcesContent[index] = await fsp
             .readFile(resolvedSourcePath, 'utf-8')
             .catch(() => {
@@ -153,12 +202,13 @@ export function applySourcemapIgnoreList(
 export function extractSourcemapFromFile(
   code: string,
   filePath: string,
+  logger: Logger,
 ): { code: string; map: SourceMap } | undefined {
   const map = (
     convertSourceMap.fromSource(code) ||
     convertSourceMap.fromMapFileSource(
       code,
-      createConvertSourceMapReadMap(filePath),
+      createConvertSourceMapReadMap(filePath, logger),
     )
   )?.toObject()
 
@@ -170,11 +220,24 @@ export function extractSourcemapFromFile(
   }
 }
 
-function createConvertSourceMapReadMap(originalFileName: string) {
+function createConvertSourceMapReadMap(
+  originalFileName: string,
+  logger: Logger,
+) {
+  const packageRoot = getNodeModulesPackageRoot(originalFileName)
   return (filename: string) => {
-    return fs.readFileSync(
-      path.resolve(path.dirname(originalFileName), filename),
-      'utf-8',
-    )
+    const resolvedPath = path.resolve(path.dirname(originalFileName), filename)
+    if (
+      packageRoot &&
+      !isParentDirectory(packageRoot, normalizePath(resolvedPath))
+    ) {
+      logger.warnOnce(
+        colors.yellow(
+          `Sourcemap in "${originalFileName}" references a map file outside its package: "${filename}"`,
+        ),
+      )
+      return '{}'
+    }
+    return fs.readFileSync(resolvedPath, 'utf-8')
   }
 }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -293,7 +293,7 @@ async function loadAndTransform(
     }
     if (code) {
       try {
-        const extracted = extractSourcemapFromFile(code, file)
+        const extracted = extractSourcemapFromFile(code, file, logger)
         if (extracted) {
           code = extracted.code
           map = extracted.map

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -16,6 +16,14 @@ import {
   serverLogs,
 } from '~utils'
 
+function createMapFileReader(moduleUrl: string) {
+  return async (filename: string): Promise<string> => {
+    const base = new URL(moduleUrl, page.url())
+    const res = await page.request.get(new URL(filename, base).href)
+    return res.text()
+  }
+}
+
 if (!isBuild) {
   test('js', async () => {
     const res = await page.request.get(new URL('./foo.js', page.url()).href)
@@ -143,6 +151,44 @@ if (!isBuild) {
     serverLogs.forEach((log) => {
       expect(log).not.toMatch(/Sourcemap for .+ points to missing source files/)
     })
+  })
+
+  test('should not leak file contents via sourcemap path traversal in node_modules', async () => {
+    const res = await page.request.get(
+      new URL('./malicious-import.js', page.url()).href,
+    )
+    const js = await res.text()
+    // Find the rewritten import URL for the malicious dep
+    const depUrlMatch = js.match(/from\s+"([^"]*malicious-sourcemap[^"]*)"/)
+    expect(depUrlMatch).toBeTruthy()
+    const depUrl = depUrlMatch![1]
+    const depRes = await page.request.get(new URL(depUrl, page.url()).href)
+    const depJs = await depRes.text()
+    const map = extractSourcemap(depJs)
+    expect(map.sourcesContent).toBeDefined()
+    expect(map.sourcesContent).not.toContainEqual(
+      expect.stringContaining('defineConfig'),
+    )
+  })
+
+  test('should not leak file contents via sourcemap path traversal in optimized deps', async () => {
+    const res = await page.request.get(
+      new URL('./optimized-malicious-import.js', page.url()).href,
+    )
+    const js = await res.text()
+    // Find the rewritten import URL for the optimized malicious dep
+    const depUrlMatch = js.match(/from\s+"([^"]*optimized-malicious[^"]*)"/)
+    expect(depUrlMatch).toBeTruthy()
+    const depUrl = depUrlMatch![1]
+    // Ensure the dep was actually optimized (served from .vite/deps)
+    expect(depUrl).toContain('.vite/deps')
+    const depRes = await page.request.get(new URL(depUrl, page.url()).href)
+    const depJs = await depRes.text()
+    const map = await extractSourcemap(depJs, createMapFileReader(depUrl))
+    expect(map.sourcesContent).toBeDefined()
+    expect(map.sourcesContent).not.toContainEqual(
+      expect.stringContaining('defineConfig'),
+    )
   })
 }
 

--- a/playground/js-sourcemap/dep-malicious-sourcemap/index.js
+++ b/playground/js-sourcemap/dep-malicious-sourcemap/index.js
@@ -1,0 +1,2 @@
+export const malicious = 'value'
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uL3BsYXlncm91bmQvanMtc291cmNlbWFwL3ZpdGUuY29uZmlnLmpzIl0sInNvdXJjZXNDb250ZW50IjpbbnVsbF0sIm1hcHBpbmdzIjoiQUFBQSIsIm5hbWVzIjpbXX0=

--- a/playground/js-sourcemap/dep-malicious-sourcemap/package.json
+++ b/playground/js-sourcemap/dep-malicious-sourcemap/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-dep-malicious-sourcemap",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/playground/js-sourcemap/dep-optimized-malicious/index.js
+++ b/playground/js-sourcemap/dep-optimized-malicious/index.js
@@ -1,0 +1,3 @@
+const optimizedMalicious = 'value'
+module.exports = { optimizedMalicious }
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uLy4uLy4uL3BsYXlncm91bmQvanMtc291cmNlbWFwL3ZpdGUuY29uZmlnLmpzIl0sInNvdXJjZXNDb250ZW50IjpbbnVsbF0sIm1hcHBpbmdzIjoiQUFBQSIsIm5hbWVzIjpbXX0=

--- a/playground/js-sourcemap/dep-optimized-malicious/package.json
+++ b/playground/js-sourcemap/dep-optimized-malicious/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-dep-optimized-malicious",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/playground/js-sourcemap/index.html
+++ b/playground/js-sourcemap/index.html
@@ -11,3 +11,5 @@
 <script type="module" src="./with-multiline-import.ts"></script>
 <script type="module" src="./zoo.js"></script>
 <script type="module" src="./with-define-object.ts"></script>
+<script type="module" src="./malicious-import.js"></script>
+<script type="module" src="./optimized-malicious-import.js"></script>

--- a/playground/js-sourcemap/malicious-import.js
+++ b/playground/js-sourcemap/malicious-import.js
@@ -1,0 +1,2 @@
+import { malicious } from '@vitejs/test-dep-malicious-sourcemap'
+console.log('malicious-import', malicious)

--- a/playground/js-sourcemap/optimized-malicious-import.js
+++ b/playground/js-sourcemap/optimized-malicious-import.js
@@ -1,0 +1,2 @@
+import { optimizedMalicious } from '@vitejs/test-dep-optimized-malicious'
+console.log('optimized-malicious-import', optimizedMalicious)

--- a/playground/js-sourcemap/package.json
+++ b/playground/js-sourcemap/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vitejs/test-dep-malicious-sourcemap": "file:dep-malicious-sourcemap",
+    "@vitejs/test-dep-optimized-malicious": "file:dep-optimized-malicious",
     "@vitejs/test-importee-pkg": "file:importee-pkg",
     "magic-string": "^0.30.21"
   }

--- a/playground/js-sourcemap/vite.config.js
+++ b/playground/js-sourcemap/vite.config.js
@@ -7,6 +7,9 @@ export default defineConfig({
     transformFooWithInlineSourceMap(),
     transformZooWithSourcemapPlugin(),
   ],
+  optimizeDeps: {
+    exclude: ['@vitejs/test-dep-malicious-sourcemap'],
+  },
   build: {
     sourcemap: true,
     rollupOptions: {

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -11,7 +11,11 @@ import type {
 } from 'playwright-chromium'
 import type { DepOptimizationMetadata, Manifest } from 'vite'
 import { normalizePath } from 'vite'
-import { fromComment, removeComments } from 'convert-source-map'
+import {
+  fromComment,
+  fromMapFileComment,
+  removeComments,
+} from 'convert-source-map'
 import { expect } from 'vitest'
 import type { ResultPromise as ExecaResultPromise } from 'execa'
 import { isWindows, page, sourcemapSnapshot, testDir } from './vitestSetup'
@@ -369,9 +373,28 @@ async function untilBrowserLog(
   return logs
 }
 
-export const extractSourcemap = (content: string): any => {
+export function extractSourcemap(content: string): any
+export function extractSourcemap(
+  content: string,
+  read: (filename: string) => Promise<string>,
+): Promise<any>
+export function extractSourcemap(
+  content: string,
+  read?: (filename: string) => Promise<string>,
+): any {
   const lines = content.trim().split('\n')
-  return fromComment(lines[lines.length - 1]).toObject()
+  const lastLine = lines[lines.length - 1]
+  if (read) {
+    const result = fromMapFileComment(lastLine, async (url) => {
+      if (url.startsWith('data:')) {
+        throw new Error(`Omit read argument when sourcemap is inline`)
+      }
+      const content = await read(url)
+      return content
+    })
+    return result.then((r) => r.toObject())
+  }
+  return fromComment(lastLine).toObject()
 }
 
 export const formatSourcemapForSnapshot = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,12 +881,22 @@ importers:
 
   playground/js-sourcemap:
     dependencies:
+      '@vitejs/test-dep-malicious-sourcemap':
+        specifier: file:dep-malicious-sourcemap
+        version: file:playground/js-sourcemap/dep-malicious-sourcemap
+      '@vitejs/test-dep-optimized-malicious':
+        specifier: file:dep-optimized-malicious
+        version: file:playground/js-sourcemap/dep-optimized-malicious
       '@vitejs/test-importee-pkg':
         specifier: file:importee-pkg
         version: file:playground/js-sourcemap/importee-pkg
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
+
+  playground/js-sourcemap/dep-malicious-sourcemap: {}
+
+  playground/js-sourcemap/dep-optimized-malicious: {}
 
   playground/js-sourcemap/importee-pkg: {}
 
@@ -4334,6 +4344,9 @@ packages:
   '@vitejs/test-dep-license-mit@file:packages/vite/src/node/__tests__/plugins/fixtures/license/dep-license-mit':
     resolution: {directory: packages/vite/src/node/__tests__/plugins/fixtures/license/dep-license-mit, type: directory}
 
+  '@vitejs/test-dep-malicious-sourcemap@file:playground/js-sourcemap/dep-malicious-sourcemap':
+    resolution: {directory: playground/js-sourcemap/dep-malicious-sourcemap, type: directory}
+
   '@vitejs/test-dep-nested-license-isc@file:packages/vite/src/node/__tests__/plugins/fixtures/license/dep-nested-license-isc':
     resolution: {directory: packages/vite/src/node/__tests__/plugins/fixtures/license/dep-nested-license-isc, type: directory}
 
@@ -4357,6 +4370,9 @@ packages:
 
   '@vitejs/test-dep-optimize-with-glob@file:playground/optimize-deps/dep-optimize-with-glob':
     resolution: {directory: playground/optimize-deps/dep-optimize-with-glob, type: directory}
+
+  '@vitejs/test-dep-optimized-malicious@file:playground/js-sourcemap/dep-optimized-malicious':
+    resolution: {directory: playground/js-sourcemap/dep-optimized-malicious, type: directory}
 
   '@vitejs/test-dep-relative-to-main@file:playground/optimize-deps/dep-relative-to-main':
     resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
@@ -10447,6 +10463,8 @@ snapshots:
     dependencies:
       '@vitejs/test-dep-nested-license-isc': file:packages/vite/src/node/__tests__/plugins/fixtures/license/dep-nested-license-isc
 
+  '@vitejs/test-dep-malicious-sourcemap@file:playground/js-sourcemap/dep-malicious-sourcemap': {}
+
   '@vitejs/test-dep-nested-license-isc@file:packages/vite/src/node/__tests__/plugins/fixtures/license/dep-nested-license-isc': {}
 
   '@vitejs/test-dep-no-discovery@file:playground/optimize-deps-no-discovery/dep-no-discovery': {}
@@ -10462,6 +10480,8 @@ snapshots:
   '@vitejs/test-dep-optimize-exports-with-root-glob@file:playground/optimize-deps/dep-optimize-exports-with-root-glob': {}
 
   '@vitejs/test-dep-optimize-with-glob@file:playground/optimize-deps/dep-optimize-with-glob': {}
+
+  '@vitejs/test-dep-optimized-malicious@file:playground/js-sourcemap/dep-optimized-malicious': {}
 
   '@vitejs/test-dep-relative-to-main@file:playground/optimize-deps/dep-relative-to-main': {}
 


### PR DESCRIPTION
If a package references a sourcemap with `sources` field without a corresponding `sourcesContent` value, Vite will read the content of that file and inject it to the served sourcemap.

If there's a package that contains a malicious sourcemap, the content of arbitrary file can be included in the sourcemap. This behavior itself is expected and aligns with other tools. It is also out of scope of [Vite's threat model](https://github.com/vitejs/vite/blob/main/.github/SECURITY.md#what-vite-trusts) as the file referenced by the project is considered as trusted.

That said, we think that it's better to add some warning when possible, and this PR adds that. Vite will output a warning if a sourcemap in a package references a file outside the package. It will also remove the content. Note that it is not possible to catch all cases by this and is not considered as a security boundary.
