### PR TITLE
docs: add ambiguous default import from CJS section in troubleshooting

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -287,6 +287,18 @@ An example of cross drive links are:
 
 Related issue: [#10802](https://github.com/vitejs/vite/issues/10802)
 
+### Default import unexpectedly returns an object
+
+The default import returns the `module.exports` object for CJS modules, while you may expect it to return the `module.exports.default` value.
+
+This may cause errors like:
+
+> Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
+
+> foo is not a function
+
+See Rolldown's docs about this problem for more details: [Ambiguous `default` import from CJS modules - Bundling CJS | Rolldown](https://rolldown.rs/in-depth/bundling-cjs#ambiguous-default-import-from-cjs-modules).
+
 <script setup lang="ts">
 // redirect old links with hash to old version docs
 if (typeof window !== "undefined") {


### PR DESCRIPTION
Adding this section to the troubleshooting guide so that it can be found when searching with the common error:

> Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
