### PR TITLE
fix(css): preserve CSS modules linked from HTML in build

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -226,6 +226,7 @@ export function resolveCSSOptions(
 
 const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)
 const directRequestRE = /[?&]direct\b/
+const htmlStyleRE = /[?&]html-style\b/
 const htmlProxyRE = /[?&]html-proxy\b/
 const htmlProxyIndexRE = /&index=(\d+)/
 const commonjsProxyRE = /[?&]commonjs-proxy/
@@ -556,6 +557,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         const inlined = inlineRE.test(id)
+        const htmlStyle = htmlStyleRE.test(id)
         const modules = cssModulesCache.get(config)!.get(id)
 
         // #6984, #7552
@@ -617,7 +619,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         let code: string
-        if (modulesCode) {
+        if (htmlStyle) {
+          code = ''
+        } else if (modulesCode) {
           code = modulesCode
         } else if (inlined) {
           let content = css
@@ -635,7 +639,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           map: { mappings: '' },
           // avoid the css module from being tree-shaken so that we can retrieve
           // it in renderChunk()
-          moduleSideEffects: modulesCode || inlined ? false : 'no-treeshake',
+          moduleSideEffects:
+            htmlStyle || (!modulesCode && !inlined) ? 'no-treeshake' : false,
           moduleType: 'js',
         }
       },
@@ -682,7 +687,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                 }
 
                 // a css module contains JS, so it makes this not a pure css chunk
-                if (cssModuleRE.test(id)) {
+                if (cssModuleRE.test(id) && !htmlStyleRE.test(id)) {
                   isPureCssChunk = false
                 }
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -24,6 +24,7 @@ import {
   encodeURIPath,
   generateCodeFrame,
   getHash,
+  injectQuery,
   isCSSRequest,
   isDataUrl,
   isExternalUrl,
@@ -47,7 +48,7 @@ import {
   publicAssetUrlRE,
   urlToBuiltUrl,
 } from './asset'
-import { cssBundleNameCache } from './css'
+import { cssBundleNameCache, isModuleCSSRequest } from './css'
 import { modulePreloadPolyfillId } from './modulePreloadPolyfill'
 
 interface ScriptAssetsUrl {
@@ -656,7 +657,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   !('media' in attr.attributes || 'disabled' in attr.attributes)
                 ) {
                   // CSS references, convert to import
-                  const importExpression = `\nimport ${JSON.stringify(url)}`
+                  const importExpression = `\nimport ${JSON.stringify(
+                    isModuleCSSRequest(url)
+                      ? injectQuery(url, 'html-style')
+                      : url,
+                  )}`
                   styleUrls.push({
                     url,
                     start: nodeStartWithLeadingWhitespace(node),

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -27,9 +27,13 @@ export const tests = (isLightningCSS: boolean) => {
   test('linked css', async () => {
     const linked = await page.$('.linked')
     const atImport = await page.$('.linked-at-import')
+    const linkedModule = await page.$('.linked-module-css')
+    const linkedModuleNested = await page.$('.linked-module-css span')
 
     expect(await getColor(linked)).toBe('blue')
     expect(await getColor(atImport)).toBe('red')
+    expect(await getColor(linkedModule)).toBe('mediumseagreen')
+    expect(await getColor(linkedModuleNested)).toBe('tomato')
 
     if (isBuild) return
 

--- a/playground/css/html-linked.module.css
+++ b/playground/css/html-linked.module.css
@@ -1,0 +1,7 @@
+:global(.linked-module-css) {
+  color: mediumseagreen;
+
+  & span {
+    color: tomato;
+  }
+}

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -1,10 +1,15 @@
 <link rel="stylesheet" href="./linked.css" />
+<link rel="stylesheet" href="./html-linked.module.css" />
 
 <div class="wrapper">
   <h1>CSS</h1>
 
   <p class="linked">&lt;link&gt;: This should be blue</p>
   <p class="linked-at-import">@import in &lt;link&gt;: This should be red</p>
+  <p class="linked-module-css">
+    CSS module in &lt;link&gt;: this should be mediumseagreen and
+    <span>this should be tomato</span>
+  </p>
 
   <p class="imported">import from js: This should be green</p>
   <p class="imported-at-import">


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

  ### Description

  Fixes a dev/build inconsistency where CSS Modules referenced directly from HTML with `<link rel="stylesheet">` were applied in dev but
  could be dropped from production builds.

  In build, HTML stylesheet links are converted into JS imports. For CSS Modules, that meant the imported module produced JS exports and
  was marked side-effect-free, so Rollup could tree-shake the import when the exports were unused. The CSS was then not collected into the
  final CSS asset.

  This change marks CSS Modules imported from HTML stylesheet links with an internal `?html-style` query. The CSS still goes through the
  normal CSS Modules/PostCSS pipeline, but the generated JS module is empty and kept as a side-effect import so the processed CSS is
  included in the build output.

  ### Changes

  - Add an internal `?html-style` marker for CSS Modules linked from HTML stylesheets.
  - Keep `?html-style` CSS Modules from being tree-shaken during build.
  - Treat HTML stylesheet CSS Modules as pure CSS chunks instead of JS-bearing CSS Module chunks.
  - Add a playground regression covering `<link rel="stylesheet" href="./html-linked.module.css">`.

  ### Tests

  - `git diff --check`
  - `pnpm run test-build playground/css`

  ### Notes

  `pnpm run test-serve playground/css` hung without output in the local environment and was terminated. The regression is build-specific
  and is covered by the passing build playground test.

Fixes #22242