### PR TITLE
docs: fix environment hook grammar

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -194,7 +194,7 @@ const UnoCssPlugin = () => {
 }
 ```
 
-If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `applyToEnvironment` hook allows to easily make it per-environment.
+If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `applyToEnvironment` hook allows you to easily make it per-environment.
 
 ```js
 import { nonShareablePlugin } from 'non-shareable-plugin'


### PR DESCRIPTION
Fixes a small grammar issue in the Environment API plugin docs.\n\n`allows to easily make it` -> `allows you to easily make it`.\n\nDocs-only change; no tests needed.