### PR TITLE
fix(build): preserve rolldownOptions proxy (fix #22033)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -891,6 +891,41 @@ test.for([true, false])(
   },
 )
 
+// https://github.com/vitejs/vite/issues/22033
+test('runtime mutations of rolldownOptions are reflected on rollupOptions', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/minify')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    configFile: false,
+    environments: {
+      client: {
+        build: {
+          write: false,
+          outDir: './dist/client',
+        },
+      },
+    },
+  })
+
+  // Reassign the whole `rolldownOptions` object after config resolution. This
+  // mirrors how plugins/builders set the input at runtime. Without the proxy
+  // being re-installed on the resolved build options, the client environment
+  // would fall back to looking up `index.html`.
+  builder.environments.client.config.build.rolldownOptions = {
+    input: '/entry.js',
+  }
+
+  expect(builder.environments.client.config.build.rollupOptions.input).toBe(
+    '/entry.js',
+  )
+
+  const result = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+  expect(result.output[0].fileName).toMatch(/entry-[-\w]+\.js$/)
+})
+
 test('sharedConfigBuild and emitAssets', async () => {
   const root = resolve(dirname, 'fixtures/shared-config-build/emitAssets')
   const builder = await createBuilder({

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -498,6 +498,12 @@ export function resolveBuildEnvironmentOptions(
               ...merged.modulePreload,
             },
   }
+  // Spreading `merged` above turns the `rollupOptions` getter installed by
+  // `setupRollupOptionCompat` into a plain data property on `resolved`. Re-install
+  // the proxy so that runtime mutations of either `rolldownOptions` or
+  // `rollupOptions` (e.g. `builder.environments.<name>.config.build.rolldownOptions = {...}`)
+  // stay in sync. See https://github.com/vitejs/vite/issues/22033.
+  setupRollupOptionCompat(resolved, 'build')
 
   return resolved
 }


### PR DESCRIPTION
### Description

Fixes #22033.

When a builder (or plugin) reassigns the whole `build.rolldownOptions` object on a resolved environment config, the resulting build ignores the new `input` and falls back to `index.html`, producing a chunk named `index-*.js` instead of `entry-*.js`.

**Root cause.** `resolveBuildEnvironmentOptions` in `packages/vite/src/node/build.ts` installs a getter/setter proxy via `setupRollupOptionCompat(merged, 'build')` so that `rollupOptions` and `rolldownOptions` stay in sync. The next step builds `resolved` with `{ ...merged, ... }`. The spread invokes the getter and copies the *current value* as a plain data property, so `resolved.rollupOptions` and `resolved.rolldownOptions` become two independent properties that happen to point at the same object. Once a consumer replaces the whole `rolldownOptions`, `rollupOptions` keeps the stale reference; `resolveRolldownOptions` then reads `options.rollupOptions.input` (still `undefined`) and falls back to `index.html`.

This is why earlier attempts (#22034, #22051) didn't catch it — they didn't identify the proxy-breaking spread.

**Fix.** Re-install the proxy on `resolved` after the spread by calling `setupRollupOptionCompat(resolved, 'build')` again. Six lines of change including a comment that points at #22033.

### Alternatives explored

- Replacing the spread with manual property assignment: more invasive and easy to regress on future refactors.
- Eagerly reading both fields before the spread and copying both: doesn't fix the underlying problem (later reassignment of one field still desyncs the other).
- Re-installing the proxy after the spread (this PR): minimal and matches the existing setup pattern.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

### Testing

- Added regression test in `packages/vite/src/node/__tests__/build.spec.ts` that:
  1. Resolves the client environment config,
  2. Reassigns the whole `rolldownOptions` to `{ input: '/entry.js' }`,
  3. Asserts the proxy mirrors the change to `rollupOptions.input`,
  4. Runs the build and asserts the output chunk filename is `entry-*.js` (not `index-*.js`, which would mean a fallback to `index.html`).

  Verified failing before the fix and passing after.

- `pnpm run test-unit` — full suite passes (780 passed, 4 skipped, includes the new test).
- `pnpm run typecheck` — passes.
- `pnpm run build` — passes.
- `pnpm run lint` — clean apart from a pre-existing parse error in `playground/preserve-symlinks/module-a/linked.js`, which is unrelated to this change.
