### PR TITLE
fix: avoid destructure lowering for newer safari

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -241,6 +241,78 @@ describe('resolveEsbuildTranspileOptions', () => {
       },
     })
   })
+
+  describe('destructuring workaround for safari/ios (esbuild#4436)', () => {
+    const workaroundNeededTargets = [
+      'safari10',
+      'safari12.1',
+      'safari14.0',
+      'ios10',
+      'ios12.2',
+      'ios14',
+      'ios14.4',
+      ['chrome87', 'safari14'],
+    ]
+    const workaroundNotNeededTargets = [
+      'safari9',
+      'safari14.1',
+      'safari14.2',
+      'safari15',
+      'safari16',
+      'ios9',
+      'ios14.5',
+      'ios15',
+      'es2020',
+      'chrome87',
+    ]
+
+    test('sets supported.destructuring=true for necessary targets', () => {
+      for (const target of workaroundNeededTargets) {
+        const options = resolveEsbuildTranspileOptions(
+          defineResolvedConfig({
+            build: { target, minify: false },
+          }),
+          'es',
+        )
+        expect(options?.supported).toStrictEqual(
+          expect.objectContaining({
+            destructuring: true,
+          }),
+        )
+      }
+    })
+
+    test('does not set supported.destructuring=true for unnecessary targets', () => {
+      for (const target of workaroundNotNeededTargets) {
+        const options = resolveEsbuildTranspileOptions(
+          defineResolvedConfig({
+            build: { target, minify: false },
+          }),
+          'es',
+        )
+        expect(options?.supported).toStrictEqual(
+          expect.not.objectContaining({
+            destructuring: true,
+          }),
+        )
+      }
+    })
+
+    test('user override wins over auto-set destructuring', () => {
+      const options = resolveEsbuildTranspileOptions(
+        defineResolvedConfig({
+          build: { target: 'safari14', minify: false },
+          esbuild: { supported: { destructuring: false } },
+        }),
+        'es',
+      )
+      expect(options?.supported).toEqual({
+        'dynamic-import': true,
+        'import-meta': true,
+        destructuring: false,
+      })
+    })
+  })
 })
 
 describe('transformWithEsbuild', () => {

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -384,6 +384,35 @@ export const buildEsbuildPlugin = (): Plugin => {
   }
 }
 
+const destructuringBugRE = /^(safari|ios)(\d+)(?:\.(\d+))?$/
+
+// Workaround for https://github.com/evanw/esbuild/issues/4436
+// Safari 10 through 14.1 and ios 10 through 14.5 have a bug related to destructuring.
+// So esbuild 0.27.7+ treats those browsers as not supporting destructuring.
+// However, because esbuild does not support lowering destructuring, it errors when it encounters it.
+// Since it was not lowered in old Vite versions, we set `destructuring: true` to revert to the old behavior.
+// This means the end users using those Safari versions will encounter the bug,
+// but at least it won't cause a complete build failure.
+// If the user wants to avoid that, they can use Vite v8 + plugin-legacy.
+function needsDestructuringSupportedWorkaround(
+  target: string | string[] | false | undefined,
+): boolean {
+  if (!target) return false
+  const targets = Array.isArray(target) ? target : [target]
+  for (const t of targets) {
+    const match = destructuringBugRE.exec(t)
+    if (!match) continue
+    const major = Number(match[2])
+    if (major < 10) continue
+    if (major < 14) return true
+    if (major > 14) continue
+    const minor = match[3] ? Number(match[3]) : 0
+    const requiredMinor = match[1] === 'safari' ? 1 : 5
+    if (minor < requiredMinor) return true
+  }
+  return false
+}
+
 export function resolveEsbuildTranspileOptions(
   config: ResolvedConfig,
   format: InternalModuleFormat,
@@ -408,6 +437,9 @@ export function resolveEsbuildTranspileOptions(
     format: rollupToEsbuildFormatMap[format],
     supported: {
       ...defaultEsbuildSupported,
+      ...(needsDestructuringSupportedWorkaround(target)
+        ? { destructuring: true }
+        : null),
       ...esbuildOptions.supported,
     },
   }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -387,7 +387,7 @@ export const buildEsbuildPlugin = (): Plugin => {
 const destructuringBugRE = /^(safari|ios)(\d+)(?:\.(\d+))?$/
 
 // Workaround for https://github.com/evanw/esbuild/issues/4436
-// Safari 10 through 14.1 and ios 10 through 14.5 have a bug related to destructuring.
+// Safari 10 through 14.0.x and ios 10 through 14.4 have a bug related to destructuring.
 // So esbuild 0.27.7+ treats those browsers as not supporting destructuring.
 // However, because esbuild does not support lowering destructuring, it errors when it encounters it.
 // Since it was not lowered in old Vite versions, we set `destructuring: true` to revert to the old behavior.


### PR DESCRIPTION
close #22225

If Safari 10 - 14.1 or iOS 10 - 14.5 is specified to `build.target`, set `supported.destructuring: true` so that we restore the behavior of esbuild before v0.27.7.
This means if the user wants to avoid the safari bug described in https://github.com/evanw/esbuild/issues/4436, they would need to use Vite v8 + plugin-legacy.
