### PR TITLE
fix: patch parseurl to remove deprecated url.parse usage

### DIFF
--- a/patches/parseurl@1.3.3.patch
+++ b/patches/parseurl@1.3.3.patch
@@ -1,0 +1,77 @@
+diff --git a/index.js b/index.js
+index ece722327959f3bd9721488a035947387f1c1db1..9fd14fe1ca996abcf7987e0444661bb93d5ac748 100644
+--- a/index.js
++++ b/index.js
+@@ -7,15 +7,6 @@
+ 
+ 'use strict'
+ 
+-/**
+- * Module dependencies.
+- * @private
+- */
+-
+-var url = require('url')
+-var parse = url.parse
+-var Url = url.Url
+-
+ /**
+  * Module exports.
+  * @public
+@@ -94,7 +85,20 @@ function originalurl (req) {
+ 
+ function fastparse (str) {
+   if (typeof str !== 'string' || str.charCodeAt(0) !== 0x2f /* / */) {
+-    return parse(str)
++    // Full URL (not a relative path) - use WHATWG URL API
++    try {
++      var u = new URL(str)
++      return {
++        href: u.href,
++        path: u.pathname + u.search,
++        pathname: u.pathname,
++        search: u.search || null,
++        query: u.search ? u.search.slice(1) : null
++      }
++    } catch (e) {
++      // Malformed URL - return a minimal object
++      return { href: str, path: str, pathname: str, search: null, query: null }
++    }
+   }
+ 
+   var pathname = str
+@@ -121,13 +125,23 @@ function fastparse (str) {
+       case 0x23: /* #  */
+       case 0xa0:
+       case 0xfeff:
+-        return parse(str)
++        // Contains control characters - use WHATWG URL API with localhost base
++        try {
++          var u2 = new URL(str, 'http://localhost')
++          return {
++            href: str,
++            path: u2.pathname + u2.search,
++            pathname: u2.pathname,
++            search: u2.search || null,
++            query: u2.search ? u2.search.slice(1) : null
++          }
++        } catch (e2) {
++          return { href: str, path: str, pathname: str, search: null, query: null }
++        }
+     }
+   }
+ 
+-  var url = Url !== undefined
+-    ? new Url()
+-    : {}
++  var url = {}
+ 
+   url.path = str
+   url.href = str
+@@ -153,6 +167,5 @@ function fastparse (str) {
+ function fresh (url, parsedUrl) {
+   return typeof parsedUrl === 'object' &&
+     parsedUrl !== null &&
+-    (Url === undefined || parsedUrl instanceof Url) &&
+     parsedUrl._raw === url
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ patchedDependencies:
   dotenv-expand@12.0.3:
     hash: 49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889
     path: patches/dotenv-expand@12.0.3.patch
+  parseurl@1.3.3:
+    hash: 1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a
+    path: patches/parseurl@1.3.3.patch
   sirv@3.0.2:
     hash: c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95
     path: patches/sirv@3.0.2.patch
@@ -11395,7 +11398,7 @@ snapshots:
     dependencies:
       debug: obug@1.0.2(ms@2.1.3)
       finalhandler: 1.1.2(ms@2.1.3)
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - ms
@@ -11863,7 +11866,7 @@ snapshots:
       mime-types: 3.0.2
       on-finished: 2.4.1
       once: 1.4.0
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
@@ -11944,7 +11947,7 @@ snapshots:
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       statuses: 1.5.0
       unpipe: 1.0.0
     transitivePeerDependencies:
@@ -11956,7 +11959,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       statuses: 2.0.2
     transitivePeerDependencies:
       - ms
@@ -13102,7 +13105,7 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parseurl@1.3.3: {}
+  parseurl@1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a): {}
 
   path-browserify@1.0.1: {}
 
@@ -13625,7 +13628,7 @@ snapshots:
       debug: obug@1.0.2(ms@2.1.3)
       depd: 2.0.0
       is-promise: 4.0.0
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - ms
@@ -13784,7 +13787,7 @@ snapshots:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
-      parseurl: 1.3.3
+      parseurl: 1.3.3(patch_hash=1df193c575ab0f8a6e4464b1a128d71d5daa2627b5ba9037539baf5d4351611a)
       send: 1.2.1
 
   setprototypeof@1.2.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,46 +3,49 @@ packages:
   - 'playground/**'
   - 'packages/**/__tests__/**'
   - docs
+allowBuilds:
+  "@parcel/watcher": true
+  "@tailwindcss/oxide": true
+  core-js: false
+  esbuild: true
+  playwright-chromium: true
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: true
+  vue-demi: false
+  workerd: true
+autoInstallPeers: false
+dedupeInjectedDeps: false
+
+dedupePeers: true
 
 hoistPattern:
   - postcss # package/vite
   - pug # playground/tailwind: @vue/compiler-sfc
   - eslint-import-resolver-* # eslint-plugin-import-x
-shellEmulator: true
-autoInstallPeers: false
-dedupeInjectedDeps: false
 overrides:
+  debug: 'npm:obug@^1.0.2'
   rolldown: $rolldown
   vite: 'workspace:*'
-  debug: 'npm:obug@^1.0.2'
-patchedDependencies:
-  "sirv@3.0.2": "patches/sirv@3.0.2.patch"
-  "chokidar@3.6.0": "patches/chokidar@3.6.0.patch"
-  "dotenv-expand@12.0.3": "patches/dotenv-expand@12.0.3.patch"
-peerDependencyRules:
-  allowedVersions:
-    vite: "*"
 packageExtensions:
+  '@rollup/plugin-dynamic-import-vars':
+    dependencies:
+      '@types/estree': ^1.0.0
   sass-embedded:
     peerDependencies:
       source-map-js: "*"
     peerDependenciesMeta:
       source-map-js:
         optional: true
-  '@rollup/plugin-dynamic-import-vars':
-    dependencies:
-      '@types/estree': ^1.0.0
-allowBuilds:
-  core-js: false
-  vue-demi: false
-  "@parcel/watcher": true
-  "@tailwindcss/oxide": true
-  esbuild: true
-  playwright-chromium: true
-  sharp: true
-  simple-git-hooks: true
-  unrs-resolver: true
-  workerd: true
+patchedDependencies:
+  "chokidar@3.6.0": "patches/chokidar@3.6.0.patch"
+  "dotenv-expand@12.0.3": "patches/dotenv-expand@12.0.3.patch"
+  parseurl@1.3.3: patches/parseurl@1.3.3.patch
+  "sirv@3.0.2": "patches/sirv@3.0.2.patch"
+peerDependencyRules:
+  allowedVersions:
+    vite: "*"
+shellEmulator: true
 
 trustPolicy: no-downgrade
 trustPolicyExclude:
@@ -50,5 +53,3 @@ trustPolicyExclude:
   - semver@5.7.2 || 6.3.1
   - tailwindcss@3.4.18
   - undici-types@6.21.0 # https://github.com/nodejs/undici/issues/4666
-
-dedupePeers: true


### PR DESCRIPTION
## Summary

Closes #20367.

The `url.parse` Node.js API was deprecated in v18.13.0 and became a runtime-deprecation warning in v24. This PR eliminates the last remaining `url.parse` usage in Vite's dependency tree by patching `parseurl@1.3.3`.

**Why a patch instead of a PR to parseurl?**
The [parseurl](https://github.com/pillarjs/parseurl) package appears unmaintained (last release in 2017, no recent activity). As discussed in this issue, applying the fix as a Vite-side patch is the practical path forward.

**What changes in the patch:**

- Removes the `require('url')`, `url.parse`, and `url.Url` references entirely
- For the fast-path (relative URLs starting with `/`): no change — already parses without any Node.js URL API
- For absolute URLs (e.g. `http://example.com/path`): replaced `url.parse(str)` with `new URL(str)`
- For relative paths containing control characters (`\t`, `\n`, space, `#`, etc.): replaced `url.parse(str)` with `new URL(str, 'http://localhost')`
- Removes the `parsedUrl instanceof Url` check in `fresh()` — redundant since `_raw` memoization is sufficient

**Testing:**
- All existing unit tests pass (the `create-vite` CLI test failures are pre-existing and unrelated)
- Verified manually that pathname, query, search, path, and href fields are returned correctly for all URL shapes
- Verified that no `url.parse` deprecation warning is emitted under Node.js 24