### PR TITLE
fix: refer to `rolldownOptions` instead of deprecated `rollupOptions` in messages

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -21,7 +21,7 @@ Note the build will output a warning if the code contains features that cannot b
 - **Type:** `boolean | { polyfill?: boolean, resolveDependencies?: ResolveModulePreloadDependenciesFn }`
 - **Default:** `{ polyfill: true }`
 
-By default, a [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill) is automatically injected. The polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-HTML custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
+By default, a [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill) is automatically injected. The polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-HTML custom entry via `build.rolldownOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
 
 ```js
 import 'vite/modulepreload-polyfill'
@@ -269,7 +269,7 @@ When the value is a string, it will be used as the manifest file path relative t
 - **Default:** `false`
 - **Related:** [Server-Side Rendering](/guide/ssr)
 
-Produce SSR-oriented build. The value can be a string to directly specify the SSR entry, or `true`, which requires specifying the SSR entry via `rollupOptions.input`.
+Produce SSR-oriented build. The value can be a string to directly specify the SSR entry, or `true`, which requires specifying the SSR entry via `rolldownOptions.input`.
 
 ## build.emitAssets
 

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -8,7 +8,7 @@ Unless noted, the options in this section are only applied to the dependency opt
 
 - **Type:** `string | string[]`
 
-By default, Vite will crawl all your `.html` files to detect dependencies that need to be pre-bundled (ignoring `node_modules`, `build.outDir`, `__tests__` and `coverage`). If `build.rollupOptions.input` is specified, Vite will crawl those entry points instead.
+By default, Vite will crawl all your `.html` files to detect dependencies that need to be pre-bundled (ignoring `node_modules`, `build.outDir`, `__tests__` and `coverage`). If `build.rolldownOptions.input` is specified, Vite will crawl those entry points instead.
 
 If neither of these fit your needs, you can specify custom entries using this option - the value should be a [`tinyglobby` pattern](https://superchupu.dev/tinyglobby/comparison) or array of patterns that are relative from Vite project root. This will overwrite default entries inference. Only `node_modules` and `build.outDir` folders will be ignored by default when `optimizeDeps.entries` is explicitly defined. If other folders need to be ignored, you can use an ignore pattern as part of the entries list, marked with an initial `!`. `node_modules` will not be ignored for patterns that explicitly include the string `node_modules`.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -433,7 +433,7 @@ export default defineConfig({
 
 Whether or not to ignore source files in the server sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/articles/x-google-ignore-list/).
 
-`server.sourcemapIgnoreList` is the equivalent of [`build.rollupOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) for the dev server. A difference between the two config options is that the rollup function is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source in the same folder, so the relative path for `sourcePath` is the file name itself. In these cases, absolute paths makes it convenient to be used instead.
+`server.sourcemapIgnoreList` is the equivalent of [`build.rolldownOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) for the dev server. A difference between the two config options is that the rollup function is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source in the same folder, so the relative path for `sourcePath` is the file name itself. In these cases, absolute paths makes it convenient to be used instead.
 
 By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
 
@@ -450,5 +450,5 @@ export default defineConfig({
 ```
 
 ::: tip Note
-[`server.sourcemapIgnoreList`](#server-sourcemapignorelist) and [`build.rollupOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) need to be set independently. `server.sourcemapIgnoreList` is a server only config and doesn't get its default value from the defined rollup options.
+[`server.sourcemapIgnoreList`](#server-sourcemapignorelist) and [`build.rolldownOptions.output.sourcemapIgnoreList`](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) need to be set independently. `server.sourcemapIgnoreList` is a server only config and doesn't get its default value from the defined rollup options.
 :::

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -145,7 +145,7 @@ When `find` is a regular expression, the `replacement` can use [replacement patt
 If you have duplicated copies of the same dependency in your app (likely due to hoisting or linked packages in monorepos), use this option to force Vite to always resolve listed dependencies to the same copy (from project root).
 
 :::warning SSR + ESM
-For SSR builds, deduplication does not work for ESM build outputs configured from `build.rollupOptions.output`. A workaround is to use CJS build outputs until ESM has better plugin support for module loading.
+For SSR builds, deduplication does not work for ESM build outputs configured from `build.rolldownOptions.output`. A workaround is to use CJS build outputs until ESM has better plugin support for module loading.
 :::
 
 ## resolve.conditions <NonInheritBadge />

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -213,7 +213,7 @@ await build({
   root: path.resolve(import.meta.dirname, './project'),
   base: '/foo/',
   build: {
-    rollupOptions: {
+    rolldownOptions: {
       // ...
     },
   },

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -21,7 +21,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
      build: {
        // generate .vite/manifest.json in outDir
        manifest: true,
-       rollupOptions: {
+       rolldownOptions: {
          // overwrite default .html entry
          input: '/path/to/main.js',
        },
@@ -179,7 +179,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    ```
 
    Each entry in the manifest represents one of the following:
-   - **Entry chunks**: Generated from files specified in [`build.rollupOptions.input`](https://rollupjs.org/configuration-options/#input). These chunks have `isEntry: true` and their key is the relative src path from project root.
+   - **Entry chunks**: Generated from files specified in [`build.rolldownOptions.input`](https://rollupjs.org/configuration-options/#input). These chunks have `isEntry: true` and their key is the relative src path from project root.
    - **Dynamic entry chunks**: Generated from dynamic imports. These chunks have `isDynamicEntry: true` and their key is the relative src path from project root.
    - **Non-entry chunks**: Their key is the base name of the generated file prefixed with `_`.
    - **Asset chunks**: Generated from imported assets like images, fonts. Their key is the relative src path from project root.

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -364,7 +364,7 @@ describe('resolveBuildOutputs', () => {
     const resolveBuild = () => resolveBuildOutputs(outputs, libOptions, logger)
 
     expect(resolveBuild).toThrowError(
-      /Entries in "build\.rollupOptions\.output" must specify "name"/,
+      /Entries in "build\.rolldownOptions\.output" must specify "name"/,
     )
   })
 
@@ -375,7 +375,7 @@ describe('resolveBuildOutputs', () => {
     const resolveBuild = () => resolveBuildOutputs(outputs, libOptions, logger)
 
     expect(resolveBuild).toThrowError(
-      /Entries in "build\.rollupOptions\.output" must specify "name"/,
+      /Entries in "build\.rolldownOptions\.output" must specify "name"/,
     )
   })
 })

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -702,7 +702,7 @@ describe('resolveBuildOutputs', () => {
     ).toEqual([{ name: 'A' }])
     expect(log.warn).toHaveBeenLastCalledWith(
       colors.yellow(
-        `"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.`,
+        `"build.lib.formats" will be ignored because "build.rolldownOptions.output" is already an array format.`,
       ),
     )
   })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -669,21 +669,21 @@ export function resolveRolldownOptions(
     // @ts-expect-error See https://github.com/vitejs/vite/issues/5812#issuecomment-984345618
     if (output.output) {
       logger.warn(
-        `You've set "rollupOptions.output.output" in your config. ` +
+        `You've set "rolldownOptions.output.output" in your config. ` +
           `This is deprecated and will override all Vite.js default output options. ` +
-          `Please use "rollupOptions.output" instead.`,
+          `Please use "rolldownOptions.output" instead.`,
       )
     }
     if (output.file) {
       throw new Error(
-        `Vite does not support "rollupOptions.output.file". ` +
-          `Please use "rollupOptions.output.dir" and "rollupOptions.output.entryFileNames" instead.`,
+        `Vite does not support "rolldownOptions.output.file". ` +
+          `Please use "rolldownOptions.output.dir" and "rolldownOptions.output.entryFileNames" instead.`,
       )
     }
     if (output.sourcemap) {
       logger.warnOnce(
         colors.yellow(
-          `Vite does not support "rollupOptions.output.sourcemap". ` +
+          `Vite does not support "rolldownOptions.output.sourcemap". ` +
             `Please use "build.sourcemap" instead.`,
         ),
       )
@@ -1037,7 +1037,7 @@ export function resolveBuildOutputs(
     if (libOptions.formats) {
       logger.warn(
         colors.yellow(
-          '"build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.',
+          '"build.lib.formats" will be ignored because "build.rolldownOptions.output" is already an array format.',
         ),
       )
     }
@@ -1048,7 +1048,7 @@ export function resolveBuildOutputs(
         !output.name
       ) {
         throw new Error(
-          'Entries in "build.rollupOptions.output" must specify "name" when the format is "umd" or "iife".',
+          'Entries in "build.rolldownOptions.output" must specify "name" when the format is "umd" or "iife".',
         )
       }
     })
@@ -1090,7 +1090,7 @@ export function onRollupLog(
           `[vite]: Rolldown failed to resolve import "${exporter}" from "${id}".\n` +
             `This is most likely unintended because it can break your application at runtime.\n` +
             `If you do want to externalize this module explicitly add it to\n` +
-            `\`build.rollupOptions.external\``,
+            `\`build.rolldownOptions.external\``,
         )
       }
     }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2105,7 +2105,7 @@ export async function resolveConfig(
       if (hasDifferentReference) {
         resolved.logger.warn(
           colors.yellow(`
-assetFileNames isn't equal for every build.rollupOptions.output. A single pattern across all outputs is supported by Vite.
+assetFileNames isn't equal for every build.rolldownOptions.output. A single pattern across all outputs is supported by Vite.
 `),
         )
       }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -176,7 +176,7 @@ export interface DepOptimizationConfig {
 export type DepOptimizationOptions = DepOptimizationConfig & {
   /**
    * By default, Vite will crawl your `index.html` to detect dependencies that
-   * need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite
+   * need to be pre-bundled. If `build.rolldownOptions.input` is specified, Vite
    * will crawl those entry points instead.
    *
    * If neither of these fit your needs, you can specify custom entries using

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -214,7 +214,7 @@ async function computeEntries(environment: ScanEnvironment) {
       )?.id
       if (id === undefined) {
         throw new Error(
-          `failed to resolve rollupOptions.input value: ${JSON.stringify(p)}.`,
+          `failed to resolve rolldownOptions.input value: ${JSON.stringify(p)}.`,
         )
       }
       return id

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -130,7 +130,7 @@ export function scanImports(environment: ScanEnvironment): {
       if (!config.optimizeDeps.entries && !config.optimizeDeps.include) {
         environment.logger.warn(
           colors.yellow(
-            '(!) Could not auto-determine entry point from rollupOptions or html files ' +
+            '(!) Could not auto-determine entry point from rolldownOptions or html files ' +
               'and there are no explicit optimizeDeps.include patterns. ' +
               'Skipping dependency pre-bundling.',
           ),
@@ -226,7 +226,7 @@ async function computeEntries(environment: ScanEnvironment) {
     } else if (isObject(buildInput)) {
       entries = await Promise.all(Object.values(buildInput).map(resolvePath))
     } else {
-      throw new Error('invalid rollupOptions.input value.')
+      throw new Error('invalid rolldownOptions.input value.')
     }
   } else {
     entries = await globEntries('**/*.html', environment)


### PR DESCRIPTION
A targeted fix for https://github.com/vitejs/vite/issues/22399

Per https://vite.dev/config/build-options#build-rollupoptions :

> This option is an alias of `build.rolldownOptions` option. Use `build.rolldownOptions` option instead.