### PR TITLE
fix(client): ignore forward console send failures (fix #22407)

### DIFF
--- a/packages/vite/src/shared/__tests__/forwardConsole.spec.ts
+++ b/packages/vite/src/shared/__tests__/forwardConsole.spec.ts
@@ -1,5 +1,17 @@
-import { describe, expect, test } from 'vitest'
-import { formatConsoleArgs } from '../forwardConsole'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  formatConsoleArgs,
+  setupForwardConsoleHandler,
+} from '../forwardConsole'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function waitForUnhandledRejectionCheck() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 describe('formatConsoleArgs', () => {
   test('formats placeholders', () => {
@@ -57,5 +69,77 @@ describe('formatConsoleArgs', () => {
     ).toMatchInlineSnapshot(
       `"1n undefined true Symbol(s) [Function: sampleFn] Error: boom {"ok":true,"big":"2n","err":{"name":"Error","message":"nested"},"self":"[Circular]"}"`,
     )
+  })
+})
+
+describe('setupForwardConsoleHandler', () => {
+  test('swallows transport errors while forwarding unhandled rejections', async () => {
+    const transport = {
+      send: vi
+        .fn()
+        .mockRejectedValue(new Error('send was called before connect')),
+    }
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    try {
+      const window = new EventTarget()
+      vi.stubGlobal('window', window)
+      setupForwardConsoleHandler(transport as any, {
+        enabled: true,
+        unhandledErrors: true,
+        logLevels: [],
+      })
+
+      const event = new Event('unhandledrejection') as Event & {
+        reason: unknown
+      }
+      Object.defineProperty(event, 'reason', {
+        value: new Error('original rejection'),
+      })
+      window.dispatchEvent(event)
+
+      await waitForUnhandledRejectionCheck()
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+    }
+  })
+
+  test('swallows transport errors while forwarding console logs', async () => {
+    const consoleDebug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const transport = {
+      send: vi
+        .fn()
+        .mockRejectedValue(new Error('send was called before connect')),
+    }
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandledRejection)
+
+    try {
+      setupForwardConsoleHandler(transport as any, {
+        enabled: true,
+        unhandledErrors: false,
+        logLevels: ['debug'],
+      })
+
+      console.debug('after disconnect')
+
+      await waitForUnhandledRejectionCheck()
+
+      expect(consoleDebug).toHaveBeenCalledWith('after disconnect')
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+    }
   })
 })

--- a/packages/vite/src/shared/forwardConsole.ts
+++ b/packages/vite/src/shared/forwardConsole.ts
@@ -28,32 +28,37 @@ export function setupForwardConsoleHandler(
     return
   }
 
+  function sendForwardConsolePayload(data: ForwardConsolePayload) {
+    transport
+      .send({
+        type: 'custom',
+        event: 'vite:forward-console',
+        data,
+      })
+      .catch(() => {
+        // Ignore forwarding failures, e.g. when the WebSocket was disconnected.
+        // Re-throwing here would trigger `unhandledrejection` and recurse.
+      })
+  }
+
   function sendError(type: 'error' | 'unhandled-rejection', error: any) {
-    transport.send({
-      type: 'custom',
-      event: 'vite:forward-console',
+    sendForwardConsolePayload({
+      type,
       data: {
-        type,
-        data: {
-          name: error?.name || 'Unknown Error',
-          message: error?.message || String(error),
-          stack: error?.stack,
-        },
-      } satisfies ForwardConsolePayload,
+        name: error?.name || 'Unknown Error',
+        message: error?.message || String(error),
+        stack: error?.stack,
+      },
     })
   }
 
   function sendLog(level: ForwardConsoleLogLevel, args: unknown[]) {
-    transport.send({
-      type: 'custom',
-      event: 'vite:forward-console',
+    sendForwardConsolePayload({
+      type: 'log',
       data: {
-        type: 'log',
-        data: {
-          level,
-          message: formatConsoleArgs(args),
-        },
-      } satisfies ForwardConsolePayload,
+        level,
+        message: formatConsoleArgs(args),
+      },
     })
   }
 


### PR DESCRIPTION
### Description

Fixes #22407.

When forward console reports logs or unhandled errors after the client transport disconnects, `transport.send()` rejects. If that rejection is left unhandled, the forward console `unhandledrejection` listener can try to forward the send failure too and enter a loop.

This change routes forwarded console payloads through a shared helper that catches send failures and drops them when the transport is no longer available.

### Tests

- `pnpm --filter vite build-bundle`
- `pnpm run test-unit packages/vite/src/shared/__tests__/forwardConsole.spec.ts`
- `pnpm exec eslint packages/vite/src/shared/forwardConsole.ts packages/vite/src/shared/__tests__/forwardConsole.spec.ts --concurrency auto`
- `pnpm --filter vite build-types`
- `pnpm --filter vite typecheck`
- `git diff --check`
