### PR TITLE
fix(html): handle trailing slash paths in transformIndexHtml

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -128,6 +128,10 @@ function isBareRelative(url: string) {
   return wordCharRE.test(url[0]) && !url.includes(':')
 }
 
+function getHtmlDirnameForRelativeUrl(htmlPath: string): string {
+  return htmlPath.endsWith('/') ? htmlPath : path.posix.dirname(htmlPath)
+}
+
 const processNodeUrl = (
   url: string,
   useSrcSetReplacer: boolean,
@@ -165,7 +169,7 @@ const processNodeUrl = (
       } else if (url[0] === '.' || isBareRelative(url)) {
         preTransformUrl = path.posix.join(
           config.base,
-          path.posix.dirname(htmlPath),
+          getHtmlDirnameForRelativeUrl(htmlPath),
           url,
         )
       }

--- a/playground/ssr-html/__tests__/serve.ts
+++ b/playground/ssr-html/__tests__/serve.ts
@@ -3,12 +3,10 @@
 
 import path from 'node:path'
 import kill from 'kill-port'
-import type { ViteDevServer } from 'vite'
 import { createInMemoryLogger, hmrPorts, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-html']
 export const serverLogs: string[] = []
-export let viteServer: ViteDevServer
 
 export async function serve(): Promise<{ close(): Promise<void> }> {
   await kill(port)
@@ -19,7 +17,6 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
     hmrPorts['ssr-html'],
     createInMemoryLogger(serverLogs),
   )
-  viteServer = vite
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-html/__tests__/serve.ts
+++ b/playground/ssr-html/__tests__/serve.ts
@@ -3,15 +3,23 @@
 
 import path from 'node:path'
 import kill from 'kill-port'
-import { hmrPorts, ports, rootDir } from '~utils'
+import type { ViteDevServer } from 'vite'
+import { createInMemoryLogger, hmrPorts, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-html']
+export const serverLogs: string[] = []
+export let viteServer: ViteDevServer
 
 export async function serve(): Promise<{ close(): Promise<void> }> {
   await kill(port)
 
   const { createServer } = await import(path.resolve(rootDir, 'server.js'))
-  const { app, vite } = await createServer(rootDir, hmrPorts['ssr-html'])
+  const { app, vite } = await createServer(
+    rootDir,
+    hmrPorts['ssr-html'],
+    createInMemoryLogger(serverLogs),
+  )
+  viteServer = vite
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -2,9 +2,10 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { setTimeout } from 'node:timers/promises'
 import { describe, expect, test } from 'vitest'
 import { port, serverLogs } from './serve'
-import { editFile, isServe, page, viteServer } from '~utils'
+import { editFile, isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -51,27 +52,10 @@ describe.runIf(isServe)('trailing slash html paths', () => {
     expect(response.status).toBe(200)
     await response.text()
 
-    await expect
-      .poll(() => [
-        viteServer.environments.client.moduleGraph.urlToModuleMap.has(
-          '/trailing-slash/dir/filename.js',
-        ),
-        viteServer.environments.client.moduleGraph.urlToModuleMap.has(
-          '/trailing-slash/other.js',
-        ),
-      ])
-      .toEqual([true, true])
-    expect(
-      viteServer.environments.client.moduleGraph.urlToModuleMap.has(
-        '/trailing-slash/filename.js',
-      ),
-    ).toBe(false)
-    expect(
-      viteServer.environments.client.moduleGraph.urlToModuleMap.has(
-        '/other.js',
-      ),
-    ).toBe(false)
-    expect(serverLogs.join('\n')).not.toContain('Pre-transform error')
+    await setTimeout(100) // wait for pre-transform to happen
+    expect(serverLogs).not.toEqual(
+      expect.arrayContaining([expect.stringContaining('Pre-transform error')]),
+    )
   })
 
   test('loads relative module scripts from the trailing slash directory', async () => {
@@ -80,9 +64,9 @@ describe.runIf(isServe)('trailing slash html paths', () => {
     await expect
       .poll(() => page.textContent('.relative-script'))
       .toBe('relative module loaded')
-    expect(await page.locator('html').getAttribute('data-parent-script')).toBe(
-      'loaded',
-    )
+    await expect
+      .poll(() => page.textContent('.relative-parent-script'))
+      .toBe('relative parent module loaded')
   })
 })
 

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -3,8 +3,8 @@ import { promisify } from 'node:util'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
-import { port } from './serve'
-import { editFile, isServe, page } from '~utils'
+import { port, serverLogs } from './serve'
+import { editFile, isServe, page, viteServer } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -40,6 +40,49 @@ describe.runIf(isServe)('injected inline scripts', () => {
     for (const code of scriptContents) {
       expect(code).toBeTruthy()
     }
+  })
+})
+
+describe.runIf(isServe)('trailing slash html paths', () => {
+  test('pre-transforms relative module scripts from the trailing slash directory', async () => {
+    serverLogs.length = 0
+
+    const response = await fetch(`${url}/trailing-slash/dir/`)
+    expect(response.status).toBe(200)
+    await response.text()
+
+    await expect
+      .poll(() => [
+        viteServer.environments.client.moduleGraph.urlToModuleMap.has(
+          '/trailing-slash/dir/filename.js',
+        ),
+        viteServer.environments.client.moduleGraph.urlToModuleMap.has(
+          '/trailing-slash/other.js',
+        ),
+      ])
+      .toEqual([true, true])
+    expect(
+      viteServer.environments.client.moduleGraph.urlToModuleMap.has(
+        '/trailing-slash/filename.js',
+      ),
+    ).toBe(false)
+    expect(
+      viteServer.environments.client.moduleGraph.urlToModuleMap.has(
+        '/other.js',
+      ),
+    ).toBe(false)
+    expect(serverLogs.join('\n')).not.toContain('Pre-transform error')
+  })
+
+  test('loads relative module scripts from the trailing slash directory', async () => {
+    await page.goto(`${url}/trailing-slash/dir/`)
+
+    await expect
+      .poll(() => page.textContent('.relative-script'))
+      .toBe('relative module loaded')
+    expect(await page.locator('html').getAttribute('data-parent-script')).toBe(
+      'loaded',
+    )
   })
 })
 

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -78,8 +78,6 @@ export async function createServer(
       if (url === '/trailing-slash/dir/') {
         const template = fs.readFileSync(resolve(`.${url}index.html`), 'utf-8')
         const html = await vite.transformIndexHtml(url, template)
-        await vite.waitForRequestsIdle()
-
         return res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
       }
 

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -21,7 +21,11 @@ const DYNAMIC_STYLES = `
   </style>
 `
 
-export async function createServer(root = process.cwd(), hmrPort) {
+export async function createServer(
+  root = process.cwd(),
+  hmrPort,
+  customLogger,
+) {
   const resolve = (p) => path.resolve(import.meta.dirname, p)
 
   const app = express()
@@ -47,6 +51,7 @@ export async function createServer(root = process.cwd(), hmrPort) {
       },
     },
     appType: 'custom',
+    customLogger,
     plugins: [
       {
         name: 'virtual-file',
@@ -69,6 +74,15 @@ export async function createServer(root = process.cwd(), hmrPort) {
   app.use('*all', async (req, res, next) => {
     try {
       let [url] = req.originalUrl.split('?')
+
+      if (url === '/trailing-slash/dir/') {
+        const template = fs.readFileSync(resolve(`.${url}index.html`), 'utf-8')
+        const html = await vite.transformIndexHtml(url, template)
+        await vite.waitForRequestsIdle()
+
+        return res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+      }
+
       if (url.endsWith('/')) url += 'index.html'
 
       if (url.startsWith('/favicon.ico')) {

--- a/playground/ssr-html/trailing-slash/dir/filename.js
+++ b/playground/ssr-html/trailing-slash/dir/filename.js
@@ -1,0 +1,2 @@
+document.querySelector('.relative-script').textContent =
+  'relative module loaded'

--- a/playground/ssr-html/trailing-slash/dir/index.html
+++ b/playground/ssr-html/trailing-slash/dir/index.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <div class="relative-script"></div>
+    <div class="relative-parent-script"></div>
     <script type="module" src="./filename.js"></script>
     <script type="module" src="../other.js"></script>
   </body>

--- a/playground/ssr-html/trailing-slash/dir/index.html
+++ b/playground/ssr-html/trailing-slash/dir/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Trailing slash</title>
+  </head>
+  <body>
+    <div class="relative-script"></div>
+    <script type="module" src="./filename.js"></script>
+    <script type="module" src="../other.js"></script>
+  </body>
+</html>

--- a/playground/ssr-html/trailing-slash/other.js
+++ b/playground/ssr-html/trailing-slash/other.js
@@ -1,1 +1,2 @@
-document.documentElement.dataset.parentScript = 'loaded'
+document.querySelector('.relative-parent-script').textContent =
+  'relative parent module loaded'

--- a/playground/ssr-html/trailing-slash/other.js
+++ b/playground/ssr-html/trailing-slash/other.js
@@ -1,0 +1,1 @@
+document.documentElement.dataset.parentScript = 'loaded'


### PR DESCRIPTION
Fixes #18964.

When `transformIndexHtml` receives a trailing-slash HTML path, relative pre-transform URLs should resolve from that directory instead of `path.posix.dirname(htmlPath)`, which drops the last segment.

This follows the direction discussed in #18976 and includes focused coverage for trailing-slash, root, HTML file, and parent-relative paths.