### PR TITLE
fix: avoid `dns.getDefaultResultOrder` temporary

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -7,7 +7,7 @@ import crypto from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import type { ServerOptions as HttpsServerOptions } from 'node:https'
 import { builtinModules } from 'node:module'
-import { promises as dns, getDefaultResultOrder } from 'node:dns'
+import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
 import type { AddressInfo, Server } from 'node:net'
 import fsp from 'node:fs/promises'
@@ -925,7 +925,10 @@ export function unique<T>(arr: T[]): T[] {
 export function getLocalhostAddressIfDiffersFromDNS():
   | Promise<string | undefined>
   | undefined {
-  if (getDefaultResultOrder() === 'verbatim') {
+  // dns.getDefaultResultOrder is not available in bun 1.3.11 and deno 2.7.11
+  // while this is a bug in bun and deno, since this function is commonly called,
+  // we give a workaround specially until the API is supported in a few versions
+  if (dns.getDefaultResultOrder && dns.getDefaultResultOrder() === 'verbatim') {
     return undefined
   }
   return Promise.all([


### PR DESCRIPTION
Adding a check temporary to unblock running on deno.

refs #22185
