### PR TITLE
docs(create-vite): list overwrite flag in help

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -218,6 +218,7 @@ test('return help usage how to use create-vite', () => {
   const { stdout } = run(['--help'], { cwd: import.meta.dirname })
   const message = 'Usage: create-vite [OPTION]... [DIRECTORY]'
   expect(stdout).toContain(message)
+  expect(stdout).toContain('--overwrite')
 })
 
 test('return help usage how to use create-vite with -h alias', () => {

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -45,6 +45,7 @@ When running in TTY, the CLI will start in interactive mode.
 Options:
   -t, --template NAME                   use a specific template
   -i, --immediate                       install dependencies and start dev
+  --overwrite                           remove existing files if target directory is not empty
   --interactive / --no-interactive      force interactive / non-interactive mode
 
 Available templates:


### PR DESCRIPTION
## Summary

- add the supported `--overwrite` flag to `create-vite --help`
- add a small CLI test assertion so the help output keeps listing it

## Problem

`create-vite` already parses `--overwrite` and has behavior coverage for using it with a non-empty target directory, but the flag was missing from the hand-written help output.

That made a supported option harder to discover from `create-vite --help`.

## Fix

- add `--overwrite` to the help text in `packages/create-vite/src/index.ts`
- add a CLI test assertion to ensure the help output includes it

## Verification

```bash
pnpm --filter=./packages/create-vite run build
node packages/create-vite --help
pnpm exec oxfmt --check packages/create-vite/src/index.ts packages/create-vite/__tests__/cli.spec.ts
pnpm exec vitest run packages/create-vite/__tests__/cli.spec.ts
git diff --check -- packages/create-vite/src/index.ts packages/create-vite/__tests__/cli.spec.ts