### PR TITLE
docs: fix wording in sass error comment

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2684,7 +2684,7 @@ const scssProcessor = (
             // to re-generate a new frame (same as legacy api)
             e.frame = e.message
           }
-          // sass sometimes re-uses the error instance
+          // sass sometimes reuses the error instance
           // avoid mutating the same instance multiple times
           normalizedErrors.add(e)
         }


### PR DESCRIPTION
Related issue: N/A (trivial comment wording fix)

Fixes a wording typo in the CSS plugin by changing `re-uses` to `reuses` in an internal comment.

---

- [x] What is this PR solving? Write a clear and concise description. (comment wording typo only)
- [x] Reference the issues it solves (e.g. `fixes #123`). (N/A)
- [x] What other alternatives have you explored? (N/A for trivial typo fix)
- [x] Are there any parts you think require more attention from reviewers? (No)
- [x] Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- [x] Check that there isn't already a PR that solves the problem the same way.
- [x] Update the corresponding documentation if needed. (Not needed for an internal comment fix)
- [x] Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why. (Not run; comment-only change)
