### PR TITLE
fix(ssr): class property keys hoisting matching imports

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -860,25 +860,35 @@ test('class props', async () => {
   expect(
     await ssrTransformSimpleCode(
       `
-import { remove, add } from 'vue'
+import { remove, add, update, del, call } from 'vue'
 
 class A {
   remove = 1
   add = null
+  update = update
+  del = () => del()
+  call = call(4)
 }
+
+remove(2);
+add(4);
 `,
     ),
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["remove","add"]});
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["remove","add","update","del","call"]});
 
 
 
-    const add = __vite_ssr_import_0__.add;
-    const remove = __vite_ssr_import_0__.remove;
     class A {
       remove = 1
       add = null
+      update = __vite_ssr_import_0__.update
+      del = () => (0,__vite_ssr_import_0__.del)()
+      call = (0,__vite_ssr_import_0__.call)(4)
     }
+
+    (0,__vite_ssr_import_0__.remove)(2);
+    (0,__vite_ssr_import_0__.add)(4);
     "
   `)
 })

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -344,7 +344,6 @@ async function ssrTransformScript(
       }
     },
     onIdentifier(id, parent, parentStack) {
-      const grandparent = parentStack[1]
       const binding = idToImportMap.get(id.name)
       if (!binding) {
         return
@@ -360,9 +359,8 @@ async function ssrTransformScript(
           s.appendLeft(id.end, `: ${binding}`)
         }
       } else if (
-        (parent.type === 'PropertyDefinition' &&
-          grandparent?.type === 'ClassBody') ||
-        (parent.type === 'ClassDeclaration' && id === parent.superClass)
+        parent.type === 'ClassDeclaration' &&
+        id === parent.superClass
       ) {
         if (!declaredConst.has(id.name)) {
           declaredConst.add(id.name)
@@ -678,6 +676,13 @@ function isRefIdentifier(
   // class method name
   if (parent.type === 'MethodDefinition' && !parent.computed) {
     return false
+  }
+
+  // class property key
+  if (parent.type === 'PropertyDefinition' && !parent.computed) {
+    // values can still contain identifier references,
+    // but keys cannot unless computed.
+    return parent.value === id
   }
 
   // property key


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

In an SSR environment, vite will incorrectly hoist imports whose names match class property keys.

This was first identified in vitest:
Reproduction: https://github.com/SunsetFi/vitest-class-method-name-collision/tree/main
Issue: https://github.com/vitest-dev/vitest/issues/10093
PR: https://github.com/vitest-dev/vitest/pull/10094

This PR was made on the request of @sheremet-va, over in the vitest PR for this issue.

I do not have a reproduction at hand, but the [class props test](https://github.com/vitejs/vite/blob/94fd9e7fe1a7d7970ba5e154d588f88318a72302/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts#L876) in ssrTransform.spec.ts demonstrate the bug occurring:

```
    const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["remove","add"]});


    // Incorrect: Should not be hoisted, as the class identifiers are keys, not references
    const add = __vite_ssr_import_0__.add;
    const remove = __vite_ssr_import_0__.remove;
    class A {
      remove = 1
      add = null
    }
```

This PR provides 2 code changes, both related:
- Fix isRefIdentifier incorrectly indicating non-computed class property keys are references
- Roll back the fix from https://github.com/vitest-dev/vitest/issues/303

Based on our research, the initial reason for the identifier references getting hoisted was introduced due to #2221.  In order to reference a variable in the 'extends' directive of a class, the variable must not be a property path:
```ts
// Wrong
class MyClass extends __vite_ssr_import_0__.MySuper {}
```

The fix in #2221 was to extract it to its own variable:
```ts
// The intent behind the fix
const MySuper = __vite_ssr_import_0__.MySuper;
class MyClass extends MySuper {}
```

However, at some point, it was noted that vitest was mangling class property keys as if they were imports: https://github.com/vitest-dev/vitest/issues/303.

The fix for this was implemented in https://github.com/vitejs/vite/pull/6261.  However, the fix itself seems to function only indirectly, and it introduced the bug seen in https://github.com/vitest-dev/vitest/issues/10093.  The effect of this fix was to treat all class property key identifiers as if they were super references in class declarations.  This consequently triggers the variable hoisting behavior on all matches.  The root cause, that class property keys were treated as references to identifiers, was never resolved, and still surfaces through the hoisting mechanism kicking in when it sees an import that coincidentally matches the name of a class property key.

The appropriate fix for https://github.com/vitest-dev/vitest/issues/303 seems to be instead changing isRefIdentifier to correctly specify that non-computed class property key identifiers are not references.