### PR TITLE
fix(importMetaGlob): throw early for relative glob patterns in virtual modules

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -448,9 +448,7 @@ export async function transformGlobImport(
           onlyValues,
         }) => {
           if (!dir && isRelative && !options.base) {
-            throw new Error(
-              "In virtual modules, all globs must start with '/'",
-            )
+            throw new Error("In virtual modules, all globs must start with '/'")
           }
           const cwd = getCommonBase(globsResolved) ?? root
           const files = (

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -447,6 +447,11 @@ export async function transformGlobImport(
           onlyKeys,
           onlyValues,
         }) => {
+          if (!dir && isRelative && !options.base) {
+            throw new Error(
+              "In virtual modules, all globs must start with '/'",
+            )
+          }
           const cwd = getCommonBase(globsResolved) ?? root
           const files = (
             await glob(globsResolved, {


### PR DESCRIPTION
Fixes #22345.

## Problem

When a plugin produces a virtual module that calls `import.meta.glob` with a relative pattern (e.g. `'./*.js'`), Vite silently returns `{}` instead of throwing the documented error:

> In virtual modules, all globs must start with '/'

The existing check inside `resolvePaths` is only reached when matched files are iterated. If the relative pattern matches no files (or matches files that are then filtered out), `resolvePaths` is never called — so the error is never thrown and the caller gets an empty object with no diagnostic.

**Minimal repro:**
```js
// vite plugin
load(id) {
  if (id === '\0foo') return `export default import.meta.glob('./*.js')`
}
```
`modules` is `{}` with no warning or error logged.

## Fix

Add an early guard immediately before the `glob()` call. If the module is virtual (`!dir`), the pattern is relative (`isRelative`), and no `base` option is set, throw the same error message that already exists further down in `resolvePaths`. This ensures the user gets a clear diagnostic regardless of whether any files happen to match the broken pattern.