### PR TITLE
fix: use js alias plugin for build aliases

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/index.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/index.spec.ts
@@ -1,7 +1,13 @@
 import { RUNTIME_MODULE_ID } from 'rolldown'
 import { exactRegex } from 'rolldown/filter'
 import { afterAll, describe, expect, test, vi } from 'vitest'
-import { type InlineConfig, type Plugin, build, createServer } from '../..'
+import {
+  type InlineConfig,
+  type Plugin,
+  build,
+  createServer,
+  resolveConfig,
+} from '../..'
 
 const getConfigWithPlugin = (
   plugins: Plugin[],
@@ -166,4 +172,44 @@ describe('hook filter with build', async () => {
       any,
     )
   })
+})
+
+test('build uses the JS alias plugin for resolve.alias', async () => {
+  const config = await resolveConfig(
+    {
+      configFile: false,
+      resolve: {
+        alias: {
+          '@': '/src',
+        },
+      },
+    },
+    'build',
+  )
+
+  expect(config.plugins.some((plugin) => plugin.name === 'alias')).toBe(true)
+  expect(
+    config.plugins.some((plugin) => plugin.name === 'builtin:vite-alias'),
+  ).toBe(false)
+})
+
+test('bundled dev keeps the native alias plugin for resolve.alias', async () => {
+  const config = await resolveConfig(
+    {
+      configFile: false,
+      experimental: {
+        bundledDev: true,
+      },
+      resolve: {
+        alias: {
+          '@': '/src',
+        },
+      },
+    },
+    'serve',
+  )
+
+  expect(
+    config.plugins.some((plugin) => plugin.name === 'builtin:vite-alias'),
+  ).toBe(true)
 })

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -49,6 +49,10 @@ export async function resolvePlugins(
   const isBuild = config.command === 'build'
   const isBundled = config.isBundled
   const isWorker = config.isWorker
+  // Build keeps the JS alias plugin to preserve Vite resolver semantics in
+  // programmatic build hosts; bundled dev can still use the native alias plugin.
+  const useNativeAliasPlugin =
+    isBundled && !isBuild && !config.resolve.alias.some((v) => v.customResolver)
   const buildPlugins = isBundled
     ? (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
@@ -62,7 +66,7 @@ export async function resolvePlugins(
     !isBundled ? optimizedDepsPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     !isBundled ? preAliasPlugin(config) : null,
-    isBundled && !config.resolve.alias.some((v) => v.customResolver)
+    useNativeAliasPlugin
       ? nativeAliasPlugin({
           entries: config.resolve.alias.map((item) => {
             return {


### PR DESCRIPTION
### Description

Fixes #22410.

`resolve.alias` in build currently selects Rolldown's native `viteAliasPlugin` when there is no custom resolver. In a Windows Cypress 15 preprocessor `build()` run, that plugin stays in the Vite plugin list but does not resolve `@/...`. The JS alias plugin path, and the user workaround of moving the alias to `build.rolldownOptions.resolve.alias`, both resolve it.

This keeps build on the JS alias plugin so programmatic build hosts use Vite's JS resolver path for aliases. The native alias plugin remains available for bundled dev when no custom resolver is used.

### Validation

- `pnpm exec vitest run packages/vite/src/node/__tests__/plugins/index.spec.ts`
- `pnpm --filter vite build`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/plugins/index.ts packages/vite/src/node/__tests__/plugins/index.spec.ts`
- Windows repro: Cypress 15.14.1, Node 22.22.2, Vite tarball from this branch, `npx cypress run --browser electron --headless --spec cypress/e2e/alert.cy.js`