### PR TITLE
docs: mention native config loader in CLI options

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -48,30 +48,30 @@ vite build [root]
 
 #### Options
 
-| Options                        |                                                                                                                          |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
-| `--target <target>`            | Transpile target (default: `"baseline-widely-available"`) (`string`)                                                     |
-| `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                            |
-| `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                               |
-| `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                               |
-| `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                               |
-| `--sourcemap [output]`         | Output source maps for build (default: `false`) (`boolean \| "inline" \| "hidden"`)                                      |
-| `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"oxc"`) (`boolean \| "oxc" \| "terser" \| "esbuild"`) |
-| `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                           |
-| `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                             |
-| `--emptyOutDir`                | Force empty outDir when it's outside of root (`boolean`)                                                                 |
-| `-w, --watch`                  | Rebuilds when modules have changed on disk (`boolean`)                                                                   |
-| `-c, --config <file>`          | Use specified config file (`string`)                                                                                     |
-| `--base <path>`                | Public base path (default: `/`) (`string`)                                                                               |
-| `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                               |
-| `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                      |
-| `--configLoader <loader>`      | Use `bundle` to bundle the config with Rolldown or `runner` (experimental) to process it on the fly (default: `bundle`)  |
-| `--profile`                    | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))       |
-| `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                                    |
-| `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                             |
-| `-m, --mode <mode>`            | Set env mode (`string`)                                                                                                  |
-| `-h, --help`                   | Display available CLI options                                                                                            |
-| `--app`                        | Build all environments, same as `builder: {}` (`boolean`, experimental)                                                  |
+| Options                        |                                                                                                                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--target <target>`            | Transpile target (default: `"baseline-widely-available"`) (`string`)                                                                                                                  |
+| `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                                                                                         |
+| `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                                                                                            |
+| `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                                                                                            |
+| `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                                                                                            |
+| `--sourcemap [output]`         | Output source maps for build (default: `false`) (`boolean \| "inline" \| "hidden"`)                                                                                                   |
+| `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"oxc"`) (`boolean \| "oxc" \| "terser" \| "esbuild"`)                                                              |
+| `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                                                                                        |
+| `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                                                                                          |
+| `--emptyOutDir`                | Force empty outDir when it's outside of root (`boolean`)                                                                                                                              |
+| `-w, --watch`                  | Rebuilds when modules have changed on disk (`boolean`)                                                                                                                                |
+| `-c, --config <file>`          | Use specified config file (`string`)                                                                                                                                                  |
+| `--base <path>`                | Public base path (default: `/`) (`string`)                                                                                                                                            |
+| `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                                                                                            |
+| `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                                                                                   |
+| `--configLoader <loader>`      | Use `bundle` to bundle the config with Rolldown, or `runner` (experimental) to process it on the fly, or `native` (experimental) to load using the native runtime (default: `bundle`) |
+| `--profile`                    | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))                                                                    |
+| `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                                                                                                 |
+| `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                                                                                          |
+| `-m, --mode <mode>`            | Set env mode (`string`)                                                                                                                                                               |
+| `-h, --help`                   | Display available CLI options                                                                                                                                                         |
+| `--app`                        | Build all environments, same as `builder: {}` (`boolean`, experimental)                                                                                                               |
 
 ## Others
 
@@ -89,18 +89,18 @@ vite optimize [root]
 
 #### Options
 
-| Options                   |                                                                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--force`                 | Force the optimizer to ignore the cache and re-bundle (`boolean`)                                                       |
-| `-c, --config <file>`     | Use specified config file (`string`)                                                                                    |
-| `--base <path>`           | Public base path (default: `/`) (`string`)                                                                              |
-| `-l, --logLevel <level>`  | Info \| warn \| error \| silent (`string`)                                                                              |
-| `--clearScreen`           | Allow/disable clear screen when logging (`boolean`)                                                                     |
-| `--configLoader <loader>` | Use `bundle` to bundle the config with Rolldown or `runner` (experimental) to process it on the fly (default: `bundle`) |
-| `-d, --debug [feat]`      | Show debug logs (`string \| boolean`)                                                                                   |
-| `-f, --filter <filter>`   | Filter debug logs (`string`)                                                                                            |
-| `-m, --mode <mode>`       | Set env mode (`string`)                                                                                                 |
-| `-h, --help`              | Display available CLI options                                                                                           |
+| Options                   |                                                                                                                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--force`                 | Force the optimizer to ignore the cache and re-bundle (`boolean`)                                                                                                                     |
+| `-c, --config <file>`     | Use specified config file (`string`)                                                                                                                                                  |
+| `--base <path>`           | Public base path (default: `/`) (`string`)                                                                                                                                            |
+| `-l, --logLevel <level>`  | Info \| warn \| error \| silent (`string`)                                                                                                                                            |
+| `--clearScreen`           | Allow/disable clear screen when logging (`boolean`)                                                                                                                                   |
+| `--configLoader <loader>` | Use `bundle` to bundle the config with Rolldown, or `runner` (experimental) to process it on the fly, or `native` (experimental) to load using the native runtime (default: `bundle`) |
+| `-d, --debug [feat]`      | Show debug logs (`string \| boolean`)                                                                                                                                                 |
+| `-f, --filter <filter>`   | Filter debug logs (`string`)                                                                                                                                                          |
+| `-m, --mode <mode>`       | Set env mode (`string`)                                                                                                                                                               |
+| `-h, --help`              | Display available CLI options                                                                                                                                                         |
 
 ### `vite preview`
 
@@ -116,19 +116,19 @@ vite preview [root]
 
 #### Options
 
-| Options                   |                                                                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--host [host]`           | Specify hostname (`string`)                                                                                             |
-| `--port <port>`           | Specify port (`number`)                                                                                                 |
-| `--strictPort`            | Exit if specified port is already in use (`boolean`)                                                                    |
-| `--open [path]`           | Open browser on startup (`boolean \| string`)                                                                           |
-| `--outDir <dir>`          | Output directory (default: `dist`)(`string`)                                                                            |
-| `-c, --config <file>`     | Use specified config file (`string`)                                                                                    |
-| `--base <path>`           | Public base path (default: `/`) (`string`)                                                                              |
-| `-l, --logLevel <level>`  | Info \| warn \| error \| silent (`string`)                                                                              |
-| `--clearScreen`           | Allow/disable clear screen when logging (`boolean`)                                                                     |
-| `--configLoader <loader>` | Use `bundle` to bundle the config with Rolldown or `runner` (experimental) to process it on the fly (default: `bundle`) |
-| `-d, --debug [feat]`      | Show debug logs (`string \| boolean`)                                                                                   |
-| `-f, --filter <filter>`   | Filter debug logs (`string`)                                                                                            |
-| `-m, --mode <mode>`       | Set env mode (`string`)                                                                                                 |
-| `-h, --help`              | Display available CLI options                                                                                           |
+| Options                   |                                                                                                                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--host [host]`           | Specify hostname (`string`)                                                                                                                                                           |
+| `--port <port>`           | Specify port (`number`)                                                                                                                                                               |
+| `--strictPort`            | Exit if specified port is already in use (`boolean`)                                                                                                                                  |
+| `--open [path]`           | Open browser on startup (`boolean \| string`)                                                                                                                                         |
+| `--outDir <dir>`          | Output directory (default: `dist`)(`string`)                                                                                                                                          |
+| `-c, --config <file>`     | Use specified config file (`string`)                                                                                                                                                  |
+| `--base <path>`           | Public base path (default: `/`) (`string`)                                                                                                                                            |
+| `-l, --logLevel <level>`  | Info \| warn \| error \| silent (`string`)                                                                                                                                            |
+| `--clearScreen`           | Allow/disable clear screen when logging (`boolean`)                                                                                                                                   |
+| `--configLoader <loader>` | Use `bundle` to bundle the config with Rolldown, or `runner` (experimental) to process it on the fly, or `native` (experimental) to load using the native runtime (default: `bundle`) |
+| `-d, --debug [feat]`      | Show debug logs (`string \| boolean`)                                                                                                                                                 |
+| `-f, --filter <filter>`   | Filter debug logs (`string`)                                                                                                                                                          |
+| `-m, --mode <mode>`       | Set env mode (`string`)                                                                                                                                                               |
+| `-h, --help`              | Display available CLI options                                                                                                                                                         |


### PR DESCRIPTION
## Summary

Document `native` as a supported value for `--configLoader` in the CLI guide.

## Problem

The global CLI help already lists `native` as an experimental config loader option, but the `vite build`, `vite optimize`, and `vite preview` CLI guide entries only mentioned `bundle` and `runner`.

## Fix

Update the `--configLoader <loader>` rows in `docs/guide/cli.md` to include `native` and describe it as loading config through the native runtime.

## Verification

- `pnpm exec oxfmt --check docs/guide/cli.md`