### PR TITLE
fix(css): preserve source import order in bundle

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -470,7 +470,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
   // when there are multiple rollup outputs and extracting CSS, only emit once,
   // since output formats have no effect on the generated CSS.
   let hasEmitted = false
-  let chunkCSSMap: Map<string, string>
+  // For cssCodeSplit:false, we record CSS per module (keyed by module id)
+  // within each chunk so that `generateBundle` can interleave styles in the
+  // original source-import order, rather than the chunk-import order.
+  // The outer map key is `chunk.fileName` (which equals `preliminaryFileName`
+  // at `generateBundle` time).
+  let chunkCSSMap: Map<string, Map<string, string>>
 
   const rollupOptionsOutput = config.build.rollupOptions.output
   const assetFileNames = (
@@ -662,6 +667,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
             const isJsChunkEmpty = code === '' && !chunk.isEntry
             let isPureCssChunk = chunk.exports.length === 0
+            // Track CSS per source module, so `generateBundle` can interleave
+            // styles in source-import order when `cssCodeSplit` is `false`.
+            const moduleCSSMap = new Map<string, string>()
             const ids = Object.keys(chunk.modules)
             for (const id of ids) {
               if (styles.has(id)) {
@@ -686,7 +694,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   isPureCssChunk = false
                 }
 
-                chunkCSS = (chunkCSS || '') + styles.get(id)
+                const moduleCSS = styles.get(id)!
+                moduleCSSMap.set(id, moduleCSS)
+                chunkCSS = (chunkCSS || '') + moduleCSS
               } else if (!isJsChunkEmpty) {
                 // if the module does not have a style, then it's not a pure css chunk.
                 // this is true because in the `transform` hook above, only modules
@@ -947,15 +957,23 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   injectInlinedCSS(s, this, code, opts.format, injectCode)
                 }
               } else {
-                // resolve public URL from CSS paths, we need to use absolute paths
-                chunkCSS = resolveAssetUrlsInCss(
-                  chunkCSS,
-                  getCssBundleName(),
-                  defaultCssBundleName,
-                )
+                // resolve public URL from CSS paths, we need to use absolute paths.
+                // Apply per-module so that `generateBundle` can preserve the
+                // original source-import order when assembling the bundle.
+                const resolvedModuleCSSMap = new Map<string, string>()
+                for (const [id, css] of moduleCSSMap) {
+                  resolvedModuleCSSMap.set(
+                    id,
+                    resolveAssetUrlsInCss(
+                      css,
+                      getCssBundleName(),
+                      defaultCssBundleName,
+                    ),
+                  )
+                }
                 // finalizeCss is called for the aggregated chunk in generateBundle
 
-                chunkCSSMap.set(chunk.fileName, chunkCSS)
+                chunkCSSMap.set(chunk.fileName, resolvedModuleCSSMap)
               }
             }
 
@@ -1004,27 +1022,128 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       ) {
         let extractedCss = ''
         const collected = new Set<OutputChunk>()
+        const visitedModules = new Set<string>()
         // will be populated in order they are used by entry points
         const dynamicImports = new Set<string>()
+
+        // Build a map from module id to the chunk it belongs to so that, while
+        // traversing a chunk's modules in source-import order, we can recurse
+        // into another chunk at the exact position where its module is
+        // imported. This preserves the original CSS import order across chunk
+        // boundaries — see https://github.com/vitejs/vite/issues/22301.
+        const moduleToChunkMap = new Map<string, string>()
+        for (const file in bundle) {
+          const c = bundle[file]
+          if (c.type === 'chunk') {
+            for (const id in c.modules) {
+              moduleToChunkMap.set(id, file)
+            }
+          }
+        }
+
+        const getModuleInfo = this.getModuleInfo.bind(this)
 
         function collect(chunk: OutputChunk | OutputAsset | undefined) {
           if (!chunk || chunk.type !== 'chunk' || collected.has(chunk)) return
           collected.add(chunk)
 
-          // First collect all styles from the synchronous imports (lowest priority)
-          chunk.imports.forEach((importName) => collect(bundle[importName]))
+          const localModuleIds = Object.keys(chunk.modules)
+          const localModuleSet = new Set(localModuleIds)
+          const moduleCSSMap = chunkCSSMap.get(chunk.preliminaryFileName)
+
+          // Walk the chunk's modules in source-import order using
+          // `getModuleInfo(id).importedIds` (which preserves source order).
+          // For modules in another chunk, recurse into that chunk at the
+          // exact position the import appears, interleaving cross-chunk CSS
+          // with this chunk's own CSS. The fallback iteration over
+          // `chunk.modules` catches modules that aren't reached from the
+          // facade module (e.g., side-effect-only auto-injected modules).
+          function walkModule(id: string) {
+            if (visitedModules.has(id)) return
+
+            if (!localModuleSet.has(id)) {
+              // This module belongs to another chunk; recurse into that
+              // chunk and let it process the module. We deliberately do
+              // not mark `id` as visited here so the destination chunk's
+              // own walk can mark it and emit its CSS.
+              const otherChunkName = moduleToChunkMap.get(id)
+              if (otherChunkName !== undefined) {
+                collect(bundle[otherChunkName])
+              } else {
+                // module is not in any chunk; mark visited so we don't
+                // re-traverse it through other importers
+                visitedModules.add(id)
+              }
+              return
+            }
+
+            visitedModules.add(id)
+
+            const info = getModuleInfo(id)
+            if (info) {
+              for (const importedId of info.importedIds) {
+                walkModule(importedId)
+              }
+            }
+
+            const moduleCSS = moduleCSSMap?.get(id)
+            if (moduleCSS) {
+              extractedCss += moduleCSS
+            }
+          }
+
+          if (
+            chunk.facadeModuleId &&
+            localModuleSet.has(chunk.facadeModuleId)
+          ) {
+            walkModule(chunk.facadeModuleId)
+          }
+          for (const id of localModuleIds) {
+            walkModule(id)
+          }
+
           // Save dynamic imports in deterministic order to add the styles later (to have the highest priority)
           chunk.dynamicImports.forEach((importName) =>
             dynamicImports.add(importName),
           )
-          // Then collect the styles of the current chunk (might overwrite some styles from previous imports)
-          extractedCss += chunkCSSMap.get(chunk.preliminaryFileName) ?? ''
+          // Catch any synchronous chunk imports not reached via the module
+          // walk (e.g., implicit imports introduced by Rollup that aren't
+          // declared in any module's `importedIds`).
+          chunk.imports.forEach((importName) => collect(bundle[importName]))
         }
 
         // The bundle is guaranteed to be deterministic, if not then we have a bug in rollup.
-        // So we use it to ensure a deterministic order of styles
+        // So we use it to ensure a deterministic order of styles.
+        // Entries that are imported by another entry are processed last so
+        // that the importer entry's CSS gets to emit in source-import order
+        // (cross-chunk imports recursively trigger `collect` from inside
+        // `walkModule`). Otherwise, with multi-input setups where one entry
+        // is also imported by another entry (e.g., a force-split chunk),
+        // iterating entries in bundle insertion order would emit the
+        // dependency entry's CSS before the importer's CSS.
+        // See https://github.com/vitejs/vite/issues/22301.
+        const entryChunks: OutputChunk[] = []
         for (const chunk of Object.values(bundle)) {
           if (chunk.type === 'chunk' && chunk.isEntry) {
+            entryChunks.push(chunk)
+          }
+        }
+        const entryFileNames = new Set(entryChunks.map((c) => c.fileName))
+        const importedByOtherEntry = new Set<string>()
+        for (const chunk of entryChunks) {
+          for (const imp of chunk.imports) {
+            if (entryFileNames.has(imp)) {
+              importedByOtherEntry.add(imp)
+            }
+          }
+        }
+        for (const chunk of entryChunks) {
+          if (!importedByOtherEntry.has(chunk.fileName)) {
+            collect(chunk)
+          }
+        }
+        for (const chunk of entryChunks) {
+          if (importedByOtherEntry.has(chunk.fileName)) {
             collect(chunk)
           }
         }

--- a/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
+++ b/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { getColor, isBuild, listAssets } from '~utils'
+import { findAssetFile, getColor, isBuild, listAssets } from '~utils'
 
 test('should load all stylesheets', async () => {
   expect(await getColor('.shared-linked')).toBe('blue')
@@ -13,5 +13,28 @@ describe.runIf(isBuild)('build', () => {
       expect.stringMatching(/shared-linked-.*\.js$/),
     )
     expect(assets).not.toContainEqual(expect.stringMatching(/async-js-.*\.js$/))
+  })
+
+  // regression test for https://github.com/vitejs/vite/issues/22301
+  // `order-static.js` imports `order-static-base.css` (red) first, then
+  // `order-static-dep.js` (force-split into its own chunk because it is also
+  // a build input) which imports `order-static-dep.css` (green). The merged
+  // CSS bundle must place `base` before `dep` so the rule from the later
+  // source-import wins.
+  test('should preserve source-import order across force-split chunks', () => {
+    const css = findAssetFile(/style-[-\w]+\.css$/)
+    const baseIdx = css.indexOf('.order-static')
+    const depIdx = css.indexOf('.order-static', baseIdx + 1)
+    expect(baseIdx).toBeGreaterThanOrEqual(0)
+    if (depIdx >= 0) {
+      // unminified bundle: both rules are present in source-import order
+      expect(css.slice(baseIdx, depIdx)).toContain('red')
+      expect(css.slice(depIdx)).toContain('green')
+    } else {
+      // minified bundle: duplicate `.order-static` rules collapse and
+      // the last (later-source-order) rule wins
+      expect(css).toContain('green')
+      expect(css).not.toContain('red')
+    }
   })
 })

--- a/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
+++ b/playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts
@@ -28,13 +28,13 @@ describe.runIf(isBuild)('build', () => {
     expect(baseIdx).toBeGreaterThanOrEqual(0)
     if (depIdx >= 0) {
       // unminified bundle: both rules are present in source-import order
-      expect(css.slice(baseIdx, depIdx)).toContain('red')
-      expect(css.slice(depIdx)).toContain('green')
+      expect(css.slice(baseIdx, depIdx)).toMatch(/color:\s*red/)
+      expect(css.slice(depIdx)).toMatch(/color:\s*green/)
     } else {
       // minified bundle: duplicate `.order-static` rules collapse and
       // the last (later-source-order) rule wins
-      expect(css).toContain('green')
-      expect(css).not.toContain('red')
+      expect(css).toMatch(/color:\s*green/)
+      expect(css).not.toMatch(/color:\s*red/)
     }
   })
 })

--- a/playground/css-no-codesplit/order-static-base.css
+++ b/playground/css-no-codesplit/order-static-base.css
@@ -1,0 +1,3 @@
+.order-static {
+  color: red;
+}

--- a/playground/css-no-codesplit/order-static-dep.css
+++ b/playground/css-no-codesplit/order-static-dep.css
@@ -1,0 +1,3 @@
+.order-static {
+  color: green;
+}

--- a/playground/css-no-codesplit/order-static-dep.js
+++ b/playground/css-no-codesplit/order-static-dep.js
@@ -1,0 +1,1 @@
+import './order-static-dep.css'

--- a/playground/css-no-codesplit/order-static.html
+++ b/playground/css-no-codesplit/order-static.html
@@ -1,0 +1,3 @@
+<script type="module" src="./order-static.js"></script>
+
+<p class="order-static">order-static: this should be green</p>

--- a/playground/css-no-codesplit/order-static.js
+++ b/playground/css-no-codesplit/order-static.js
@@ -1,0 +1,10 @@
+// regression test for https://github.com/vitejs/vite/issues/22301
+// `order-static-base.css` is imported first, then `order-static-dep.js`
+// (force-split into its own chunk because it's a separate build input).
+// The CSS bundle must list `order-static-base.css` before
+// `order-static-dep.css` so the rule from the dep — semantically the
+// later import — overrides the base.
+import './order-static-base.css'
+import './order-static-dep.js'
+
+document.querySelector('.order-static')

--- a/playground/css-no-codesplit/vite.config.js
+++ b/playground/css-no-codesplit/vite.config.js
@@ -8,6 +8,18 @@ export default defineConfig({
       input: {
         index: resolve(import.meta.dirname, './index.html'),
         sub: resolve(import.meta.dirname, './sub.html'),
+        // regression entry for https://github.com/vitejs/vite/issues/22301:
+        // `order-static.html` imports `order-static.js` which statically
+        // imports `order-static-base.css` first, then `order-static-dep.js`.
+        // Because `order-static-dep.js` is also a build input, it is
+        // force-split into its own chunk that owns `order-static-dep.css`.
+        // The bundled CSS must place `order-static-base.css` before
+        // `order-static-dep.css` to match source-import order.
+        'order-static': resolve(import.meta.dirname, './order-static.html'),
+        'order-static-dep': resolve(
+          import.meta.dirname,
+          './order-static-dep.js',
+        ),
       },
     },
   },


### PR DESCRIPTION
## Description

Fixes the CSS bundle ordering when `cssCodeSplit: false`. The previous chunk-level walk visited `chunk.imports` (cross-chunk CSS) first and appended the chunk's own CSS last. Because a chunk's "own CSS" can come from modules imported *before* other modules whose CSS lives in another chunk, this inverted the source-import order whenever a force-split dependency was involved.

Concrete repro from the issue: an entry that does

```js
import './style.css'
import './counter.js' // force-split into its own chunk
```

emitted `counter-style.css` *before* `style.css` in the bundled stylesheet — the opposite of source order — so later overrides in `counter.js`'s CSS lost to earlier base styles.

### Root cause

In `packages/vite/src/node/plugins/css.ts`, the old `collect(chunkName)` recursion walked `chunk.imports` first and only then appended `chunkCSSMap.get(chunkName)`. That ordering is fine when a chunk has no own CSS interleaved with imports, but breaks the moment a module's CSS comes *between* other imports in the source.

### Fix

Replaced the chunk-level walk with a per-module walk, scoped strictly to the `cssCodeSplit: false` branch:

- During `renderChunk`, record CSS keyed by source module id (per chunk) in addition to the existing per-chunk map.
- In `generateBundle`, walk modules via `getModuleInfo(id).importedIds`, which preserves source-import order. When the walk encounters an import that lives in a different chunk, recurse into that chunk *at exactly that source position*, so cross-chunk CSS is interleaved correctly.
- Iterate multi-entry builds in two passes: entries that are NOT imported by another entry first, so an importing entry's walk gets the chance to recurse into its dependency entries at the correct source position.

`cssCodeSplit: true` and the rest of the pipeline are untouched.

fixes #22301

## Alternatives explored

This is a non-trivial change. Earlier reporters and patches tried more localized fixes — e.g. swapping the order of "own CSS" vs "imported CSS" inside `collect()`, or sorting chunks by entry order — and each one broke a different ordering case (CSS overrides from a dependency vs. CSS overrides from the entry, multi-entry shared chunks, async imports). The only ordering that's actually well-defined is the *source import order of the modules*, which Rollup already exposes via `getModuleInfo().importedIds`. Walking that graph directly avoids having to reconstruct module order from chunk metadata.

## Testing

Added a regression scenario to `playground/css-no-codesplit`:

- New entries `order-static.html` / `order-static.js` import a base stylesheet and then a force-split dependency (`order-static-dep.js`) whose CSS overrides the base.
- `vite.config.js` adds the new entry and force-splits the dep into its own chunk to reproduce the original bug shape.
- New assertion in `playground/css-no-codesplit/__tests__/css-no-codesplit.spec.ts` verifies the source-imported override (`green`) wins over the earlier-imported base (`red`) in the built bundle.

Verified failing-before / passing-after by reverting only the `css.ts` change.

Validation run locally:

- `pnpm run build` — pass
- `pnpm run test-unit` — 779 passed, 4 skipped (all 44 css unit tests pass)
- `pnpm run typecheck` — pass
- `pnpm run lint` — pass (only a pre-existing parse error in `playground/preserve-symlinks/module-a/linked.js`, unrelated)
- `playground/css-codesplit` (`cssCodeSplit: true`) and `playground/css` builds still succeed — fix is scoped to `cssCodeSplit: false`
- `playground/css-no-codesplit` build output verified manually; full e2e on Windows is blocked by an unrelated symlink fixture setup limitation.

## What type of PR is this?

- Bug fix
