### PR TITLE
fix(worker): apply `build.target` to worker bundle

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -189,6 +189,7 @@ async function bundleWorkerEntry(
   await workerEnvironment.init()
 
   const chunkMetadataMap = new ChunkMetadataMap()
+  const workerBuildTarget = workerEnvironment.config.build.target
   const bundle = await rolldown({
     ...rollupOptions,
     input,
@@ -197,6 +198,10 @@ async function bundleWorkerEntry(
     ),
     onLog(level, log) {
       onRollupLog(level, log, workerEnvironment)
+    },
+    transform: {
+      target: workerBuildTarget === false ? undefined : workerBuildTarget,
+      ...rollupOptions.transform,
     },
     // TODO: remove this and enable rolldown's CSS support later
     moduleTypes: {


### PR DESCRIPTION
## Description

Worker bundles silently ignored `build.target` because the worker pipeline did not thread `target` into the `rolldown()` call. The main bundle in `build.ts` mirrors `options.target` into `transform.target`, but `plugins/worker.ts` skipped this step entirely.

As a result, ES2021+ syntax (logical assignment `??=`, `&&=`, `||=`, etc.) leaked into worker output even when the user explicitly set `build.target: 'es2020'`. On platforms like iOS WebView or older Android, this surfaces as a silent `SyntaxError` at runtime.

## Fix

Mirror the existing `transform.target` threading from `build.ts` (lines 638–646) inside `bundleWorkerEntry`. The worker bundle now respects the resolved `build.target` for the worker environment, with `rollupOptions.transform` still able to override per the user's intent.

```ts
const workerBuildTarget = workerEnvironment.config.build.target
const bundle = await rolldown({
  // ...
  transform: {
    target: workerBuildTarget === false ? undefined : workerBuildTarget,
    ...rollupOptions.transform,
  },
  // ...
})
```

## Reproduction

Minimal config:

```ts
// vite.config.ts
export default defineConfig({
  build: { target: 'es2020' },
  worker: { format: 'es' },
})
```

Worker source containing any ES2021+ syntax (e.g. `let a; a ??= 1`):

- Before: `??=` is preserved in the worker output despite `build.target: 'es2020'`.
- After: Output is correctly downleveled to ES2020.

Verified end-to-end against a real-world Vite 8 + Capacitor (iOS) project where the worker chunk previously contained 5× `??=`, 7× `&&=`, 27× `||=`, all of which are gone after the fix (worker chunk hash also changes, confirming bytewise different output).

## Alternatives considered

- Fixing the `workerResolved` merge order in `config.ts` so worker plugin `config()` returns can override oxc/esbuild for workers. This is a related but separate issue (worker plugins still cannot override target on a per-worker basis). The minimal fix here addresses the more fundamental bug — `build.target` was completely silenced for workers regardless of any config layer.
- Calling `convertEsbuildConfigToOxcConfig` for `workerConfig.esbuild`. This would not have helped, because the worker bundler never read from oxc/esbuild config in the first place — the target option was simply not passed to rolldown.

## Tests

Existing worker playground tests (`playground/worker/__tests__/*`) all continue to pass locally. I did not add a dedicated regression test in this PR — happy to add one in `playground/worker/__tests__/` (e.g. a `target` subdirectory verifying that a worker built with `build.target: 'es2020'` does not contain `??=` in output) if reviewers prefer. Pointing me at a preferred location/style would be helpful.

## Reviewer attention

- The `transform.target` precedence: worker `rollupOptions.transform` (if set) still wins, matching `build.ts`. Want to confirm this matches the intended override semantics.
- Whether `build.ts`'s `define` (e.g. `process.env.NODE_ENV` handling) should also be threaded for workers. I kept this PR minimal to the target bug; happy to extend if appropriate.