### PR TITLE
fix: detect Deno workspace root (fix #22237)

### DIFF
--- a/packages/vite/src/node/server/__tests__/fixtures/deno/deno.json
+++ b/packages/vite/src/node/server/__tests__/fixtures/deno/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["nested"]
+}

--- a/packages/vite/src/node/server/__tests__/fixtures/deno/nested/package.json
+++ b/packages/vite/src/node/server/__tests__/fixtures/deno/nested/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/packages/vite/src/node/server/__tests__/search-root.spec.ts
+++ b/packages/vite/src/node/server/__tests__/search-root.spec.ts
@@ -31,6 +31,18 @@ describe('searchForWorkspaceRoot', () => {
     expect(resolved).toBe(resolve(dirname, 'fixtures/yarn'))
   })
 
+  test('deno', () => {
+    const resolved = searchForWorkspaceRoot(
+      resolve(dirname, 'fixtures/deno/nested'),
+    )
+    expect(resolved).toBe(resolve(dirname, 'fixtures/deno'))
+  })
+
+  test('deno at root', () => {
+    const resolved = searchForWorkspaceRoot(resolve(dirname, 'fixtures/deno'))
+    expect(resolved).toBe(resolve(dirname, 'fixtures/deno'))
+  })
+
   test('none', () => {
     const resolved = searchForWorkspaceRoot(
       resolve(dirname, 'fixtures/none/nested'),

--- a/packages/vite/src/node/server/searchRoot.ts
+++ b/packages/vite/src/node/server/searchRoot.ts
@@ -35,6 +35,24 @@ function hasWorkspacePackageJSON(root: string): boolean {
   }
 }
 
+// https://docs.deno.com/runtime/fundamentals/workspaces/
+function hasWorkspaceDenoJSON(root: string): boolean {
+  for (const name of ['deno.json', 'deno.jsonc']) {
+    const path = join(root, name)
+    if (!isFileReadable(path)) {
+      continue
+    }
+    try {
+      const content = JSON.parse(fs.readFileSync(path, 'utf-8')) || {}
+      if (content.workspace) return true
+    } catch {
+      // deno.jsonc is only detected when it is also valid JSON. Full
+      // JSONC parsing would require an additional parser.
+    }
+  }
+  return false
+}
+
 function hasRootFile(root: string): boolean {
   return ROOT_FILES.some((file) => fs.existsSync(join(root, file)))
 }
@@ -69,6 +87,7 @@ export function searchForWorkspaceRoot(
 ): string {
   if (hasRootFile(current)) return current
   if (hasWorkspacePackageJSON(current)) return current
+  if (hasWorkspaceDenoJSON(current)) return current
 
   const dir = dirname(current)
   // reach the fs root

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,6 +497,8 @@ importers:
 
   packages/vite/src/node/__tests__/plugins/fixtures/license/dep-nested-license-isc: {}
 
+  packages/vite/src/node/server/__tests__/fixtures/deno/nested: {}
+
   packages/vite/src/node/server/__tests__/fixtures/lerna/nested: {}
 
   packages/vite/src/node/server/__tests__/fixtures/none/nested: {}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
 ### Description

  Adds Deno workspace detection to `searchForWorkspaceRoot`.

  Deno workspaces are declared with the `workspace` field in `deno.json`. Without recognizing this config, Vite may resolve the workspace
  root to a nested package directory instead of the repository root. This can make the default `server.fs.allow` too narrow for Deno
  projects where npm packages are installed under the repository-level `node_modules/.deno` directory.

  This became visible after `server.fs` checks started applying to environment transport module fetches.

  ### Changes

  - Detect `deno.json` and `deno.jsonc` files with a `workspace` field in `searchForWorkspaceRoot`
  - Add Deno workspace fixtures
  - Add tests for nested and root Deno workspace resolution

  ### Notes

  `deno.jsonc` is detected only when its contents are also valid JSON. Full JSONC parsing would require an additional parser, which this PR
  avoids.


  ### Tests

  pnpm exec vitest run packages/vite/src/node/server/__tests__/search-root.spec.ts

  Fixes #22237