### PR TITLE
test(glob-import): add backslash-escaped glob pattern test

### DIFF
--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -311,6 +311,16 @@ test('escapes special chars in globs without mangling user supplied glob suffix'
     .toEqual(expectedNames)
 })
 
+test('escape literal parenthesis in glob pattern', async () => {
+  // https://github.com/vitejs/vite/issues/22166
+  // Backslash-escaped parens must match literal "(" / ")" in both dev and build.
+  await expect
+    .poll(async () =>
+      JSON.parse(await page.textContent('.escape-literal-parenthesis')),
+    )
+    .toStrictEqual(['/escape/(parenthesis)/mod/index.js'])
+})
+
 test('subpath imports', async () => {
   await expect
     .poll(async () => await page.textContent('.subpath-imports'))

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -21,6 +21,8 @@
 <pre class="escape-relative"></pre>
 <h2>Escape alias glob</h2>
 <pre class="escape-alias"></pre>
+<h2>Escape literal parenthesis</h2>
+<pre class="escape-literal-parenthesis"></pre>
 <h2>Subpath imports</h2>
 <pre class="subpath-imports"></pre>
 <h2>Subpath imports (sub dir)</h2>
@@ -148,6 +150,17 @@
     .filter(([_, mod]) => Object.keys(mod?.alias ?? {}).length === 1)
     .map(([glob]) => glob)
   document.querySelector('.escape-alias').textContent = alias.sort().join('\n')
+</script>
+
+<script type="module">
+  // https://github.com/vitejs/vite/issues/22166
+  // Backslash-escaped glob metachars must match their literal counterparts
+  // consistently in dev and build.
+  const literalParen = import.meta.glob('/escape/\\(parenthesis\\)/mod/*.js', {
+    eager: true,
+  })
+  document.querySelector('.escape-literal-parenthesis').textContent =
+    JSON.stringify(Object.keys(literalParen).sort())
 </script>
 
 <script type="module">


### PR DESCRIPTION
## Description

Adds a regression test for the dev/build inconsistency reported in #22166, where `import.meta.glob` produced different results for directories containing parentheses depending on whether the pattern's metacharacters were backslash-escaped:

```js
// before the rolldown fix:
import.meta.glob('./\\(dir\\)/*.js', { eager: true }) // populated only in dev
import.meta.glob('./(dir)/*.js',       { eager: true }) // populated only in build
```

The upstream fix landed in rolldown/rolldown#9077, which switches the `vite_import_glob` plugin to POSIX path join/normalize so backslash-escaped glob syntax (`\(`, `\)`, `\?`, `\[`) is preserved instead of being mistaken for a Windows path separator, and normalizes separators consistently during matching.

The existing `escape/**/glob.js` playground cases only exercise the `**` wildcard traversing into a special-char directory — they never hit the user-written backslash-escape code path. This PR adds a focused test for that path.

Related:
- Closes #22166
- Upstream fix: rolldown/rolldown#9077
