### PR TITLE
docs: update pnpm overrides URL link

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -268,7 +268,7 @@ Then go to your Vite based project and run `pnpm link vite` (or the package mana
 To learn more about how and when Vite does releases, check out the [Releases](../releases.md) documentation.
 
 ::: tip Dependencies using Vite
-To replace the Vite version used by dependencies transitively, you should use [npm overrides](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides) or [pnpm overrides](https://pnpm.io/9.x/package_json#pnpmoverrides).
+To replace the Vite version used by dependencies transitively, you should use [npm overrides](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#overrides) or [pnpm overrides](https://pnpm.io/settings#overrides).
 :::
 
 ## Community


### PR DESCRIPTION
## Description

Updates the pnpm overrides documentation link in the 'Using Unreleased Commits' section of `docs/guide/index.md`. The old URL `https://pnpm.io/9.x/package_json#pnpmoverrides` now redirects to the general package.json docs where the anchor fragment is lost. The correct new URL is `https://pnpm.io/settings#overrides`.

Fixes #22456

## Changes

- Updated pnpm overrides URL in `docs/guide/index.md`