### PR TITLE
docs: link to @oxc-project/fast-glob for import.meta.glob pattern syntax

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -626,7 +626,7 @@ Note that:
 
 - This is a Vite-only feature and is not a web or ES standard.
 - The glob patterns are treated like import specifiers: they must be either relative (start with `./`) or absolute (start with `/`, resolved relative to project root) or an alias path (see [`resolve.alias` option](/config/shared-options.md#resolve-alias)).
-- The glob matching is done via [`tinyglobby`](https://github.com/SuperchupuDev/tinyglobby) - check out its documentation for [supported glob patterns](https://superchupu.dev/tinyglobby/comparison).
+- The glob matching is done via [`@oxc-project/fast-glob`](https://github.com/oxc-project/fast-glob) - check out its documentation for supported glob patterns.
 - You should also be aware that all the arguments in the `import.meta.glob` must be **passed as literals**. You can NOT use variables or expressions in them.
 
 ## Dynamic Import


### PR DESCRIPTION
## Summary

- Update the glob syntax reference in the `import.meta.glob` docs (`docs/guide/features.md`) to point users to [`@oxc-project/fast-glob`](https://github.com/oxc-project/fast-glob) instead of `tinyglobby`.
- Drops the now-stale `superchupu.dev/tinyglobby/comparison` link and lets readers consult the upstream project directly for the list of supported glob patterns.

## Motivation

Vite's build is moving onto Rolldown, whose native `import.meta.glob` plugin matches patterns with [`@oxc-project/fast-glob`](https://github.com/oxc-project/fast-glob) rather than `tinyglobby`. `@oxc-project/fast-glob` intentionally drops extglob support, so the set of valid patterns users can write differs from what `tinyglobby`'s docs advertise. Going forward, the same matcher will be exposed to the JS side via a napi binding so dev and build share one implementation — pointing users at the oxc repo now keeps the documented syntax consistent with the matcher they will actually hit.

## Scope

Docs-only change. The JS-side implementation in `packages/vite/src/node/plugins/importMetaGlob.ts` still imports from `tinyglobby`; swapping it to the upcoming napi binding will land in a follow-up. Similar links elsewhere (`optimizeDeps.entries`, `server.warmup`) were intentionally left alone since they describe different features and are not affected by the Rolldown migration.