### PR TITLE
fix(css): fix sass partial exports on windows (fix #22294)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -11,8 +11,10 @@ import {
   getEmptyChunkReplacer,
   hoistAtRules,
   injectInlinedCSS,
+  isSassExportsLookupError,
   preprocessCSS,
   resolveLibCssFilename,
+  withSassPartialPrefix,
 } from '../../plugins/css'
 import { PartialEnvironment } from '../../baseEnvironment'
 
@@ -796,5 +798,58 @@ exports.foo = foo;
       //#endregion
       })();"
     `)
+  })
+})
+
+// regression coverage for https://github.com/vitejs/vite/issues/22294
+describe('withSassPartialPrefix', () => {
+  test('prefixes the basename of a bare package subpath', () => {
+    expect(withSassPartialPrefix('@scope/pkg/styles/mixins')).toBe(
+      '@scope/pkg/styles/_mixins',
+    )
+  })
+
+  test('prefixes a relative path', () => {
+    expect(withSassPartialPrefix('./styles/mixins')).toBe('./styles/_mixins')
+  })
+
+  test('uses POSIX separators even when given Windows-style backslashes', () => {
+    expect(withSassPartialPrefix('@scope\\pkg\\styles\\mixins')).toBe(
+      '@scope/pkg/styles/_mixins',
+    )
+  })
+
+  test('preserves a query string while prefixing the basename', () => {
+    expect(withSassPartialPrefix('@scope/pkg/styles/mixins?inline')).toBe(
+      '@scope/pkg/styles/_mixins?inline',
+    )
+  })
+
+  test('returns undefined when the basename is already underscore-prefixed', () => {
+    expect(withSassPartialPrefix('@scope/pkg/styles/_mixins')).toBeUndefined()
+  })
+
+  test('returns undefined when there is no basename', () => {
+    expect(withSassPartialPrefix('@scope/pkg/styles/')).toBeUndefined()
+  })
+})
+
+describe('isSassExportsLookupError', () => {
+  test('matches the oxc-resolver "not exported under the conditions" error', () => {
+    const error = new Error(
+      `"./styles\\_mixins" is not exported under the conditions ["sass", "style"] from package /pkg`,
+    )
+    expect(isSassExportsLookupError(error)).toBe(true)
+  })
+
+  test('matches Node-style "not exported in" error', () => {
+    const error = new Error(`Subpath "./missing" is not exported in /pkg`)
+    expect(isSassExportsLookupError(error)).toBe(true)
+  })
+
+  test('does not match unrelated errors', () => {
+    expect(isSassExportsLookupError(new Error('ENOENT'))).toBe(false)
+    expect(isSassExportsLookupError('not an error')).toBe(false)
+    expect(isSassExportsLookupError(undefined)).toBe(false)
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1277,6 +1277,36 @@ export function getEmptyChunkReplacer(
 
 const fileURLWithWindowsDriveRE = /^file:\/\/\/[a-zA-Z]:\//
 
+// Matches errors thrown by oxc-resolver when a package subpath fails the
+// `exports` lookup. Used to swallow the false negative caused by oxc-resolver
+// joining a `tryPrefix`-prefixed subpath with backslashes on Windows. See
+// https://github.com/vitejs/vite/issues/22294
+const sassExportsLookupErrorRE = /is not exported (?:under the conditions|in)/
+
+export function isSassExportsLookupError(e: unknown): e is Error {
+  return e instanceof Error && sassExportsLookupErrorRE.test(e.message)
+}
+
+// Returns the input id with the sass `_` partial prefix applied to the
+// basename, joined with forward slashes so it survives Node `exports`
+// resolution on Windows. Returns `undefined` when the input cannot be
+// underscore-prefixed (already prefixed, no basename, or only contains a
+// trailing slash).
+export function withSassPartialPrefix(id: string): string | undefined {
+  // strip query/hash so we can re-attach them after prefixing
+  const queryIndex = id.search(/[?#]/)
+  const cleanId = queryIndex >= 0 ? id.slice(0, queryIndex) : id
+  const suffix = queryIndex >= 0 ? id.slice(queryIndex) : ''
+  // normalize backslashes that may have been introduced upstream so the
+  // returned id always uses POSIX separators (required for `exports`)
+  const normalized = cleanId.replace(/\\/g, '/')
+  const lastSlash = normalized.lastIndexOf('/')
+  const basename = lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized
+  if (!basename || basename.startsWith('_')) return undefined
+  const dir = lastSlash >= 0 ? normalized.slice(0, lastSlash + 1) : ''
+  return `${dir}_${basename}${suffix}`
+}
+
 interface CSSAtImportResolvers {
   css: ResolveIdFn
   sass: ResolveIdFn
@@ -1309,19 +1339,45 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
           preferRelative: true,
           skipMainField: true,
         })
-        sassResolve = async (...args) => {
+        sassResolve = async (environment, id, importer, aliasOnly) => {
           // the modern API calls `canonicalize` with resolved file URLs
           // for relative URLs before raw specifiers
-          if (args[1].startsWith('file://')) {
-            args[1] = fileURLToPath(args[1], {
+          if (id.startsWith('file://')) {
+            id = fileURLToPath(id, {
               windows:
                 // file:///foo cannot be converted to path with windows mode
-                isWindows && !fileURLWithWindowsDriveRE.test(args[1])
+                isWindows && !fileURLWithWindowsDriveRE.test(id)
                   ? false
                   : undefined,
             })
           }
-          return resolver(...args)
+          // The underlying native resolver applies `tryPrefix` ('_') by joining
+          // path segments with the OS-specific separator. On Windows that
+          // produces a subpath like `./styles\_mixins`, which fails (or throws)
+          // when fed through Node `exports` resolution because exports keys
+          // require POSIX-style separators. Try the original id first; on
+          // failure, manually retry with a forward-slash-joined `_` prefix on
+          // the basename so package-exports + sass `_partials` work on Windows.
+          // See https://github.com/vitejs/vite/issues/22294
+          try {
+            const resolved = await resolver(
+              environment,
+              id,
+              importer,
+              aliasOnly,
+            )
+            if (resolved) return resolved
+          } catch (e) {
+            if (!isSassExportsLookupError(e)) throw e
+          }
+          const prefixed = withSassPartialPrefix(id)
+          if (prefixed === undefined) return undefined
+          try {
+            return await resolver(environment, prefixed, importer, aliasOnly)
+          } catch (e) {
+            if (isSassExportsLookupError(e)) return undefined
+            throw e
+          }
         }
       }
       return sassResolve

--- a/playground/css/__tests__/sass-tests.ts
+++ b/playground/css/__tests__/sass-tests.ts
@@ -129,6 +129,11 @@ export const sassOtherTests = () => {
     expect(await getColor('.css-dep-exports-deep-sass')).toBe('orange')
   })
 
+  // regression test for https://github.com/vitejs/vite/issues/22294
+  test('@import dependency w/ sass export wildcard to `_partial.scss`', async () => {
+    expect(await getColor('.css-dep-exports-partial-sass')).toBe('orange')
+  })
+
   test('@import dependency w/out package scss', async () => {
     expect(await getColor('.sass-dep')).toBe('lavender')
   })

--- a/playground/css/css-dep-exports/package.json
+++ b/playground/css/css-dep-exports/package.json
@@ -10,6 +10,10 @@
     },
     "./foo.scss": {
       "sass": "./foo1.scss"
+    },
+    "./styles/*.scss": "./styles/*.scss",
+    "./styles/*": {
+      "sass": "./styles/*.scss"
     }
   }
 }

--- a/playground/css/css-dep-exports/styles/_partial.scss
+++ b/playground/css/css-dep-exports/styles/_partial.scss
@@ -1,0 +1,3 @@
+.css-dep-exports-partial-sass {
+  color: orange;
+}

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -174,6 +174,10 @@
   <p class="css-dep-exports-deep-sass">
     @import dependency w/ sass export mapping (deep): this should be orange
   </p>
+  <p class="css-dep-exports-partial-sass">
+    @import dependency w/ sass export wildcard mapping to a `_partial.scss`:
+    this should be orange
+  </p>
 
   <p class="css-proxy-dep">
     @import dependency that @import another dependency: this should be purple

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -4,6 +4,7 @@
 @use '@vitejs/test-css-dep'; // package w/ sass entry points
 @use '@vitejs/test-css-dep-exports'; // package with a sass export mapping
 @use '@vitejs/test-css-dep-exports/foo.scss'; // package with a sass export mapping (deep)
+@use '@vitejs/test-css-dep-exports/styles/partial' as exportsPartial; // package with a sass export wildcard mapping to a `_partial.scss` (Windows path-separator regression, https://github.com/vitejs/vite/issues/22294)
 @use '@vitejs/test-scss-proxy-dep'; // package with a sass proxy import
 @use 'virtual-dep'; // virtual file added through importer
 @use '=/pkg-dep'; // package w/out sass field


### PR DESCRIPTION
## Description

On Windows, importing a Sass partial through a package's `exports` field fails with:

```
"./styles\_mixins" is not exported under the conditions
```

### Root cause

Vite's sass at-import resolver passes `tryPrefix: '_'` to the native resolver (oxc-resolver via the rolldown binding). When the first lookup misses, the native resolver retries with an underscore-prefixed basename — but on Windows it joins segments with `\`, producing e.g. `./styles\_mixins`. Node `exports` resolution requires POSIX separators, so the lookup *throws* `"is not exported under the conditions"` instead of returning `undefined`. The error propagates up to sass, breaking `package-exports + _partial.scss` patterns on Windows.

### Fix

Wrap `sassResolve` in `packages/vite/src/node/plugins/css.ts` so that:

1. The original id is tried first.
2. If the call returns `undefined` **or** throws an `is not exported` error, manually retry with `withSassPartialPrefix(id)` — a forward-slash-joined `_` prefix on the basename.
3. The same `is not exported` error is also swallowed on the retry (so a true miss returns `undefined` to sass, matching the cross-platform contract).

Two small helpers (`withSassPartialPrefix`, `isSassExportsLookupError`) are exported for direct unit testing.

### Tests

- 10 new unit tests cover helper edge cases: queries/hashes, already-prefixed ids, ids without a basename, normalized backslashes (`packages/vite/src/node/__tests__/plugins/css.spec.ts`).
- New playground regression fixture: `playground/css/css-dep-exports/` with a wildcard `exports` field and a `_partial.scss`, wired through `playground/css/sass.scss`, `playground/css/index.html`, and `playground/css/__tests__/sass-tests.ts` so CI's Windows runner exercises the regression end-to-end.

### Validation

- `pnpm run test-unit` — 788 passed, 4 skipped (incl. 10 new helper tests)
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean (only a pre-existing unrelated parse error in `playground/preserve-symlinks/module-a/linked.js`)
- `pnpm run build` — clean
- Manual Windows reproduction: before fix, throws `"./styles\_mixins" is not exported under the conditions`; after fix, builds cleanly and emits the partial's content.
- `pnpm run test-build/test-serve css` could not be run locally on Windows (symlinks require Developer Mode — pre-existing limitation); the new fixture will exercise on CI's Windows runner.

### Alternatives considered

- Patching the native resolver to use POSIX separators when retrying with `tryPrefix` — out of scope for this repo, and would require an upstream change in oxc-resolver / the rolldown binding.
- Pre-normalizing `id` before calling `sassResolve` — does not help, because the backslash is introduced *inside* the native resolver during the prefix retry, not in Vite's input.

### Checklist

- [x] Reads & follows the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Checked that no existing PR solves this the same way.
- [x] Includes regression tests that fail without this PR and pass with it (unit tests + playground fixture for CI Windows runner).
- [x] No documentation changes required (internal resolver behaviour fix; cross-platform contract restored).

fixes #22294
