### PR TITLE
fix: apply server.fs check to env transport

### DIFF
--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -156,7 +156,7 @@ function createWorkerdDevEnvironment(
 }
 ```
 
-By default, `HotChannel` transports (non-WebSocket) have `server.fs` restrictions applied, meaning only files within the allowed directories can be served. If your transport is not exposed over the network (e.g., it communicates via worker threads or in-process calls), you can set `skipFsCheck: true` on the `HotChannel` to bypass these restrictions.
+By default, `HotChannel` transports have `server.fs` restrictions applied, meaning only files within the allowed directories can be served. If your transport is not exposed over the network (e.g., it communicates via worker threads or in-process calls), you can set `skipFsCheck: true` on the `HotChannel` to bypass these restrictions.
 
 There are [multiple communication levels for the `DevEnvironment`](/guide/api-environment-frameworks#devenvironment-communication-levels). To make it easier for frameworks to write runtime agnostic code, we recommend to implement the most flexible communication level possible.
 

--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -156,6 +156,8 @@ function createWorkerdDevEnvironment(
 }
 ```
 
+By default, `HotChannel` transports (non-WebSocket) have `server.fs` restrictions applied, meaning only files within the allowed directories can be served. If your transport is not exposed over the network (e.g., it communicates via worker threads or in-process calls), you can set `skipFsCheck: true` on the `HotChannel` to bypass these restrictions.
+
 There are [multiple communication levels for the `DevEnvironment`](/guide/api-environment-frameworks#devenvironment-communication-levels). To make it easier for frameworks to write runtime agnostic code, we recommend to implement the most flexible communication level possible.
 
 ## `ModuleRunner`
@@ -369,6 +371,8 @@ function createWorkerEnvironment(name, config, context) {
   }
 
   const workerHotChannel = {
+    // Worker threads post messages are not exposed over the network, skip server.fs checks
+    skipFsCheck: true,
     send: (data) => worker.postMessage(data),
     on: (event, handler) => {
       // client is already connected

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -254,6 +254,7 @@ function defaultCreateClientDevEnvironment(
   return new DevEnvironment(name, config, {
     hot: true,
     transport: context.ws,
+    disableFetchModule: true,
   })
 }
 

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -26,10 +26,7 @@ import type {
   NormalizedHotChannelClient,
 } from './hmr'
 import { getShortName, normalizeHotChannel, updateModules } from './hmr'
-import type {
-  TransformOptionsInternal,
-  TransformResult,
-} from './transformRequest'
+import type { TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import type { EnvironmentPluginContainer } from './pluginContainer'
 import {
@@ -61,6 +58,10 @@ export class DevEnvironment extends BaseEnvironment {
    * @internal
    */
   _remoteRunnerOptions: DevEnvironmentContext['remoteRunner']
+  /**
+   * @internal
+   */
+  _skipFsCheck: boolean
 
   get pluginContainer(): EnvironmentPluginContainer<DevEnvironment> {
     if (!this._pluginContainer)
@@ -128,6 +129,11 @@ export class DevEnvironment extends BaseEnvironment {
     this._crawlEndFinder = setupOnCrawlEnd()
 
     this._remoteRunnerOptions = context.remoteRunner ?? {}
+    this._skipFsCheck = !!(
+      context.transport &&
+      !(isWebSocketServer in context.transport) &&
+      context.transport.skipFsCheck
+    )
 
     this.hot = context.transport
       ? isWebSocketServer in context.transport
@@ -233,12 +239,8 @@ export class DevEnvironment extends BaseEnvironment {
     }
   }
 
-  transformRequest(
-    url: string,
-    /** @internal */
-    options?: TransformOptionsInternal,
-  ): Promise<TransformResult | null> {
-    return transformRequest(this, url, options)
+  transformRequest(url: string): Promise<TransformResult | null> {
+    return transformRequest(this, url, { skipFsCheck: this._skipFsCheck })
   }
 
   async warmupRequest(url: string): Promise<void> {

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -45,6 +45,8 @@ export interface DevEnvironmentContext {
     inlineSourceMap?: boolean
   }
   depsOptimizer?: DepsOptimizer
+  /** @internal used for client environment */
+  disableFetchModule?: boolean
   /** @internal used for full bundle mode */
   disableDepsOptimizer?: boolean
 }
@@ -143,6 +145,9 @@ export class DevEnvironment extends BaseEnvironment {
 
     this.hot.setInvokeHandler({
       fetchModule: (id, importer, options) => {
+        if (context.disableFetchModule) {
+          throw new Error('fetchModule is disabled in this environment')
+        }
         return this.fetchModule(id, importer, options)
       },
       getBuiltins: async () => {
@@ -245,7 +250,7 @@ export class DevEnvironment extends BaseEnvironment {
 
   async warmupRequest(url: string): Promise<void> {
     try {
-      await this.transformRequest(url)
+      await transformRequest(this, url, { skipFsCheck: true })
     } catch (e) {
       if (
         e?.code === ERR_OUTDATED_OPTIMIZED_DEP ||

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -90,6 +90,11 @@ export type HotChannelListener<T extends string = string> = (
 
 export interface HotChannel<Api = any> {
   /**
+   * When true, the fs access check is skipped in fetchModule.
+   * Set this for transports that is not exposed over the network.
+   */
+  skipFsCheck?: boolean
+  /**
    * Broadcast events to all clients
    */
   send?(payload: HotPayload): void
@@ -1130,6 +1135,7 @@ export function createServerHotChannel(): ServerHotChannel {
   const outsideEmitter = new EventEmitter()
 
   return {
+    skipFsCheck: true,
     send(payload: HotPayload) {
       outsideEmitter.emit('send', payload)
     },

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -57,7 +57,10 @@ const rawRE = /[?&]raw\b/
 const inlineRE = /[?&]inline\b/
 const svgRE = /\.svg\b/
 
-function isServerAccessDeniedForTransform(config: ResolvedConfig, id: string) {
+export function isServerAccessDeniedForTransform(
+  config: ResolvedConfig,
+  id: string,
+): boolean {
   if (rawRE.test(id) || urlRE.test(id) || inlineRE.test(id) || svgRE.test(id)) {
     return checkLoadingAccess(config, id) !== 'allowed'
   }
@@ -244,14 +247,7 @@ export function transformMiddleware(
         }
 
         // resolve, load and transform using the plugin container
-        const result = await environment.transformRequest(url, {
-          allowId(id) {
-            return (
-              id[0] === '\0' ||
-              !isServerAccessDeniedForTransform(server.config, id)
-            )
-          },
-        })
+        const result = await environment.transformRequest(url)
         if (result) {
           const depsOptimizer = environment.depsOptimizer
           const type = isDirectCSSRequest(url) ? 'css' : 'js'

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -35,6 +35,7 @@ import {
 import { isFileLoadingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
 import type { DevEnvironment } from './environment'
+import { isServerAccessDeniedForTransform } from './middlewares/transform'
 
 export const ERR_LOAD_URL = 'ERR_LOAD_URL'
 export const ERR_LOAD_PUBLIC_URL = 'ERR_LOAD_PUBLIC_URL'
@@ -60,11 +61,11 @@ export interface TransformOptions {
   ssr?: boolean
 }
 
-export interface TransformOptionsInternal {
+interface TransformOptionsInternal {
   /**
-   * @internal
+   * Whether to skip the `server.fs` check.
    */
-  allowId?: (id: string) => boolean
+  skipFsCheck: boolean
 }
 
 // TODO: This function could be moved to the DevEnvironment class.
@@ -77,7 +78,7 @@ export interface TransformOptionsInternal {
 export function transformRequest(
   environment: DevEnvironment,
   url: string,
-  options: TransformOptionsInternal = {},
+  options: TransformOptionsInternal,
 ): Promise<TransformResult | null> {
   if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
@@ -248,7 +249,11 @@ async function loadAndTransform(
 
   const moduleGraph = environment.moduleGraph
 
-  if (options.allowId && !options.allowId(id)) {
+  if (
+    !options.skipFsCheck &&
+    id[0] !== '\0' &&
+    isServerAccessDeniedForTransform(config, id)
+  ) {
     const err: any = new Error(`Denied ID ${id}`)
     err.code = ERR_DENIED_ID
     err.id = id
@@ -272,7 +277,7 @@ async function loadAndTransform(
     // only try the fallback if access is allowed, skip for out of root url
     // like /service-worker.js or /api/users
     if (
-      environment.config.consumer === 'server' ||
+      options.skipFsCheck ||
       isFileLoadingAllowed(environment.getTopLevelConfig(), slash(file))
     ) {
       try {

--- a/packages/vite/src/node/ssr/__tests__/fixtures/basic/file.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/basic/file.js
@@ -1,0 +1,1 @@
+export default 'ok'

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -406,3 +406,26 @@ test('buildStart before transform', async () => {
     ]
   `)
 })
+
+test('server.fs check is not applied to ssrLoadModule', async () => {
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'silent',
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    server: {
+      fs: {
+        allow: [
+          path.resolve(import.meta.dirname, './fixtures/named-overwrite-all'),
+        ],
+      },
+    },
+  })
+  onTestFinished(() => server.close())
+  await server.environments.ssr.pluginContainer.buildStart({})
+
+  const mod = await server.ssrLoadModule('/fixtures/basic/file.js')
+  expect(mod.default).toBe('ok')
+})

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixture-outside.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixture-outside.js
@@ -1,0 +1,1 @@
+export default 'error'

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from 'node:fs'
-import { posix, win32 } from 'node:path'
+import { posix, resolve, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { setTimeout } from 'node:timers/promises'
 import { describe, expect, it, vi } from 'vitest'
@@ -623,5 +623,20 @@ describe('full-reload during close', () => {
     expect(
       errors.some((e) => e.toString().includes('transport was disconnected')),
     ).toBe(false)
+  })
+})
+
+describe('server.fs check', async () => {
+  const it = await createModuleRunnerTester({
+    server: {
+      fs: {
+        allow: [resolve(import.meta.dirname, './fixtures/circular')],
+      },
+    },
+  })
+
+  it('it is not applied to the server module runner', async ({ runner }) => {
+    const mod = await runner.import('/fixtures/basic.js')
+    expect(mod.name).toBe('basic')
   })
 })

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.invoke.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.invoke.spec.ts
@@ -1,4 +1,5 @@
 import { BroadcastChannel, Worker } from 'node:worker_threads'
+import path from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import type { BirpcReturn } from 'birpc'
 import { createBirpc } from 'birpc'
@@ -33,6 +34,9 @@ describe('running module runner inside a worker and using the ModuleRunnerTransp
         watch: null,
         hmr: {
           port: 9610,
+        },
+        fs: {
+          allow: [path.resolve(import.meta.dirname, './fixtures')],
         },
       },
       environments: {
@@ -108,5 +112,14 @@ describe('running module runner inside a worker and using the ModuleRunnerTransp
     expect(output).toHaveProperty('result')
     expect(output.result).toBe('baz.txt')
     expect(output.error).toBeUndefined()
+  })
+
+  it('server.fs check is applied to the custom transport by default', async () => {
+    handleInvoke = (data: any) =>
+      server.environments.worker.hot.handleInvoke(data)
+
+    const output = await run('./fixture-outside.js')
+    expect(output).toHaveProperty('error')
+    expect(output.error).toContain('Failed to load url')
   })
 })

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -1,4 +1,5 @@
 import { BroadcastChannel, Worker } from 'node:worker_threads'
+import path from 'node:path'
 import { describe, expect, it, onTestFinished } from 'vitest'
 import type { HotChannel, HotChannelListener, HotPayload } from 'vite'
 import { DevEnvironment } from '../../..'
@@ -111,5 +112,49 @@ describe('running module runner inside a worker', () => {
       }
       channel.postMessage({ id: './fixtures/default-string.ts' })
     })
+  })
+
+  it('server.fs check is applied to the custom transport by default', async () => {
+    const worker = new Worker(
+      new URL('./fixtures/worker.mjs', import.meta.url),
+      { stdout: true },
+    )
+    await new Promise<void>((resolve, reject) => {
+      worker.on('message', () => resolve())
+      worker.on('error', reject)
+    })
+    const server = await createServer({
+      root: import.meta.dirname,
+      logLevel: 'error',
+      server: {
+        middlewareMode: true,
+        watch: null,
+        hmr: {
+          port: 9609,
+        },
+        fs: {
+          allow: [path.resolve(import.meta.dirname, './fixtures')],
+        },
+      },
+      environments: {
+        worker: {
+          dev: {
+            createEnvironment: (name, config) => {
+              return new DevEnvironment(name, config, {
+                hot: false,
+                transport: createWorkerTransport(worker),
+              })
+            },
+          },
+        },
+      },
+    })
+    onTestFinished(async () => {
+      await Promise.allSettled([server.close(), worker.terminate()])
+    })
+
+    await expect(
+      server.environments.worker.transformRequest('./fixture-outside.js'),
+    ).rejects.toThrow('Failed to load url')
   })
 })

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -1,4 +1,7 @@
 import http from 'node:http'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { setTimeout } from 'node:timers/promises'
 import {
   afterEach,
   beforeAll,
@@ -456,6 +459,72 @@ describe('cross origin', () => {
         expect(result2).toBe(false)
       },
     )
+  })
+})
+
+describe.runIf(isServe)('fetchModule via WebSocket', () => {
+  const root = path.resolve(
+    import.meta.dirname.replace('playground', 'playground-temp'),
+    '..',
+  )
+
+  const fetchModuleViaWebSocket = async (filePath: string) => {
+    const resolvedPath = path.resolve(root, filePath)
+    const token = viteServer.config.webSocketToken
+    const wsUrl = viteTestUrl.replace('http', 'ws')
+    const ws = new WebSocket(`${wsUrl}?token=${token}`, ['vite-hmr'])
+
+    try {
+      return await Promise.race([
+        new Promise<any>((resolve, reject) => {
+          ws.on('open', () => {
+            ws.send(
+              JSON.stringify({
+                type: 'custom',
+                event: 'vite:invoke',
+                data: {
+                  name: 'fetchModule',
+                  id: 'send:1',
+                  data: [pathToFileURL(resolvedPath).href],
+                },
+              }),
+            )
+          })
+
+          ws.on('message', (raw: Buffer) => {
+            const parsed = JSON.parse(raw.toString())
+            if (
+              parsed.type === 'custom' &&
+              parsed.event === 'vite:invoke' &&
+              parsed.data?.id === 'response:1'
+            ) {
+              resolve(parsed.data.data)
+            }
+          })
+
+          ws.on('error', (err) => {
+            reject(err)
+          })
+        }),
+        setTimeout(10_000).then(() =>
+          Promise.reject(new Error('WebSocket response timed out')),
+        ),
+      ])
+    } finally {
+      ws.close()
+    }
+  }
+
+  test('should read files inside allowed directories', async () => {
+    const result = await fetchModuleViaWebSocket('root/src/safe.txt?raw')
+    expect(result.result).toBeTruthy()
+    expect(result.error).toBeFalsy()
+  })
+
+  test('should not read files outside allowed directories', async () => {
+    const result = await fetchModuleViaWebSocket('root/unsafe.txt?raw')
+    expect(result.result).toBeUndefined()
+    expect(result.error).toBeTruthy()
   })
 })
 

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -515,10 +515,10 @@ describe.runIf(isServe)('fetchModule via WebSocket', () => {
     }
   }
 
-  test('should read files inside allowed directories', async () => {
+  test('should not read files inside allowed directories as fetchModule is disabled', async () => {
     const result = await fetchModuleViaWebSocket('root/src/safe.txt?raw')
-    expect(result.result).toBeTruthy()
-    expect(result.error).toBeFalsy()
+    expect(result.result).toBeUndefined()
+    expect(result.error).toBeTruthy()
   })
 
   test('should not read files outside allowed directories', async () => {


### PR DESCRIPTION
Add `skipFsCheck` property that is `false` by default to `HotChannel` interface. When this is `false`, `server.fs` checks are applied when `environment.transformRequest` is called. `ServerHotChannel` has `skipFsCheck: true` as it's not exposed to the network.

Also disabled `fetchModule` method for the default client environment. I didn't expose the option to disable it for other environments as I don't think there's a case that doesn't require `fetchModule`.

fixes https://github.com/vitejs/vite/security/advisories/GHSA-p9ff-h696-f583
