### PR TITLE
docs: update stat numbers

### DIFF
--- a/docs/.vitepress/theme/landing/Community.vue
+++ b/docs/.vitepress/theme/landing/Community.vue
@@ -106,7 +106,7 @@ const testimonials: Testimonial[] = [
       >
         <!-- GitHub Stars -->
         <div class="flex flex-col gap-3">
-          <h2 class="text-white">75k+</h2>
+          <h2 class="text-white">80k+</h2>
           <p class="text-grey flex items-center gap-2">
             <Icon icon="simple-icons:github" width="20px" height="20px" />
             Github Stars
@@ -115,7 +115,7 @@ const testimonials: Testimonial[] = [
 
         <!-- NPM Downloads -->
         <div class="flex flex-col gap-3">
-          <h2 class="text-white">40m+</h2>
+          <h2 class="text-white">80m+</h2>
           <p class="text-grey">Weekly NPM downloads</p>
         </div>
       </div>


### PR DESCRIPTION
GitHub stars: 75k -> 80k
npm downloads: 40m -> 80m

We actually have 90m weekly downloads now, but it's still slightly fluctuating, plus 80k & 80m looks kinda nice together, so I've set to 80m for now. But happy to switch to 90m too.