### PR TITLE
perf(vite): narrow test for changed files in esbuild plugin

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -542,32 +542,29 @@ export async function reloadOnTsconfigChange(
   changedFile: string,
 ): Promise<void> {
   // any tsconfig.json that's added in the workspace could be closer to a code file than a previously cached one
-  // any json file in the tsconfig cache could have been used to compile ts
-  if (changedFile.endsWith('.json')) {
+  if (changedFile.endsWith('/tsconfig.json')) {
     const cache = getTSConfigResolutionCache(server.config)
-    if (changedFile.endsWith('/tsconfig.json')) {
-      server.config.logger.info(
-        `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
-        { clear: server.config.clearScreen, timestamp: true },
-      )
+    server.config.logger.info(
+      `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
+      { clear: server.config.clearScreen, timestamp: true },
+    )
 
-      // TODO: more finegrained invalidation than the nuclear option below
+    // TODO: more finegrained invalidation than the nuclear option below
 
-      // clear module graph to remove code compiled with outdated config
-      for (const environment of Object.values(server.environments)) {
-        environment.moduleGraph.invalidateAll()
-      }
+    // clear module graph to remove code compiled with outdated config
+    for (const environment of Object.values(server.environments)) {
+      environment.moduleGraph.invalidateAll()
+    }
 
-      // reset the cache so that recompile works with up2date configs
-      cache.clear()
+    // reset the cache so that recompile works with up2date configs
+    cache.clear()
 
-      // reload environments
-      for (const environment of Object.values(server.environments)) {
-        environment.hot.send({
-          type: 'full-reload',
-          path: '*',
-        })
-      }
+    // reload environments
+    for (const environment of Object.values(server.environments)) {
+      environment.hot.send({
+        type: 'full-reload',
+        path: '*',
+      })
     }
   }
 }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -542,29 +542,30 @@ export async function reloadOnTsconfigChange(
   changedFile: string,
 ): Promise<void> {
   // any tsconfig.json that's added in the workspace could be closer to a code file than a previously cached one
-  if (changedFile.endsWith('/tsconfig.json')) {
-    const cache = getTSConfigResolutionCache(server.config)
-    server.config.logger.info(
-      `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
-      { clear: server.config.clearScreen, timestamp: true },
-    )
+  if (!changedFile.endsWith('/tsconfig.json')) {
+    return
+  }
 
-    // TODO: more finegrained invalidation than the nuclear option below
+  server.config.logger.info(
+    `changed tsconfig file detected: ${changedFile} - Clearing cache and forcing full-reload to ensure TypeScript is compiled with updated config values.`,
+    { clear: server.config.clearScreen, timestamp: true },
+  )
 
-    // clear module graph to remove code compiled with outdated config
-    for (const environment of Object.values(server.environments)) {
-      environment.moduleGraph.invalidateAll()
-    }
+  // TODO: more finegrained invalidation than the nuclear option below
 
-    // reset the cache so that recompile works with up2date configs
-    cache.clear()
+  // clear module graph to remove code compiled with outdated config
+  for (const environment of Object.values(server.environments)) {
+    environment.moduleGraph.invalidateAll()
+  }
 
-    // reload environments
-    for (const environment of Object.values(server.environments)) {
-      environment.hot.send({
-        type: 'full-reload',
-        path: '*',
-      })
-    }
+  // reset the cache so that recompile works with up2date configs
+  getTSConfigResolutionCache(server.config).clear()
+
+  // reload environments
+  for (const environment of Object.values(server.environments)) {
+    environment.hot.send({
+      type: 'full-reload',
+      path: '*',
+    })
   }
 }


### PR DESCRIPTION
was browsing the codebase and noticed this pattern:

```ts
  if (changedFile.endsWith('.json')) {
    const cache = getTSConfigResolutionCache(server.config)
    if (changedFile.endsWith('/tsconfig.json')) {
      // ...
    }
  }
```

as `getTSConfigResolutionCache` doesn't seem to have side effects, and since https://github.com/vitejs/vite/pull/21622 the cache is only used in the second if block, I think we can slightly refactor. I've made an early return but could leave the if and simply reduce if checks by one.

it's a tiny, tiny improvement but thought it was worth it 🤷 