### PR TITLE
docs: explain mergeConfig skips null/undefined

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -312,6 +312,25 @@ function mergeConfig(
 
 Deeply merge two Vite configs. `isRoot` represents the level within the Vite config which is being merged. For example, set `false` if you're merging two `build` options.
 
+::: info Handling of `null` and `undefined`
+`null` and `undefined` values in `overrides` are skipped, so the corresponding values in `defaults` are preserved. This makes it convenient to merge in options conditionally without unintentionally clearing values from `defaults`:
+
+```ts twoslash
+import { mergeConfig, type UserConfig } from 'vite'
+declare const baseConfig: UserConfig
+declare const condition: boolean
+
+// ---cut---
+mergeConfig(baseConfig, {
+  // when `condition` is false, `base` is `undefined` and
+  // `baseConfig.base` is preserved
+  base: condition ? '/admin/' : undefined,
+})
+```
+
+If you need to explicitly clear a value from `defaults`, modify the result of `mergeConfig` directly instead of passing `null` or `undefined` as the override.
+:::
+
 ::: tip NOTE
 `mergeConfig` accepts only config in object form. If you have a config in callback form, you should call it before passing into `mergeConfig`.
 

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -312,7 +312,7 @@ function mergeConfig(
 
 Deeply merge two Vite configs. `isRoot` represents the level within the Vite config which is being merged. For example, set `false` if you're merging two `build` options.
 
-::: info Handling of `null` and `undefined`
+::: tip NOTE
 `null` and `undefined` values in `overrides` are skipped, so the corresponding values in `defaults` are preserved. This makes it convenient to merge in options conditionally without unintentionally clearing values from `defaults`:
 
 ```ts twoslash

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -312,24 +312,7 @@ function mergeConfig(
 
 Deeply merge two Vite configs. `isRoot` represents the level within the Vite config which is being merged. For example, set `false` if you're merging two `build` options.
 
-::: tip NOTE
-`null` and `undefined` values in `overrides` are skipped, so the corresponding values in `defaults` are preserved. This makes it convenient to merge in options conditionally without unintentionally clearing values from `defaults`:
-
-```ts twoslash
-import { mergeConfig, type UserConfig } from 'vite'
-declare const baseConfig: UserConfig
-declare const condition: boolean
-
-// ---cut---
-mergeConfig(baseConfig, {
-  // when `condition` is false, `base` is `undefined` and
-  // `baseConfig.base` is preserved
-  base: condition ? '/admin/' : undefined,
-})
-```
-
-If you need to explicitly clear a value from `defaults`, modify the result of `mergeConfig` directly instead of passing `null` or `undefined` as the override.
-:::
+Note that `null` and `undefined` values in `overrides` are skipped and not merged. If you need to explicitly clear a value from `defaults`, modify the result of `mergeConfig` directly.
 
 ::: tip NOTE
 `mergeConfig` accepts only config in object form. If you have a config in callback form, you should call it before passing into `mergeConfig`.


### PR DESCRIPTION
### Description

Documents the existing behavior of `mergeConfig`: `null` and `undefined` values in `overrides` are intentionally skipped, so the corresponding values in `defaults` are preserved.

Per the maintainer's resolution in the issue thread:

> @bluwy — "I'd lean on documenting this for now, so I'll label it as so"

The added `::: info` block in `docs/guide/api-javascript.md` explains:

1. **What** — `null`/`undefined` overrides are skipped.
2. **Why** — enables conditional merging without unintentionally clearing values from `defaults`, with a runnable `twoslash` example.
3. **Workaround** — modify the result of `mergeConfig` directly if explicit clearing is needed.

### Why no tests / source change

This is documentation-only; the behavior at `packages/vite/src/node/utils.ts` (the `if (value == null) continue` check) is unchanged. A previously proposed `skipNil` option was rejected in the issue discussion in favor of documenting the current behavior.

Closes #18943
