### PR TITLE
fix(create-vite): add missing quotes around viteLogo src attribute

### DIFF
--- a/packages/create-vite/template-vanilla-ts/src/main.ts
+++ b/packages/create-vite/template-vanilla-ts/src/main.ts
@@ -28,7 +28,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <ul>
       <li>
         <a href="https://vite.dev/" target="_blank">
-          <img class="logo" src=${viteLogo} alt="" />
+          <img class="logo" src="${viteLogo}" alt="" />
           Explore Vite
         </a>
       </li>

--- a/packages/create-vite/template-vanilla-ts/src/main.ts
+++ b/packages/create-vite/template-vanilla-ts/src/main.ts
@@ -9,7 +9,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div class="hero">
     <img src="${heroImg}" class="base" width="170" height="179">
     <img src="${typescriptLogo}" class="framework" alt="TypeScript logo"/>
-    <img src=${viteLogo} class="vite" alt="Vite logo" />
+    <img src="${viteLogo}" class="vite" alt="Vite logo" />
   </div>
   <div>
     <h1>Get started</h1>

--- a/packages/create-vite/template-vanilla/src/main.js
+++ b/packages/create-vite/template-vanilla/src/main.js
@@ -9,7 +9,7 @@ document.querySelector('#app').innerHTML = `
   <div class="hero">
     <img src="${heroImg}" class="base" width="170" height="179">
     <img src="${javascriptLogo}" class="framework" alt="JavaScript logo"/>
-    <img src=${viteLogo} class="vite" alt="Vite logo" />
+    <img src="${viteLogo}" class="vite" alt="Vite logo" />
   </div>
   <div>
     <h1>Get started</h1>

--- a/packages/create-vite/template-vanilla/src/main.js
+++ b/packages/create-vite/template-vanilla/src/main.js
@@ -28,7 +28,7 @@ document.querySelector('#app').innerHTML = `
     <ul>
       <li>
         <a href="https://vite.dev/" target="_blank">
-          <img class="logo" src=${viteLogo} alt="" />
+          <img class="logo" src="${viteLogo}" alt="" />
           Explore Vite
         </a>
       </li>


### PR DESCRIPTION
The `src` attribute for `viteLogo` in the vanilla template was missing quotes around the template literal interpolation.

Before:
```
html
<img src=${viteLogo} class="vite" alt="Vite logo" />
```

After:
```
html
<img src="${viteLogo}" class="vite" alt="Vite logo" />
```
This makes it consistent with the other two image tags in the same block and ensures valid HTML attribute syntax.