### PR TITLE
fix(resolve): fall back to module entry when browser entry is non-ESM in build

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/browser-module-fallback/index.js
+++ b/packages/vite/src/node/__tests__/fixtures/browser-module-fallback/index.js
@@ -1,0 +1,3 @@
+import rough from 'test-browser-module-fallback'
+
+export default rough

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -311,3 +311,34 @@ describe('file url', () => {
     expect(mod2.default.default).toBe('ok')
   })
 })
+
+describe('browser/module fallback', () => {
+  test('build falls back from non-esm browser entry to module entry', async () => {
+    let resolvedId: string | undefined
+
+    await build({
+      configFile: false,
+      root: join(import.meta.dirname, 'fixtures/browser-module-fallback'),
+      logLevel: 'error',
+      build: {
+        write: false,
+        rollupOptions: { input: { index: 'index.js' } },
+      },
+      plugins: [
+        {
+          name: 'test-capture-resolved-id',
+          async transform(_, id) {
+            if (!id.endsWith('/fixtures/browser-module-fallback/index.js')) {
+              return
+            }
+            resolvedId = (
+              await this.resolve('test-browser-module-fallback', id)
+            )?.id
+          },
+        },
+      ],
+    })
+
+    expect(resolvedId).toContain('bundled/fallback.esm.js')
+  })
+})

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -226,6 +226,70 @@ export function oxcResolvePlugin(
   overrideEnvConfig: (ResolvedConfig & ResolvedEnvironmentOptions) | undefined,
 ): Plugin[] {
   return [
+    ...perEnvironmentOrWorkerPlugin(
+      'vite:resolve-package-entry-heuristics',
+      overrideEnvConfig,
+      (partialEnv) => {
+        const options: InternalResolveOptions = {
+          ...partialEnv.config.resolve,
+          ...resolveOptions,
+        }
+
+        return {
+          name: 'vite:resolve-package-entry-heuristics',
+          resolveId: {
+            order: 'pre',
+            filter: {
+              id: {
+                exclude: [/^\0/, /^virtual:/, /^\/virtual:/, /^__vite-/],
+              },
+            },
+            handler(id, importer, resolveOpts) {
+              if (resolveOpts.scan || !options.isBuild || options.isRequire) {
+                return
+              }
+
+              if (!bareImportRE.test(id) || deepImportRE.test(id)) {
+                return
+              }
+
+              const pkgId = cleanUrl(id)
+              const basedir =
+                importer && path.isAbsolute(importer)
+                  ? path.dirname(importer)
+                  : options.root
+              const pkg = resolvePackageData(
+                pkgId,
+                basedir,
+                options.preserveSymlinks,
+                options.packageCache,
+              )
+
+              if (!pkg || pkg.data.exports) {
+                return
+              }
+
+              const browserEntry =
+                typeof pkg.data.browser === 'string'
+                  ? pkg.data.browser
+                  : isObject(pkg.data.browser) && pkg.data.browser['.']
+
+              if (
+                !browserEntry ||
+                typeof pkg.data.module !== 'string' ||
+                pkg.data.module === browserEntry ||
+                !options.mainFields.includes('browser') ||
+                !options.mainFields.includes('module')
+              ) {
+                return
+              }
+
+              return tryNodeResolve(id, importer, options, undefined, false)
+            },
+          },
+        }
+      },
+    ),
     ...(resolveOptions.optimizeDeps && !resolveOptions.isBuild
       ? [optimizerResolvePlugin(resolveOptions)]
       : []),


### PR DESCRIPTION
… in build

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

                                                                                                                                                                                                                                                                           
  ## Summary                                                                                                                                      
  - Packages like `roughjs@4.5.2` have `browser` pointing to an IIFE bundle and `module` pointing to ESM, with no `exports` field                 
  - Rolldown's native resolver picks the `browser` entry first, which has no ESM exports → `MISSING_EXPORT` error                                 
  - Vite's `tryResolveBrowserEntry` already has a heuristic (`hasESMSyntax` check) to fall back to `module` when `browser` is non-ESM, but it     
  wasn't being used during Rolldown builds                                                                                                        
  - Added a pre-resolve plugin in `oxcResolvePlugin` that intercepts these cases and routes through Vite's resolver                               
                                                                                                                                                  
  ## Test plan                                                                                                                                    
  - [x] Added unit test verifying non-ESM browser entry falls back to module entry                                                                
  - [ ] Verify with reproduction from #22285 (`@visactor/vrender-kits` → `roughjs@4.5.2`)                                                         
                                                                                                                                                  
  Fixes #22285                         