### PR TITLE
refactor: typecheck client directory

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -65,7 +65,7 @@
     "build-types": "pnpm build-types-roll && pnpm build-types-check",
     "build-types-roll": "rolldown --config rolldown.dts.config.ts",
     "build-types-check": "tsc --project tsconfig.check.json",
-    "typecheck": "tsc && tsc -p src/node && tsc -p src/module-runner && tsc -p src/shared && tsc -p src/node/__tests_dts__ && tsc -p src/module-runner/__tests_dts__",
+    "typecheck": "tsc && tsc -p src/node && tsc -p src/client && tsc -p src/module-runner && tsc -p src/shared && tsc -p src/node/__tests_dts__ && tsc -p src/module-runner/__tests_dts__",
     "lint": "eslint --cache --ext .ts src/**",
     "format": "oxfmt",
     "generate-target": "tsx scripts/generateTarget.ts",

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -12,6 +12,7 @@ import {
 import { createHMRHandler } from '../shared/hmrHandler'
 import { setupForwardConsoleHandler } from '../shared/forwardConsole'
 import { ErrorOverlay, cspNonce, overlayId } from './overlay'
+// @ts-expect-error internal virtual module
 import '@vite/env'
 
 // injected by the hmr plugin when served
@@ -661,5 +662,6 @@ if (isBundleMode && typeof DevRuntime !== 'undefined') {
   }
   ;(globalThis as any).__rolldown_runtime__ ??= new ViteDevRuntime(
     wrappedSocket,
+    '',
   )
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid/non-secure'
 import type {
   DevRuntime as DevRuntimeType,
   Messenger,
@@ -660,8 +661,9 @@ if (isBundleMode && typeof DevRuntime !== 'undefined') {
       }
     },
   }
+  const clientId = nanoid()
   ;(globalThis as any).__rolldown_runtime__ ??= new ViteDevRuntime(
     wrappedSocket,
-    '',
+    clientId,
   )
 }


### PR DESCRIPTION
Enable typechecking for `vite/src/client` directory. 