### PR TITLE
fix(module-runner): prevent partial-exports race on concurrent imports of in-flight invalidated re-export chains

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -133,37 +133,32 @@ export class ModuleRunner {
     return exports
   }
 
-  private isCircularModule(mod: EvaluatedModuleNode) {
-    for (const importedFile of mod.imports) {
-      if (mod.importers.has(importedFile)) {
-        return true
-      }
-    }
-    return false
-  }
-
-  private isCircularImport(
-    importers: Set<string>,
-    moduleUrl: string,
+  private isCircularRequest(
+    mod: EvaluatedModuleNode,
+    callstack: string[],
     visited = new Set<string>(),
-  ) {
-    for (const importer of importers) {
-      if (visited.has(importer)) {
-        continue
-      }
-      visited.add(importer)
-      if (importer === moduleUrl) {
+  ): boolean {
+    if (visited.has(mod.id)) {
+      return false
+    }
+    visited.add(mod.id)
+
+    for (const importedModuleId of mod.imports) {
+      if (callstack.includes(importedModuleId)) {
         return true
       }
-      const mod = this.evaluatedModules.getModuleById(importer)
+
+      const importedModule =
+        this.evaluatedModules.getModuleById(importedModuleId)
       if (
-        mod &&
-        mod.importers.size &&
-        this.isCircularImport(mod.importers, moduleUrl, visited)
+        importedModule?.promise &&
+        !importedModule.evaluated &&
+        this.isCircularRequest(importedModule, callstack, visited)
       ) {
         return true
       }
     }
+
     return false
   }
 
@@ -176,24 +171,23 @@ export class ModuleRunner {
     const meta = mod.meta!
     const moduleId = meta.id
 
-    const { importers } = mod
-
     const importee = callstack[callstack.length - 1]
 
-    if (importee) importers.add(importee)
+    if (importee) mod.importers.add(importee)
 
     // fast path: already evaluated modules can't deadlock
     if (mod.evaluated && mod.promise) {
       return this.processImport(await mod.promise, meta, metadata)
     }
 
-    // check circular dependency (only for modules still being evaluated)
-    if (
-      callstack.includes(moduleId) ||
-      this.isCircularModule(mod) ||
-      this.isCircularImport(importers, moduleId)
-    ) {
-      if (mod.exports) return this.processImport(mod.exports, meta, metadata)
+    if (mod.promise) {
+      if (
+        mod.exports &&
+        (callstack.includes(moduleId) || this.isCircularRequest(mod, callstack))
+      ) {
+        return this.processImport(mod.exports, meta, metadata)
+      }
+      return this.processImport(await mod.promise, meta, metadata)
     }
 
     let debugTimer: any
@@ -212,10 +206,6 @@ export class ModuleRunner {
     }
 
     try {
-      // cached module (in-progress, not yet evaluated)
-      if (mod.promise)
-        return this.processImport(await mod.promise, meta, metadata)
-
       const promise = this.directRequest(url, mod, callstack)
       mod.promise = promise
       mod.evaluated = false

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/core.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/core.js
@@ -1,0 +1,5 @@
+await globalThis.__vite_ssr_hmr_reexport_race__?.wait?.()
+
+export function createThing(value) {
+  return value
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/entry-a.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/entry-a.js
@@ -1,0 +1,5 @@
+import { createThing } from './shared.js'
+
+export const result = createThing('a')
+
+import.meta.hot?.accept()

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/entry-b.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/entry-b.js
@@ -1,0 +1,5 @@
+import { createThing } from './shared.js'
+
+export const result = createThing('b')
+
+import.meta.hot?.accept()

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/shared.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/hmr-reexport-race/shared.js
@@ -1,0 +1,3 @@
+import './entry-a.js'
+
+export * from './core.js'

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, onTestFinished } from 'vitest'
 import { createModuleRunnerTester } from './utils'
 
 describe(
@@ -45,6 +45,9 @@ describe(
       testGlobal.__vite_ssr_hmr_reexport_race__ = {
         wait: () => Promise.resolve(),
       }
+      onTestFinished(() => {
+        delete testGlobal.__vite_ssr_hmr_reexport_race__
+      })
 
       await runner.import('/fixtures/hmr-reexport-race/entry-a.js')
       await runner.import('/fixtures/hmr-reexport-race/entry-b.js')
@@ -129,8 +132,6 @@ describe(
       expect(hmrListeners.has('/fixtures/hmr-reexport-race/entry-b.js')).toBe(
         true,
       )
-
-      delete testGlobal.__vite_ssr_hmr_reexport_race__
     })
   },
   process.env.CI ? 50_00 : 5_000,

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-hmr.spec.ts
@@ -36,6 +36,102 @@ describe(
         expect(runner.hmrClient!.ctxToListenersMap.has(fixture)).toBe(true)
       }
     })
+
+    it('does not expose partial exports during concurrent updates', async ({
+      runner,
+    }) => {
+      const testGlobal = globalThis as any
+
+      testGlobal.__vite_ssr_hmr_reexport_race__ = {
+        wait: () => Promise.resolve(),
+      }
+
+      await runner.import('/fixtures/hmr-reexport-race/entry-a.js')
+      await runner.import('/fixtures/hmr-reexport-race/entry-b.js')
+
+      const sharedModule = runner.evaluatedModules.getModuleByUrl(
+        '/fixtures/hmr-reexport-race/shared.js',
+      )
+      const coreModule = runner.evaluatedModules.getModuleByUrl(
+        '/fixtures/hmr-reexport-race/core.js',
+      )
+      const entryAModule = runner.evaluatedModules.getModuleByUrl(
+        '/fixtures/hmr-reexport-race/entry-a.js',
+      )
+      const entryBModule = runner.evaluatedModules.getModuleByUrl(
+        '/fixtures/hmr-reexport-race/entry-b.js',
+      )
+      expect(sharedModule).toBeDefined()
+      expect(coreModule).toBeDefined()
+      expect(entryAModule).toBeDefined()
+      expect(entryBModule).toBeDefined()
+
+      let waitStarted!: () => void
+      const waitStartedPromise = new Promise<void>((resolve) => {
+        waitStarted = resolve
+      })
+      let releaseWait!: () => void
+      const waitPromise = new Promise<void>((resolve) => {
+        releaseWait = resolve
+      })
+
+      testGlobal.__vite_ssr_hmr_reexport_race__ = {
+        wait: () => {
+          waitStarted()
+          return waitPromise
+        },
+      }
+
+      for (const module of [
+        entryAModule!,
+        entryBModule!,
+        sharedModule!,
+        coreModule!,
+      ]) {
+        runner.evaluatedModules.invalidateModule(module)
+      }
+
+      const importA = runner.import('/fixtures/hmr-reexport-race/entry-a.js')
+      await waitStartedPromise
+
+      const importB = runner.import('/fixtures/hmr-reexport-race/entry-b.js')
+      // Wait deterministically until entry-b has reached the point where it
+      // observes shared as in-flight. The `mod.imports.add(depMod.id)` line
+      // in `request()` runs synchronously immediately before `cachedRequest`
+      // executes its cycle-detection prefix, so observing this edge means
+      // the buggy/fixed branch has either just run or is about to run on
+      // the same microtask. `imports` is cleared by invalidateModule, so
+      // this is a fresh signal (unlike `importers`, which is preserved).
+      const entryBNode = runner.evaluatedModules.getModuleByUrl(
+        '/fixtures/hmr-reexport-race/entry-b.js',
+      )!
+      while (!entryBNode.imports.has(sharedModule!.id)) {
+        await new Promise((resolve) => setImmediate(resolve))
+      }
+      releaseWait()
+      const results = await Promise.allSettled([importA, importB] as const)
+
+      expect(results).toEqual([
+        {
+          status: 'fulfilled',
+          value: expect.objectContaining({ result: 'a' }),
+        },
+        {
+          status: 'fulfilled',
+          value: expect.objectContaining({ result: 'b' }),
+        },
+      ])
+
+      const hmrListeners = runner.hmrClient!.hotModulesMap
+      expect(hmrListeners.has('/fixtures/hmr-reexport-race/entry-a.js')).toBe(
+        true,
+      )
+      expect(hmrListeners.has('/fixtures/hmr-reexport-race/entry-b.js')).toBe(
+        true,
+      )
+
+      delete testGlobal.__vite_ssr_hmr_reexport_race__
+    })
   },
   process.env.CI ? 50_00 : 5_000,
 )


### PR DESCRIPTION
## Summary

Fixes an SSR/HMR module runner race where a concurrent import can observe an incomplete namespace from an in-flight module evaluation.

The same shape reproduces in any project where:

1. Two entry modules share a dependency that does `export *` from a deeper module
2. The shared dependency has a real cycle with one of the entries
3. HMR invalidates the chain and two requests race through it

The runner mis-detects the second request as "circular" and hands it the partial in-flight `mod.exports` object before `export *` has populated it, exposing an empty namespace to user code.

## Root Cause

`ModuleRunner.cachedRequest` decides between returning partial `mod.exports` (cycle break) vs. `await mod.promise` (wait for full evaluation). The pre-fix logic used three signals; two of them consulted `mod.importers`:

```ts
if (
  callstack.includes(moduleId) ||
  this.isCircularModule(mod) ||                 // mod.imports ∩ mod.importers
  this.isCircularImport(importers, moduleId)    // BFS over mod.importers
) {
  if (mod.exports) return mod.exports
}
```

`mod.importers` is a monotonic set, never cleared by `invalidateModule`. After HMR it carries every historical caller. A new concurrent caller is therefore frequently mis-classified as "in a cycle" with a stale importer, and receives an empty exports object.

## Walkthrough

Module graph

```txt
entry-a --\
           +--> shared --> core   (core gated on async work; wildcard-reexported by shared)
entry-b --/      ^
                 |
                 +-- import './entry-a.js'  (real cycle: shared <-> entry-a)
```

## Old Behavior

1. Cold start: both entries import successfully. `shared.importers = { entry-a, entry-b }`, `shared.imports = { entry-a, core }`.
2. HMR invalidates the chain. `evaluated`/`promise`/`exports` reset; `importers` preserved.
3. `entry-a` re-imports -> reaches `shared.directRequest` -> reaches `core` -> suspends on async work. `shared.promise` set, `shared.evaluated = false`, `shared.exports = {}` (empty placeholder).
4. `entry-b` concurrently re-imports -> reaches `cachedRequest(shared)` with `callstack = [entry-b]`.
5. Cycle check runs:
   - `callstack.includes(shared)` -> false
   - `isCircularModule(shared)`: `shared.imports = { entry-a, core }` intersects `shared.importers = { entry-a, entry-b }` -> true (`entry-a` is in both)
6. Returns `shared.exports`, which is empty. `entry-b` body executes `createThing(...)` against an empty namespace -> `TypeError: createThing is not a function`.

## New Behavior

Replace the importer-based heuristics with a callstack-driven forward-graph check:

```ts
if (mod.promise) {
  if (
    mod.exports &&
    (callstack.includes(moduleId) || this.isCircularRequest(mod, callstack))
  ) {
    return this.processImport(mod.exports, meta, metadata)
  }
  return this.processImport(await mod.promise, meta, metadata)
}
```

`isCircularRequest(mod, callstack)` walks `mod.imports` transitively (bounded by `visited`, descent halted at already-evaluated modules) and asks the only question that matters for deadlock: does anything `mod` is waiting on appear in my current callstack?

Replaying the same scenario:

5. `callstack = [entry-b]`. Walk `shared.imports = { entry-a, core }`:
   - `entry-a` not in `[entry-b]`; recurse: `entry-a.imports = { shared }`; `shared` already visited -> false
   - `core` not in `[entry-b]`; `core.imports = {}` -> false
   - returns false
6. Falls through to `await mod.promise`. `entry-b` waits until `shared` finishes evaluating, then sees the fully populated namespace.

Real cycles still break correctly: when `shared` re-enters `entry-a` during `entry-a`'s own evaluation, `callstack = [entry-a, shared]` -> `callstack.includes(entry-a)` -> returns partial exports (ESM spec-correct cycle break).

## Why Previous Heuristics Fail

- `isCircularModule`: cannot distinguish "I am in a cycle with my caller" from "I have ever been in a cycle with anyone".
- `isCircularImport`: `mod.importers` is a historical reverse-edge set, not a runtime callstack. Across HMR it grows unboundedly. The check is also `O(importers^2)` in the worst case.

The new check is local to the live request, `O(V+E)` over the forward subgraph (visited-bounded), and matches the actual deadlock condition.

## Performance

- Fast path for already-evaluated modules (added in #21632) is preserved verbatim.
- New `isCircularRequest` only runs when `mod.promise` is set and `mod.evaluated` is false, i.e. the rare in-flight overlap case.
- Eliminates a redundant `await mod.promise` branch that was inside the `try` block.

## Test

Adds `does not expose partial exports during concurrent updates` in `server-hmr.spec.ts` with fixtures under `__tests__/fixtures/hmr-reexport-race/`.

The test:

1. Cold-imports `entry-a` and `entry-b` (both import `shared`, which `export *` from `core` and has a self-cycle to `entry-a`).
2. Invalidates the chain.
3. Installs a global gate that suspends `core`'s top-level await.
4. Starts `entry-a` re-import; awaits "gate hit".
5. Starts `entry-b` re-import; flushes a macrotask; releases the gate.
6. Asserts both promises fulfill with the full namespace and HMR listeners are intact.

The test fails on `main` and passes with the fix.

## Refs

- Closes TanStack/router#7285
- Builds on #21632 (preserves the evaluated-module fast path)
