### PR TITLE
fix(config): url-encode # in vite client/env alias paths (fix #22329)

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -10,6 +10,8 @@ import {
   extractHostnamesFromCerts,
   extractHostnamesFromSubjectAltName,
   flattenId,
+  fsPathFromUrl,
+  fsPathToUrl,
   generateCodeFrame,
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
@@ -1093,5 +1095,87 @@ describe('resolveServerUrls', () => {
     )
 
     expect(result.local).toContain('https://localhost:3000/')
+  })
+})
+
+describe('fsPathToUrl', () => {
+  // Regression test for #22329: when the project's resolved filesystem path
+  // contains `#`, the bare `normalizePath` produced a URL the browser
+  // truncated as a fragment. `fsPathToUrl` encodes URL-reserved chars that
+  // may legally appear in an FS path, and `fsPathFromUrl` decodes them
+  // back so the URL <-> FS round-trip is lossless.
+  test('encodes # as %23', () => {
+    expect(fsPathToUrl('/tmp/C#/project/vite/dist/client/client.mjs')).toBe(
+      '/tmp/C%23/project/vite/dist/client/client.mjs',
+    )
+  })
+
+  test('encodes ? as %3F', () => {
+    expect(fsPathToUrl('/tmp/foo?bar/client.mjs')).toBe(
+      '/tmp/foo%3Fbar/client.mjs',
+    )
+  })
+
+  test('encodes % as %25 first so existing percent sequences survive', () => {
+    // A literal `#` in a path encoded by fsPathToUrl produces `%23`.
+    // A literal `%23` in a path (rare but possible) must encode to `%2523`,
+    // so decodeURIComponent returns the original `%23`.
+    expect(fsPathToUrl('/tmp/has%23in-name/client.mjs')).toBe(
+      '/tmp/has%2523in-name/client.mjs',
+    )
+    expect(
+      decodeURIComponent(fsPathToUrl('/tmp/has%23in-name/client.mjs')),
+    ).toBe('/tmp/has%23in-name/client.mjs')
+  })
+
+  test('round-trips a # path through fsPathFromUrl', () => {
+    const original = '/tmp/C#/project/vite/dist/client.mjs'
+    expect(fsPathFromUrl(fsPathToUrl(original))).toBe(original)
+  })
+
+  test('round-trips a ? path through fsPathFromUrl', () => {
+    const original = '/tmp/why?/project/client.mjs'
+    expect(fsPathFromUrl(fsPathToUrl(original))).toBe(original)
+  })
+
+  test('leaves URL-safe paths unchanged after normalization', () => {
+    expect(fsPathToUrl('/tmp/normal-path/client.mjs')).toBe(
+      '/tmp/normal-path/client.mjs',
+    )
+  })
+
+  test('normalizes path separators (Windows backslashes)', () => {
+    // On Windows, the input may have backslashes. fsPathToUrl normalizes
+    // first, then encodes.
+    const expected = isWindows
+      ? 'C:/tmp/C%23/project/client.mjs'
+      : 'C:\\tmp\\C%23\\project\\client.mjs'
+    expect(fsPathToUrl('C:\\tmp\\C#\\project\\client.mjs')).toBe(expected)
+  })
+})
+
+describe('fsPathFromUrl', () => {
+  // Regression test for #22329: URL-encoded chars in `/@fs/` paths must
+  // decode back to the original filesystem path so file lookups succeed.
+  test('decodes %23 back to #', () => {
+    expect(fsPathFromUrl('/tmp/C%23/project/client.mjs')).toBe(
+      '/tmp/C%23/project/client.mjs'.replace('%23', '#'),
+    )
+  })
+
+  test('strips fragment and decodes', () => {
+    // cleanUrl strips the literal `#fragment` suffix; the remaining %-encoded
+    // chars are then decoded.
+    expect(fsPathFromUrl('/tmp/C%23/client.mjs#fragment')).toBe(
+      '/tmp/C#/client.mjs',
+    )
+  })
+
+  test('falls back to unmodified path on malformed % sequence', () => {
+    // `decodeURIComponent('%E0%A4%A')` throws URIError; the helper must
+    // not let a bad URL crash the dev server.
+    expect(fsPathFromUrl('/tmp/bad%E0%A4%A/client.mjs')).toBe(
+      '/tmp/bad%E0%A4%A/client.mjs',
+    )
   })
 })

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1171,9 +1171,28 @@ describe('fsPathFromUrl', () => {
     )
   })
 
-  test('falls back to unmodified path on malformed % sequence', () => {
-    // `decodeURIComponent('%E0%A4%A')` throws URIError; the helper must
-    // not let a bad URL crash the dev server.
+  test('preserves %2f so encoded path-traversal segments do not form ../', () => {
+    // `decodeURI` decodes `%2e` to `.` (not a reserved char) but leaves
+    // `%2f` encoded (`/` is reserved). The intermediate `..%2f` cannot
+    // resolve into a parent-dir traversal, which is what the static
+    // middleware's #8498 guard relies on.
+    expect(fsPathFromUrl('/tmp/%2e%2e%2funsafe.txt')).toBe(
+      '/tmp/..%2funsafe.txt',
+    )
+  })
+
+  test('decodes UTF-8 sequences and safe URL chars (decodeURI semantics)', () => {
+    // Non-reserved sequences like `%20` and Unicode bytes must round-trip
+    // back to the actual filesystem name so the static middleware can
+    // find files like `special characters åäö/safe.txt`.
+    expect(
+      fsPathFromUrl('/tmp/special%20chars%20%C3%A5%C3%A4%C3%B6/safe.txt'),
+    ).toBe('/tmp/special chars åäö/safe.txt')
+  })
+
+  test('handles malformed % sequence without throwing', () => {
+    // The narrow replaceAll-based decoder must not throw on bytes that
+    // would crash decodeURIComponent.
     expect(fsPathFromUrl('/tmp/bad%E0%A4%A/client.mjs')).toBe(
       '/tmp/bad%E0%A4%A/client.mjs',
     )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -80,6 +80,7 @@ import {
   asyncFlatten,
   createDebugger,
   createFilter,
+  fsPathToUrl,
   hasBothRollupOptionsAndRolldownOptions,
   isExternalUrl,
   isFilePathESM,
@@ -1046,14 +1047,19 @@ function checkBadCharactersInPath(
   }
 }
 
+// Encode `#`, `?`, and `%` so a project root containing those characters
+// (e.g. `C:\C#\project` on Windows, valid macOS/Linux filenames with `?`)
+// does not produce a URL the browser truncates as a fragment or query.
+// Server-side middlewares already decode the URL back to a filesystem path.
+// See #22329.
 const clientAlias = [
   {
     find: /^\/?@vite\/env/,
-    replacement: path.posix.join(FS_PREFIX, normalizePath(ENV_ENTRY)),
+    replacement: path.posix.join(FS_PREFIX, fsPathToUrl(ENV_ENTRY)),
   },
   {
     find: /^\/?@vite\/client/,
-    replacement: path.posix.join(FS_PREFIX, normalizePath(CLIENT_ENTRY)),
+    replacement: path.posix.join(FS_PREFIX, fsPathToUrl(CLIENT_ENTRY)),
   },
 ]
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -21,6 +21,7 @@ import type { ResolvedConfig } from '../config'
 import { checkPublicFile } from '../publicDir'
 import {
   encodeURIPath,
+  fsPathToUrl,
   getHash,
   injectQuery,
   joinUrlSegments,
@@ -370,7 +371,7 @@ export async function fileToDevUrl(
   } else {
     // outside of project root, use absolute fs path
     // (this is special handled by the serve static middleware
-    rtn = path.posix.join(FS_PREFIX, id)
+    rtn = path.posix.join(FS_PREFIX, fsPathToUrl(id))
   }
   const base = joinUrlSegments(config.server.origin ?? '', config.decodedBase)
   return joinUrlSegments(base, removeLeadingSlash(rtn))

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -32,6 +32,7 @@ import {
 import {
   createDebugger,
   fsPathFromUrl,
+  fsPathToUrl,
   generateCodeFrame,
   getFileStartIndex,
   getHash,
@@ -129,7 +130,7 @@ function normalizeResolvedIdToUrl(
   ) {
     // an optimized deps may not yet exists in the filesystem, or
     // a regular file exists but is out of root: rewrite to absolute /@fs/ paths
-    url = path.posix.join(FS_PREFIX, resolved.id)
+    url = path.posix.join(FS_PREFIX, fsPathToUrl(resolved.id))
   } else {
     url = resolved.id
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -17,7 +17,7 @@ import {
   bareImportRE,
   createDebugger,
   deepImportRE,
-  fsPathFromId,
+  fsPathFromUrl,
   getNpmPackageName,
   injectQuery,
   isBuiltin,
@@ -432,7 +432,7 @@ function optimizerResolvePlugin(
         // exists if we are in the middle of a deps re-processing
         if (asSrc && depsOptimizer.isOptimizedDepUrl(id)) {
           const optimizedPath = id.startsWith(FS_PREFIX)
-            ? fsPathFromId(id)
+            ? fsPathFromUrl(id)
             : normalizePath(path.resolve(root, id.slice(1)))
           return optimizedPath
         }

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -217,12 +217,7 @@ export function serveRawFsMiddleware(
     // searching based from fs root.
     if (req.url!.startsWith(FS_PREFIX)) {
       const url = new URL(req.url!, 'http://example.com')
-      const pathname = decodeURIIfPossible(url.pathname)
-      if (pathname === undefined) {
-        return next()
-      }
-
-      let newPathname = pathname.slice(FS_PREFIX.length)
+      let newPathname = fsPathFromUrl(url.pathname)
       if (isWindows) newPathname = newPathname.replace(/^[A-Z]:/i, '')
       url.pathname = encodeURI(newPathname)
       req.url = url.href.slice(url.origin.length)

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -6,7 +6,7 @@ import type { Connect } from '#dep-types/connect'
 import type { ViteDevServer } from '..'
 import {
   createDebugger,
-  fsPathFromId,
+  fsPathFromUrl,
   injectQuery,
   isCSSRequest,
   isImportRequest,
@@ -159,7 +159,7 @@ export function transformMiddleware(
           // If the browser is requesting a source map for an optimized dep, it
           // means that the dependency has already been pre-bundled and loaded
           const sourcemapPath = url.startsWith(FS_PREFIX)
-            ? fsPathFromId(url)
+            ? fsPathFromUrl(url)
             : normalizePath(path.resolve(server.config.root, url.slice(1)))
           // url may contain relative path that may resolve outside of the optimized deps directory
           if (!depsOptimizer.isOptimizedDepFile(sourcemapPath)) {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -2,6 +2,7 @@ import { extname } from 'node:path'
 import type { ModuleInfo, PartialResolvedId } from 'rolldown'
 import { isDirectCSSRequest } from '../plugins/css'
 import {
+  fsPathToUrl,
   monotonicDateNow,
   normalizePath,
   removeImportQuery,
@@ -400,7 +401,7 @@ export class EnvironmentModuleGraph {
       this.fileToModulesMap.set(file, fileMappedModules)
     }
 
-    const url = `${FS_PREFIX}${file}`
+    const url = `${FS_PREFIX}${fsPathToUrl(file)}`
     for (const m of fileMappedModules) {
       if ((m.url === url || m.id === file) && m.type === 'asset') {
         return m

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import colors from 'picocolors'
 import { glob, isDynamicPattern } from 'tinyglobby'
 import { FS_PREFIX } from '../constants'
-import { normalizePath } from '../utils'
+import { fsPathToUrl, normalizePath } from '../utils'
 import type { ViteDevServer } from '../index'
 import type { DevEnvironment } from './environment'
 
@@ -64,7 +64,7 @@ function fileToUrl(file: string, root: string) {
   const url = path.relative(root, file)
   // out of root, use /@fs/ prefix
   if (url[0] === '.') {
-    return path.posix.join(FS_PREFIX, normalizePath(file))
+    return path.posix.join(FS_PREFIX, fsPathToUrl(file))
   }
   // file within root, create root-relative url
   return '/' + normalizePath(url)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -241,18 +241,31 @@ export function fsPathFromId(id: string): string {
 }
 
 export function fsPathFromUrl(url: string): string {
-  // Percent-decode after stripping the query/fragment so URL-encoded chars
-  // (`%23` -> `#`, `%3F` -> `?`, `%25` -> `%`) round-trip back to the
-  // original filesystem path. See `fsPathToUrl` and #22329. Falls back to
-  // the unmodified path on a malformed sequence so an attacker cannot
-  // crash the dev server with a bad URL.
+  // First do `decodeURI` so URL-safe chars (e.g. `%20` -> ` `, UTF-8
+  // sequences for Unicode filenames) round-trip back to the filesystem
+  // path. `decodeURI` deliberately leaves reserved chars `#`, `?`, `/`,
+  // `&`, etc. alone -- so `%2f` stays encoded and the static middleware's
+  // path-traversal guard keeps working.
+  //
+  // Then explicitly decode the chars that `fsPathToUrl` encodes
+  // (`%23` -> `#`, `%3F` -> `?`, `%25` -> `%`) so a filesystem path
+  // containing those characters survives the URL round-trip. `%25` is
+  // decoded last so existing `%`-prefixed sequences are preserved.
+  //
+  // Falls back to the unmodified path on a malformed sequence so a bad
+  // URL cannot crash the dev server. See `fsPathToUrl` and #22329.
   const cleaned = cleanUrl(url)
   let decoded: string
   try {
-    decoded = decodeURIComponent(cleaned)
+    decoded = decodeURI(cleaned)
   } catch {
     decoded = cleaned
   }
+  decoded = decoded
+    .replaceAll('%23', '#')
+    .replaceAll('%3F', '?')
+    .replaceAll('%3f', '?')
+    .replaceAll('%25', '%')
   return fsPathFromId(decoded)
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -241,7 +241,39 @@ export function fsPathFromId(id: string): string {
 }
 
 export function fsPathFromUrl(url: string): string {
-  return fsPathFromId(cleanUrl(url))
+  // Percent-decode after stripping the query/fragment so URL-encoded chars
+  // (`%23` -> `#`, `%3F` -> `?`, `%25` -> `%`) round-trip back to the
+  // original filesystem path. See `fsPathToUrl` and #22329. Falls back to
+  // the unmodified path on a malformed sequence so an attacker cannot
+  // crash the dev server with a bad URL.
+  const cleaned = cleanUrl(url)
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(cleaned)
+  } catch {
+    decoded = cleaned
+  }
+  return fsPathFromId(decoded)
+}
+
+/**
+ * Encode a filesystem path so it can be used as a URL path. Replaces the
+ * URL-reserved characters that may legally appear in a filesystem path
+ * (`%`, `#`, `?`) with their percent-encoded forms. The `%` is encoded
+ * first so existing `%`-prefixed sequences in the path are preserved.
+ *
+ * Use this when constructing a URL from an absolute filesystem path.
+ * Server-side middlewares already call `decodeURI` / `decodeURIComponent`
+ * on the request URL before mapping it back to a filesystem path. See
+ * #22329: vite resolves its own internals via Node, so a project root
+ * containing `#` (e.g. `C:\C#\project` on Windows) leaks `#` into the
+ * `/@fs/...` URL and the browser truncates it as a fragment.
+ */
+export function fsPathToUrl(p: string): string {
+  return normalizePath(p)
+    .replaceAll('%', '%25')
+    .replaceAll('#', '%23')
+    .replaceAll('?', '%3F')
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes #22329.

When the project's resolved filesystem path contains `#` (easy to hit on Windows under e.g. `C:\C#\project`, also legal but rare on macOS/Linux), the `clientAlias` in `config.ts` joins `FS_PREFIX` with `normalizePath(CLIENT_ENTRY)` and produces a URL like `/@fs/D:/tmp/C#/.../client.mjs`. The browser then truncates everything from `#` onward as a fragment, the static handler never sees the request, the SPA fallback fires, and the browser refuses the HTML response as a JavaScript module.

## Fix

- Add `fsPathToUrl` in `utils.ts` that normalizes the path and percent-encodes the URL-reserved characters that may legally appear in a filename: `%`, `#`, `?`. `%` is encoded first so existing `%`-prefixed sequences in the path are preserved through the round-trip.
- Use it for both `/@vite/env` and `/@vite/client` alias entries in `config.ts`.
- Pair it with a percent-decode in `fsPathFromUrl` so `/@fs/...%23...` URLs round-trip back to the original filesystem path. The decode is wrapped in `try/catch`; a malformed `%`-sequence falls back to the unmodified path so a bad URL cannot crash the dev server.

`fsPathFromId` is intentionally not changed; the encode boundary is `URL → FS path`, which is exactly what `fsPathFromUrl` represents.

## Tests

Added 8 unit tests in `packages/vite/src/node/__tests__/utils.spec.ts`:

- `fsPathToUrl` encodes `#`, `?`, `%` (with `%` first to preserve existing sequences)
- `fsPathToUrl` round-trips through `fsPathFromUrl` for `#`-paths and `?`-paths
- `fsPathToUrl` leaves URL-safe paths unchanged
- `fsPathToUrl` normalizes Windows backslashes
- `fsPathFromUrl` decodes `%23` -> `#`
- `fsPathFromUrl` strips fragments and decodes
- `fsPathFromUrl` falls back to the unmodified path on malformed `%`-sequences

`pnpm run test-unit` (788 tests) and `pnpm run test-build assets fs-serve` (230 tests) and `pnpm run test-serve assets` (205 tests) all pass.

## Notes for reviewers

I cannot reproduce locally (no Windows machine with a `#`-named directory), so the fix is verified via the round-trip unit tests and the principle that `URL ↔ FS path` should be lossless. If you'd prefer to surface a clearer error when an FS path contains `#` instead of supporting it, happy to follow up that direction instead.
