### PR TITLE
fix: add filesystem root guard to hasCorrectCase to prevent infinite recursion

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { fileURLToPath } from 'mlly'
 import {
   asyncFlatten,
@@ -14,6 +14,7 @@ import {
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
   getServerUrlByHost,
+  hasCorrectCase,
   injectQuery,
   isFileReadable,
   isParentDirectory,
@@ -1093,5 +1094,52 @@ describe('resolveServerUrls', () => {
     )
 
     expect(result.local).toContain('https://localhost:3000/')
+  })
+})
+
+describe('hasCorrectCase', () => {
+  let readdirSyncSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    readdirSyncSpy = vi.spyOn(fs, 'readdirSync')
+  })
+
+  afterEach(() => {
+    readdirSyncSpy.mockRestore()
+  })
+
+  test('returns true when file equals assets root (base case)', () => {
+    expect(hasCorrectCase('/project', '/project')).toBe(true)
+    expect(readdirSyncSpy).not.toHaveBeenCalled()
+  })
+
+  test('returns true for correctly cased file path under root', () => {
+    readdirSyncSpy.mockImplementation((dir: unknown) => {
+      if (dir === '/project/src') return ['index.ts'] as any
+      if (dir === '/project') return ['src'] as any
+      return [] as any
+    })
+    expect(hasCorrectCase('/project/src/index.ts', '/project')).toBe(true)
+  })
+
+  test('returns false for incorrectly cased file', () => {
+    readdirSyncSpy.mockImplementation((dir: unknown) => {
+      if (dir === '/project/src') return ['index.ts'] as any
+      return [] as any
+    })
+    expect(hasCorrectCase('/project/src/INDEX.ts', '/project')).toBe(false)
+  })
+
+  test('returns false when file is outside root without infinite recursion', () => {
+    // Without `if (parent === file) return false`, reaching the OS root would
+    // cause readdirSync('/').includes('') to be true here ('' is in the mock
+    // listing), recurse into hasCorrectCase('/', ...) again, and loop forever.
+    // The guard makes this termination explicit and correct on all platforms.
+    readdirSyncSpy.mockImplementation((dir: unknown) => {
+      if (dir === '/outside') return ['file.ts'] as any
+      if (dir === '/') return ['outside', ''] as any
+      return [] as any
+    })
+    expect(hasCorrectCase('/outside/file.ts', '/project')).toBe(false)
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1547,10 +1547,11 @@ export function shouldServeFile(filePath: string, root: string): boolean {
  * Note that we can't use realpath here, because we don't want to follow
  * symlinks.
  */
-function hasCorrectCase(file: string, assets: string): boolean {
+export function hasCorrectCase(file: string, assets: string): boolean {
   if (file === assets) return true
 
   const parent = path.dirname(file)
+  if (parent === file) return false
 
   if (fs.readdirSync(parent).includes(path.basename(file))) {
     return hasCorrectCase(parent, assets)


### PR DESCRIPTION
## What does this PR fix?
`hasCorrectCase` in `packages/vite/src/node/utils.ts` recursively walks 
up the directory tree to verify path casing on case-insensitive filesystems. 
The function had no explicit base case at the OS root (`/` or `C:\`), 
relying coincidentally on `path.basename('/')` never appearing in directory 
listings. A mocked or unusual filesystem where this assumption breaks causes 
infinite recursion and a stack overflow.

## Root cause
Line ~1550 in `utils.ts` — the recursive call had no `if (parent === file) 
return false` guard, so traversal past the root was theoretically unbounded.

## Fix
Added a one-line guard: `if (parent === file) return false` before the 
recursive call. This is the standard termination condition for directory 
tree walkers.

## Test added
Added test coverage for `hasCorrectCase` in `utils.spec.ts` covering the 
normal case, wrong-case input, and the root boundary condition.

## Related issue
N/A — discovered during codebase exploration