### PR TITLE
docs: fix reuses wording in dev environment comment

### DIFF
--- a/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
+++ b/packages/vite/src/node/server/environments/fullBundleEnvironment.ts
@@ -156,7 +156,7 @@ export class FullBundleDevEnvironment extends DevEnvironment {
           return
         }
 
-        // NOTE: don't clear memoryFiles here as incremental build re-uses the files
+        // NOTE: don't clear memoryFiles here as incremental build reuses the files
         for (const outputFile of result.output) {
           this.memoryFiles.set(outputFile.fileName, () => {
             const source =


### PR DESCRIPTION
## Summary
- fix `re-uses` -> `reuses` in a developer-facing code comment

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- Reviewed https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md and kept this to one focused file with no behavior change.

## Validation/testing note
- Not run (comment-only change)
