### PR TITLE
fix(glob): align hmr matcher options with glob enumeration

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -66,23 +66,30 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
           config.logger,
         )
         if (result) {
-          const allGlobs = result.matches.map((i) => i.globsResolved)
           if (!importGlobMaps.has(this.environment)) {
             importGlobMaps.set(this.environment, new Map())
           }
 
-          const globMatchers = allGlobs.map((globs) => {
+          const globMatchers = result.matches.map((i) => {
             const affirmed: string[] = []
             const negated: string[] = []
-            for (const glob of globs) {
+            for (const glob of i.globsResolved) {
               if (glob[0] === '!') {
                 negated.push(glob.slice(1))
               } else {
                 affirmed.push(glob)
               }
             }
-            const affirmedMatcher = picomatch(affirmed)
-            const negatedMatcher = picomatch(negated)
+            const affirmedMatcher = picomatch(affirmed, {
+              noextglob: true,
+              dot: !!i.options.exhaustive,
+              ignore: i.options.exhaustive ? [] : ['**/node_modules/**'],
+            })
+            const negatedMatcher = picomatch(negated, {
+              noextglob: true,
+              dot: !!i.options.exhaustive,
+              ignore: i.options.exhaustive ? [] : ['**/node_modules/**'],
+            })
 
             return (file: string) => {
               // (glob1 || glob2) && !(glob3 || glob4)...


### PR DESCRIPTION
## Summary

The `hotUpdate` hook in the `importGlobPlugin` uses a `picomatch` matcher to decide which `import.meta.glob` consumer modules should be invalidated when a file is created or deleted. That matcher was built with picomatch's defaults, which disagreed with the options used by the actual glob enumeration in `transformGlobImport` (the `tinyglobby` call at `importMetaGlob.ts:452`).

| picomatch option | enumeration | hmr matcher (before) | hmr matcher (after) |
| --- | --- | --- | --- |
| `noextglob` | `true` (`extglob: false` on tinyglobby) | `false` (default) | `true` |
| `dot` | `!!options.exhaustive` | `false` (default) | `!!options.exhaustive` |
| `ignore` | `['**/node_modules/**']` unless `exhaustive` | — | `['**/node_modules/**']` unless `exhaustive` |

As a result the HMR matcher could match paths that the glob enumeration would never include — e.g. a newly created file under `node_modules/...`, inside a dot-directory, or matching an extglob-only expression — and wake up every glob that "looked like" it covered those paths, forcing unnecessary invalidation.

## Fix

Pass the same `noextglob` / `dot` / `ignore` options to the picomatch matchers used for HMR, so create/delete events only invalidate globs whose enumeration would have actually picked up the file.

The loop is also restructured to iterate `result.matches` directly instead of first mapping to `allGlobs`, so each matcher construction has access to its `options.exhaustive` flag.