### PR TITLE
fix: validate import.meta.glob query option shape

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importGlob/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/parse.spec.ts
@@ -381,6 +381,16 @@ describe('parse negatives', async () => {
       '[Error: Expected glob option "query" to be of type object or string, but got number]',
     )
     expect(
+      await runError('import.meta.glob("./*.js", { query: null })'),
+    ).toMatchInlineSnapshot(
+      '[Error: Expected glob option "query" to be of type object or string, but got null]',
+    )
+    expect(
+      await runError('import.meta.glob("./*.js", { query: [] })'),
+    ).toMatchInlineSnapshot(
+      '[Error: Expected glob option "query" to be of type object or string, but got array]',
+    )
+    expect(
       await runError('import.meta.glob("./*.js", { query: { foo: {} } })'),
     ).toMatchInlineSnapshot(
       '[Error: Expected glob option "query.foo" to be of type string, number, or boolean, but got object]',

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -188,6 +188,14 @@ function parseGlobOptions(
   }
 
   if (typeof opts.query === 'object') {
+    if (opts.query === null || Array.isArray(opts.query)) {
+      throw err(
+        `Expected glob option "query" to be of type object or string, but got ${
+          opts.query === null ? 'null' : 'array'
+        }`,
+        optsStartIndex,
+      )
+    }
     for (const key in opts.query) {
       const value = opts.query[key]
       if (!['string', 'number', 'boolean'].includes(typeof value)) {


### PR DESCRIPTION
## Summary

Reject `null` and array values for `import.meta.glob`'s `query` option and add parser coverage for both invalid inputs.

## Problem

`query` is typed as `string | Record<string, string | number | boolean>`, but the runtime validator accepted any value whose `typeof` was `"object"`.

That allowed:
- `query: null` to pass validation and reach lower-level handling
- `query: []` to be treated as a valid object-shaped value even though it does not match the public type

## Fix

- explicitly reject `null` values for `query`
- explicitly reject array values for `query`
- add parser tests covering both invalid cases

## Test

```bash
pnpm exec vitest run packages/vite/src/node/__tests__/plugins/importGlob/parse.spec.ts
pnpm exec oxfmt --check packages/vite/src/node/plugins/importMetaGlob.ts packages/vite/src/node/__tests__/plugins/importGlob/parse.spec.ts
git diff --check -- packages/vite/src/node/plugins/importMetaGlob.ts packages/vite/src/node/__tests__/plugins/importGlob/parse.spec.ts