### PR TITLE
test: add test for configEnvironment mutation leaking between environments

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1090,6 +1090,32 @@ test('config compat 3', async () => {
   `)
 })
 
+test('configEnvironment mutation does not leak between environments', async () => {
+  const resolved = await resolveConfig(
+    {
+      environments: {
+        custom1: {},
+        custom2: {},
+      },
+      plugins: [
+        {
+          name: 'test-mutate-env',
+          configEnvironment(name, config) {
+            if (name === 'custom1') {
+              config.resolve ??= {}
+              config.resolve.noExternal = true
+            }
+          },
+        },
+      ],
+    },
+    'serve',
+  )
+
+  expect(resolved.environments.custom1.resolve.noExternal).toBe(true)
+  expect(resolved.environments.custom2.resolve.noExternal).not.toBe(true)
+})
+
 test('preTransformRequests', async () => {
   async function testConfig(inlineConfig: InlineConfig) {
     return Object.fromEntries(


### PR DESCRIPTION
This is just a test reproducing issue described in #22249