### PR TITLE
docs(create-vite): list react-compiler templates in README

### DIFF
--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -63,7 +63,9 @@ Currently supported template presets include:
 - `vue`
 - `vue-ts`
 - `react`
+- `react-compiler`
 - `react-ts`
+- `react-compiler-ts`
 - `preact`
 - `preact-ts`
 - `lit`


### PR DESCRIPTION
## Summary

Add the `react-compiler` and `react-compiler-ts` presets to the `create-vite` README template list.

## Problem

`create-vite` already supports these React Compiler templates and shows them in `create-vite --help`, but the README template list did not include them.

## Fix

Update `packages/create-vite/README.md` so the documented preset list matches the supported template variants.

## Verification

- `pnpm vitest run packages/create-vite/__tests__/cli.spec.ts -t "return help usage"`