### PR TITLE
docs: clarify imported CSS metadata timing

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -526,6 +526,7 @@ Example:
 function outputMetadataPlugin(): Plugin {
   return {
     name: 'output-metadata-plugin',
+    enforce: 'post',
     generateBundle(_, bundle) {
       for (const output of Object.values(bundle)) {
         const css = output.viteMetadata?.importedCss
@@ -541,6 +542,12 @@ function outputMetadataPlugin(): Plugin {
   }
 }
 ```
+
+::: tip Inspecting final CSS metadata
+
+Use `enforce: 'post'` when reading `viteMetadata.importedCss` in `generateBundle`. This ensures the hook runs after Vite moves metadata from empty CSS-only chunks to the chunks that import them, so the metadata reflects the final output bundle.
+
+:::
 
 ## Plugin Ordering
 


### PR DESCRIPTION
### What changed

- Added `enforce: 'post'` to the `viteMetadata` example plugin.
- Added a tip explaining why plugin authors should use post-enforcement when reading `viteMetadata.importedCss` in `generateBundle`.

### Why

Vite removes empty CSS-only chunks and moves their CSS metadata onto the importing chunks later in the build plugin pipeline. A user plugin without `enforce: 'post'` can observe that intermediate state, which makes `importedCss` look orphaned or incomplete.

Fixes #22209.

### Validation

- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 mise exec node@24.15.0 -- pnpm install --frozen-lockfile`
- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 mise exec node@24.15.0 -- pnpm run build`
- `SHARP_IGNORE_GLOBAL_LIBVIPS=1 mise exec node@24.15.0 -- pnpm run docs-build`
- `git diff --check`
- `mise exec node@24.15.0 -- pnpm exec oxfmt --check docs/guide/api-plugin.md`
