### PR TITLE
fix(create-vite): make template icons relative-base safe

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -55,8 +55,33 @@ const clearAnyPreviousFolders = () => {
   }
 }
 
+const readFilesRecursively = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const filePath = path.join(dir, entry.name)
+    return entry.isDirectory() ? readFilesRecursively(filePath) : [filePath]
+  })
+
 beforeAll(() => clearAnyPreviousFolders())
 afterEach(() => clearAnyPreviousFolders())
+
+test('built-in templates avoid root-absolute icon sprite references', () => {
+  const templateDirs = fs
+    .readdirSync(CLI_PATH, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && entry.name.startsWith('template-'),
+    )
+
+  for (const templateDir of templateDirs) {
+    const files = readFilesRecursively(path.join(CLI_PATH, templateDir.name))
+    for (const file of files) {
+      if (!/\.(?:[cm]?[jt]sx?|vue|svelte|html|css|json|md|svg)$/.test(file)) {
+        continue
+      }
+      const source = fs.readFileSync(file, 'utf-8')
+      expect(source, path.relative(CLI_PATH, file)).not.toContain('/icons.svg#')
+    }
+  }
+})
 
 test('prompts for the project name if none supplied', () => {
   const { stdout } = run(['--interactive'])

--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -55,33 +55,8 @@ const clearAnyPreviousFolders = () => {
   }
 }
 
-const readFilesRecursively = (dir: string): string[] =>
-  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const filePath = path.join(dir, entry.name)
-    return entry.isDirectory() ? readFilesRecursively(filePath) : [filePath]
-  })
-
 beforeAll(() => clearAnyPreviousFolders())
 afterEach(() => clearAnyPreviousFolders())
-
-test('built-in templates avoid root-absolute icon sprite references', () => {
-  const templateDirs = fs
-    .readdirSync(CLI_PATH, { withFileTypes: true })
-    .filter(
-      (entry) => entry.isDirectory() && entry.name.startsWith('template-'),
-    )
-
-  for (const templateDir of templateDirs) {
-    const files = readFilesRecursively(path.join(CLI_PATH, templateDir.name))
-    for (const file of files) {
-      if (!/\.(?:[cm]?[jt]sx?|vue|svelte|html|css|json|md|svg)$/.test(file)) {
-        continue
-      }
-      const source = fs.readFileSync(file, 'utf-8')
-      expect(source, path.relative(CLI_PATH, file)).not.toContain('/icons.svg#')
-    }
-  }
-})
 
 test('prompts for the project name if none supplied', () => {
   const { stdout } = run(['--interactive'])

--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from 'lit'
+import icons from '/icons.svg'
 import { customElement, property } from 'lit/decorators.js'
 import litLogo from './assets/lit.svg'
 import viteLogo from './assets/vite.svg'
@@ -43,7 +44,7 @@ export class MyElement extends LitElement {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href=${icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -64,7 +65,7 @@ export class MyElement extends LitElement {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href=${icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -72,7 +73,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href=${icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -80,7 +81,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href=${icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -88,7 +89,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href=${icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -96,7 +97,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href=${icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html } from 'lit'
-import icons from '/icons.svg'
 import { customElement, property } from 'lit/decorators.js'
+import icons from '/icons.svg'
 import litLogo from './assets/lit.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from 'lit'
+import icons from '/icons.svg'
 import litLogo from './assets/lit.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -49,7 +50,7 @@ export class MyElement extends LitElement {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href=${icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -70,7 +71,7 @@ export class MyElement extends LitElement {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href=${icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -78,7 +79,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href=${icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -86,7 +87,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href=${icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -94,7 +95,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href=${icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -102,7 +103,7 @@ export class MyElement extends LitElement {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href=${icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-preact-ts/src/app.tsx
+++ b/packages/create-vite/template-preact-ts/src/app.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'preact/hooks'
+import icons from '/icons.svg'
 import preactLogo from './assets/preact.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -31,7 +32,7 @@ export function App() {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -52,7 +53,7 @@ export function App() {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -60,7 +61,7 @@ export function App() {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -68,7 +69,7 @@ export function App() {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -76,7 +77,7 @@ export function App() {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -84,7 +85,7 @@ export function App() {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-preact/src/app.jsx
+++ b/packages/create-vite/template-preact/src/app.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'preact/hooks'
+import icons from '/icons.svg'
 import preactLogo from './assets/preact.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -31,7 +32,7 @@ export function App() {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -52,7 +53,7 @@ export function App() {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -60,7 +61,7 @@ export function App() {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -68,7 +69,7 @@ export function App() {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -76,7 +77,7 @@ export function App() {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -84,7 +85,7 @@ export function App() {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-qwik-ts/src/app.tsx
+++ b/packages/create-vite/template-qwik-ts/src/app.tsx
@@ -1,4 +1,5 @@
 import { component$, useSignal } from '@builder.io/qwik'
+import icons from '/icons.svg'
 
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'
@@ -32,7 +33,7 @@ export const App = component$(() => {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -53,7 +54,7 @@ export const App = component$(() => {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -61,7 +62,7 @@ export const App = component$(() => {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -69,7 +70,7 @@ export const App = component$(() => {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -77,7 +78,7 @@ export const App = component$(() => {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -85,7 +86,7 @@ export const App = component$(() => {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-qwik-ts/src/app.tsx
+++ b/packages/create-vite/template-qwik-ts/src/app.tsx
@@ -1,6 +1,5 @@
 import { component$, useSignal } from '@builder.io/qwik'
 import icons from '/icons.svg'
-
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'

--- a/packages/create-vite/template-qwik/src/app.jsx
+++ b/packages/create-vite/template-qwik/src/app.jsx
@@ -1,4 +1,5 @@
 import { component$, useSignal } from '@builder.io/qwik'
+import icons from '/icons.svg'
 
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'
@@ -32,7 +33,7 @@ export const App = component$(() => {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -53,7 +54,7 @@ export const App = component$(() => {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -61,7 +62,7 @@ export const App = component$(() => {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -69,7 +70,7 @@ export const App = component$(() => {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -77,7 +78,7 @@ export const App = component$(() => {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -85,7 +86,7 @@ export const App = component$(() => {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-qwik/src/app.jsx
+++ b/packages/create-vite/template-qwik/src/app.jsx
@@ -1,6 +1,5 @@
 import { component$, useSignal } from '@builder.io/qwik'
 import icons from '/icons.svg'
-
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'

--- a/packages/create-vite/template-react-ts/src/App.tsx
+++ b/packages/create-vite/template-react-ts/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import icons from '/icons.svg'
 import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -34,7 +35,7 @@ function App() {
       <section id="next-steps">
         <div id="docs">
           <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -55,7 +56,7 @@ function App() {
         </div>
         <div id="social">
           <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -67,7 +68,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -79,7 +80,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -91,7 +92,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -103,7 +104,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-react/src/App.jsx
+++ b/packages/create-vite/template-react/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import icons from '/icons.svg'
 import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -34,7 +35,7 @@ function App() {
       <section id="next-steps">
         <div id="docs">
           <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -55,7 +56,7 @@ function App() {
         </div>
         <div id="social">
           <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -67,7 +68,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -79,7 +80,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -91,7 +92,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -103,7 +104,7 @@ function App() {
                   role="presentation"
                   aria-hidden="true"
                 >
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-solid-ts/src/App.tsx
+++ b/packages/create-vite/template-solid-ts/src/App.tsx
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js'
+import icons from '/icons.svg'
 import solidLogo from './assets/solid.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -31,7 +32,7 @@ function App() {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -52,7 +53,7 @@ function App() {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -60,7 +61,7 @@ function App() {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -68,7 +69,7 @@ function App() {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -76,7 +77,7 @@ function App() {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -84,7 +85,7 @@ function App() {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-solid/src/App.jsx
+++ b/packages/create-vite/template-solid/src/App.jsx
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js'
+import icons from '/icons.svg'
 import solidLogo from './assets/solid.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -31,7 +32,7 @@ function App() {
       <section id="next-steps">
         <div id="docs">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
+            <use href={icons + '#documentation-icon'}></use>
           </svg>
           <h2>Documentation</h2>
           <p>Your questions, answered</p>
@@ -52,7 +53,7 @@ function App() {
         </div>
         <div id="social">
           <svg class="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
+            <use href={icons + '#social-icon'}></use>
           </svg>
           <h2>Connect with us</h2>
           <p>Join the Vite community</p>
@@ -60,7 +61,7 @@ function App() {
             <li>
               <a href="https://github.com/vitejs/vite" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#github-icon"></use>
+                  <use href={icons + '#github-icon'}></use>
                 </svg>
                 GitHub
               </a>
@@ -68,7 +69,7 @@ function App() {
             <li>
               <a href="https://chat.vite.dev/" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#discord-icon"></use>
+                  <use href={icons + '#discord-icon'}></use>
                 </svg>
                 Discord
               </a>
@@ -76,7 +77,7 @@ function App() {
             <li>
               <a href="https://x.com/vite_js" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#x-icon"></use>
+                  <use href={icons + '#x-icon'}></use>
                 </svg>
                 X.com
               </a>
@@ -84,7 +85,7 @@ function App() {
             <li>
               <a href="https://bsky.app/profile/vite.dev" target="_blank">
                 <svg class="button-icon" role="presentation" aria-hidden="true">
-                  <use href="/icons.svg#bluesky-icon"></use>
+                  <use href={icons + '#bluesky-icon'}></use>
                 </svg>
                 Bluesky
               </a>

--- a/packages/create-vite/template-svelte-ts/src/App.svelte
+++ b/packages/create-vite/template-svelte-ts/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  import icons from '/icons.svg'
   import svelteLogo from './assets/svelte.svg'
   import viteLogo from './assets/vite.svg'
   import heroImg from './assets/hero.png'
@@ -23,7 +24,7 @@
 <section id="next-steps">
   <div id="docs">
     <svg class="icon" role="presentation" aria-hidden="true">
-      <use href="/icons.svg#documentation-icon"></use>
+      <use href={icons + '#documentation-icon'}></use>
     </svg>
     <h2>Documentation</h2>
     <p>Your questions, answered</p>
@@ -44,7 +45,7 @@
   </div>
   <div id="social">
     <svg class="icon" role="presentation" aria-hidden="true">
-      <use href="/icons.svg#social-icon"></use>
+      <use href={icons + '#social-icon'}></use>
     </svg>
     <h2>Connect with us</h2>
     <p>Join the Vite community</p>
@@ -52,7 +53,7 @@
       <li>
         <a href="https://github.com/vitejs/vite" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#github-icon"></use>
+            <use href={icons + '#github-icon'}></use>
           </svg>
           GitHub
         </a>
@@ -60,7 +61,7 @@
       <li>
         <a href="https://chat.vite.dev/" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#discord-icon"></use>
+            <use href={icons + '#discord-icon'}></use>
           </svg>
           Discord
         </a>
@@ -68,7 +69,7 @@
       <li>
         <a href="https://x.com/vite_js" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#x-icon"></use>
+            <use href={icons + '#x-icon'}></use>
           </svg>
           X.com
         </a>
@@ -76,7 +77,7 @@
       <li>
         <a href="https://bsky.app/profile/vite.dev" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#bluesky-icon"></use>
+            <use href={icons + '#bluesky-icon'}></use>
           </svg>
           Bluesky
         </a>

--- a/packages/create-vite/template-svelte/src/App.svelte
+++ b/packages/create-vite/template-svelte/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  import icons from '/icons.svg'
   import svelteLogo from './assets/svelte.svg'
   import viteLogo from './assets/vite.svg'
   import heroImg from './assets/hero.png'
@@ -23,7 +24,7 @@
 <section id="next-steps">
   <div id="docs">
     <svg class="icon" role="presentation" aria-hidden="true">
-      <use href="/icons.svg#documentation-icon"></use>
+      <use href={icons + '#documentation-icon'}></use>
     </svg>
     <h2>Documentation</h2>
     <p>Your questions, answered</p>
@@ -44,7 +45,7 @@
   </div>
   <div id="social">
     <svg class="icon" role="presentation" aria-hidden="true">
-      <use href="/icons.svg#social-icon"></use>
+      <use href={icons + '#social-icon'}></use>
     </svg>
     <h2>Connect with us</h2>
     <p>Join the Vite community</p>
@@ -52,7 +53,7 @@
       <li>
         <a href="https://github.com/vitejs/vite" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#github-icon"></use>
+            <use href={icons + '#github-icon'}></use>
           </svg>
           GitHub
         </a>
@@ -60,7 +61,7 @@
       <li>
         <a href="https://chat.vite.dev/" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#discord-icon"></use>
+            <use href={icons + '#discord-icon'}></use>
           </svg>
           Discord
         </a>
@@ -68,7 +69,7 @@
       <li>
         <a href="https://x.com/vite_js" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#x-icon"></use>
+            <use href={icons + '#x-icon'}></use>
           </svg>
           X.com
         </a>
@@ -76,7 +77,7 @@
       <li>
         <a href="https://bsky.app/profile/vite.dev" target="_blank" rel="noreferrer">
           <svg class="button-icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#bluesky-icon"></use>
+            <use href={icons + '#bluesky-icon'}></use>
           </svg>
           Bluesky
         </a>

--- a/packages/create-vite/template-vanilla-ts/src/main.ts
+++ b/packages/create-vite/template-vanilla-ts/src/main.ts
@@ -1,4 +1,5 @@
 import './style.css'
+import icons from '/icons.svg'
 import typescriptLogo from './assets/typescript.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -22,7 +23,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
 <section id="next-steps">
   <div id="docs">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#documentation-icon"></use></svg>
+    <svg class="icon" role="presentation" aria-hidden="true"><use href="${icons}#documentation-icon"></use></svg>
     <h2>Documentation</h2>
     <p>Your questions, answered</p>
     <ul>
@@ -41,14 +42,14 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     </ul>
   </div>
   <div id="social">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#social-icon"></use></svg>
+    <svg class="icon" role="presentation" aria-hidden="true"><use href="${icons}#social-icon"></use></svg>
     <h2>Connect with us</h2>
     <p>Join the Vite community</p>
     <ul>
-      <li><a href="https://github.com/vitejs/vite" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#github-icon"></use></svg>GitHub</a></li>
-      <li><a href="https://chat.vite.dev/" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#discord-icon"></use></svg>Discord</a></li>
-      <li><a href="https://x.com/vite_js" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#x-icon"></use></svg>X.com</a></li>
-      <li><a href="https://bsky.app/profile/vite.dev" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#bluesky-icon"></use></svg>Bluesky</a></li>
+      <li><a href="https://github.com/vitejs/vite" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#github-icon"></use></svg>GitHub</a></li>
+      <li><a href="https://chat.vite.dev/" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#discord-icon"></use></svg>Discord</a></li>
+      <li><a href="https://x.com/vite_js" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#x-icon"></use></svg>X.com</a></li>
+      <li><a href="https://bsky.app/profile/vite.dev" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#bluesky-icon"></use></svg>Bluesky</a></li>
     </ul>
   </div>
 </section>

--- a/packages/create-vite/template-vanilla/src/main.js
+++ b/packages/create-vite/template-vanilla/src/main.js
@@ -1,4 +1,5 @@
 import './style.css'
+import icons from '/icons.svg'
 import javascriptLogo from './assets/javascript.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -22,7 +23,7 @@ document.querySelector('#app').innerHTML = `
 
 <section id="next-steps">
   <div id="docs">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#documentation-icon"></use></svg>
+    <svg class="icon" role="presentation" aria-hidden="true"><use href="${icons}#documentation-icon"></use></svg>
     <h2>Documentation</h2>
     <p>Your questions, answered</p>
     <ul>
@@ -41,14 +42,14 @@ document.querySelector('#app').innerHTML = `
     </ul>
   </div>
   <div id="social">
-    <svg class="icon" role="presentation" aria-hidden="true"><use href="/icons.svg#social-icon"></use></svg>
+    <svg class="icon" role="presentation" aria-hidden="true"><use href="${icons}#social-icon"></use></svg>
     <h2>Connect with us</h2>
     <p>Join the Vite community</p>
     <ul>
-      <li><a href="https://github.com/vitejs/vite" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#github-icon"></use></svg>GitHub</a></li>
-      <li><a href="https://chat.vite.dev/" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#discord-icon"></use></svg>Discord</a></li>
-      <li><a href="https://x.com/vite_js" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#x-icon"></use></svg>X.com</a></li>
-      <li><a href="https://bsky.app/profile/vite.dev" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="/icons.svg#bluesky-icon"></use></svg>Bluesky</a></li>
+      <li><a href="https://github.com/vitejs/vite" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#github-icon"></use></svg>GitHub</a></li>
+      <li><a href="https://chat.vite.dev/" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#discord-icon"></use></svg>Discord</a></li>
+      <li><a href="https://x.com/vite_js" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#x-icon"></use></svg>X.com</a></li>
+      <li><a href="https://bsky.app/profile/vite.dev" target="_blank"><svg class="button-icon" role="presentation" aria-hidden="true"><use href="${icons}#bluesky-icon"></use></svg>Bluesky</a></li>
     </ul>
   </div>
 </section>

--- a/packages/create-vite/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-vite/template-vue-ts/src/components/HelloWorld.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import icons from '/icons.svg'
 import viteLogo from '../assets/vite.svg'
 import heroImg from '../assets/hero.png'
 import vueLogo from '../assets/vue.svg'
@@ -26,7 +27,7 @@ const count = ref(0)
   <section id="next-steps">
     <div id="docs">
       <svg class="icon" role="presentation" aria-hidden="true">
-        <use href="/icons.svg#documentation-icon"></use>
+        <use :href="icons + '#documentation-icon'"></use>
       </svg>
       <h2>Documentation</h2>
       <p>Your questions, answered</p>
@@ -47,7 +48,7 @@ const count = ref(0)
     </div>
     <div id="social">
       <svg class="icon" role="presentation" aria-hidden="true">
-        <use href="/icons.svg#social-icon"></use>
+        <use :href="icons + '#social-icon'"></use>
       </svg>
       <h2>Connect with us</h2>
       <p>Join the Vite community</p>
@@ -55,7 +56,7 @@ const count = ref(0)
         <li>
           <a href="https://github.com/vitejs/vite" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#github-icon"></use>
+              <use :href="icons + '#github-icon'"></use>
             </svg>
             GitHub
           </a>
@@ -63,7 +64,7 @@ const count = ref(0)
         <li>
           <a href="https://chat.vite.dev/" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#discord-icon"></use>
+              <use :href="icons + '#discord-icon'"></use>
             </svg>
             Discord
           </a>
@@ -71,7 +72,7 @@ const count = ref(0)
         <li>
           <a href="https://x.com/vite_js" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#x-icon"></use>
+              <use :href="icons + '#x-icon'"></use>
             </svg>
             X.com
           </a>
@@ -79,7 +80,7 @@ const count = ref(0)
         <li>
           <a href="https://bsky.app/profile/vite.dev" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#bluesky-icon"></use>
+              <use :href="icons + '#bluesky-icon'"></use>
             </svg>
             Bluesky
           </a>

--- a/packages/create-vite/template-vue/src/components/HelloWorld.vue
+++ b/packages/create-vite/template-vue/src/components/HelloWorld.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+import icons from '/icons.svg'
 import viteLogo from '../assets/vite.svg'
 import heroImg from '../assets/hero.png'
 import vueLogo from '../assets/vue.svg'
@@ -26,7 +27,7 @@ const count = ref(0)
   <section id="next-steps">
     <div id="docs">
       <svg class="icon" role="presentation" aria-hidden="true">
-        <use href="/icons.svg#documentation-icon"></use>
+        <use :href="icons + '#documentation-icon'"></use>
       </svg>
       <h2>Documentation</h2>
       <p>Your questions, answered</p>
@@ -47,7 +48,7 @@ const count = ref(0)
     </div>
     <div id="social">
       <svg class="icon" role="presentation" aria-hidden="true">
-        <use href="/icons.svg#social-icon"></use>
+        <use :href="icons + '#social-icon'"></use>
       </svg>
       <h2>Connect with us</h2>
       <p>Join the Vite community</p>
@@ -55,7 +56,7 @@ const count = ref(0)
         <li>
           <a href="https://github.com/vitejs/vite" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#github-icon"></use>
+              <use :href="icons + '#github-icon'"></use>
             </svg>
             GitHub
           </a>
@@ -63,7 +64,7 @@ const count = ref(0)
         <li>
           <a href="https://chat.vite.dev/" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#discord-icon"></use>
+              <use :href="icons + '#discord-icon'"></use>
             </svg>
             Discord
           </a>
@@ -71,7 +72,7 @@ const count = ref(0)
         <li>
           <a href="https://x.com/vite_js" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#x-icon"></use>
+              <use :href="icons + '#x-icon'"></use>
             </svg>
             X.com
           </a>
@@ -79,7 +80,7 @@ const count = ref(0)
         <li>
           <a href="https://bsky.app/profile/vite.dev" target="_blank">
             <svg class="button-icon" role="presentation" aria-hidden="true">
-              <use href="/icons.svg#bluesky-icon"></use>
+              <use :href="icons + '#bluesky-icon'"></use>
             </svg>
             Bluesky
           </a>


### PR DESCRIPTION
## Summary

This updates the create-vite templates to import the shared `icons.svg` sprite URL instead of referencing it with root-absolute `/icons.svg#...` hrefs. That keeps the generated icon references working when an app is built with a relative base such as `base: './'`.

Fixes #22300

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter vite run build`
- `pnpm --filter create-vite run build`
- `pnpm run test-unit create-vite`
- `pnpm --filter create-vite run typecheck`
- `git diff --check`
- Scaffolded `react` and `react-ts` templates, set `base: './'`, built both apps, and verified the output uses bundled relative `icons.svg` references rather than `/icons.svg`.
