### PR TITLE
fix(module-graph): keep bare-specifier urls intact

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -474,7 +474,13 @@ export class EnvironmentModuleGraph {
     if (
       url !== resolvedId &&
       !url.includes('\0') &&
-      !url.startsWith(`virtual:`)
+      !url.startsWith(`virtual:`) &&
+      // Skip extension append for bare specifiers (e.g. `pkg-name`,
+      // `@scope/pkg`). The extension append is meant to align path-style
+      // URLs (e.g. `/foo` -> `/foo.js`) with their resolved file id, but
+      // is meaningless for bare module specifiers used as runner entries
+      // and would produce unresolvable urls like `pkg-name.js` (#19975).
+      (url[0] === '/' || url[0] === '.')
     ) {
       const ext = extname(cleanUrl(resolvedId))
       if (ext) {

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -228,6 +228,33 @@ describe('module runner initialization', async () => {
     expect(fn.called).toBe(true)
   })
 
+  // regression test for #19975: when a bare specifier (node_modules dep) is
+  // used directly as the runner entry, the cached module url must not have a
+  // file extension appended to the bare specifier. Otherwise re-importing the
+  // entry (e.g. on full reload) tries to resolve a non-existent specifier
+  // like `pkg.js` and fails with "Failed to load url pkg.js".
+  it('importing node_modules dep as runner entry preserves bare specifier url', async ({
+    runner,
+  }) => {
+    const mod = await runner.import('@vitejs/esm-external')
+    expect(mod.hello()).toBe('world')
+
+    // mimic the full-reload path: collect entrypoint urls from the runner's
+    // module graph (modules without importers) and re-import them.
+    const entrypointUrls = [...runner.evaluatedModules.idToModuleMap.values()]
+      .filter((m) => !m.importers.size)
+      .map((m) => m.url)
+    expect(entrypointUrls).toContain('@vitejs/esm-external')
+
+    runner.evaluatedModules.clear()
+    for (const url of entrypointUrls) {
+      const reloaded = await runner.import(url)
+      if (url === '@vitejs/esm-external') {
+        expect((reloaded as { hello: () => string }).hello()).toBe('world')
+      }
+    }
+  })
+
   it('importing native node package', async ({ runner }) => {
     const mod = await runner.import('/fixtures/native.js')
     expect(mod.readdirSync).toBe(readdirSync)


### PR DESCRIPTION
### Description

Fixes #19975.

When a bare specifier like `test-dep` is imported as an entry through the SSR module runner, `EnvironmentModuleGraph._resolveUrl` resolved it to an absolute file path and then ran the extension-alignment branch, which appended `.js` to the URL — producing `test-dep.js`. That URL was stored on `mod.url` and propagated to the runner's module graph. On full reload (via `vite:beforeFullReload` in `hmrHandler.ts`), the runner re-imports modules by their `url`, and `test-dep.js` is not a resolvable specifier, so `loadAndTransform` throws.

The extension alignment is intentional for path-style URLs (so `/foo` and `/foo.js` map to the same module), but it is meaningless and harmful for bare module specifiers used as runner entries.

The fix is a one-line guard so the extension append only runs for path-style URLs (`url[0] === '/' || url[0] === '.'`). Bare specifiers are now left unchanged, matching how `\0`-prefixed and `virtual:`-prefixed URLs are already left alone in the same guard.

### Additional context

Alternatives considered:

- Stripping the appended extension at the runner side before re-importing: rejected because `mod.url` would still be wrong for any other consumer of the module graph.
- Skipping the alignment whenever the resolved id differs from the URL: rejected because path-style URLs intentionally rely on the alignment.

The chosen guard mirrors the existing handling of `\0` and `virtual:` URLs in the same code path, keeping the rule "URLs that aren't path-style are passed through verbatim" consistent.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

---

#### Testing

- Added a regression test in `packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts` that imports `@vitejs/esm-external` as a bare-specifier entry, asserts the entrypoint URL stays `@vitejs/esm-external` (not `@vitejs/esm-external.mjs`), then simulates full reload by clearing evaluated modules and re-importing. Fails before the fix, passes after.
- `pnpm run test-unit` — 780 passed, 4 skipped (full suite).
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed (only a pre-existing parse error in `playground/preserve-symlinks/module-a/linked.js`, unrelated).
- `pnpm run build` — passed.
