### PR TITLE
docs: update build CLI defaults

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -48,30 +48,30 @@ vite build [root]
 
 #### Options
 
-| Options                        |                                                                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `--target <target>`            | Transpile target (default: `"modules"`) (`string`)                                                                      |
-| `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                           |
-| `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                              |
-| `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                              |
-| `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                              |
-| `--sourcemap [output]`         | Output source maps for build (default: `false`) (`boolean \| "inline" \| "hidden"`)                                     |
-| `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"esbuild"`) (`boolean \| "terser" \| "esbuild"`)     |
-| `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                          |
-| `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                            |
-| `--emptyOutDir`                | Force empty outDir when it's outside of root (`boolean`)                                                                |
-| `-w, --watch`                  | Rebuilds when modules have changed on disk (`boolean`)                                                                  |
-| `-c, --config <file>`          | Use specified config file (`string`)                                                                                    |
-| `--base <path>`                | Public base path (default: `/`) (`string`)                                                                              |
-| `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                              |
-| `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                     |
-| `--configLoader <loader>`      | Use `bundle` to bundle the config with Rolldown or `runner` (experimental) to process it on the fly (default: `bundle`) |
-| `--profile`                    | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))      |
-| `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                                   |
-| `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                            |
-| `-m, --mode <mode>`            | Set env mode (`string`)                                                                                                 |
-| `-h, --help`                   | Display available CLI options                                                                                           |
-| `--app`                        | Build all environments, same as `builder: {}` (`boolean`, experimental)                                                 |
+| Options                        |                                                                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `--target <target>`            | Transpile target (default: `"baseline-widely-available"`) (`string`)                                                     |
+| `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                            |
+| `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                               |
+| `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                               |
+| `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                               |
+| `--sourcemap [output]`         | Output source maps for build (default: `false`) (`boolean \| "inline" \| "hidden"`)                                      |
+| `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"oxc"`) (`boolean \| "oxc" \| "terser" \| "esbuild"`) |
+| `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                           |
+| `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                             |
+| `--emptyOutDir`                | Force empty outDir when it's outside of root (`boolean`)                                                                 |
+| `-w, --watch`                  | Rebuilds when modules have changed on disk (`boolean`)                                                                   |
+| `-c, --config <file>`          | Use specified config file (`string`)                                                                                     |
+| `--base <path>`                | Public base path (default: `/`) (`string`)                                                                               |
+| `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                               |
+| `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                      |
+| `--configLoader <loader>`      | Use `bundle` to bundle the config with Rolldown or `runner` (experimental) to process it on the fly (default: `bundle`)  |
+| `--profile`                    | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))       |
+| `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                                    |
+| `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                             |
+| `-m, --mode <mode>`            | Set env mode (`string`)                                                                                                  |
+| `-h, --help`                   | Display available CLI options                                                                                            |
+| `--app`                        | Build all environments, same as `builder: {}` (`boolean`, experimental)                                                  |
 
 ## Others
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -329,8 +329,8 @@ cli
   )
   .option(
     '--minify [minifier]',
-    `[boolean | "terser" | "esbuild"] enable/disable minification, ` +
-      `or specify minifier to use (default: esbuild)`,
+    `[boolean | "oxc" | "terser" | "esbuild"] enable/disable minification, ` +
+      `or specify minifier to use (default: oxc)`,
   )
   .option('--manifest [name]', `[boolean | string] emit build manifest json`)
   .option('--ssrManifest [name]', `[boolean | string] emit ssr manifest json`)


### PR DESCRIPTION
## Summary

- update the `vite build` CLI guide to document the current `--target` and `--minify` defaults
- update `vite build --help` to include `oxc` as a valid minifier and show `oxc` as the default

## Problem

Vite 8 uses `baseline-widely-available` as the default `build.target`, and `build.minify` supports `oxc`, `terser`, and `esbuild`, with `oxc` as the default for client builds.

The build options docs and implementation already reflect this, but the CLI guide and `--minify` help text still referenced older defaults.

## Fix

- update the `--target` row in the CLI guide to show `baseline-widely-available`
- update the `--minify` row in the CLI guide to show `oxc` as the default and include it in the supported values
- update the `--minify` help text in `packages/vite/src/node/cli.ts` to match current behavior

## Verification

```bash
pnpm exec tsx packages/vite/src/node/cli.ts build --help
pnpm exec oxfmt --check packages/vite/src/node/cli.ts docs/guide/cli.md
git diff --check -- packages/vite/src/node/cli.ts docs/guide/cli.md