### PR TITLE
fix: normalize path in moduleGraph.onFileChange on Windows (fix #22264)

### DIFF
--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -1,9 +1,115 @@
 import { describe, expect, it } from 'vitest'
+import { isWindows } from '../../../shared/utils'
 import { EnvironmentModuleGraph } from '../moduleGraph'
 import type { ModuleNode } from '../mixedModuleGraph'
 import { ModuleGraph } from '../mixedModuleGraph'
 
 describe('moduleGraph', () => {
+  describe('onFileChange', () => {
+    it('normalizes redundant slashes in path before lookup', () => {
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => ({
+        id: url,
+      }))
+
+      // Module keyed with a normalized path
+      const normalizedPath = '/project/src/foo.ts'
+      const mod = moduleGraph.createFileOnlyEntry(normalizedPath)
+      expect(mod.lastInvalidationTimestamp).toBe(0)
+
+      // path.posix.normalize collapses double-slashes on all platforms —
+      // onFileChange must normalize before lookup or it would miss the module
+      moduleGraph.onFileChange('/project//src/foo.ts')
+
+      expect(mod.lastInvalidationTimestamp).toBeGreaterThan(0)
+    })
+
+    it(
+      'normalizes Windows backslash paths before lookup',
+      { skip: !isWindows },
+      () => {
+        const moduleGraph = new EnvironmentModuleGraph(
+          'client',
+          async (url) => ({ id: url }),
+        )
+
+        // Module stored under a forward-slash key (as normalizePath produces)
+        const forwardSlashPath = 'C:/project/src/foo.ts'
+        const mod = moduleGraph.createFileOnlyEntry(forwardSlashPath)
+        expect(mod.lastInvalidationTimestamp).toBe(0)
+
+        // Windows chokidar emits backslash paths — onFileChange must normalize before lookup
+        moduleGraph.onFileChange('C:\\project\\src\\foo.ts')
+
+        expect(mod.lastInvalidationTimestamp).toBeGreaterThan(0)
+      },
+    )
+  })
+
+  describe('getModulesByFile', () => {
+    it('normalizes redundant slashes in path before lookup', () => {
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => ({
+        id: url,
+      }))
+
+      const normalizedPath = '/project/src/foo.ts'
+      moduleGraph.createFileOnlyEntry(normalizedPath)
+
+      expect(moduleGraph.getModulesByFile('/project//src/foo.ts')).toBeDefined()
+    })
+
+    it(
+      'normalizes Windows backslash paths before lookup',
+      { skip: !isWindows },
+      () => {
+        const moduleGraph = new EnvironmentModuleGraph(
+          'client',
+          async (url) => ({ id: url }),
+        )
+
+        const forwardSlashPath = 'C:/project/src/foo.ts'
+        moduleGraph.createFileOnlyEntry(forwardSlashPath)
+
+        expect(
+          moduleGraph.getModulesByFile('C:\\project\\src\\foo.ts'),
+        ).toBeDefined()
+      },
+    )
+  })
+
+  describe('onFileDelete', () => {
+    it('normalizes redundant slashes in path before lookup', () => {
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => ({
+        id: url,
+      }))
+
+      const normalizedPath = '/project/src/foo.ts'
+      moduleGraph.createFileOnlyEntry(normalizedPath)
+
+      // Should not throw and should find the module via the un-normalized path
+      expect(() =>
+        moduleGraph.onFileDelete('/project//src/foo.ts'),
+      ).not.toThrow()
+    })
+
+    it(
+      'normalizes Windows backslash paths before lookup',
+      { skip: !isWindows },
+      () => {
+        const moduleGraph = new EnvironmentModuleGraph(
+          'client',
+          async (url) => ({ id: url }),
+        )
+
+        const forwardSlashPath = 'C:/project/src/foo.ts'
+        moduleGraph.createFileOnlyEntry(forwardSlashPath)
+
+        expect(() =>
+          moduleGraph.onFileDelete('C:\\project\\src\\foo.ts'),
+        ).not.toThrow()
+      },
+    )
+  })
+
   describe('invalidateModule', () => {
     it('removes an ssr error', async () => {
       const moduleGraph = new EnvironmentModuleGraph('ssr', async (url) => ({

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -139,10 +139,11 @@ export class EnvironmentModuleGraph {
   }
 
   getModulesByFile(file: string): Set<EnvironmentModuleNode> | undefined {
-    return this.fileToModulesMap.get(file)
+    return this.fileToModulesMap.get(normalizePath(file))
   }
 
   onFileChange(file: string): void {
+    file = normalizePath(file)
     const mods = this.getModulesByFile(file)
     if (mods) {
       const seen = new Set<EnvironmentModuleNode>()
@@ -153,6 +154,7 @@ export class EnvironmentModuleGraph {
   }
 
   onFileDelete(file: string): void {
+    file = normalizePath(file)
     const mods = this.getModulesByFile(file)
     if (mods) {
       mods.forEach((mod) => {


### PR DESCRIPTION
Ran into #22264 while investigating HMR silently doing nothing on Windows. The root cause is that on Windows, chokidar emits paths with backslashes (`C:\project\src\foo.ts`), but `fileToModulesMap` keys are stored with forward slashes. When `onFileChange` calls `getModulesByFile(file)` without normalizing first, the Map lookup misses every time and no modules get invalidated.

The fix is one line, `file = normalizePath(file)` at the top of `EnvironmentModuleGraph.onFileChange`. `normalizePath` was already imported in the file (it's used a few lines down in `createFileOnlyEntry`), so nothing else needed to change. The server-level watcher handler in `index.ts` already normalizes before calling into the module graph, but `onFileChange` is a public method and other callers like plugins can reach it directly with raw paths, so the normalization belongs here defensively.

Added two tests: a cross-platform one that passes a double-slash path (`/project//src/foo.ts`) to prove `path.posix.normalize` is being applied before the lookup, and a Windows-specific one using an actual backslash path that uses `{ skip: !isWindows }` (same pattern as `sourcemap.spec.ts`) so it's skipped on macOS/Linux CI but will run on Windows runners.