### PR TITLE
fix(css): allow css module identifiers to be arbitrary names

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -564,7 +564,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const modulesCode =
           modules &&
           !inlined &&
-          dataToEsm(modules, { namedExports: true, preferConst: true })
+          dataToEsm(modules, { namedExports: true, preferConst: true, includeArbitraryNames: true })
 
         if (config.command === 'serve') {
           const getContentWithSourcemap = async (content: string) => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -564,7 +564,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const modulesCode =
           modules &&
           !inlined &&
-          dataToEsm(modules, { namedExports: true, preferConst: true, includeArbitraryNames: true })
+          dataToEsm(modules, {
+            namedExports: true,
+            preferConst: true,
+            includeArbitraryNames: true,
+          })
 
         if (config.command === 'serve') {
           const getContentWithSourcemap = async (content: string) => {


### PR DESCRIPTION
CSS modules, when used as ES modules, generate ESM modules that export the generated scoped class for each class. That conceptually looks something like:
```css
.Foo { background: red; }
.Bar { background: green; }
```
```ts
export const Foo = "generatedScopedClassname1";
export const Bar = "generatedScopedClassname2";

export default { Foo, Bar };
```
When you have class names that aren't valid JS identifiers, however, they aren't exported as named values. That looks something like:
```css
.Foo { background: red; }
.Bar { background: green; }
.Foo-Bar { background: pink; }
```
```ts
export const Foo = "generatedScopedClassname1";
export const Bar = "generatedScopedClassname2";

export default { Foo, Bar, 'Foo-Bar': "generatedScopedClassname3" };
```

This means that `import * as styles from './foo.module.css'` doesn't see the same identifiers as `import styles from './foo.module.css'`. The former is preferable because it can be tree-shaken to only the used identifiers, so it would be nice to be able to use it.

ESMs support [arbitrary module namespace identifier names](https://github.com/tc39/ecma262/pull/2154), which can be taken advantage of here simply by enabling the `includeArbitraryNames` option for dataToEsm from rollup's pluginutils.

With that enabled, the generated module looks something like:
```ts
export const Foo = "generatedScopedClassname1";
export const Bar = "generatedScopedClassname2";
const __arbitrary = "generatedScopedClassname3";
export { __arbitrary as 'Foo-Bar' };

export default { Foo, Bar, 'Foo-Bar': __arbitrary };
```