### PR TITLE
ci: set `allowBuilds` instead of `onlyBuiltDependencies` for disabling installation scripts before publishing

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -37,7 +37,7 @@ jobs:
           package-manager-cache: false
 
       - name: Disallow installation scripts
-        run: yq '.onlyBuiltDependencies = []' -i pnpm-workspace.yaml
+        run: yq '.allowBuilds[]=false' -i pnpm-workspace.yaml
 
       - name: Install deps
         run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           package-manager-cache: false
 
       - name: Disallow installation scripts
-        run: yq '.onlyBuiltDependencies = []' -i pnpm-workspace.yaml
+        run: yq '.allowBuilds[]=false' -i pnpm-workspace.yaml
 
       - name: Install deps
         run: pnpm install


### PR DESCRIPTION
`onlyBuiltDependencies` is deprecated and we already use `allowBuilds`

refs https://github.com/vitejs/vite/pull/22157
