### PR TITLE
fix(css): await sass/less/styl worker disposal on teardown (fix #22274)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts
@@ -28,7 +28,7 @@ describe('css preprocessor worker teardown', () => {
       root,
       logLevel: 'silent',
       configFile: false,
-      server: { port: 0, ws: false },
+      server: { ws: false },
     })
     await server.listen()
 

--- a/packages/vite/src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ChildProcess } from 'node:child_process'
+import { describe, expect, test } from 'vitest'
+import { createServer } from '../../index'
+
+const getActiveHandles = (): unknown[] => (process as any)._getActiveHandles()
+
+const runningSassWorkers = (): ChildProcess[] =>
+  getActiveHandles().filter((h): h is ChildProcess => {
+    if (!h || (h as object).constructor?.name !== 'ChildProcess') return false
+    const cp = h as ChildProcess & { spawnfile?: string }
+    return (
+      cp.exitCode == null &&
+      typeof cp.spawnfile === 'string' &&
+      cp.spawnfile.includes('sass')
+    )
+  })
+
+describe('css preprocessor worker teardown', () => {
+  test('awaits sass-embedded worker disposal on server.close()', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-sass-teardown-'))
+    const scssPath = path.join(root, 'a.scss')
+    fs.writeFileSync(scssPath, '$c: red;\nbody { color: $c; }\n')
+
+    const server = await createServer({
+      root,
+      logLevel: 'silent',
+      configFile: false,
+      server: { port: 0, ws: false },
+    })
+    await server.listen()
+
+    try {
+      await server.pluginContainer.transform(
+        fs.readFileSync(scssPath, 'utf8'),
+        scssPath,
+      )
+    } catch {
+      // the optimizer can throw ERR_OUTDATED_OPTIMIZED_DEP post-transform;
+      // not relevant here — we only need the scss processor to have run.
+    }
+
+    expect(runningSassWorkers().length).toBeGreaterThan(0)
+
+    await server.close()
+
+    expect(runningSassWorkers().length).toBe(0)
+  }, 30_000)
+})

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2391,7 +2391,7 @@ type StylePreprocessor<Options extends StylePreprocessorInternalOptions> = {
     options: Options,
     resolvers: CSSAtImportResolvers,
   ) => StylePreprocessorResults | Promise<StylePreprocessorResults>
-  close: () => Promise<void>
+  close: () => void | Promise<void>
 }
 
 export interface StylePreprocessorResults {
@@ -2911,8 +2911,8 @@ const lessProcessor = (
   let worker: ReturnType<typeof makeLessWorker> | undefined
 
   return {
-    async close() {
-      await worker?.stop()
+    close() {
+      worker?.stop()
     },
     async process(environment, source, root, options, resolvers) {
       const lessPath = loadPreprocessorPath(PreprocessLang.less, root)
@@ -3034,8 +3034,8 @@ const stylProcessor = (
   let worker: ReturnType<typeof makeStylWorker> | undefined
 
   return {
-    async close() {
-      await worker?.stop()
+    close() {
+      worker?.stop()
     },
     async process(_environment, source, root, options, _resolvers) {
       const stylusPath = loadPreprocessorPath(PreprocessLang.stylus, root)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -331,8 +331,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       )
     },
 
-    buildEnd() {
-      preprocessorWorkerController?.close()
+    async buildEnd() {
+      await preprocessorWorkerController?.close()
     },
 
     load: {
@@ -2391,7 +2391,7 @@ type StylePreprocessor<Options extends StylePreprocessorInternalOptions> = {
     options: Options,
     resolvers: CSSAtImportResolvers,
   ) => StylePreprocessorResults | Promise<StylePreprocessorResults>
-  close: () => void
+  close: () => Promise<void>
 }
 
 export interface StylePreprocessorResults {
@@ -2612,8 +2612,8 @@ const scssProcessor = (
   const normalizedErrors = new WeakSet<Error>()
 
   return {
-    close() {
-      worker?.stop()
+    async close() {
+      await worker?.stop()
     },
     async process(environment, source, root, options, resolvers) {
       let sassPackage = loadSassPackage(root, failedSassEmbedded ?? false)
@@ -2911,8 +2911,8 @@ const lessProcessor = (
   let worker: ReturnType<typeof makeLessWorker> | undefined
 
   return {
-    close() {
-      worker?.stop()
+    async close() {
+      await worker?.stop()
     },
     async process(environment, source, root, options, resolvers) {
       const lessPath = loadPreprocessorPath(PreprocessLang.less, root)
@@ -3034,8 +3034,8 @@ const stylProcessor = (
   let worker: ReturnType<typeof makeStylWorker> | undefined
 
   return {
-    close() {
-      worker?.stop()
+    async close() {
+      await worker?.stop()
     },
     async process(_environment, source, root, options, _resolvers) {
       const stylusPath = loadPreprocessorPath(PreprocessLang.stylus, root)
@@ -3150,10 +3150,8 @@ const createPreprocessorWorkerController = (maxWorkers: number | undefined) => {
       return scss.process(environment, source, root, opts, resolvers)
     }
 
-  const close = () => {
-    less.close()
-    scss.close()
-    styl.close()
+  const close = async () => {
+    await Promise.all([less.close(), scss.close(), styl.close()])
   }
 
   return {


### PR DESCRIPTION
### Description

`cssPlugin.buildEnd()` and `scssProcessor.close()` were synchronous but dropped an async `worker?.stop()` promise. On the scss path, that promise awaits `compiler.dispose()`, which sends the IPC shutdown to the sass-embedded Dart subprocess — so `server.close()` could resolve while the Dart worker was still running, leaving its `ChildProcess` handle alive on the event loop.

In long-lived processes the event loop eventually reaps the workers. In processes that expect to exit after `server.close()` — scripts, programmatic use, Vitest global teardown — the orphaned `ChildProcess` keeps Node alive.

See #22274 for the minimal standalone reproduction and `exitCode` before/after. Different code path from #18224 (file watchers) but the same user-visible symptom.

### Changes

- `cssPlugin.buildEnd`: sync → `async`, awaits `preprocessorWorkerController?.close()`
- `scssProcessor.close`: sync → `async`, awaits `worker?.stop()` — the only path where `stop()` is actually async, since `makeScssWorker` returns a hand-rolled object whose `stop()` awaits `compiler.dispose()`
- `createPreprocessorWorkerController` fan-out `close`: sync → `async`, disposes the three processors in parallel via `Promise.all`
- `StylePreprocessor<Options>.close` type: `() => void` → `() => void | Promise<void>` (matches the convention used elsewhere in the repo)

`lessProcessor.close` and `stylProcessor.close` are unchanged — they go through real `artichokie` `WorkerWithFallback` whose `stop()` is synchronous, so awaiting would be a no-op.

On the teardown path, `server.close()` now waits for scss's `compiler.dispose()` to actually complete before resolving.

### Tests

New regression test: `packages/vite/src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts`. Starts a dev server, triggers scss transform, asserts no running sass `ChildProcess` after `await server.close()`. Fails on `main` without this change (`expected 1 to be +0`).

```sh
pnpm --filter vite exec vitest run src/node/__tests__/plugins/cssPreprocessorTeardown.spec.ts
```

Fixes #22274

### AI Disclosure

Used `claude-opus-4-7-thinking-xhigh` to file the PR.


