### PR TITLE
fix(css): add charset for non-ASCII bundles (fix #22381)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -81,6 +81,43 @@ describe('build', () => {
     assertOutputHashContentChange(result[0], result[1])
   })
 
+  test('prepends a charset rule to emitted CSS with non-ASCII codepoints', async () => {
+    const result = (await build({
+      root: resolve(dirname, 'packages/build-project'),
+      logLevel: 'silent',
+      build: {
+        write: false,
+      },
+      plugins: [
+        {
+          name: 'test',
+          resolveId(id) {
+            if (id === 'entry.js' || id === 'foo.css') {
+              return '\0' + id
+            }
+          },
+          load(id) {
+            if (id === '\0entry.js') {
+              return `import 'foo.css'`
+            }
+            if (id === '\0foo.css') {
+              return `.icon::before { content: "\uf200" }`
+            }
+          },
+        },
+      ],
+    })) as RolldownOutput
+
+    const cssAsset = result.output.find(
+      (chunk) => chunk.type === 'asset' && chunk.fileName.endsWith('.css'),
+    )
+
+    expect(cssAsset?.source).toEqual(
+      expect.stringMatching(/^@charset "UTF-8";/),
+    )
+    expect(cssAsset?.source).toContain('\uf200')
+  })
+
   test('file hash should change when pure css chunk changes', async () => {
     const buildProject = async (cssColor: string) => {
       return (await build({

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1900,6 +1900,7 @@ function combineSourcemapsIfExists(
 
 const viteHashUpdateMarker = '/*$vite$:1*/'
 const viteHashUpdateMarkerRE = /\/\*\$vite\$:\d+\*\//
+const cssCharsetUTF8 = '@charset "UTF-8";'
 
 async function finalizeCss(css: string, config: ResolvedConfig) {
   // hoist external @imports and @charset to the top of the CSS chunk per spec (#1845 and #6333)
@@ -1908,6 +1909,9 @@ async function finalizeCss(css: string, config: ResolvedConfig) {
   }
   if (config.build.cssMinify) {
     css = await minifyCSS(css, config, false)
+  }
+  if (needsCharset(css)) {
+    css = cssCharsetUTF8 + css
   }
   // inject an additional string to generate a different hash for https://github.com/vitejs/vite/issues/18038
   //
@@ -2309,6 +2313,26 @@ const atImportRE =
   /@import(?:\s*(?:url\([^)]*\)|"(?:[^"]|(?<=\\)")*"|'(?:[^']|(?<=\\)')*').*?|[^;]*);/g
 const atCharsetRE =
   /@charset(?:\s*(?:"(?:[^"]|(?<=\\)")*"|'(?:[^']|(?<=\\)')*').*?|[^;]*);/g
+
+function needsCharset(css: string): boolean {
+  if (!hasNonAscii(css) || css.charCodeAt(0) === 0xfeff) {
+    return false
+  }
+
+  atCharsetRE.lastIndex = 0
+  const hasCharset = atCharsetRE.test(emptyCssComments(css))
+  atCharsetRE.lastIndex = 0
+  return !hasCharset
+}
+
+function hasNonAscii(css: string): boolean {
+  for (let i = 0; i < css.length; i++) {
+    if (css.charCodeAt(i) > 0x7f) {
+      return true
+    }
+  }
+  return false
+}
 
 export async function hoistAtRules(css: string): Promise<string> {
   const s = new MagicString(css)


### PR DESCRIPTION
## Description

Fixes #22381.

Vite can emit CSS bundles containing raw non-ASCII codepoints (for example private-use icon font glyphs in `content:` rules). If the CSS response is served without a charset signal, browsers may decode the UTF-8 bytes using a legacy fallback encoding and icon fonts can render incorrectly.

This prepends `@charset "UTF-8";` to emitted CSS assets only when the finalized CSS contains non-ASCII codepoints and does not already have a charset rule/BOM.

## Tests

- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts packages/vite/src/node/__tests__/plugins/css.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/plugins/css.ts packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/plugins/css.ts packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm --filter vite build-bundle`
- `git diff --check HEAD~1..HEAD`
