### PR TITLE
feat(css): emit named exports for JS keyword class names in CSS modules

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -77,7 +77,9 @@ describe('css modules', () => {
       },
     })
 
-    expect(code).toContain('_arbitrary0 as "switch"')
+    // `switch` is a valid IdentifierName, so it uses the unquoted ES2015 form;
+    // only `foo-bar` needs the quoted arbitrary-namespace form.
+    expect(code).toContain('_arbitrary0 as switch')
     expect(code).toContain('_arbitrary1 as "foo-bar"')
   })
 
@@ -89,7 +91,7 @@ describe('css modules', () => {
       },
     })
 
-    expect(code).toContain('export {\n\t_identifier0 as switch\n};')
+    expect(code).toContain('_arbitrary0 as switch')
     expect(code).toContain('"switch": "_switch_')
     expect(code).not.toContain(' as "foo-bar"')
     expect(code).toContain('"foo-bar": "_foo-bar_')

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -7,10 +7,12 @@ import type { InlineConfig } from '../../config'
 import {
   convertTargets,
   cssPlugin,
+  cssPostPlugin,
   cssUrlRE,
   getEmptyChunkReplacer,
   hoistAtRules,
   injectInlinedCSS,
+  isArbitraryModuleNamespaceIdentifierNameSupported,
   preprocessCSS,
   resolveLibCssFilename,
 } from '../../plugins/css'
@@ -67,6 +69,32 @@ describe('search css url function', () => {
 })
 
 describe('css modules', () => {
+  test('includes arbitrary named exports for supported targets', async () => {
+    const code = await transformCssModuleToJs({
+      configFile: false,
+      build: {
+        target: 'es2022',
+      },
+    })
+
+    expect(code).toContain('_arbitrary0 as "switch"')
+    expect(code).toContain('_arbitrary1 as "foo-bar"')
+  })
+
+  test('includes keyword named exports for unsupported arbitrary name targets', async () => {
+    const code = await transformCssModuleToJs({
+      configFile: false,
+      build: {
+        target: 'es2021',
+      },
+    })
+
+    expect(code).toContain('export {\n\t_identifier0 as switch\n};')
+    expect(code).toContain('"switch": "_switch_')
+    expect(code).not.toContain(' as "foo-bar"')
+    expect(code).toContain('"foo-bar": "_foo-bar_')
+  })
+
   test('css module compose/from path resolutions', async () => {
     const { transform } = await createCssPluginTransform({
       configFile: false,
@@ -259,7 +287,81 @@ async function createCssPluginTransform(inlineConfig: InlineConfig = {}) {
   }
 }
 
+async function transformCssModuleToJs(inlineConfig: InlineConfig = {}) {
+  const config = await resolveConfig(inlineConfig, 'build')
+  const environment = new PartialEnvironment('client', config)
+  const css = `.switch {
+  color: red;
+}
+.foo-bar {
+  color: blue;
+}`
+  const id = '/foo.module.css'
+
+  const { transform, buildStart } = cssPlugin(config)
+
+  // @ts-expect-error buildStart is function
+  await buildStart.call({})
+
+  // @ts-expect-error transform.handler is function
+  const cssResult = await transform.handler.call(
+    {
+      addWatchFile() {
+        return
+      },
+      environment,
+    },
+    css,
+    id,
+  )
+
+  const postPlugin = cssPostPlugin(config)
+
+  // @ts-expect-error transform.handler is function
+  const jsResult = await postPlugin.transform.handler.call(
+    {
+      environment,
+    },
+    cssResult.code,
+    id,
+  )
+
+  return jsResult.code
+}
+
 describe('convertTargets', () => {
+  test('detects arbitrary module namespace identifier name target support', () => {
+    expect(isArbitraryModuleNamespaceIdentifierNameSupported('es2022')).toBe(
+      true,
+    )
+    expect(
+      isArbitraryModuleNamespaceIdentifierNameSupported(
+        'baseline-widely-available',
+      ),
+    ).toBe(true)
+    expect(isArbitraryModuleNamespaceIdentifierNameSupported('es2021')).toBe(
+      false,
+    )
+    expect(isArbitraryModuleNamespaceIdentifierNameSupported('node16')).toBe(
+      true,
+    )
+    expect(
+      isArbitraryModuleNamespaceIdentifierNameSupported([
+        'chrome90',
+        'safari14.1',
+      ]),
+    ).toBe(true)
+    expect(
+      isArbitraryModuleNamespaceIdentifierNameSupported([
+        'chrome90',
+        'safari14.0',
+      ]),
+    ).toBe(false)
+    expect(isArbitraryModuleNamespaceIdentifierNameSupported('chrome89')).toBe(
+      false,
+    )
+  })
+
   test('basic cases', () => {
     expect(convertTargets('es2018')).toStrictEqual({
       chrome: 4128768,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -566,7 +566,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const modulesCode =
           modules &&
           !inlined &&
-          dataToEsm(modules, { namedExports: true, preferConst: true })
+          dataToEsm(modules, {
+            namedExports: true,
+            preferConst: true,
+            includeArbitraryNames: true,
+          })
 
         if (config.command === 'serve') {
           const getContentWithSourcemap = async (content: string) => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -14,7 +14,7 @@ import type {
   RollupError,
   SourceMapInput,
 } from 'rolldown'
-import { dataToEsm, makeLegalIdentifier } from '@rollup/pluginutils'
+import { dataToEsm } from '@rollup/pluginutils'
 import colors from 'picocolors'
 import MagicString from 'magic-string'
 import type * as PostCSS from 'postcss'
@@ -3505,54 +3505,20 @@ const arbitraryModuleNamespaceIdentifierNameSupport: Record<
   safari: [14, 1],
 }
 
-const identifierNameRE = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u
-
+// Reserved-word class names (e.g. `switch`, `default`) and other keys that are
+// valid `IdentifierName`s are handled by `dataToEsm`, which emits the ES2015-safe
+// `export { _x as switch }` form. The quoted arbitrary-namespace form (ES2022+)
+// is gated on `includeArbitraryNames` based on the build target.
 const getCssModulesCode = (
   modules: Record<string, string>,
   esbuildTarget: string | string[] | false,
-): string => {
-  const includeArbitraryNames =
-    isArbitraryModuleNamespaceIdentifierNameSupported(esbuildTarget)
-  const code = dataToEsm(modules, {
+): string =>
+  dataToEsm(modules, {
     namedExports: true,
     preferConst: true,
-    includeArbitraryNames,
+    includeArbitraryNames:
+      isArbitraryModuleNamespaceIdentifierNameSupported(esbuildTarget),
   })
-
-  if (includeArbitraryNames) {
-    return code
-  }
-
-  const identifierNameKeys = Object.keys(modules).filter(
-    (key) => key !== makeLegalIdentifier(key) && identifierNameRE.test(key),
-  )
-  if (identifierNameKeys.length === 0) {
-    return code
-  }
-
-  let maxUnderbarPrefixLength = 0
-  for (const key of Object.keys(modules)) {
-    const underbarPrefixLength = /^_+/.exec(key)?.[0].length ?? 0
-    if (underbarPrefixLength > maxUnderbarPrefixLength) {
-      maxUnderbarPrefixLength = underbarPrefixLength
-    }
-  }
-
-  const identifierNamePrefix = `${'_'.repeat(maxUnderbarPrefixLength + 1)}identifier`
-  const identifierNameExportRows = identifierNameKeys.map((key, index) => {
-    const variableName = `${identifierNamePrefix}${index}`
-    return {
-      declaration: `const ${variableName} = ${JSON.stringify(modules[key])};`,
-      export: `${variableName} as ${key}`,
-    }
-  })
-
-  return `${identifierNameExportRows.map(({ declaration }) => declaration).join('\n')}
-export {
-\t${identifierNameExportRows.map(({ export: row }) => row).join(',\n\t')}
-};
-${code}`
-}
 
 export const isArbitraryModuleNamespaceIdentifierNameSupported = (
   esbuildTarget: string | string[] | false,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -14,7 +14,7 @@ import type {
   RollupError,
   SourceMapInput,
 } from 'rolldown'
-import { dataToEsm } from '@rollup/pluginutils'
+import { dataToEsm, makeLegalIdentifier } from '@rollup/pluginutils'
 import colors from 'picocolors'
 import MagicString from 'magic-string'
 import type * as PostCSS from 'postcss'
@@ -564,13 +564,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         // `foo.module.css` => modulesCode
         // `foo.module.css?inline` => cssContent
         const modulesCode =
-          modules &&
-          !inlined &&
-          dataToEsm(modules, {
-            namedExports: true,
-            preferConst: true,
-            includeArbitraryNames: true,
-          })
+          modules && !inlined && getCssModulesCode(modules, config.build.target)
 
         if (config.command === 'serve') {
           const getContentWithSourcemap = async (content: string) => {
@@ -3495,6 +3489,112 @@ const esMap: Record<number, string[]> = {
 
 const esRE = /es(6|\d{4})/
 const versionRE = /\d/
+
+// Minimum versions that support arbitrary module namespace identifier names
+// (e.g. `export { x as "string name" }`), matching esbuild's compat table.
+// https://github.com/evanw/esbuild/blob/main/internal/compat/js_table.go (ArbitraryModuleNamespaceNames)
+const arbitraryModuleNamespaceIdentifierNameSupport: Record<
+  string,
+  [major: number, minor: number]
+> = {
+  chrome: [90, 0],
+  edge: [90, 0],
+  firefox: [87, 0],
+  ios: [14, 5],
+  node: [16, 0],
+  safari: [14, 1],
+}
+
+const identifierNameRE = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u
+
+const getCssModulesCode = (
+  modules: Record<string, string>,
+  esbuildTarget: string | string[] | false,
+): string => {
+  const includeArbitraryNames =
+    isArbitraryModuleNamespaceIdentifierNameSupported(esbuildTarget)
+  const code = dataToEsm(modules, {
+    namedExports: true,
+    preferConst: true,
+    includeArbitraryNames,
+  })
+
+  if (includeArbitraryNames) {
+    return code
+  }
+
+  const identifierNameKeys = Object.keys(modules).filter(
+    (key) => key !== makeLegalIdentifier(key) && identifierNameRE.test(key),
+  )
+  if (identifierNameKeys.length === 0) {
+    return code
+  }
+
+  let maxUnderbarPrefixLength = 0
+  for (const key of Object.keys(modules)) {
+    const underbarPrefixLength = /^_+/.exec(key)?.[0].length ?? 0
+    if (underbarPrefixLength > maxUnderbarPrefixLength) {
+      maxUnderbarPrefixLength = underbarPrefixLength
+    }
+  }
+
+  const identifierNamePrefix = `${'_'.repeat(maxUnderbarPrefixLength + 1)}identifier`
+  const identifierNameExportRows = identifierNameKeys.map((key, index) => {
+    const variableName = `${identifierNamePrefix}${index}`
+    return {
+      declaration: `const ${variableName} = ${JSON.stringify(modules[key])};`,
+      export: `${variableName} as ${key}`,
+    }
+  })
+
+  return `${identifierNameExportRows.map(({ declaration }) => declaration).join('\n')}
+export {
+\t${identifierNameExportRows.map(({ export: row }) => row).join(',\n\t')}
+};
+${code}`
+}
+
+export const isArbitraryModuleNamespaceIdentifierNameSupported = (
+  esbuildTarget: string | string[] | false,
+): boolean => {
+  if (
+    !esbuildTarget ||
+    esbuildTarget === 'esnext' ||
+    esbuildTarget === 'baseline-widely-available'
+  ) {
+    return true
+  }
+
+  return arraify(esbuildTarget).every((entry) => {
+    if (entry === 'esnext') {
+      return true
+    }
+
+    const esMatch = esRE.exec(entry)
+    if (esMatch) {
+      const year = esMatch[1] === '6' ? 2015 : Number(esMatch[1])
+      return year >= 2022
+    }
+
+    const index = entry.search(versionRE)
+    if (index >= 0) {
+      const browser = entry.slice(0, index)
+      const minVersion = arbitraryModuleNamespaceIdentifierNameSupport[browser]
+      if (!minVersion) {
+        return false
+      }
+
+      const [major, minor = 0] = entry
+        .slice(index)
+        .split('.')
+        .map((v) => parseInt(v, 10))
+      const [minMajor, minMinor] = minVersion
+      return major > minMajor || (major === minMajor && minor >= minMinor)
+    }
+
+    return false
+  })
+}
 
 const convertTargetsCache = new Map<
   string | string[],

--- a/patches/@rollup__pluginutils@5.3.0.patch
+++ b/patches/@rollup__pluginutils@5.3.0.patch
@@ -1,0 +1,60 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 9559fa134c9c2e598107c3d24b6da028c668bb57..3f337e4f1ffaaef53e8e02d1aed53274f0ded740 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -303,6 +303,7 @@ function isWellFormedString(input) {
+     // https://github.com/tc39/proposal-is-usv-string/blob/main/README.md#algorithm
+     return !/\p{Surrogate}/u.test(input);
+ }
++const identifierNameRE = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
+ const dataToEsm = function dataToEsm(data, options = {}) {
+     var _a, _b;
+     const t = options.compact ? '' : 'indent' in options ? options.indent : '\t';
+@@ -340,10 +341,13 @@ const dataToEsm = function dataToEsm(data, options = {}) {
+         }
+         else {
+             defaultExportRows.push(`${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`);
+-            if (options.includeArbitraryNames && isWellFormedString(key)) {
+-                const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
+-                namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(value, options.compact ? null : t, '')};${n}`;
+-                arbitraryNameExportRows.push(`${variableName} as ${JSON.stringify(key)}`);
++            if (key !== 'default') {
++                const isIdentifierName = identifierNameRE.test(key);
++                if (isIdentifierName || (options.includeArbitraryNames && isWellFormedString(key))) {
++                    const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
++                    namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(value, options.compact ? null : t, '')};${n}`;
++                    arbitraryNameExportRows.push(`${variableName} as ${isIdentifierName ? key : JSON.stringify(key)}`);
++                }
+             }
+         }
+     }
+diff --git a/dist/es/index.js b/dist/es/index.js
+index eae161749d18d564f901a52000bfb36192ab411e..a4da9a939afb7194614ffd9556745e8b36edd507 100644
+--- a/dist/es/index.js
++++ b/dist/es/index.js
+@@ -299,6 +299,7 @@ function isWellFormedString(input) {
+     // https://github.com/tc39/proposal-is-usv-string/blob/main/README.md#algorithm
+     return !/\p{Surrogate}/u.test(input);
+ }
++const identifierNameRE = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
+ const dataToEsm = function dataToEsm(data, options = {}) {
+     var _a, _b;
+     const t = options.compact ? '' : 'indent' in options ? options.indent : '\t';
+@@ -336,10 +337,13 @@ const dataToEsm = function dataToEsm(data, options = {}) {
+         }
+         else {
+             defaultExportRows.push(`${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`);
+-            if (options.includeArbitraryNames && isWellFormedString(key)) {
+-                const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
+-                namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(value, options.compact ? null : t, '')};${n}`;
+-                arbitraryNameExportRows.push(`${variableName} as ${JSON.stringify(key)}`);
++            if (key !== 'default') {
++                const isIdentifierName = identifierNameRE.test(key);
++                if (isIdentifierName || (options.includeArbitraryNames && isWellFormedString(key))) {
++                    const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
++                    namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(value, options.compact ? null : t, '')};${n}`;
++                    arbitraryNameExportRows.push(`${variableName} as ${isIdentifierName ? key : JSON.stringify(key)}`);
++                }
+             }
+         }
+     }

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -192,6 +192,10 @@ export const tests = (isLightningCSS: boolean) => {
     await expect.poll(() => getColor(imported)).toBe('red')
   })
 
+  test('css modules with JS keyword class name', async () => {
+    expect(await getColor('.modules-keyword')).toBe('tomato')
+  })
+
   test('css modules composes/from path resolving', async () => {
     const imported = await page.$('.path-resolved-modules-css')
     expect(await getColor(imported)).toBe('turquoise')

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -134,6 +134,10 @@
 
   <p class="modules-treeshake">CSS modules should treeshake in build</p>
 
+  <p class="modules-keyword">
+    CSS modules with JS keyword class name: this should be tomato
+  </p>
+
   <p>Imported compose/from CSS/SASS module:</p>
   <p class="path-resolved-modules-css">
     CSS modules composes path resolving: this should be turquoise

--- a/playground/css/keyword.module.css
+++ b/playground/css/keyword.module.css
@@ -1,0 +1,3 @@
+.switch {
+  color: tomato;
+}

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -25,6 +25,9 @@ import sassMod from './mod.module.scss'
 document.querySelector('.modules-sass').classList.add(sassMod['apply-color'])
 text('.modules-sass-code', JSON.stringify(sassMod, null, 2))
 
+import * as keywordMod from './keyword.module.css'
+document.querySelector('.modules-keyword').classList.add(keywordMod.switch)
+
 import { a as treeshakeMod } from './treeshake-module/index.js'
 document
   .querySelector('.modules-treeshake')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ overrides:
 packageExtensionsChecksum: sha256-Tldxs3DhJEw/FFBonUidqhCBqApA0zxQnop3Y+BTO3U=
 
 patchedDependencies:
+  '@rollup/pluginutils@5.3.0':
+    hash: ba95dd7e76e187263ec83e88d9a1f0b2a4f8d8d259fdd63df5b4dc3bb1dcf1f4
+    path: patches/@rollup__pluginutils@5.3.0.patch
   chokidar@3.6.0:
     hash: 8a4f9e2b397e6034b91a0508faae3cecb97f222313faa129d7cb0eb71e9d0e84
     path: patches/chokidar@3.6.0.patch
@@ -277,7 +280,7 @@ importers:
         version: 2.1.4(rollup@4.59.0)
       '@rollup/pluginutils':
         specifier: ^5.3.0
-        version: 5.3.0(rollup@4.59.0)
+        version: 5.3.0(patch_hash=ba95dd7e76e187263ec83e88d9a1f0b2a4f8d8d259fdd63df5b4dc3bb1dcf1f4)(rollup@4.59.0)
       '@types/escape-html':
         specifier: ^1.0.4
         version: 1.0.4
@@ -10069,7 +10072,7 @@ snapshots:
 
   '@rollup/plugin-dynamic-import-vars@2.1.4(rollup@4.59.0)':
     dependencies:
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@rollup/pluginutils': 5.3.0(patch_hash=ba95dd7e76e187263ec83e88d9a1f0b2a4f8d8d259fdd63df5b4dc3bb1dcf1f4)(rollup@4.59.0)
       '@types/estree': 1.0.8
       astring: 1.9.0
       estree-walker: 2.0.2
@@ -10078,7 +10081,7 @@ snapshots:
     optionalDependencies:
       rollup: 4.59.0
 
-  '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
+  '@rollup/pluginutils@5.3.0(patch_hash=ba95dd7e76e187263ec83e88d9a1f0b2a4f8d8d259fdd63df5b4dc3bb1dcf1f4)(rollup@4.59.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ overrides:
   vite: 'workspace:*'
   debug: 'npm:obug@^1.0.2'
 patchedDependencies:
+  "@rollup/pluginutils@5.3.0": "patches/@rollup__pluginutils@5.3.0.patch"
   "sirv@3.0.2": "patches/sirv@3.0.2.patch"
   "chokidar@3.6.0": "patches/chokidar@3.6.0.patch"
   "dotenv-expand@13.0.0": "patches/dotenv-expand@13.0.0.patch"


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
                                                                                                   
  CSS modules containing class names that match JavaScript reserved keywords                                                               
  (e.g. `switch`, `if`, `for`, `class`) were not emitted as named exports,                                                                 
  making them accessible only via the default export object.
                                                                                                       
  ## Summary                                                                                                                               
                                                                                                                                           
  - `dataToEsm` skips named export generation when a key fails the                                                                         
    `key === makeLegalIdentifier(key)` check — reserved words like `switch`                                                                
    get prefixed to `_switch`, so they never match                                                                                         
  - Added `includeArbitraryNames: true` option to the `dataToEsm` call in                                                                  
    `cssPostPlugin`, which emits string-named exports for such keys:                                                                       
    `export { _arbitrary0 as "switch" }`                                                                                                   
  - Reserved keyword class names are now accessible via namespace import                                                                   
    (`styles.switch`) or string literal import (`import { "switch" as s }`)                                                                
                                                                                                                                           
  ## Related                                                                                                                               
                                                                                                                                           
  Fixes #14050                                                                                                                             
                                                                                                                                       
  ## Test plan
                                                                                                                                           
  Added playground test case with a CSS module containing a `.switch` class,                                                               
  verifying it is correctly applied via `import * as keywordMod` and                                                                       
  `keywordMod.switch`    