### PR TITLE
fix(hmr): invalidate extensionless importers on sibling extension add/unlink

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -449,6 +449,14 @@ export async function handleHMRUpdate(
 
   for (const environment of Object.values(server.environments)) {
     const mods = new Set(environment.moduleGraph.getModulesByFile(file))
+    if (type === 'create' || type === 'delete') {
+      for (const importer of collectSiblingImportersByBasename(
+        environment,
+        file,
+      )) {
+        mods.add(importer)
+      }
+    }
     if (type === 'create') {
       for (const mod of environment.moduleGraph._hasResolveFailedErrorModules) {
         mods.add(mod)
@@ -635,6 +643,35 @@ export async function handleHMRUpdate(
     })
 
   await hotUpdateEnvironments(server, hmr)
+}
+
+function collectSiblingImportersByBasename(
+  environment: DevEnvironment,
+  file: string,
+): Set<EnvironmentModuleNode> {
+  const importers = new Set<EnvironmentModuleNode>()
+  const parsed = path.posix.parse(file)
+  if (!parsed.ext) {
+    return importers
+  }
+
+  const extensions = environment.config.resolve.extensions
+  if (!extensions.includes(parsed.ext)) {
+    return importers
+  }
+
+  for (const ext of extensions) {
+    if (ext === parsed.ext) continue
+    const sibling = path.posix.join(parsed.dir, `${parsed.name}${ext}`)
+    const modules = environment.moduleGraph.getModulesByFile(sibling)
+    if (!modules) continue
+    for (const mod of modules) {
+      for (const importer of mod.importers) {
+        importers.add(importer)
+      }
+    }
+  }
+  return importers
 }
 
 type HasDeadEnd = string | boolean

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -330,6 +330,40 @@ if (!isBuild) {
     }
   })
 
+  test('handles extensionless bar.ts -> bar.tsx rename', async () => {
+    const tsFile = 'extensionless-import-rename-non-index/Foo/bar.ts'
+    const tsxFile = 'extensionless-import-rename-non-index/Foo/bar.tsx'
+
+    await page.goto(
+      viteTestUrl + '/extensionless-import-rename-non-index/index.html',
+      {
+        waitUntil: 'networkidle',
+      },
+    )
+
+    try {
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename-non-index'))
+        .toBe('from ts')
+
+      const tsContent = readFile(tsFile)
+      addFile(tsxFile, tsContent.replace('from ts', 'from tsx'))
+      removeFile(tsFile)
+
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename-non-index'))
+        .toBe('from tsx')
+
+      editFile(tsxFile, (code) => code.replace('from tsx', 'from tsx updated'))
+
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename-non-index'))
+        .toBe('from tsx updated')
+    } finally {
+      await page.goto(viteTestUrl, { waitUntil: 'networkidle' })
+    }
+  })
+
   test('plugin client-server communication', async () => {
     const el = await page.$('.custom-communication')
     await expect.poll(() => el.textContent()).toMatch('3')

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -299,6 +299,37 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toMatch('edited')
   })
 
+  test('handles extensionless index.ts -> index.tsx rename', async () => {
+    const tsFile = 'extensionless-import-rename/Foo/index.ts'
+    const tsxFile = 'extensionless-import-rename/Foo/index.tsx'
+
+    await page.goto(viteTestUrl + '/extensionless-import-rename/index.html', {
+      waitUntil: 'networkidle',
+    })
+
+    try {
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename'))
+        .toBe('from ts')
+
+      const tsContent = readFile(tsFile)
+      addFile(tsxFile, tsContent.replace('from ts', 'from tsx'))
+      removeFile(tsFile)
+
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename'))
+        .toBe('from tsx')
+
+      editFile(tsxFile, (code) => code.replace('from tsx', 'from tsx updated'))
+
+      await expect
+        .poll(() => page.textContent('.extensionless-import-rename'))
+        .toBe('from tsx updated')
+    } finally {
+      await page.goto(viteTestUrl, { waitUntil: 'networkidle' })
+    }
+  })
+
   test('plugin client-server communication', async () => {
     const el = await page.$('.custom-communication')
     await expect.poll(() => el.textContent()).toMatch('3')

--- a/playground/hmr/extensionless-import-rename-non-index/Foo/bar.ts
+++ b/playground/hmr/extensionless-import-rename-non-index/Foo/bar.ts
@@ -1,0 +1,1 @@
+export const msg = 'from ts'

--- a/playground/hmr/extensionless-import-rename-non-index/index.html
+++ b/playground/hmr/extensionless-import-rename-non-index/index.html
@@ -1,0 +1,2 @@
+<div class="extensionless-import-rename-non-index"></div>
+<script type="module" src="./main.ts"></script>

--- a/playground/hmr/extensionless-import-rename-non-index/main.ts
+++ b/playground/hmr/extensionless-import-rename-non-index/main.ts
@@ -1,0 +1,10 @@
+import { msg } from './Foo/bar'
+
+const el = document.querySelector('.extensionless-import-rename-non-index')!
+el.textContent = msg
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./Foo/bar', ({ msg }) => {
+    el.textContent = msg
+  })
+}

--- a/playground/hmr/extensionless-import-rename/Foo/index.ts
+++ b/playground/hmr/extensionless-import-rename/Foo/index.ts
@@ -1,0 +1,1 @@
+export const msg = 'from ts'

--- a/playground/hmr/extensionless-import-rename/index.html
+++ b/playground/hmr/extensionless-import-rename/index.html
@@ -1,0 +1,2 @@
+<div class="extensionless-import-rename"></div>
+<script type="module" src="./main.ts"></script>

--- a/playground/hmr/extensionless-import-rename/main.ts
+++ b/playground/hmr/extensionless-import-rename/main.ts
@@ -1,0 +1,10 @@
+import { msg } from './Foo'
+
+const el = document.querySelector('.extensionless-import-rename')!
+el.textContent = msg
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./Foo', ({ msg }) => {
+    el.textContent = msg
+  })
+}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

### Motivation

Fix HMR breakage when an extensionless import (e.g. `./Foo` or `./Foo/bar`) points to a file that is renamed across extensions during dev (e.g. `.ts` -> `.tsx`).

### Description

- On `create`/`delete` HMR updates, also invalidate importers of sibling files with the same basename and different configured `resolve.extensions`.
- This ensures extensionless importers are re-resolved after extension rename-like events, instead of keeping stale resolved targets.
- Added focused playground fixtures and e2e tests for both:
  - `index.ts -> index.tsx` (`./Foo`)
  - `bar.ts -> bar.tsx` (`./Foo/bar`)
- The extra invalidation is intentionally limited to `create`/`delete` to keep normal `update` behavior unchanged.

### Why both create and delete?

File rename is typically observed as `add`/`unlink` (or `create`/`delete`) pairs, and ordering can vary by OS/watcher timing. Handling both sides makes the behavior robust.

### Issue

Fixes #21157.

### Testing

- Added/updated tests in `playground/hmr/__tests__/hmr.spec.ts`:
  - `handles extensionless index.ts -> index.tsx rename`
  - `handles extensionless bar.ts -> bar.tsx rename`
- Re-ran representative existing HMR tests to verify no regression:
  - `css modules`
  - `plugin client-server communication`
  - `should not full reload when accepted module is removed`