### PR TITLE
docs: add guide for handling query parameters in plugins

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -108,6 +108,35 @@ export default function myPlugin() {
 
 See the example in the [next section](#virtual-modules-convention).
 
+## Handling Query Parameters
+
+Module IDs passed to plugin hooks may include query parameters (e.g., `?raw`, `?url`). These are used by Vite's internal plugins to determine how a module should be processed.
+
+If your plugin is transforming a specific file type (e.g., `.mdx`), it should check if the ID contains any of Vite's special query parameters before processing it. If it does, you should likely return `null` to let Vite's internal plugins handle it.
+
+Special query parameters include:
+- `?raw`: Load the asset as a string.
+- `?url`: Load the asset as a URL.
+- `?worker` / `?sharedworker`: Load the script as a Web Worker.
+
+You can use a simple regex to check for these:
+
+```js
+const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
+
+export default function myPlugin() {
+  return {
+    name: 'my-plugin',
+    transform(code, id) {
+      if (SPECIAL_QUERY_RE.test(id)) {
+        return null
+      }
+      // ... transform logic
+    }
+  }
+}
+```
+
 ## Virtual Modules Convention
 
 Virtual modules are a useful scheme that allows you to pass build time information to the source files using normal ESM import syntax.

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -104,11 +104,7 @@ export default function myPlugin() {
 }
 ```
 
-### Importing a Virtual File
-
-See the example in the [next section](#virtual-modules-convention).
-
-## Handling Query Parameters
+#### Handling Query Parameters
 
 Module IDs passed to plugin hooks may include query parameters (e.g., `?raw`, `?url`). These are used by Vite's internal plugins to determine how a module should be processed.
 
@@ -116,14 +112,13 @@ If your plugin is transforming a specific file type (e.g., `.mdx`), it should ch
 
 Special query parameters include:
 
-- `?raw`: Load the asset as a string.
-- `?url`: Load the asset as a URL.
-- `?worker` / `?sharedworker`: Load the script as a Web Worker.
+- [`?raw`](/guide/assets#importing-asset-as-string): Load the asset as a string.
+- [`?url`](/guide/assets#url-imports): Load the asset as a URL.
 
 You can use a simple regex to check for these:
 
 ```js
-const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
+const SPECIAL_QUERY_RE = /[?&](?:raw|url)\b/
 
 export default function myPlugin() {
   return {
@@ -137,6 +132,10 @@ export default function myPlugin() {
   }
 }
 ```
+
+### Importing a Virtual File
+
+See the example in the [next section](#virtual-modules-convention).
 
 ## Virtual Modules Convention
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -115,6 +115,7 @@ Module IDs passed to plugin hooks may include query parameters (e.g., `?raw`, `?
 If your plugin is transforming a specific file type (e.g., `.mdx`), it should check if the ID contains any of Vite's special query parameters before processing it. If it does, you should likely return `null` to let Vite's internal plugins handle it.
 
 Special query parameters include:
+
 - `?raw`: Load the asset as a string.
 - `?url`: Load the asset as a URL.
 - `?worker` / `?sharedworker`: Load the script as a Web Worker.
@@ -132,7 +133,7 @@ export default function myPlugin() {
         return null
       }
       // ... transform logic
-    }
+    },
   }
 }
 ```


### PR DESCRIPTION
This PR adds a section to the Plugin API guide explaining how to handle query parameters like ?raw and ?url. This clarifies the expected behavior for plugin authors, as discussed in #22417.