### PR TITLE
fix: remove format sniffing module resolution from JS resolver

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -4,7 +4,6 @@ import colors from 'picocolors'
 import type { PartialResolvedId } from 'rolldown'
 import { viteResolvePlugin } from 'rolldown/experimental'
 import { exports, imports } from 'resolve.exports'
-import { hasESMSyntax } from 'mlly'
 import type { Plugin } from '../plugin'
 import {
   CLIENT_ENTRY,
@@ -932,12 +931,7 @@ export function resolvePackageEntry(
     // fallback to mainFields if still not resolved
     if (!entryPoint) {
       for (const field of options.mainFields) {
-        if (field === 'browser') {
-          entryPoint = tryResolveBrowserEntry(dir, data, options)
-          if (entryPoint) {
-            break
-          }
-        } else if (typeof data[field] === 'string') {
+        if (typeof data[field] === 'string') {
           entryPoint = data[field]
           break
         }
@@ -1105,53 +1099,6 @@ function resolveDeepImport(
       )
       setResolvedCache(id, resolved, options)
       return resolved
-    }
-  }
-}
-
-function tryResolveBrowserEntry(
-  dir: string,
-  data: PackageData['data'],
-  options: InternalResolveOptions,
-) {
-  // handle edge case with browser and module field semantics
-
-  // check browser field
-  // https://github.com/defunctzombie/package-browser-field-spec
-  const browserEntry =
-    typeof data.browser === 'string'
-      ? data.browser
-      : isObject(data.browser) && data.browser['.']
-  if (browserEntry) {
-    // check if the package also has a "module" field.
-    if (
-      !options.isRequire &&
-      options.mainFields.includes('module') &&
-      typeof data.module === 'string' &&
-      data.module !== browserEntry
-    ) {
-      // if both are present, we may have a problem: some package points both
-      // to ESM, with "module" targeting Node.js, while some packages points
-      // "module" to browser ESM and "browser" to UMD/IIFE.
-      // the heuristics here is to actually read the browser entry when
-      // possible and check for hints of ESM. If it is not ESM, prefer "module"
-      // instead; Otherwise, assume it's ESM and use it.
-      const resolvedBrowserEntry = tryFsResolve(
-        path.join(dir, browserEntry),
-        options,
-      )
-      if (resolvedBrowserEntry) {
-        const content = fs.readFileSync(resolvedBrowserEntry, 'utf-8')
-        if (hasESMSyntax(content)) {
-          // likely ESM, prefer browser
-          return browserEntry
-        } else {
-          // non-ESM, UMD or IIFE or CJS(!!! e.g. firebase 7.x), prefer module
-          return data.module
-        }
-      }
-    } else {
-      return browserEntry
     }
   }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -934,6 +934,12 @@ export function resolvePackageEntry(
         if (typeof data[field] === 'string') {
           entryPoint = data[field]
           break
+        } else if (field === 'browser') {
+          const browser = data[field]
+          if (isObject(browser) && browser['.']) {
+            entryPoint = browser['.']
+            break
+          }
         }
       }
     }


### PR DESCRIPTION
This was not implemented on the native resolver: https://vite.dev/guide/migration#removed-module-resolution-using-format-sniffing
But was not removed from the JS resolver.


