### PR TITLE
fix(html): skip html comments in tag injection (fix #18386)

### DIFF
--- a/packages/vite/src/node/__tests__/html.spec.ts
+++ b/packages/vite/src/node/__tests__/html.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import type { OutputBundle, OutputChunk } from 'rolldown'
-import { getCssFilesForChunk } from '../plugins/html'
+import {
+  getCssFilesForChunk,
+  injectToBody,
+  injectToHead,
+} from '../plugins/html'
 
 function createChunk(
   fileName: string,
@@ -238,5 +242,120 @@ describe('getCssFilesForChunk', () => {
       'b.css',
       'a.css',
     ])
+  })
+})
+
+describe('injectToHead/injectToBody (#18386: skip HTML comments)', () => {
+  const scriptTag = {
+    tag: 'script',
+    attrs: { type: 'module', src: '/@vite/client' },
+  }
+
+  test('injectToHead injects after the real <head>, not one inside a comment', () => {
+    const html = [
+      '<!-- <!DOCTYPE html>',
+      '<html lang="en">',
+      '  <head>',
+      '    <title>old</title>',
+      '  </head>',
+      '  <body></body>',
+      '</html> -->',
+      '<!DOCTYPE html>',
+      '<html lang="en">',
+      '  <head>',
+      '    <title>real</title>',
+      '  </head>',
+      '  <body></body>',
+      '</html>',
+    ].join('\n')
+
+    const out = injectToHead(html, [scriptTag], true)
+
+    // The injected script must not be placed inside the leading comment
+    const commentEnd = out.indexOf('-->')
+    const injected = out.indexOf('/@vite/client')
+    expect(injected).toBeGreaterThan(commentEnd)
+    // And it must be inside the real head (before </head> of the real document)
+    const realHeadOpen = out.indexOf('<head>', commentEnd)
+    const realHeadClose = out.indexOf('</head>', realHeadOpen)
+    expect(injected).toBeGreaterThan(realHeadOpen)
+    expect(injected).toBeLessThan(realHeadClose)
+    // The original commented document should remain unchanged
+    expect(out).toContain(
+      '<!-- <!DOCTYPE html>\n<html lang="en">\n  <head>\n    <title>old</title>\n  </head>\n  <body></body>\n</html> -->',
+    )
+  })
+
+  test('injectToHead (append) injects before the real </head>, not one inside a comment', () => {
+    const html = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '  <head>',
+      '    <!-- legacy </head> reference inside a comment -->',
+      '    <title>real</title>',
+      '  </head>',
+      '  <body></body>',
+      '</html>',
+    ].join('\n')
+
+    const out = injectToHead(html, [scriptTag])
+
+    const commentStart = out.indexOf('<!--')
+    const commentEnd = out.indexOf('-->', commentStart)
+    const injected = out.indexOf('/@vite/client')
+    // Injected tag must not land inside the comment
+    expect(injected < commentStart || injected > commentEnd).toBe(true)
+    // Injected tag must be just before the real </head>
+    const realHeadClose = out.lastIndexOf('</head>')
+    expect(injected).toBeLessThan(realHeadClose)
+  })
+
+  test('injectToBody injects before the real </body>, not one inside a comment', () => {
+    const html = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '  <head></head>',
+      '  <body>',
+      '    <!-- prior layout had </body> here -->',
+      '    <div id="root"></div>',
+      '  </body>',
+      '</html>',
+    ].join('\n')
+
+    const out = injectToBody(html, [scriptTag])
+
+    const commentStart = out.indexOf('<!--')
+    const commentEnd = out.indexOf('-->', commentStart)
+    const injected = out.indexOf('/@vite/client')
+    expect(injected < commentStart || injected > commentEnd).toBe(true)
+    const realBodyClose = out.lastIndexOf('</body>')
+    expect(injected).toBeLessThan(realBodyClose)
+    // The original commented marker should still be present unchanged
+    expect(out).toContain('<!-- prior layout had </body> here -->')
+  })
+
+  test('injectToHead falls back to body when only commented head exists', () => {
+    const html = [
+      '<!DOCTYPE html>',
+      '<!-- <head></head> -->',
+      '<html>',
+      '  <body>',
+      '    <div id="root"></div>',
+      '  </body>',
+      '</html>',
+    ].join('\n')
+
+    const out = injectToHead(html, [scriptTag])
+
+    // Must not be injected inside the comment
+    const commentStart = out.indexOf('<!--')
+    const commentEnd = out.indexOf('-->', commentStart)
+    const injected = out.indexOf('/@vite/client')
+    expect(injected < commentStart || injected > commentEnd).toBe(true)
+    // Should land before the real <body>
+    const bodyOpen = out.indexOf('<body>')
+    expect(injected).toBeLessThan(bodyOpen)
+    // The comment itself remains intact
+    expect(out).toContain('<!-- <head></head> -->')
   })
 })

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1475,33 +1475,72 @@ const bodyPrependInjectRE = /([ \t]*)<body[^>]*>/i
 
 const doctypePrependInjectRE = /<!doctype html>/i
 
-function injectToHead(
+const htmlCommentRE = /<!--[\s\S]*?-->/g
+
+// Returns a copy of `html` with the contents of HTML comments replaced by
+// spaces of equal length so that match indices in the masked string map 1:1
+// to positions in the original. This lets us run the head/body/html injection
+// regexes without matching markers that appear inside comments (#18386).
+function maskHtmlComments(html: string): string {
+  return html.replace(htmlCommentRE, (m) => ' '.repeat(m.length))
+}
+
+function testOutsideComments(html: string, re: RegExp): boolean {
+  return re.test(maskHtmlComments(html))
+}
+
+function replaceFirstOutsideComments(
+  html: string,
+  re: RegExp,
+  replacement: string | ((substring: string, ...args: any[]) => string),
+): string {
+  const masked = maskHtmlComments(html)
+  const match = re.exec(masked)
+  if (!match) return html
+  const start = match.index
+  const matched = match[0]
+  const end = start + matched.length
+  let replaced: string
+  if (typeof replacement === 'function') {
+    replaced = replacement(matched, ...match.slice(1))
+  } else {
+    // Delegate to String.prototype.replace on the matched span so that
+    // replacement-string semantics (e.g. `$&`, `$1`) are preserved.
+    replaced = matched.replace(re, replacement)
+  }
+  return html.slice(0, start) + replaced + html.slice(end)
+}
+
+export function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],
   prepend = false,
-) {
+): string {
   if (tags.length === 0) return html
 
   if (prepend) {
     // inject as the first element of head
-    if (headPrependInjectRE.test(html)) {
-      return html.replace(
+    if (testOutsideComments(html, headPrependInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
         headPrependInjectRE,
         (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`,
       )
     }
   } else {
     // inject before head close
-    if (headInjectRE.test(html)) {
+    if (testOutsideComments(html, headInjectRE)) {
       // respect indentation of head tag
-      return html.replace(
+      return replaceFirstOutsideComments(
+        html,
         headInjectRE,
         (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`,
       )
     }
     // try to inject before the body tag
-    if (bodyPrependInjectRE.test(html)) {
-      return html.replace(
+    if (testOutsideComments(html, bodyPrependInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
         bodyPrependInjectRE,
         (match, p1) => `${serializeTags(tags, p1)}\n${match}`,
       )
@@ -1511,24 +1550,26 @@ function injectToHead(
   return prependInjectFallback(html, tags)
 }
 
-function injectToBody(
+export function injectToBody(
   html: string,
   tags: HtmlTagDescriptor[],
   prepend = false,
-) {
+): string {
   if (tags.length === 0) return html
 
   if (prepend) {
     // inject after body open
-    if (bodyPrependInjectRE.test(html)) {
-      return html.replace(
+    if (testOutsideComments(html, bodyPrependInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
         bodyPrependInjectRE,
         (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`,
       )
     }
     // if no there is no body tag, inject after head or fallback to prepend in html
-    if (headInjectRE.test(html)) {
-      return html.replace(
+    if (testOutsideComments(html, headInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
         headInjectRE,
         (match, p1) => `${match}\n${serializeTags(tags, p1)}`,
       )
@@ -1536,15 +1577,20 @@ function injectToBody(
     return prependInjectFallback(html, tags)
   } else {
     // inject before body close
-    if (bodyInjectRE.test(html)) {
-      return html.replace(
+    if (testOutsideComments(html, bodyInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
         bodyInjectRE,
         (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`,
       )
     }
     // if no body tag is present, append to the html tag, or at the end of the file
-    if (htmlInjectRE.test(html)) {
-      return html.replace(htmlInjectRE, `${serializeTags(tags)}\n$&`)
+    if (testOutsideComments(html, htmlInjectRE)) {
+      return replaceFirstOutsideComments(
+        html,
+        htmlInjectRE,
+        `${serializeTags(tags)}\n$&`,
+      )
     }
     return html + `\n` + serializeTags(tags)
   }
@@ -1552,11 +1598,19 @@ function injectToBody(
 
 function prependInjectFallback(html: string, tags: HtmlTagDescriptor[]) {
   // prepend to the html tag, append after doctype, or the document start
-  if (htmlPrependInjectRE.test(html)) {
-    return html.replace(htmlPrependInjectRE, `$&\n${serializeTags(tags)}`)
+  if (testOutsideComments(html, htmlPrependInjectRE)) {
+    return replaceFirstOutsideComments(
+      html,
+      htmlPrependInjectRE,
+      `$&\n${serializeTags(tags)}`,
+    )
   }
-  if (doctypePrependInjectRE.test(html)) {
-    return html.replace(doctypePrependInjectRE, `$&\n${serializeTags(tags)}`)
+  if (testOutsideComments(html, doctypePrependInjectRE)) {
+    return replaceFirstOutsideComments(
+      html,
+      doctypePrependInjectRE,
+      `$&\n${serializeTags(tags)}`,
+    )
   }
   return serializeTags(tags) + html
 }


### PR DESCRIPTION
### Description

fixes #18386

When an HTML file begins with a commented-out HTML document (e.g. an old template kept as a reference at the top of the file), Vite was injecting `<script>` / CSS tags into the comment instead of into the real `<head>`. The injected assets were therefore never loaded and dev/build silently broke.

**Root cause:** the injection regexes in `packages/vite/src/node/plugins/html.ts` (`headInjectRE`, `headPrependInjectRE`, `bodyInjectRE`, `bodyPrependInjectRE`, `htmlInjectRE`, `htmlPrependInjectRE`, `doctypePrependInjectRE`) were applied directly to the raw HTML via `.test()` / `.replace()` and matched the *first* occurrence of markers like `<head>` or `</body>` — including markers that lived inside `<!-- ... -->`.

**Fix:** introduced a small helper `maskHtmlComments(html)` that replaces the contents of HTML comments with same-length spaces so byte indices stay aligned, plus `testOutsideComments` / `replaceFirstOutsideComments` wrappers. `injectToHead`, `injectToBody`, and `prependInjectFallback` now use these wrappers; the existing regexes themselves are unchanged. `injectToHead` and `injectToBody` are now `export`ed so the regression tests can exercise them directly (mirrors `getCssFilesForChunk`).

### What is the purpose of this pull request?

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other

### Additional context

**Alternatives considered:**
- *Strip comments outright before injecting.* Rejected — comments are part of the user's source and must round-trip through the pipeline unchanged. Masking only during the regex test/replace and replacing back into the original string preserves the original bytes.
- *Switch to a real HTML parser for injection.* Rejected for now as out-of-scope and a much larger change; the masking approach is minimal, surgical, and keeps the existing well-tested regex paths intact.

**Regression tests** (added in `packages/vite/src/node/__tests__/html.spec.ts`):
- leading commented-out HTML document — inject goes to the real `<head>`
- `</head>` inside a comment — inject still targets the real `</head>`
- `</body>` inside a comment — inject still targets the real `</body>`
- only-commented `<head>` plus a real `<body>` — exercises the `prependInjectFallback` path

Verified the bug shape against the reporter's exact HTML via a standalone repro before the fix; with the fix, an end-to-end Vite build of that HTML correctly injects into the real `<head>` and leaves the leading comment intact.

**Validation run locally:**
- `pnpm run typecheck` — pass
- `pnpm run test-unit` — 783 passed, 4 skipped (incl. the 4 new tests)
- `pnpm run test-build playground/html` — 54 passed, 8 skipped
- `pnpm run test-serve playground/html` — 54 passed, 8 skipped
- `pnpm run build` — pass
- `pnpm run lint` — pass (only a pre-existing parse error in `playground/preserve-symlinks/module-a/linked.js`, unrelated to this PR)

---

- [x] I have read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] I have searched and confirmed there is no other PR solving this the same way.
- [x] Documentation update is not required for this change.
- [x] Tests have been added that fail without this PR and pass with it.
