### PR TITLE
fix(ssr): avoid rewriting labels that collide with imports

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -49,6 +49,19 @@ test('named import: arbitrary module namespace specifier', async () => {
   )
 })
 
+test('named import colliding with label', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `import { query } from 'vue';function foo() { query: while (true) { continue query; break query } }`,
+    ),
+  ).toMatchInlineSnapshot(
+    `
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["query"]});
+    function foo() { query: while (true) { continue query; break query } }"
+  `,
+  )
+})
+
 test('namespace import', async () => {
   expect(
     await ssrTransformSimpleCode(

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -712,6 +712,16 @@ function isRefIdentifier(
     return false
   }
 
+  // label declaration or break/continue target
+  if (
+    (parent.type === 'LabeledStatement' ||
+      parent.type === 'BreakStatement' ||
+      parent.type === 'ContinueStatement') &&
+    parent.label === id
+  ) {
+    return false
+  }
+
   // meta property (e.g. import.meta)
   if (parent.type === 'MetaProperty') {
     return false


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/22412

previously, 
```ts
function foo() {
    query: while (true) {
        continue query;
        break query
    }
}
```

would generate

```ts
function foo() {
    __vite_ssr_import_0__.query: while (true) {
        continue __vite_ssr_import_0__.query;
        break __vite_ssr_import_0__.query
    }
}
```

This is invalid, as the spec says:
```
continue [no LineTerminator here] LabelIdentifier[?Yield, ?Await] ;
```

`LabelIdentifier` is an `Identifier`, member expressions are not allowed.


It now generates

```ts
function foo() {
    query: while (true) {
        continue query;
        break query
    }
}
```
