### PR TITLE
fix(css): show filename in CSS minification warnings for `.css?inline`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -622,7 +622,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else if (inlined) {
           let content = css
           if (config.build.cssMinify) {
-            content = await minifyCSS(content, config, true)
+            content = await minifyCSS(content, config, true, id)
           }
           code = `export default ${JSON.stringify(content)}`
         } else {
@@ -2202,6 +2202,7 @@ async function minifyCSS(
   css: string,
   config: ResolvedConfig,
   inlined: boolean,
+  filename: string = defaultCssBundleName,
 ) {
   // We want inlined CSS to not end with a linebreak, while ensuring that
   // regular CSS assets do end with a linebreak.
@@ -2213,6 +2214,7 @@ async function minifyCSS(
       const { code, warnings } = await transform(css, {
         loader: 'css',
         target: config.build.cssTarget || undefined,
+        sourcefile: filename,
         ...resolveMinifyCssEsbuildOptions(config.esbuild || {}),
       })
       if (warnings.length) {
@@ -2239,9 +2241,7 @@ async function minifyCSS(
       ...config.css.lightningcss,
       targets: convertTargets(config.build.cssTarget),
       cssModules: undefined,
-      // TODO: Pass actual filename here, which can also be passed to esbuild's
-      // `sourcefile` option below to improve error messages
-      filename: defaultCssBundleName,
+      filename,
       code: Buffer.from(css),
       minify: true,
     })


### PR DESCRIPTION
Good day

When CSS minification produces warnings, the filename was showing as `<stdin>` which made it difficult to track down which file had the issue.

This change passes the actual filename to esbuild's `sourcefile` option and to lightningcss, so that warning messages now contain the correct filename instead of `<stdin>`.

~~#15915~~

## Changes
- Add `filename` parameter to `minifyCSS` function with default value `defaultCssBundleName`
- Pass `filename` to esbuild's `sourcefile` option for better warning messages
- Pass actual `filename` to lightningcss instead of hardcoded `defaultCssBundleName`
- For inlined CSS, use module ID as the filename

## Before
```
warnings when minifying css:
▲ [WARNING] Unexpected "{" [css-syntax-error]

    <stdin>:484:1:
      484 │  {
          ╵  ^
```

## After
The warning message will now show the actual filename instead of `<stdin>`.

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee