### PR TITLE
fix(create-vite): pass react framework to TanStack CLI

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -174,7 +174,7 @@ const FRAMEWORKS: Framework[] = [
         link: 'https://tanstack.com/router',
         color: cyan,
         customCommand:
-          'npm exec -- @tanstack/cli@latest create TARGET_DIR --interactive',
+          'npm exec -- @tanstack/cli@latest create TARGET_DIR --framework react --interactive',
       },
       {
         name: 'redwoodsdk-standard',


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
I used `create-vite@latest` to create a React project with TanStack Router. After selecting React in Vite, the TanStack CLI asks for the framework again because Vite does not pass `--framework react` to the CLI.

The Solid TanStack Router option already passes `--framework solid`, so this updates the React option to pass `--framework react` as well.

No linked issue; this appears to be caused by a recent TanStack CLI behavior change.

Tests:
- `pnpm --filter create-vite typecheck`
- `pnpm --filter create-vite build`

