### PR TITLE
chore: update `es-module-lexer` to 2.0.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -104,7 +104,7 @@
     "cors": "^2.8.6",
     "cross-spawn": "^7.0.6",
     "dotenv-expand": "^13.0.0",
-    "es-module-lexer": "^1.7.0",
+    "es-module-lexer": "^2.0.0",
     "esbuild": "^0.28.0",
     "escape-html": "^1.0.3",
     "estree-walker": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0(patch_hash=49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889)
       es-module-lexer:
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^2.0.0
+        version: 2.0.0
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -5566,9 +5566,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -11800,8 +11797,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

While investigating https://github.com/vitejs/vite/issues/16678, I spent some time checking what were the breaking changes in `es-module-lexer@2.0.0` and how they affect Vite.

The only breaking change is that it switched from parsing import assertions (`import ... assert {}`) to parsing import attributes (`import ... with {}`): this does not affect Vite in any way, because Vite does not use `es-module-lexer` to read attributes.

This PR is effectively a no-op, but I'm opening it so that somebody else won't have to investigate again whether 2.0.0 contains breaking changes or not.