### PR TITLE
test(create-vite): use short help alias

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -222,7 +222,7 @@ test('return help usage how to use create-vite', () => {
 })
 
 test('return help usage how to use create-vite with -h alias', () => {
-  const { stdout } = run(['--h'], { cwd: import.meta.dirname })
+  const { stdout } = run(['-h'], { cwd: import.meta.dirname })
   const message = 'Usage: create-vite [OPTION]... [DIRECTORY]'
   expect(stdout).toContain(message)
 })


### PR DESCRIPTION
## Summary

Update the create-vite help alias test to use the actual short `-h` alias.

## Problem

The test name says it verifies the `-h` alias, but the test was running `--h` instead.

## Fix

Change the test input from `--h` to `-h`.

## Verification

- `pnpm vitest packages/create-vite/__tests__/cli.spec.ts`