### PR TITLE
fix: use sync dns.getDefaultResultOrder instead of dns.promises

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -7,7 +7,7 @@ import crypto from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import type { ServerOptions as HttpsServerOptions } from 'node:https'
 import { builtinModules } from 'node:module'
-import { promises as dns } from 'node:dns'
+import { promises as dns, getDefaultResultOrder } from 'node:dns'
 import { performance } from 'node:perf_hooks'
 import type { AddressInfo, Server } from 'node:net'
 import fsp from 'node:fs/promises'
@@ -925,7 +925,7 @@ export function unique<T>(arr: T[]): T[] {
 export function getLocalhostAddressIfDiffersFromDNS():
   | Promise<string | undefined>
   | undefined {
-  if (dns.getDefaultResultOrder() === 'verbatim') {
+  if (getDefaultResultOrder() === 'verbatim') {
     return undefined
   }
   return Promise.all([


### PR DESCRIPTION
## Summary

Fixes #22184

`getLocalhostAddressIfDiffersFromDNS` (introduced in #22151, commit 56ec256) calls `dns.getDefaultResultOrder()` — but `dns` is aliased from `node:dns`'s `promises` namespace (`import { promises as dns }`), so it resolves to `dns.promises.getDefaultResultOrder()` at runtime.

Bun does not implement `dns.promises.getDefaultResultOrder` (tested on 1.3.10, 1.3.11 stable, 1.3.12 canary), causing `vite build` to fail since 8.0.6:

```
TypeError: promises.getDefaultResultOrder is not a function
```

`getDefaultResultOrder` is synchronous by nature — this PR imports it directly from `node:dns` (the sync/callback namespace) instead of going through `dns.promises`.

## Change

- Import `getDefaultResultOrder` from `node:dns` alongside the existing `promises` import
- Call `getDefaultResultOrder()` directly instead of `dns.getDefaultResultOrder()`

## Test plan

- `vite build` under Bun 1.3.x no longer throws
- No behavior change on Node.js — `dns.getDefaultResultOrder` exists on both `dns` and `dns.promises` in Node