### PR TITLE
feat(plugins): include .cts files in default TypeScript transform filters

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -308,6 +308,22 @@ describe('transformWithEsbuild', () => {
     )
   })
 
+  test('transforms .cts files as TypeScript', async () => {
+    const code = 'const foo: string = "bar"'
+    const result = await transformWithEsbuild(code, 'test.cts')
+    expect(result?.code).toBeTruthy()
+    // Should not contain type annotations after transformation
+    expect(result?.code).not.toContain(': string')
+  })
+
+  test('transforms .mts files as TypeScript', async () => {
+    const code = 'const foo: string = "bar"'
+    const result = await transformWithEsbuild(code, 'test.mts')
+    expect(result?.code).toBeTruthy()
+    // Should not contain type annotations after transformation
+    expect(result?.code).not.toContain(': string')
+  })
+
   describe('useDefineForClassFields', async () => {
     const transformClassCode = async (
       target: string,

--- a/packages/vite/src/node/__tests__/plugins/oxc.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/oxc.spec.ts
@@ -153,4 +153,20 @@ describe('transformWithOxc', () => {
     )
     expect(result?.code).toContain('_decorateMetadata("design:type"')
   })
+
+  test('transforms .cts files as TypeScript', async () => {
+    const code = 'const foo: string = "bar"'
+    const result = await transformWithOxc(code, 'test.cts')
+    expect(result?.code).toBeTruthy()
+    // Should not contain type annotations after transformation
+    expect(result?.code).not.toContain(': string')
+  })
+
+  test('transforms .mts files as TypeScript', async () => {
+    const code = 'const foo: string = "bar"'
+    const result = await transformWithOxc(code, 'test.mts')
+    expect(result?.code).toBeTruthy()
+    // Should not contain type annotations after transformation
+    expect(result?.code).not.toContain(': string')
+  })
 })

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -279,7 +279,10 @@ export function esbuildPlugin(config: ResolvedConfig): Plugin {
   const options = config.esbuild as ESBuildOptions
   const { jsxInject, include, exclude, ...esbuildTransformOptions } = options
 
-  const filter = createFilter(include || /\.(m?ts|[jt]sx)$/, exclude || /\.js$/)
+  const filter = createFilter(
+    include || /\.([cm]?ts|[jt]sx)$/,
+    exclude || /\.js$/,
+  )
 
   // Remove optimization options for dev as we only need to transpile them,
   // and for build as the final optimization is in `buildEsbuildPlugin`

--- a/packages/vite/src/node/plugins/esbuildBannerFooterCompatPlugin.ts
+++ b/packages/vite/src/node/plugins/esbuildBannerFooterCompatPlugin.ts
@@ -19,7 +19,10 @@ export function esbuildBannerFooterCompatPlugin(
   const { include, exclude, banner, footer } = options
   if (!banner && !footer) return
 
-  const filter = createFilter(include || /\.(m?ts|[jt]sx)$/, exclude || /\.js$/)
+  const filter = createFilter(
+    include || /\.([cm]?ts|[jt]sx)$/,
+    exclude || /\.js$/,
+  )
 
   return {
     name: 'vite:esbuild-banner-footer-compat',

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -218,7 +218,10 @@ export function oxcPlugin(config: ResolvedConfig): Plugin {
     ...oxcTransformOptions
   } = options
 
-  const filter = createFilter(include || /\.(m?ts|[jt]sx)$/, exclude || /\.js$/)
+  const filter = createFilter(
+    include || /\.([cm]?ts|[jt]sx)$/,
+    exclude || /\.js$/,
+  )
   const jsxRefreshFilter =
     jsxRefreshInclude || jsxRefreshExclude
       ? createFilter(jsxRefreshInclude, jsxRefreshExclude)

--- a/playground/resolve/ts-extension/hellocjs.cts
+++ b/playground/resolve/ts-extension/hellocjs.cts
@@ -1,1 +1,2 @@
-export const msgCjs = '[success] use .cjs extension to import a CommonJS module'
+export const msgCjs: string =
+  '[success] use .cjs extension to import a CommonJS module'


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

This PR adds support for `.cts` files to Vite's default transform pipeline.

The underlying esbuild and oxc loaders already recognize `.cts` and `.mts` as TypeScript, but the plugin-level include filters excluded them, causing these files to skip transformation in certain scenarios.

I caught this issue while trying to add tests for loading `.cts` files in Renovate ([ref](https://github.com/renovatebot/renovate/pull/43381#discussion_r3251416590)).

_Disclaimer: this PR has been written with assistance of Claude Sonnet 4.6._
