### PR TITLE
fix(worker): forward define to worker bundle transform

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -202,6 +202,11 @@ async function bundleWorkerEntry(
     transform: {
       target: workerBuildTarget === false ? undefined : workerBuildTarget,
       ...rollupOptions.transform,
+      define: {
+        ...rollupOptions.transform?.define,
+        // disable builtin process.env.NODE_ENV replacement as it is handled by the define plugin
+        'process.env.NODE_ENV': 'process.env.NODE_ENV',
+      },
     },
     // TODO: remove this and enable rolldown's CSS support later
     moduleTypes: {


### PR DESCRIPTION
## Description
Follow-up to #22404 as requested by @sapphi-red

The main bundle in `build.ts` (lines 641–645) threads `transform.define` to rolldown so that:

1. User-provided `rollupOptions.transform.define` is forwarded.
2. `process.env.NODE_ENV` is mapped to itself, which disables oxc's builtin replacement and lets vite's `define` plugin own that substitution consistently.

This change mirrors the same pattern in `bundleWorkerEntry` so workers behave identically to the main bundle, instead of letting oxc's builtin NODE_ENV replacement run independently for workers.

## Verification

- `pnpm run build` passes locally.
- Manual e2e: built vite locally and patched it into a real-world Vite 8 monorepo (capacitor + react + workers). The worker output remains correctly downleveled to `build.target` (no regression from #22404), and `process.env.NODE_ENV` is no longer subject to oxc's builtin substitution in workers.

## Tests

No new test added — same rationale as #22404. The change purely mirrors the main bundle's pattern. Happy to add a regression test in `playground/worker/__tests__/` if reviewers prefer (suggesting a layout would be helpful).