### PR TITLE
test(glob-import): cover array patterns with sibling dirs sharing a prefix

### DIFF
--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -272,6 +272,18 @@ test('array pattern with exclusions', async () => {
     })
 })
 
+// https://github.com/vitejs/vite/issues/22170
+test('array pattern with sibling directories sharing a prefix', async () => {
+  await expect
+    .poll(async () =>
+      JSON.parse(await page.textContent('.array-common-base-result')),
+    )
+    .toStrictEqual({
+      '/array-common-base/pattern1/a.js': 'a',
+      '/array-common-base/pattern2/b.js': 'b',
+    })
+})
+
 test('tree-shake eager css', async () => {
   expect(await page.textContent('.no-tree-shake-eager-css-result')).toMatch(
     '.no-tree-shake-eager-css',

--- a/playground/glob-import/array-common-base/pattern1/a.js
+++ b/playground/glob-import/array-common-base/pattern1/a.js
@@ -1,0 +1,1 @@
+export default 'a'

--- a/playground/glob-import/array-common-base/pattern2/b.js
+++ b/playground/glob-import/array-common-base/pattern2/b.js
@@ -1,0 +1,1 @@
+export default 'b'

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -274,6 +274,24 @@
   )
 </script>
 
+<h2>Array Pattern with Sibling Directories Sharing a Prefix</h2>
+<pre class="array-common-base-result"></pre>
+
+<script type="module">
+  const arrayCommonBaseModules = import.meta.glob(
+    [
+      '/array-common-base/pattern1/**/*.js',
+      '/array-common-base/pattern2/**/*.js',
+    ],
+    {
+      eager: true,
+      import: 'default',
+    },
+  )
+  document.querySelector('.array-common-base-result').textContent =
+    JSON.stringify(arrayCommonBaseModules, null, 2)
+</script>
+
 <h2>Transform visibility</h2>
 <pre class="transform-visibility"></pre>
 


### PR DESCRIPTION
## Summary

- Adds a playground test case covering `import.meta.glob([...])` where the array entries target sibling directories whose names share a byte-level prefix but are distinct path segments (e.g. `pattern1/` and `pattern2/`).
- The fixture creates `playground/glob-import/array-common-base/pattern{1,2}/*.js`, wires up a new `array-common-base-result` block in `index.html`, and asserts the resolved modules in `glob-import.spec.ts` (runs in both serve and build modes).
- Regression guard for [vitejs/vite#22170](https://github.com/vitejs/vite/issues/22170), fixed upstream in [rolldown/rolldown#9070](https://github.com/rolldown/rolldown/pull/9070).

## Why

During `vite build`, array `import.meta.glob` patterns are handled by rolldown's native `viteImportGlobPlugin`. Its `get_common_base` used a byte-wise longest common prefix to decide where to start `walkdir`. For array entries like `/array-common-base/pattern1/**/*.js` and `/array-common-base/pattern2/**/*.js`, that produced `/array-common-base/pattern` — a path that cuts in the middle of a segment and points to no real directory. `walkdir` then found nothing and the bundled output was `Object.assign({})`. Dev (`vite dev`) took a different code path and worked fine, so the regression only surfaced in production builds.

rolldown/rolldown#9070 fixed `get_common_base` to always land on a path-segment boundary. This test pins that behavior on the Vite side so a future regression is caught by the playground e2e suite rather than by users.