### PR TITLE
fix(css): add @charset "UTF-8" for CSS bundles with non-ASCII characters

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1906,6 +1906,11 @@ async function finalizeCss(css: string, config: ResolvedConfig) {
   if (css.includes('@import') || css.includes('@charset')) {
     css = hoistAtRules(css)
   }
+  // Add @charset "UTF-8" if CSS contains non-ASCII characters and no charset is present
+  // to prevent encoding issues in browsers without explicit charset signals (#22381)
+  if (!css.includes('@charset') && /[^\x00-\x7F]/.test(css)) {
+    css = '@charset "UTF-8";\n' + css
+  }
   if (config.build.cssMinify) {
     css = await minifyCSS(css, config, false)
   }


### PR DESCRIPTION
## Description

Fixes #22381

This PR fixes a critical Vite 8 regression where CSS bundles containing non-ASCII characters (e.g. icon fonts) render incorrectly in browsers due to missing `@charset` declarations.

## Problem

In Vite 8, CSS bundles containing non-ASCII codepoints (e.g. PUA codepoints in icon fonts like `video-react`, FontAwesome) emit raw UTF-8 bytes with **no `@charset` declaration**. When browsers have no charset signal (no `@charset`, no BOM, no `Content-Type` charset), they can fall back to non-UTF-8 encodings, causing UTF-8 sequences to be mis-decoded.

**Example from the issue:**

```css
/* Source CSS */
.icon-play:before { content: ""; /* literal U+F200 PUA character */ }

/* Vite 8 bundle (no @charset) */
.icon-play:before{content:""}  /* raw UTF-8 bytes: 0xEF 0x88 0x80 */

/* Browser decodes as Windows-1252 instead of UTF-8 */
/* U+F200 (1 char) → "ïˆ€" (3 chars) */
/* Icon font renders .notdef glyphs (broken icons) */
```

**Verification from DevTools:**

```js
// Bundle on disk has correct codepoint:
const css = await (await fetch('/assets/index-XXXX.css')).text();
const m = css.match(/icon-play:before[^}]*content:"([^"]+)"/);
[...m[1]].map(c => c.codePointAt(0).toString(16))
// → ["f200"]   ✓ length 1, single PUA codepoint

// But browser-parsed CSS decodes it as three Windows-1252 chars:
const el = document.querySelector('.icon-play');
getComputedStyle(el, ':before').content
// → '"ïˆ€"'   ✗ three chars, mis-decoded UTF-8 bytes

// No @charset in bundle:
css.includes('@charset')  // false
// Response Content-Type: text/css (no charset)
```

## Root Cause

**Vite 6 behavior (worked):**
- Used esbuild as default CSS minifier
- esbuild defaults to `charset: "ascii"`, escaping non-ASCII as `\f200`
- Bundles were pure ASCII and encoding-independent

**Vite 8 behavior (broken):**
- Switched to Rolldown as default CSS minifier
- Rolldown preserves literal non-ASCII characters
- `finalizeCss` function hoists existing `@charset` rules but doesn't add missing ones
- Bundles contain raw UTF-8 bytes with no charset signal

## Solution

Add `@charset "UTF-8";` at the top of CSS bundles that:
1. Contain non-ASCII characters (detected via `/[^\x00-\x7F]/`)
2. Don't already have a `@charset` declaration

This matches CSS spec behavior and ensures browsers correctly decode UTF-8 content.

## Changes

**`packages/vite/src/node/plugins/css.ts`**

In the `finalizeCss` function (line 1904):

```typescript
async function finalizeCss(css: string, config: ResolvedConfig) {
  // hoist external @imports and @charset to the top of the CSS chunk per spec
  if (css.includes('@import') || css.includes('@charset')) {
    css = hoistAtRules(css)
  }
  
  // ✨ NEW: Add @charset "UTF-8" if CSS contains non-ASCII and no charset is present
  if (!css.includes('@charset') && /[^\x00-\x7F]/.test(css)) {
    css = '@charset "UTF-8";\n' + css
  }
  
  if (config.build.cssMinify) {
    css = await minifyCSS(css, config, false)
  }
  // ...
}
```

**Why this works:**
- Detects non-ASCII characters with `/[^\x00-\x7F]/` regex
- Only adds `@charset` when needed (no impact on ASCII-only CSS)
- Preserves existing `@charset` declarations (no duplication)
- Inserted before minification to ensure it stays at the top
- Matches CSS spec: `@charset` must be the first rule

## Impact

- ✅ **Fixes icon fonts and non-ASCII content in Vite 8** (primary fix for #22381)
- ✅ **No impact on ASCII-only CSS** (no `@charset` added)
- ✅ **No impact on CSS with existing `@charset`** (preserved by `hoistAtRules`)
- ✅ **Matches CSS spec** (`@charset` must be first rule)
- ✅ **No breaking changes** (only adds missing charset declarations)
- ✅ **Works with all minifiers** (Rolldown, esbuild, lightningcss)

## Example

**Before (broken):**
```css
.icon-play:before{content:""}  /* raw UTF-8, no @charset */
```

**After (fixed):**
```css
@charset "UTF-8";
.icon-play:before{content:""}  /* UTF-8 with explicit charset */
```

The `@charset` declaration ensures browsers decode the UTF-8 bytes correctly regardless of HTTP headers or environment encoding.

## Testing

Tested scenarios:
- ✅ CSS with icon fonts (PUA characters) → `@charset` added
- ✅ CSS with emoji/Unicode → `@charset` added
- ✅ ASCII-only CSS → no `@charset` added
- ✅ CSS with existing `@charset` → preserved, not duplicated
- ✅ Works with `cssCodeSplit: true` and `cssCodeSplit: false`
- ✅ Works with all CSS minifiers (Rolldown, esbuild, lightningcss)

## Related

- Fixes #22381
- Regression from Vite 6 → Vite 8 (Rolldown switch)
- CSS spec: https://www.w3.org/TR/css-syntax-3/#charset-rule