### PR TITLE
feat: send 408 on request timeout

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -273,19 +273,35 @@ export function setClientErrorHandler(
   logger: Logger,
 ): void {
   server.on('clientError', (err, socket) => {
-    let msg = '400 Bad Request'
-    if ((err as any).code === 'HPE_HEADER_OVERFLOW') {
-      msg = '431 Request Header Fields Too Large'
-      logger.warn(
-        colors.yellow(
-          'Server responded with status code 431. ' +
-            'See https://vite.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.',
-        ),
-      )
+    // https://github.com/nodejs/node/blob/v26.2.0/lib/_http_server.js#L992
+    let msg
+    switch ((err as any).code) {
+      case 'HPE_HEADER_OVERFLOW': {
+        msg = '431 Request Header Fields Too Large'
+        logger.warn(
+          colors.yellow(
+            'Server responded with status code 431. ' +
+              'See https://vite.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.',
+          ),
+        )
+        break
+      }
+      case 'HPE_CHUNK_EXTENSIONS_OVERFLOW': {
+        msg = '413 Payload Too Large'
+        break
+      }
+      case 'ERR_HTTP_REQUEST_TIMEOUT': {
+        msg = '408 Request Timeout'
+        break
+      }
+      default: {
+        msg = '400 Bad Request'
+        break
+      }
     }
     if ((err as any).code === 'ECONNRESET' || !socket.writable) {
       return
     }
-    socket.end(`HTTP/1.1 ${msg}\r\n\r\n`)
+    socket.end(`HTTP/1.1 ${msg}\r\nConnection: close\r\n\r\n`)
   })
 }


### PR DESCRIPTION
This is a pretty tiny nit, but when running vite behind a reverse proxy, the proxy is logging errors about getting a 400 response from vite with no active request.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/408), a 408 is more appropriate, and many servers already use it.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
