### PR TITLE
feat: don't require build.lib.name for format iife

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -338,15 +338,13 @@ describe('resolveBuildOutputs', () => {
     )
   })
 
-  test('throws an error when lib.name is missing on iife format', () => {
+  test('does not throw an error when lib.name is missing on iife format', () => {
     const logger = createLogger()
     const libOptions: LibraryOptions = {
       ...baseLibOptions,
       formats: ['iife'],
     }
-    const resolveBuild = () => resolveBuildOutputs(void 0, libOptions, logger)
-
-    expect(resolveBuild).toThrowError(/Option "build\.lib\.name" is required/)
+    resolveBuildOutputs(void 0, libOptions, logger)
   })
 
   test('throws an error when lib.name is missing on umd format', () => {
@@ -671,8 +669,8 @@ describe('resolveBuildOutputs', () => {
     })
   })
 
-  test('umd or iife: should define build.lib.name', () => {
-    ;['umd', 'iife'].forEach((format) => {
+  test('umd: should define build.lib.name', () => {
+    ;['umd'].forEach((format) => {
       expect(() =>
         resolveBuildOutputs(
           undefined,
@@ -683,7 +681,20 @@ describe('resolveBuildOutputs', () => {
           {} as Logger,
         ),
       ).toThrow(
-        `Option "build.lib.name" is required when output formats include "umd" or "iife".`,
+        `Option "build.lib.name" is required when output formats include "umd".`,
+      )
+    })
+  })
+
+  test('iife: does not need to define build.lib.name', () => {
+    ;['iife'].forEach((format) => {
+      resolveBuildOutputs(
+        undefined,
+        {
+          entry: 'entryA.js',
+          formats: [format as LibraryFormats],
+        },
+        {} as Logger,
       )
     })
   })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1022,10 +1022,11 @@ export function resolveBuildOutputs(
             'Multiple entry points are not supported when output formats include "umd" or "iife".',
           )
         }
-
+      }
+      if (libFormats.includes('umd')) {
         if (!libOptions.name) {
           throw new Error(
-            'Option "build.lib.name" is required when output formats include "umd" or "iife".',
+            'Option "build.lib.name" is required when output formats include "umd".',
           )
         }
       }


### PR DESCRIPTION
I don't understand why `build.lib.name` is currently required for `iife` format?

I understand that certain bundlers build IIFE like that:
```
var MyVariable = (() => {})();
```

But vite builds it like that:
```
(() => {})();
```

So that name is never used. It forces users to come up with some name that is not going to be used.

I checked my bundle output and I did `Find all...` searching for that name I used in the config nowhere to be found. Maybe it's just unnecessary for `iife`?