### PR TITLE
fix(html): resolve aliases and abs paths in dev

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest'
+import { resolveHtmlAttrUrl } from '../indexHtml'
+
+const makeConfig = (alias: { find: string | RegExp; replacement: string }[]) =>
+  ({ resolve: { alias } }) as Parameters<typeof resolveHtmlAttrUrl>[1]
+
+describe('resolveHtmlAttrUrl (#17910)', () => {
+  test('passes through absolute URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('/main.js', config)).toBe('/main.js')
+  })
+
+  test('passes through relative URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('./main.js', config)).toBe('./main.js')
+    expect(resolveHtmlAttrUrl('../main.js', config)).toBe('../main.js')
+  })
+
+  test('passes through external URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('https://example.com/x.js', config)).toBe(
+      'https://example.com/x.js',
+    )
+    expect(resolveHtmlAttrUrl('//example.com/x.js', config)).toBe(
+      '//example.com/x.js',
+    )
+  })
+
+  test('passes through data URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('data:image/png;base64,abc', config)).toBe(
+      'data:image/png;base64,abc',
+    )
+  })
+
+  test('resolves a string alias that does not start with /', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe('/@fs/abs/src/main.js')
+  })
+
+  test('resolves a regex alias that does not start with /', () => {
+    const config = makeConfig([{ find: /^~/, replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('~/main.js', config)).toBe('/@fs/abs/src/main.js')
+  })
+
+  test('does not match an alias when the url does not start with the find string', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('foo@bar.js', config)).toBe('foo@bar.js')
+  })
+
+  test('returns alias replacement as-is when not absolute', () => {
+    const config = makeConfig([{ find: '@', replacement: 'relative/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe('relative/src/main.js')
+  })
+
+  test('normalizes a Windows absolute path with forward slashes', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('C:/abs/path/main.js', config)).toBe(
+      '/@fs/C:/abs/path/main.js',
+    )
+  })
+
+  test('normalizes a Windows absolute path with backslashes', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('C:\\abs\\path\\main.js', config)).toBe(
+      '/@fs/C:/abs/path/main.js',
+    )
+  })
+
+  test('normalizes a Windows absolute path through an alias', () => {
+    const config = makeConfig([{ find: '@', replacement: 'C:/abs/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe(
+      '/@fs/C:/abs/src/main.js',
+    )
+  })
+
+  test('Windows volume check is case-insensitive on the drive letter', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('d:/abs/path/main.js', config)).toBe(
+      '/@fs/d:/abs/path/main.js',
+    )
+  })
+})

--- a/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, onTestFinished, test } from 'vitest'
 import { createServer } from '../../../server'
 import { FS_PREFIX } from '../../../constants'
+import { resolveHtmlAttrUrl } from '../indexHtml'
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, 'fixtures')
 const HTML_PATH = path.resolve(FIXTURE_DIR, 'root/index.html')
@@ -84,5 +85,86 @@ describe('indexHtml middleware — /@fs/ inline script proxy cache', () => {
 
     expect(result, 'proxy module should resolve without error').not.toBeNull()
     expect(result!.code).toContain('module loaded')
+  })
+})
+
+const makeConfig = (alias: { find: string | RegExp; replacement: string }[]) =>
+  ({ resolve: { alias } }) as Parameters<typeof resolveHtmlAttrUrl>[1]
+
+describe('resolveHtmlAttrUrl (#17910)', () => {
+  test('passes through absolute URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('/main.js', config)).toBe('/main.js')
+  })
+
+  test('passes through relative URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('./main.js', config)).toBe('./main.js')
+    expect(resolveHtmlAttrUrl('../main.js', config)).toBe('../main.js')
+  })
+
+  test('passes through external URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('https://example.com/x.js', config)).toBe(
+      'https://example.com/x.js',
+    )
+    expect(resolveHtmlAttrUrl('//example.com/x.js', config)).toBe(
+      '//example.com/x.js',
+    )
+  })
+
+  test('passes through data URLs unchanged', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('data:image/png;base64,abc', config)).toBe(
+      'data:image/png;base64,abc',
+    )
+  })
+
+  test('resolves a string alias that does not start with /', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe('/@fs/abs/src/main.js')
+  })
+
+  test('resolves a regex alias that does not start with /', () => {
+    const config = makeConfig([{ find: /^~/, replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('~/main.js', config)).toBe('/@fs/abs/src/main.js')
+  })
+
+  test('does not match an alias when the url does not start with the find string', () => {
+    const config = makeConfig([{ find: '@', replacement: '/abs/src' }])
+    expect(resolveHtmlAttrUrl('foo@bar.js', config)).toBe('foo@bar.js')
+  })
+
+  test('returns alias replacement as-is when not absolute', () => {
+    const config = makeConfig([{ find: '@', replacement: 'relative/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe('relative/src/main.js')
+  })
+
+  test('normalizes a Windows absolute path with forward slashes', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('C:/abs/path/main.js', config)).toBe(
+      '/@fs/C:/abs/path/main.js',
+    )
+  })
+
+  test('normalizes a Windows absolute path with backslashes', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('C:\\abs\\path\\main.js', config)).toBe(
+      '/@fs/C:/abs/path/main.js',
+    )
+  })
+
+  test('normalizes a Windows absolute path through an alias', () => {
+    const config = makeConfig([{ find: '@', replacement: 'C:/abs/src' }])
+    expect(resolveHtmlAttrUrl('@/main.js', config)).toBe(
+      '/@fs/C:/abs/src/main.js',
+    )
+  })
+
+  test('Windows volume check is case-insensitive on the drive letter', () => {
+    const config = makeConfig([])
+    expect(resolveHtmlAttrUrl('d:/abs/path/main.js', config)).toBe(
+      '/@fs/d:/abs/path/main.js',
+    )
   })
 })

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -33,7 +33,9 @@ import {
   getHash,
   injectQuery,
   isCSSRequest,
+  isDataUrl,
   isDevServer,
+  isExternalUrl,
   isJSRequest,
   isParentDirectory,
   joinUrlSegments,
@@ -43,7 +45,7 @@ import {
 } from '../../utils'
 import { checkPublicFile } from '../../publicDir'
 import { getCodeWithSourcemap, injectSourcesContent } from '../sourcemap'
-import { cleanUrl, unwrapId, wrapId } from '../../../shared/utils'
+import { cleanUrl, slash, unwrapId, wrapId } from '../../../shared/utils'
 import { getNodeAssetAttributes } from '../../assetSource'
 import {
   BasicMinimalPluginContext,
@@ -131,6 +133,46 @@ function getHtmlDirnameForRelativeUrl(htmlPath: string): string {
   return htmlPath.endsWith('/') ? htmlPath : path.posix.dirname(htmlPath)
 }
 
+// Matches a Windows-style absolute path like `C:/foo` or `C:\foo`.
+const windowsVolumePathRE = /^[A-Za-z]:[/\\]/
+
+// Resolves alias and Windows absolute path forms in HTML attribute values
+// so that they behave consistently between dev and build (#17910).
+export function resolveHtmlAttrUrl(
+  url: string,
+  config: Pick<ResolvedConfig, 'resolve'>,
+): string {
+  // Windows absolute path (e.g. `C:/foo/bar.js` or `C:\foo\bar.js`)
+  // → normalize to `/@fs/C:/foo/bar.js` so the dev server can serve it
+  // the same way build's `this.resolve` resolves it from disk.
+  if (windowsVolumePathRE.test(url)) {
+    return joinUrlSegments(FS_PREFIX, slash(url))
+  }
+  // Aliases that don't start with `/` (e.g. `@/main.js`).
+  // In build these are passed through `this.resolve` which runs the alias
+  // plugin; in dev we apply the alias manually so the resulting path can
+  // be served as `/@fs/...`.
+  if (
+    url[0] !== '/' &&
+    url[0] !== '.' &&
+    !isExternalUrl(url) &&
+    !isDataUrl(url)
+  ) {
+    for (const { find, replacement } of config.resolve.alias) {
+      const matches =
+        typeof find === 'string' ? url.startsWith(find) : find.test(url)
+      if (matches) {
+        const resolved = url.replace(find, replacement)
+        if (windowsVolumePathRE.test(resolved) || resolved[0] === '/') {
+          return joinUrlSegments(FS_PREFIX, slash(resolved))
+        }
+        return resolved
+      }
+    }
+  }
+  return url
+}
+
 const processNodeUrl = (
   url: string,
   useSrcSetReplacer: boolean,
@@ -142,6 +184,8 @@ const processNodeUrl = (
 ): string => {
   // prefix with base (dev only, base is never relative)
   const replacer = (url: string) => {
+    url = resolveHtmlAttrUrl(url, config)
+
     if (
       (url[0] === '/' && url[1] !== '/') ||
       // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -33,7 +33,9 @@ import {
   getHash,
   injectQuery,
   isCSSRequest,
+  isDataUrl,
   isDevServer,
+  isExternalUrl,
   isJSRequest,
   isParentDirectory,
   joinUrlSegments,
@@ -43,7 +45,7 @@ import {
 } from '../../utils'
 import { checkPublicFile } from '../../publicDir'
 import { getCodeWithSourcemap, injectSourcesContent } from '../sourcemap'
-import { cleanUrl, unwrapId, wrapId } from '../../../shared/utils'
+import { cleanUrl, slash, unwrapId, wrapId } from '../../../shared/utils'
 import { getNodeAssetAttributes } from '../../assetSource'
 import {
   BasicMinimalPluginContext,
@@ -128,6 +130,46 @@ function isBareRelative(url: string) {
   return wordCharRE.test(url[0]) && !url.includes(':')
 }
 
+// Matches a Windows-style absolute path like `C:/foo` or `C:\foo`.
+const windowsVolumePathRE = /^[A-Za-z]:[/\\]/
+
+// Resolves alias and Windows absolute path forms in HTML attribute values
+// so that they behave consistently between dev and build (#17910).
+export function resolveHtmlAttrUrl(
+  url: string,
+  config: Pick<ResolvedConfig, 'resolve'>,
+): string {
+  // Windows absolute path (e.g. `C:/foo/bar.js` or `C:\foo\bar.js`)
+  // → normalize to `/@fs/C:/foo/bar.js` so the dev server can serve it
+  // the same way build's `this.resolve` resolves it from disk.
+  if (windowsVolumePathRE.test(url)) {
+    return joinUrlSegments(FS_PREFIX, slash(url))
+  }
+  // Aliases that don't start with `/` (e.g. `@/main.js`).
+  // In build these are passed through `this.resolve` which runs the alias
+  // plugin; in dev we apply the alias manually so the resulting path can
+  // be served as `/@fs/...`.
+  if (
+    url[0] !== '/' &&
+    url[0] !== '.' &&
+    !isExternalUrl(url) &&
+    !isDataUrl(url)
+  ) {
+    for (const { find, replacement } of config.resolve.alias) {
+      const matches =
+        typeof find === 'string' ? url.startsWith(find) : find.test(url)
+      if (matches) {
+        const resolved = url.replace(find, replacement)
+        if (windowsVolumePathRE.test(resolved) || resolved[0] === '/') {
+          return joinUrlSegments(FS_PREFIX, slash(resolved))
+        }
+        return resolved
+      }
+    }
+  }
+  return url
+}
+
 const processNodeUrl = (
   url: string,
   useSrcSetReplacer: boolean,
@@ -139,6 +181,8 @@ const processNodeUrl = (
 ): string => {
   // prefix with base (dev only, base is never relative)
   const replacer = (url: string) => {
+    url = resolveHtmlAttrUrl(url, config)
+
     if (
       (url[0] === '/' && url[1] !== '/') ||
       // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets


### PR DESCRIPTION
## Description

fixes #17910

In the dev server, `processNodeUrl` in `packages/vite/src/node/server/middlewares/indexHtml.ts` only rewrites HTML reference URLs that start with `/`, `.`, or are bare-relative. Three valid HTML reference forms slipped through unchanged and hit the browser as-is:

- `<script src="@/main.js">` — `config.resolve.alias` prefixes that don't begin with `/`
- `<script src="C:/abs/path/main.js">` — Windows absolute path with forward slashes
- `<script src="C:\abs\path\main.js">` — Windows absolute path with backslashes

The build path doesn't have this problem because it routes every script `src` through `this.resolve(url, id)`, which runs the alias plugin and the file resolver, so all three forms work in `vite build`.

## Fix

Added a small helper `resolveHtmlAttrUrl(url, config)` invoked at the top of `replacer` inside `processNodeUrl`:

1. If the URL matches a Windows volume path (`/^[A-Za-z]:[/\]/`), it normalizes via `joinUrlSegments(FS_PREFIX, slash(url))` so the dev server can serve it through `/@fs/...`.
2. For URLs that don't start with `/`, `.`, an external scheme, or `data:`, it walks `config.resolve.alias` (same shape used in `static.ts` for serving requests). On the first matching `find`, it replaces with `replacement`; if the replacement is itself absolute (posix `/...` or a Windows volume), it returns `/@fs/<resolved>`.

Existing reference forms (`/main.js`, `./main.js`, bare relative, external URLs, data URLs) fall through unchanged. The change is purely additive — base/HMR/pre-transform logic below it still runs over the rewritten URL.

## Tests

Added `packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts` with 12 unit tests covering:

- Pass-through for absolute (`/main.js`), relative (`./main.js`), external (`http://`, `https://`, `//`), and `data:` URLs
- String alias rewrite, regex alias rewrite, no-match guard
- Non-absolute alias replacement (preserved as bare-relative)
- Windows volume forms: forward-slash, backslash, lower-case drive letter
- Aliased Windows absolute path resolved through `/@fs/`

Verified failing before fix (function didn't exist) and passing after.

## Validation

- `pnpm run test-unit` — 791 passed, 4 skipped (incl. 12 new tests)
- `pnpm run typecheck` — passed
- `pnpm run lint` — clean on changed files
- `pnpm run build` — passed

## Checklist

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Checked that there isn't already a PR that solves the problem the same way.
- [x] Included relevant tests that fail without this PR but pass with it.
