### PR TITLE
fix(utils): return null from getNpmPackageName for empty string input

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -13,6 +13,7 @@ import {
   generateCodeFrame,
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
+  getNpmPackageName,
   getServerUrlByHost,
   injectQuery,
   isFileReadable,
@@ -1093,5 +1094,33 @@ describe('resolveServerUrls', () => {
     )
 
     expect(result.local).toContain('https://localhost:3000/')
+  })
+})
+
+describe('getNpmPackageName', () => {
+  test('returns null for empty string', () => {
+    expect(getNpmPackageName('')).toBe(null)
+  })
+
+  test('returns package name for unscoped package', () => {
+    expect(getNpmPackageName('react')).toBe('react')
+  })
+
+  test('returns scoped package name', () => {
+    expect(getNpmPackageName('@tanstack/react-query')).toBe(
+      '@tanstack/react-query',
+    )
+  })
+
+  test('returns package name ignoring subpath', () => {
+    expect(getNpmPackageName('react/jsx-runtime')).toBe('react')
+  })
+
+  test('returns scoped package name ignoring subpath', () => {
+    expect(getNpmPackageName('@scope/pkg/subpath')).toBe('@scope/pkg')
+  })
+
+  test('returns null for scoped package with no name', () => {
+    expect(getNpmPackageName('@scope')).toBe(null)
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1602,6 +1602,7 @@ export function evalValue<T = any>(rawValue: string): T {
 }
 
 export function getNpmPackageName(importPath: string): string | null {
+  if (!importPath) return null
   const parts = importPath.split('/')
   if (parts[0][0] === '@') {
     if (!parts[1]) return null


### PR DESCRIPTION
## What does this PR fix?

`getNpmPackageName` in `packages/vite/src/node/utils.ts` declares a return type of `string | null`, but when called with an empty string `''`, it returns `''` instead of `null`. Callers that guard with `!= null` (such as `resolve.ts`) would incorrectly treat the empty string as a valid package name and continue processing with bad data.

## Root cause

The function had no early-exit guard for empty or falsy input. An empty string passes through all the existing logic and eventually returns `''`, violating the declared return type contract.

## Fix

Added a one-line guard at the top of the function:

```ts
if (!id) return null
```

This ensures empty string, and any other falsy input, consistently returns `null` as the type signature promises.

## Tests added

Added test cases in `utils.spec.ts` covering:
- Empty string input returns `null`
- Normal package name returns correctly
- Scoped package name returns correctly
- Subpath is correctly stripped for both normal and scoped packages

## Related

Companion to #22477 — both fixes are in `utils.ts` and were discovered during the same codebase exploration.