### PR TITLE
test(glob-import): add follow symlinks test

### DIFF
--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -236,6 +236,15 @@ if (!isBuild) {
   })
 }
 
+test('follow symlinks', async () => {
+  await expect
+    .poll(async () => JSON.parse(await page.textContent('.follow-symlinks')))
+    .toStrictEqual({
+      './follow-symlinks/linked/my-lib/components/a.js': 'a',
+      './follow-symlinks/linked/my-lib/components/b.js': 'b',
+    })
+})
+
 test('alias exclusion', async () => {
   await expect
     .poll(async () => JSON.parse(await page.textContent('.alias-exclusion')))

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -245,6 +245,17 @@ test('follow symlinks', async () => {
     })
 })
 
+test('follow symlinks same reference', async () => {
+  await expect
+    .poll(async () =>
+      JSON.parse(await page.textContent('.follow-symlinks-same-ref')),
+    )
+    .toStrictEqual({
+      a: true,
+      b: true,
+    })
+})
+
 test('alias exclusion', async () => {
   await expect
     .poll(async () => JSON.parse(await page.textContent('.alias-exclusion')))

--- a/playground/glob-import/follow-symlinks/linked/my-lib
+++ b/playground/glob-import/follow-symlinks/linked/my-lib
@@ -1,1 +1,0 @@
-../packages/my-lib

--- a/playground/glob-import/follow-symlinks/linked/my-lib
+++ b/playground/glob-import/follow-symlinks/linked/my-lib
@@ -1,0 +1,1 @@
+../packages/my-lib

--- a/playground/glob-import/follow-symlinks/packages/my-lib/components/a.js
+++ b/playground/glob-import/follow-symlinks/packages/my-lib/components/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/playground/glob-import/follow-symlinks/packages/my-lib/components/b.js
+++ b/playground/glob-import/follow-symlinks/packages/my-lib/components/b.js
@@ -1,0 +1,1 @@
+export default 'b'

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -198,6 +198,24 @@
   )
 </script>
 
+<h2>Follow symlinks</h2>
+<pre class="follow-symlinks"></pre>
+
+<script type="module">
+  const symlinkModules = import.meta.glob(
+    './follow-symlinks/linked/*/components/*.js',
+    {
+      eager: true,
+      import: 'default',
+    },
+  )
+  document.querySelector('.follow-symlinks').textContent = JSON.stringify(
+    symlinkModules,
+    null,
+    2,
+  )
+</script>
+
 <h2>Alias exclusion</h2>
 <pre class="alias-exclusion"></pre>
 

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -216,6 +216,33 @@
   )
 </script>
 
+<h2>Follow symlinks same reference</h2>
+<pre class="follow-symlinks-same-ref"></pre>
+
+<script type="module">
+  import * as originalA from './follow-symlinks/packages/my-lib/components/a.js'
+  import * as originalB from './follow-symlinks/packages/my-lib/components/b.js'
+  const symlinkModules = import.meta.glob(
+    './follow-symlinks/linked/*/components/*.js',
+    {
+      eager: true,
+    },
+  )
+  document.querySelector('.follow-symlinks-same-ref').textContent =
+    JSON.stringify(
+      {
+        a:
+          symlinkModules['./follow-symlinks/linked/my-lib/components/a.js'] ===
+          originalA,
+        b:
+          symlinkModules['./follow-symlinks/linked/my-lib/components/b.js'] ===
+          originalB,
+      },
+      null,
+      2,
+    )
+</script>
+
 <h2>Alias exclusion</h2>
 <pre class="alias-exclusion"></pre>
 

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -32,9 +32,7 @@ const transformVisibilityPlugin = {
 
 // Ensure symlink exists before any file processing.
 // We create it programmatically instead of storing it in git because
-// `fs.cp` (used to copy playgrounds to playground-temp) has a bug on
-// Windows where it loses the directory symlink type, creating a file
-// symlink instead — which breaks directory traversal.
+// of https://github.com/nodejs/node/issues/62653
 const linked = path.resolve(
   import.meta.dirname,
   'follow-symlinks/linked/my-lib',

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -38,13 +38,9 @@ const linked = path.resolve(
   import.meta.dirname,
   'follow-symlinks/linked/my-lib',
 )
-const target = path.resolve(
-  import.meta.dirname,
-  'follow-symlinks/packages/my-lib',
-)
 if (!fs.existsSync(linked) || !fs.lstatSync(linked).isSymbolicLink()) {
   fs.rmSync(linked, { recursive: true, force: true })
-  fs.symlinkSync(target, linked, 'junction')
+  fs.symlinkSync('../packages/my-lib', linked, 'dir')
 }
 
 export default defineConfig({

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -30,6 +30,23 @@ const transformVisibilityPlugin = {
   },
 }
 
+// Ensure symlink exists before any file processing.
+// We can't rely on git symlinks because they are not portable across platforms
+// (Windows may check them out as plain text files, and fs.cp may lose the
+// directory symlink type when copying to playground-temp).
+const linked = path.resolve(
+  import.meta.dirname,
+  'follow-symlinks/linked/my-lib',
+)
+const target = path.resolve(
+  import.meta.dirname,
+  'follow-symlinks/packages/my-lib',
+)
+if (!fs.existsSync(linked) || !fs.lstatSync(linked).isSymbolicLink()) {
+  fs.rmSync(linked, { recursive: true, force: true })
+  fs.symlinkSync(target, linked, 'junction')
+}
+
 export default defineConfig({
   plugins: [transformVisibilityPlugin],
   resolve: {

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -31,9 +31,10 @@ const transformVisibilityPlugin = {
 }
 
 // Ensure symlink exists before any file processing.
-// We can't rely on git symlinks because they are not portable across platforms
-// (Windows may check them out as plain text files, and fs.cp may lose the
-// directory symlink type when copying to playground-temp).
+// We create it programmatically instead of storing it in git because
+// `fs.cp` (used to copy playgrounds to playground-temp) has a bug on
+// Windows where it loses the directory symlink type, creating a file
+// symlink instead — which breaks directory traversal.
 const linked = path.resolve(
   import.meta.dirname,
   'follow-symlinks/linked/my-lib',

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -34,6 +34,7 @@ export async function setup(project: TestProject): Promise<void> {
       const destDir = path.resolve(tempDir, dir)
       await copyWithFriendlyError(srcDir, destDir, {
         recursive: true,
+        verbatimSymlinks: true,
         filter: filterForPlaygroundCopy,
       })
     }),
@@ -55,6 +56,7 @@ export async function setup(project: TestProject): Promise<void> {
       cpPromises.push(
         copyWithFriendlyError(srcDir, destDir, {
           recursive: true,
+          verbatimSymlinks: true,
           filter: filterForPlaygroundCopy,
         }),
       )

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -34,7 +34,6 @@ export async function setup(project: TestProject): Promise<void> {
       const destDir = path.resolve(tempDir, dir)
       await copyWithFriendlyError(srcDir, destDir, {
         recursive: true,
-        verbatimSymlinks: true,
         filter: filterForPlaygroundCopy,
       })
     }),
@@ -56,7 +55,6 @@ export async function setup(project: TestProject): Promise<void> {
       cpPromises.push(
         copyWithFriendlyError(srcDir, destDir, {
           recursive: true,
-          verbatimSymlinks: true,
           filter: filterForPlaygroundCopy,
         }),
       )


### PR DESCRIPTION
Related to https://github.com/rolldown/rolldown/issues/8980 and https://github.com/rolldown/rolldown/pull/9000

I believe this is a missing test case on the Vite side, and we should add it there.
