### PR TITLE
fix(optimizer): pass oxc jsx options to transformSync in dependency scan                                                           

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-glob-custom-oxc.tsx
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/entry-glob-custom-oxc.tsx
@@ -1,0 +1,3 @@
+export const pages = import.meta.glob('./pages/*.tsx')
+
+export default <div />

--- a/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/pages/index.tsx
+++ b/packages/vite/src/node/__tests__/fixtures/scan-jsx-runtime/pages/index.tsx
@@ -1,0 +1,1 @@
+export default <main />

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -175,7 +175,7 @@ test('scan jsx-runtime', async (ctx) => {
   expect(mod1).toBe(mod2)
 })
 
-test('scan import.meta.glob respects oxc jsx options', async (ctx) => {
+test('scan import.meta.glob respects rolldown transform jsx options', async (ctx) => {
   const server = await createServer({
     configFile: false,
     logLevel: 'error',
@@ -183,13 +183,21 @@ test('scan import.meta.glob respects oxc jsx options', async (ctx) => {
     oxc: {
       jsx: {
         runtime: 'automatic',
-        importSource: 'vue',
+        importSource: 'react',
       },
     },
     optimizeDeps: {
       force: true,
       noDiscovery: false,
       entries: ['./entry-glob-custom-oxc.tsx'],
+      rolldownOptions: {
+        transform: {
+          jsx: {
+            runtime: 'automatic',
+            importSource: 'vue',
+          },
+        },
+      },
     },
   })
   ctx.onTestFinished(() => server.close())

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -175,6 +175,41 @@ test('scan jsx-runtime', async (ctx) => {
   expect(mod1).toBe(mod2)
 })
 
+test('scan import.meta.glob respects oxc jsx options', async (ctx) => {
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'error',
+    root: path.join(import.meta.dirname, 'fixtures', 'scan-jsx-runtime'),
+    oxc: {
+      jsx: {
+        runtime: 'automatic',
+        importSource: 'vue',
+      },
+    },
+    optimizeDeps: {
+      force: true,
+      noDiscovery: false,
+      entries: ['./entry-glob-custom-oxc.tsx'],
+    },
+  })
+  ctx.onTestFinished(() => server.close())
+
+  const { cancel, result } = scanImports(
+    devToScanEnvironment(server.environments.client),
+  )
+  ctx.onTestFinished(cancel)
+
+  const scanResult = await result
+
+  expect(scanResult).toMatchObject({
+    deps: {
+      'vue/jsx-dev-runtime': expect.any(String),
+    },
+    missing: {},
+  })
+  expect(scanResult.deps).not.toHaveProperty('react/jsx-runtime')
+})
+
 test('scan import.meta.glob package imports patterns', async (ctx) => {
   const server = await createServer({
     configFile: false,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -37,7 +37,7 @@ import { BaseEnvironment } from '../baseEnvironment'
 import type { DevEnvironment } from '../server/environment'
 import { transformGlobImport } from '../plugins/importMetaGlob'
 import { cleanUrl } from '../../shared/utils'
-import { type OxcOptions, getRollupJsxPresets } from '../plugins/oxc'
+import { getRollupJsxPresets } from '../plugins/oxc'
 
 export class ScanEnvironment extends BaseEnvironment {
   mode = 'scan' as const
@@ -253,9 +253,6 @@ async function prepareRolldownScanner(
   const { plugins: pluginsFromConfig = [], ...rolldownOptions } =
     environment.config.optimizeDeps.rolldownOptions ?? {}
 
-  const plugins = await asyncFlatten(arraify(pluginsFromConfig))
-  plugins.push(...rolldownScanPlugin(environment, deps, missing, entries))
-
   const transformOptions = deepClone(rolldownOptions.transform) ?? {}
   if (transformOptions.jsx === undefined) {
     transformOptions.jsx = {}
@@ -268,6 +265,19 @@ async function prepareRolldownScanner(
   if (typeof transformOptions.jsx === 'object') {
     transformOptions.jsx.development ??= !environment.config.isProduction
   }
+  const transformSyncJsxOptions: OxcTransformOptions['jsx'] =
+    transformOptions.jsx === false ? undefined : transformOptions.jsx
+
+  const plugins = await asyncFlatten(arraify(pluginsFromConfig))
+  plugins.push(
+    ...rolldownScanPlugin(
+      environment,
+      deps,
+      missing,
+      entries,
+      transformSyncJsxOptions,
+    ),
+  )
 
   async function build() {
     await scan({
@@ -329,25 +339,6 @@ async function globEntries(
 
 type Loader = 'js' | 'ts' | 'jsx' | 'tsx'
 
-function getOxcTransformOptions(
-  options: OxcOptions | false,
-): OxcTransformOptions {
-  if (!options) {
-    return {}
-  }
-
-  const {
-    jsxInject: _jsxInject,
-    include: _include,
-    exclude: _exclude,
-    jsxRefreshInclude: _jsxRefreshInclude,
-    jsxRefreshExclude: _jsxRefreshExclude,
-    ...transformOptions
-  } = options
-
-  return transformOptions
-}
-
 export const scriptRE: RegExp =
   /(<script(?:\s+[a-z_:][-\w:]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^"'<>=\s]+))?)*\s*>)(.*?)<\/script>/gis
 export const commentRE: RegExp = /<!--.*?-->/gs
@@ -363,6 +354,7 @@ function rolldownScanPlugin(
   depImports: Record<string, string>,
   missing: Record<string, string>,
   entries: string[],
+  jsxOptions: OxcTransformOptions['jsx'],
 ): Plugin[] {
   const seen = new Map<string, string | undefined>()
   async function resolveId(
@@ -417,7 +409,7 @@ function rolldownScanPlugin(
     // transpile because `transformGlobImport` only expects js
     if (loader !== 'js') {
       const result = transformSync(id, contents, {
-        ...getOxcTransformOptions(environment.config.oxc),
+        ...(jsxOptions !== undefined ? { jsx: jsxOptions } : {}),
         lang: loader,
         tsconfig: false,
       })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -3,6 +3,7 @@ import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { scan } from 'rolldown/experimental'
+import type { TransformOptions as OxcTransformOptions } from 'rolldown/utils'
 import { transformSync } from 'rolldown/utils'
 import type { PartialResolvedId, Plugin } from 'rolldown'
 import colors from 'picocolors'
@@ -36,7 +37,7 @@ import { BaseEnvironment } from '../baseEnvironment'
 import type { DevEnvironment } from '../server/environment'
 import { transformGlobImport } from '../plugins/importMetaGlob'
 import { cleanUrl } from '../../shared/utils'
-import { getRollupJsxPresets } from '../plugins/oxc'
+import { type OxcOptions, getRollupJsxPresets } from '../plugins/oxc'
 
 export class ScanEnvironment extends BaseEnvironment {
   mode = 'scan' as const
@@ -328,6 +329,25 @@ async function globEntries(
 
 type Loader = 'js' | 'ts' | 'jsx' | 'tsx'
 
+function getOxcTransformOptions(
+  options: OxcOptions | false,
+): OxcTransformOptions {
+  if (!options) {
+    return {}
+  }
+
+  const {
+    jsxInject: _jsxInject,
+    include: _include,
+    exclude: _exclude,
+    jsxRefreshInclude: _jsxRefreshInclude,
+    jsxRefreshExclude: _jsxRefreshExclude,
+    ...transformOptions
+  } = options
+
+  return transformOptions
+}
+
 export const scriptRE: RegExp =
   /(<script(?:\s+[a-z_:][-\w:]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^"'<>=\s]+))?)*\s*>)(.*?)<\/script>/gis
 export const commentRE: RegExp = /<!--.*?-->/gs
@@ -397,6 +417,7 @@ function rolldownScanPlugin(
     // transpile because `transformGlobImport` only expects js
     if (loader !== 'js') {
       const result = transformSync(id, contents, {
+        ...getOxcTransformOptions(environment.config.oxc),
         lang: loader,
         tsconfig: false,
       })


### PR DESCRIPTION
The `doTransformGlobImport` function in the dependency scanner was calling  `transformSync` without passing user-configured OXC transform options. This caused custom JSX settings (e.g. importSource, pragma, runtime) to be ignored during scan, resulting in incorrect dependency resolution such as attempting to resolve `react/jsx-runtime` instead of the configured custom JSX runtime.
  Fix #22340

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
                                                                                                                                       
  ## Summary                                                                                                                               
  - `doTransformGlobImport` in `scan.ts` was calling `transformSync` with only `lang` and `tsconfig`, ignoring user-configured `oxc.jsx`   
  options                                                                                                                                  
  - Added `getOxcTransformOptions()` helper to extract transform-relevant options from `config.oxc`                                        
  - Custom JSX runtime settings (importSource, pragma, runtime, etc.) are now correctly applied during dependency scanning                 
                                                                                                                                           
  ## Related                                                                                                                               
  Fixes #22340                                                                                                                             
                                                                                                                                           
  ## Test plan                                                                                                                             
  - Added test case verifying `import.meta.glob` scan respects custom oxc jsx options (e.g. `importSource: 'vue'` resolves                 
  `vue/jsx-dev-runtime` instead of `react/jsx-runtime`)               