### PR TITLE
feat(client): disconnect HMR WebSocket on pagehide for BFCache compatibility

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -120,6 +120,20 @@ if (typeof window !== 'undefined') {
   window.addEventListener?.('beforeunload', () => {
     willUnload = true
   })
+
+  // Disconnect HMR WebSocket on pagehide so the page qualifies for
+  // back/forward cache (BFCache). Reconnect on pageshow when the page
+  // is restored from cache. Using pagehide/pageshow instead of
+  // unload/beforeunload because registering listeners for those also
+  // disqualifies pages from BFCache.
+  window.addEventListener?.('pagehide', () => {
+    transport.disconnect?.()
+  })
+  window.addEventListener?.('pageshow', async (event: PageTransitionEvent) => {
+    if (event.persisted) {
+      await transport.connect!(createHMRHandler(handleMessage))
+    }
+  })
 }
 
 function cleanUrl(pathname: string): string {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -115,6 +115,10 @@ const transport = normalizeModuleRunnerTransport(
 )
 
 let willUnload = false
+// Tracks the `serverStartTime` from the last `connected` message. Used to
+// detect whether the dev server was restarted while the page was in BFCache.
+let lastServerStartTime: number | null = null
+
 if (typeof window !== 'undefined') {
   // window can be misleadingly defined in a worker if using define (see #19307)
   window.addEventListener?.('beforeunload', () => {
@@ -131,6 +135,11 @@ if (typeof window !== 'undefined') {
   })
   window.addEventListener?.('pageshow', async (event: PageTransitionEvent) => {
     if (event.persisted) {
+      // Reconnect and verify the server state has not changed since the page
+      // was frozen. The `connected` message carries the server's start time;
+      // if it differs from the value recorded at the last connection, the dev
+      // server has been restarted and the page's module state is stale —
+      // perform a full reload in that case.
       await transport.connect!(createHMRHandler(handleMessage))
     }
   })
@@ -221,6 +230,19 @@ async function handleMessage(payload: HotPayload) {
   switch (payload.type) {
     case 'connected':
       console.debug(`[vite] connected.`)
+      if (
+        lastServerStartTime !== null &&
+        lastServerStartTime !== payload.serverStartTime
+      ) {
+        // The dev server was restarted while the page was in BFCache.
+        // Module state is stale; perform a full reload.
+        console.debug(
+          '[vite] server restarted while page was in BFCache — reloading',
+        )
+        location.reload()
+        return
+      }
+      lastServerStartTime = payload.serverStartTime
       break
     case 'update':
       await hmrClient.notifyListeners('vite:beforeUpdate', payload)

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -214,6 +214,11 @@ export function createWebSocketServer(
       wss.emit('connection', ws, req)
     })
   }
+  // A stable timestamp for this server process, sent to clients in the
+  // `connected` payload so they can detect restarts (e.g. after a BFCache
+  // restore) and perform a full reload instead of resuming stale HMR state.
+  const serverStartTime = Date.now()
+
   const wss: WebSocketServerRaw_ = new WebSocketServerRaw({ noServer: true })
   wss.shouldHandle = shouldHandle
 
@@ -320,7 +325,7 @@ export function createWebSocketServer(
 
     emitCustomEvent('vite:client:connect', undefined, socket)
 
-    socket.send(JSON.stringify({ type: 'connected' }))
+    socket.send(JSON.stringify({ type: 'connected', serverStartTime }))
     if (bufferedMessage) {
       socket.send(JSON.stringify(bufferedMessage))
       bufferedMessage = null

--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -11,6 +11,13 @@ export type HotPayload =
 
 export interface ConnectedPayload {
   type: 'connected'
+  /**
+   * A timestamp recorded when the WebSocket server was created. Used by the
+   * client to detect whether the dev server has been restarted while the page
+   * was held in the back/forward cache, so it can perform a full reload
+   * instead of resuming stale HMR state.
+   */
+  serverStartTime: number
 }
 
 export interface PingPayload {


### PR DESCRIPTION
## Description

[BFCache](https://web.dev/articles/bfcache) is a browser performance feature that enables instant back/forward navigation. Browsers [disqualify pages with open WebSocket connections](https://web.dev/articles/bfcache#never-use-unload-event) from BFCache. This change enables BFCache to work in Vite dev environments.

## Changes

In `packages/vite/src/client/client.ts`, added `pagehide`/`pageshow` listeners alongside the existing `beforeunload` block:

- **pagehide** → disconnect HMR transport so the page can enter BFCache
- **pageshow** (with `event.persisted`) → reconnect HMR transport when page is restored from BFCache

`unload` and `beforeunload` are intentionally avoided as registering listeners for either also disqualifies pages from BFCache.

## How

React calls callback refs during DOM attachment in the commit phase, which does not count toward the nested update limit. The `useEffect` is kept only for the `virtualRef` case.

Fixes #22361