### PR TITLE
perf: cache compiled RegExp for proxy context matching

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -79,6 +79,7 @@ export function proxyMiddleware(
 ): Connect.NextHandleFunction {
   // lazy require only when proxy is used
   const proxies: Record<string, [httpProxy.ProxyServer, ProxyOptions]> = {}
+  const regexCache = new Map<string, RegExp>()
 
   Object.keys(options).forEach((context) => {
     let opts = options[context]
@@ -136,13 +137,16 @@ export function proxyMiddleware(
 
     // clone before saving because http-proxy mutates the options
     proxies[context] = [proxy, { ...opts }]
+    if (context[0] === '^') {
+      regexCache.set(context, new RegExp(context))
+    }
   })
 
   if (httpServer) {
     httpServer.on('upgrade', async (req, socket, head) => {
       const url = req.url!
       for (const context in proxies) {
-        if (doesProxyContextMatchUrl(context, url)) {
+        if (doesProxyContextMatchUrl(context, url, regexCache)) {
           const [proxy, opts] = proxies[context]
           if (
             opts.ws ||
@@ -190,7 +194,7 @@ export function proxyMiddleware(
   return async function viteProxyMiddleware(req, res, next) {
     const url = req.url!
     for (const context in proxies) {
-      if (doesProxyContextMatchUrl(context, url)) {
+      if (doesProxyContextMatchUrl(context, url, regexCache)) {
         const [proxy, opts] = proxies[context]
         const options: httpProxy.ServerOptions = {}
 
@@ -228,9 +232,13 @@ export function proxyMiddleware(
   }
 }
 
-function doesProxyContextMatchUrl(context: string, url: string): boolean {
-  return (
-    (context[0] === '^' && new RegExp(context).test(url)) ||
-    url.startsWith(context)
-  )
+function doesProxyContextMatchUrl(
+  context: string,
+  url: string,
+  regexCache: Map<string, RegExp>,
+): boolean {
+  if (context[0] === '^') {
+    return regexCache.get(context)!.test(url)
+  }
+  return url.startsWith(context)
 }


### PR DESCRIPTION
## Summary

- `server.proxy` contexts starting with `^` were compiled via `new RegExp(context)` on every incoming request
- Pre-compile them once during `proxyMiddleware` initialization and reuse via a `Map` cache

## Details

`doesProxyContextMatchUrl` was called on every request for every proxy context. When a context started with `^`, it created a new `RegExp` object each time — regex compilation is relatively expensive and the pattern never changes after config is loaded.

```ts
// before: compiled on every request
(context[0] === '^' && new RegExp(context).test(url))

// after: compiled once at startup, reused from cache
regexCache.get(context)!.test(url)
```

The fix adds a `regexCache: Map<string, RegExp>` inside `proxyMiddleware` that is populated when the proxy entries are initialized, and passes it down to `doesProxyContextMatchUrl`.

## Test plan

- [ ] Existing proxy-related tests pass
- [ ] Dev server with `server.proxy: { '^/api': '...' }` routes requests correctly