### PR TITLE
fix(html): emit external inline entries as imports (fix #20053)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -278,6 +278,47 @@ describe('build', () => {
     ) as OutputChunk
     expect(foo.code).not.contains('import "external"')
   })
+
+  test('externalized module should not be inlined as bare-specifier script src in html (#20053)', async () => {
+    const result = (await build({
+      root: resolve(dirname, 'packages/build-project'),
+      logLevel: 'silent',
+      build: {
+        write: false,
+        modulePreload: { polyfill: false },
+      },
+      plugins: [
+        {
+          name: 'test',
+          resolveId: {
+            order: 'pre',
+            handler(id) {
+              if (id === 'entry.js') return '\0entry.js'
+              if (id === '@external/lib/foo.js') return false
+            },
+          },
+          load(id) {
+            if (id === '\0entry.js') {
+              return `import '@external/lib/foo.js'`
+            }
+          },
+        },
+      ],
+    })) as RolldownOutput
+
+    const html = result.output.find(
+      (o) => o.type === 'asset' && o.fileName === 'index.html',
+    ) as { source: string } | undefined
+    expect(html).toBeTruthy()
+    // The externalized module must not be emitted as a bare-specifier script
+    // `src` (which is invalid in browsers and breaks at runtime). It should
+    // instead be preserved via an inline `import` statement so an importmap
+    // can resolve it.
+    expect(html!.source).not.toMatch(
+      /<script[^>]+src=["']@external\/lib\/foo\.js["']/,
+    )
+    expect(html!.source).toContain('import "@external/lib/foo.js"')
+  })
 })
 
 const baseLibOptions: LibraryOptions = {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -838,24 +838,39 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         chunkOrUrl: OutputChunk | string,
         toOutputPath: (filename: string) => string,
         isAsync: boolean,
-      ): HtmlTagDescriptor => ({
-        tag: 'script',
-        attrs: {
-          ...(isAsync ? { async: true } : {}),
-          type: 'module',
-          // crossorigin must be set not only for serving assets in a different origin
-          // but also to make it possible to preload the script using `<link rel="preload">`.
-          // `<script type="module">` used to fetch the script with credential mode `omit`,
-          // however `crossorigin` attribute cannot specify that value.
-          // https://developer.chrome.com/blog/modulepreload/#ok-so-why-doesnt-link-relpreload-work-for-modules:~:text=For%20%3Cscript%3E,of%20other%20modules.
-          // Now `<script type="module">` uses `same origin`: https://github.com/whatwg/html/pull/3656#:~:text=Module%20scripts%20are%20always%20fetched%20with%20credentials%20mode%20%22same%2Dorigin%22%20by%20default%20and%20can%20no%20longer%0Ause%20%22omit%22
-          crossorigin: true,
-          src:
-            typeof chunkOrUrl === 'string'
-              ? chunkOrUrl
-              : toOutputPath(chunkOrUrl.fileName),
-        },
-      })
+      ): HtmlTagDescriptor => {
+        // External imports surfaced from `getImportedChunks` may be bare
+        // specifiers (e.g. resolved by an importmap). Bare specifiers are not
+        // valid as a script `src`, so emit an inline `import` statement
+        // instead so the browser/importmap resolves them. URL-like externals
+        // are also routed through an inline import for consistency.
+        if (typeof chunkOrUrl === 'string') {
+          return {
+            tag: 'script',
+            attrs: {
+              ...(isAsync ? { async: true } : {}),
+              type: 'module',
+              crossorigin: true,
+            },
+            children: `import ${JSON.stringify(chunkOrUrl)}`,
+          }
+        }
+        return {
+          tag: 'script',
+          attrs: {
+            ...(isAsync ? { async: true } : {}),
+            type: 'module',
+            // crossorigin must be set not only for serving assets in a different origin
+            // but also to make it possible to preload the script using `<link rel="preload">`.
+            // `<script type="module">` used to fetch the script with credential mode `omit`,
+            // however `crossorigin` attribute cannot specify that value.
+            // https://developer.chrome.com/blog/modulepreload/#ok-so-why-doesnt-link-relpreload-work-for-modules:~:text=For%20%3Cscript%3E,of%20other%20modules.
+            // Now `<script type="module">` uses `same origin`: https://github.com/whatwg/html/pull/3656#:~:text=Module%20scripts%20are%20always%20fetched%20with%20credentials%20mode%20%22same%2Dorigin%22%20by%20default%20and%20can%20no%20longer%0Ause%20%22omit%22
+            crossorigin: true,
+            src: toOutputPath(chunkOrUrl.fileName),
+          },
+        }
+      }
 
       const toPreloadTag = (
         filename: string,


### PR DESCRIPTION
## Description

When an HTML entry chunk is inlinable (`canInlineEntry === true` in `packages/vite/src/node/plugins/html.ts`), `toScriptTag` was emitting externalized imports as `<script src="<bare-specifier>">`. Bare specifiers are not legal as a script `src` — importmaps only resolve specifiers inside `import` statements — so the produced HTML errored at runtime when external dependencies were declared via `build.rollupOptions.external`.

This PR changes the inline path so that, when `chunkOrUrl` is a string (i.e. an externalized import), it emits a module script that imports the specifier instead of an unresolvable `<script src>`. The `OutputChunk` branch is unchanged. The non-inline branch already filters strings out of modulepreload, so only the inline path produced bad markup.

**Before:**

```html
<script type="module" crossorigin src="@external/lib/foo.js"></script>
```

**After:**

```html
<script type="module" crossorigin>import "@external/lib/foo.js"</script>
```

fixes #20053

## Alternatives considered

- Skipping externalized imports entirely on the inline path — rejected, since the user expects the external dependency to be loaded (it must reach the browser via an importmap or similar).
- Resolving the specifier to a URL at build time — rejected, since externals are intentionally left for the runtime/importmap to resolve.

## What is the purpose of this pull request?

- [ ] Documentation update
- [x] Bug fix
- [ ] New Feature
- [ ] Other

## Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#git-commit-message-convention).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

## Testing

A regression test was added in `packages/vite/src/node/__tests__/build.spec.ts` that asserts the inline HTML emits an `import` statement (not a `<script src>`) for externalized entry imports. The test fails on the unfixed `html.ts` and passes with this change.

Local validation:

- `pnpm --filter vite run build` — passing
- `pnpm run test-unit` — 780 passed, 4 skipped (incl. new test)
- `pnpm run test-build playground/html` — 54 passed, 8 skipped
- `pnpm run test-serve playground/html` — 54 passed, 8 skipped
- `pnpm run typecheck` — passing
- `pnpm run lint` — passing (only a pre-existing parse error in `playground/preserve-symlinks/module-a/linked.js`, unrelated to this change)
