### PR TITLE
fix broken internal links in breaking changes docs

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -4,7 +4,7 @@
 Give us feedback at [Environment API feedback discussion](https://github.com/vitejs/vite/discussions/16358)
 :::
 
-We're planning to deprecate the `handleHotUpdate` plugin hook in favor of [`hotUpdate` hook](/guide/api-environment#the-hotupdate-hook) to be [Environment API](/guide/api-environment.md) aware, and handle additional watch events with `create` and `delete`.
+We're planning to deprecate the `handleHotUpdate` plugin hook in favor of [`hotUpdate` hook](/guide/api-environment#the-hotupdate-hook) to be [Environment API](/guide/api-environment) aware, and handle additional watch events with `create` and `delete`.
 
 Affected scope: `Vite Plugin Authors`
 
@@ -14,7 +14,7 @@ Affected scope: `Vite Plugin Authors`
 
 ## Motivation
 
-The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
+The [`handleHotUpdate` hook](/guide/api-plugin#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
 
 ```ts
 interface HmrContext {

--- a/docs/changes/index.md
+++ b/docs/changes/index.md
@@ -1,6 +1,6 @@
 # Breaking Changes
 
-List of breaking changes in Vite including API deprecations, removals, and changes. Most of the changes below can be opt-in using the [`future` option](/config/shared-options.html#future) in your Vite config.
+List of breaking changes in Vite including API deprecations, removals, and changes. Most of the changes below can be opt-in using the [`future` option](/config/shared-options#future) in your Vite config.
 
 ## Planned
 

--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -40,4 +40,4 @@ export function myPlugin(): Plugin {
 }
 ```
 
-For a more robust long term implementation, the plugin hook should handle for [multiple environments](/guide/api-environment-plugins.html#accessing-the-current-environment-in-hooks) using fine-grained environment options instead of relying on the environment name.
+For a more robust long term implementation, the plugin hook should handle for [multiple environments](/guide/api-environment-plugins#accessing-the-current-environment-in-hooks) using fine-grained environment options instead of relying on the environment name.


### PR DESCRIPTION

**Repo:** vitejs/vite (⭐ 73000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
This change fixes three internal links in the breaking changes documentation so they point to the published VitePress routes instead of source-file URLs with `.md` or `.html` extensions. The updated links are in the breaking changes index and two related change notes under `docs/changes`.

## Why
These docs pages are meant to link readers into the published docs site, where extensionless routes are the canonical paths. Using source-file extensions in absolute internal links risks broken navigation or inconsistent routing in production, especially from change-log style pages that are already acting as an entry point for migrations.

## Testing
Verified the committed diff locally and confirmed the edited files no longer contain the affected `.md` and `.html` internal route patterns. No full docs build was run because this is a docs-only route normalization change.

## Risk
Low / Docs-only change that updates internal links without affecting runtime behavior.
