### PR TITLE
docs: fix hot update hook grammar

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -14,7 +14,7 @@ Affected scope: `Vite Plugin Authors`
 
 ## Motivation
 
-The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
+The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows you to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
 
 ```ts
 interface HmrContext {


### PR DESCRIPTION
Fixes a small grammar issue in the hot update hook migration note.\n\n`allows to perform` -> `allows you to perform`.\n\nDocs-only change; no tests needed.