### PR TITLE
fix: support manifest builds from tsx CJS scripts (fix #22485)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,6 +1,7 @@
-import { basename, resolve } from 'node:path'
-import { stripVTControlCharacters } from 'node:util'
+import { execFile } from 'node:child_process'
 import fsp from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+import { promisify, stripVTControlCharacters } from 'node:util'
 import colors from 'picocolors'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type {
@@ -24,6 +25,7 @@ import { createLogger } from '../logger'
 import { BuildEnvironment, resolveConfig } from '..'
 
 const dirname = import.meta.dirname
+const execFileAsync = promisify(execFile)
 
 type FormatsToFileNames = [LibraryFormats, string][]
 
@@ -169,6 +171,29 @@ describe('build', () => {
     expect(manifest['b/index.css']).toMatchObject({
       isEntry: true,
     })
+  })
+
+  test('manifest build works when Vite is imported from a tsx CJS script', async () => {
+    const root = resolve(dirname, 'fixtures/tsx-cjs-manifest')
+    const outDir = resolve(root, 'dist')
+    await fsp.rm(outDir, { recursive: true, force: true })
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          resolve(dirname, '../../../../..', 'node_modules/tsx/dist/cli.mjs'),
+          'build.ts',
+        ],
+        { cwd: root },
+      )
+
+      await expect(
+        fsp.readFile(resolve(outDir, '.vite/manifest.json'), 'utf-8'),
+      ).resolves.toContain('src/main.ts')
+    } finally {
+      await fsp.rm(outDir, { recursive: true, force: true })
+    }
   })
 
   test.for([

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -188,9 +188,13 @@ describe('build', () => {
         { cwd: root },
       )
 
-      await expect(
-        fsp.readFile(resolve(outDir, '.vite/manifest.json'), 'utf-8'),
-      ).resolves.toContain('src/main.ts')
+      const manifest = JSON.parse(
+        await fsp.readFile(resolve(outDir, '.vite/manifest.json'), 'utf-8'),
+      ) as Record<string, { css?: string[] }>
+      const entry = manifest['src/main.ts']
+
+      expect(entry).toBeDefined()
+      expect(entry?.css?.length).toBeGreaterThan(0)
     } finally {
       await fsp.rm(outDir, { recursive: true, force: true })
     }

--- a/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/build.ts
+++ b/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/build.ts
@@ -1,0 +1,6 @@
+import { build } from 'vite'
+
+build().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/src/main.ts
+++ b/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/src/main.ts
@@ -1,0 +1,3 @@
+import './style.css'
+
+console.log('manifest build')

--- a/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/src/style.css
+++ b/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/src/style.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/vite.config.ts
+++ b/packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    manifest: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+    },
+  },
+})

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
-import type { OutputChunk, RenderedChunk } from 'rolldown'
+import type { OutputBundle, OutputChunk, RenderedChunk } from 'rolldown'
 import { viteManifestPlugin as nativeManifestPlugin } from 'rolldown/experimental'
 import type { Plugin } from '../plugin'
-import { normalizePath } from '../utils'
+import { normalizePath, sortObjectKeys } from '../utils'
 import { perEnvironmentState } from '../environment'
 import { type Environment, perEnvironmentPlugin } from '..'
 import { cssEntriesMap } from './asset'
@@ -99,12 +99,11 @@ export function manifestPlugin(): Plugin {
         isOutputOptionsForLegacyChunks:
           environment.config.isOutputOptionsForLegacyChunks,
         cssEntries() {
+          const cssEntries = cssEntriesMap.get(envs[environment.name])
           return Object.fromEntries(
-            [...cssEntriesMap.get(envs[environment.name])!.values()].map(
-              ({ name, referenceId }) => {
-                return [referenceId, name]
-              },
-            ),
+            [...(cssEntries?.values() ?? [])].map(({ name, referenceId }) => {
+              return [referenceId, name]
+            }),
           )
         },
       }),
@@ -112,67 +111,184 @@ export function manifestPlugin(): Plugin {
         name: 'native:manifest-compatible',
         generateBundle(_, bundle) {
           const asset = bundle[outPath]
-          if (asset.type === 'asset') {
-            let manifest: Manifest | undefined
-            for (const output of Object.values(bundle)) {
-              const importedCss = output.viteMetadata?.importedCss
-              const importedAssets = output.viteMetadata?.importedAssets
-              if (!importedCss?.size && !importedAssets?.size) continue
-              manifest ??= JSON.parse(asset.source.toString()) as Manifest
-              if (output.type === 'chunk') {
-                const item = manifest[getChunkName(output)]
-                if (!item) continue
-                if (importedCss?.size) {
-                  item.css = [...importedCss]
-                }
-                if (importedAssets?.size) {
-                  item.assets = [...importedAssets]
-                }
-              } else if (output.type === 'asset' && output.names.length > 0) {
-                // Add every unique asset to the manifest, keyed by its original name
-                const keys =
-                  output.originalFileNames.length > 0
-                    ? output.originalFileNames
-                    : [`_${path.basename(output.fileName)}`]
+          const assetSource =
+            asset?.type === 'asset' ? asset.source.toString() : undefined
+          let manifest: Manifest | undefined = assetSource
+            ? undefined
+            : createManifestFromBundle(
+                bundle,
+                root,
+                this.environment,
+                (referenceId) => this.getFileName(referenceId),
+              )
+          for (const output of Object.values(bundle)) {
+            const importedCss = output.viteMetadata?.importedCss
+            const importedAssets = output.viteMetadata?.importedAssets
+            if (!importedCss?.size && !importedAssets?.size) continue
+            manifest ??= JSON.parse(assetSource!) as Manifest
+            if (output.type === 'chunk') {
+              const item = manifest[getChunkName(output)]
+              if (!item) continue
+              if (importedCss?.size) {
+                item.css = [...importedCss]
+              }
+              if (importedAssets?.size) {
+                item.assets = [...importedAssets]
+              }
+            } else if (output.type === 'asset' && output.names.length > 0) {
+              // Add every unique asset to the manifest, keyed by its original name
+              const keys =
+                output.originalFileNames.length > 0
+                  ? output.originalFileNames
+                  : [`_${path.basename(output.fileName)}`]
 
-                for (const key of keys) {
-                  const item = manifest[key]
-                  if (!item) continue
-                  if (!(item.file && endsWithJSRE.test(item.file))) {
-                    if (importedCss?.size) {
-                      item.css = [...importedCss]
-                    }
-                    if (importedAssets?.size) {
-                      item.assets = [...importedAssets]
-                    }
+              for (const key of keys) {
+                const item = manifest[key]
+                if (!item) continue
+                if (!(item.file && endsWithJSRE.test(item.file))) {
+                  if (importedCss?.size) {
+                    item.css = [...importedCss]
+                  }
+                  if (importedAssets?.size) {
+                    item.assets = [...importedAssets]
                   }
                 }
               }
             }
-            const output = this.environment.config.build.rolldownOptions.output
-            const outputLength = Array.isArray(output) ? output.length : 1
-            if (manifest && outputLength === 1) {
-              asset.source = JSON.stringify(manifest, undefined, 2)
-              return
-            }
-
-            const state = getState(this)
-            state.outputCount++
-            state.manifest = Object.assign(
-              state.manifest,
-              manifest ?? JSON.parse(asset.source.toString()),
+          }
+          const output = this.environment.config.build.rolldownOptions.output
+          const outputLength = Array.isArray(output) ? output.length : 1
+          if (manifest && outputLength === 1) {
+            const source = JSON.stringify(
+              sortObjectKeys(manifest),
+              undefined,
+              2,
             )
-            if (state.outputCount >= outputLength) {
-              asset.source = JSON.stringify(state.manifest, undefined, 2)
-              state.reset()
+            if (asset?.type === 'asset') {
+              asset.source = source
             } else {
-              delete bundle[outPath]
+              this.emitFile({ fileName: outPath, type: 'asset', source })
             }
+            return
+          }
+
+          const state = getState(this)
+          state.outputCount++
+          state.manifest = Object.assign(
+            state.manifest,
+            manifest ?? JSON.parse(assetSource!),
+          )
+          if (state.outputCount >= outputLength) {
+            const source = JSON.stringify(
+              sortObjectKeys(state.manifest),
+              undefined,
+              2,
+            )
+            if (asset?.type === 'asset') {
+              asset.source = source
+            } else {
+              this.emitFile({ fileName: outPath, type: 'asset', source })
+            }
+            state.reset()
+          } else if (asset?.type === 'asset') {
+            delete bundle[outPath]
           }
         },
       },
     ]
   })
+}
+
+function createManifestFromBundle(
+  bundle: OutputBundle,
+  root: string,
+  environment: Environment,
+  getFileName: (referenceId: string) => string,
+): Manifest {
+  const manifest: Manifest = {}
+  const entryCssAssetFileNames = new Map<string, string>()
+
+  for (const { name, referenceId } of cssEntriesMap
+    .get(environment)
+    ?.values() ?? []) {
+    try {
+      entryCssAssetFileNames.set(getFileName(referenceId), name)
+    } catch {}
+  }
+
+  function getChunkName(chunk: OutputChunk) {
+    return (
+      getChunkOriginalFileName(chunk, root, false) ??
+      `_${path.basename(chunk.fileName)}`
+    )
+  }
+
+  function getInternalImports(imports: readonly string[]) {
+    const filteredImports: string[] = []
+    for (const file of imports) {
+      const importee = bundle[file]
+      if (importee?.type === 'chunk') {
+        filteredImports.push(getChunkName(importee))
+      }
+    }
+    return filteredImports
+  }
+
+  for (const output of Object.values(bundle)) {
+    if (output.type === 'chunk') {
+      const manifestChunk: ManifestChunk = {
+        file: output.fileName,
+        name: output.name,
+      }
+      const src = getChunkOriginalFileName(output, root, false)
+      if (src) manifestChunk.src = src
+      if (output.isEntry) manifestChunk.isEntry = true
+      if (output.isDynamicEntry) manifestChunk.isDynamicEntry = true
+      if (output.imports.length) {
+        const internalImports = getInternalImports(output.imports)
+        if (internalImports.length > 0) manifestChunk.imports = internalImports
+      }
+      if (output.dynamicImports.length) {
+        const internalImports = getInternalImports(output.dynamicImports)
+        if (internalImports.length > 0) {
+          manifestChunk.dynamicImports = internalImports
+        }
+      }
+      if (output.viteMetadata?.importedCss.size) {
+        manifestChunk.css = [...output.viteMetadata.importedCss]
+      }
+      if (output.viteMetadata?.importedAssets.size) {
+        manifestChunk.assets = [...output.viteMetadata.importedAssets]
+      }
+      manifest[getChunkName(output)] = manifestChunk
+    } else if (output.names.length > 0) {
+      const src =
+        output.originalFileNames.length > 0
+          ? output.originalFileNames[0]
+          : `_${path.basename(output.fileName)}`
+      const manifestChunk: ManifestChunk = {
+        file: output.fileName,
+        src,
+      }
+      const cssEntryName = entryCssAssetFileNames.get(output.fileName)
+      if (cssEntryName) {
+        manifestChunk.isEntry = true
+        manifestChunk.name = cssEntryName
+      }
+      const file = manifest[src]?.file
+      if (!(file && endsWithJSRE.test(file))) {
+        manifest[src] = manifestChunk
+      }
+      for (const originalFileName of output.originalFileNames.slice(1)) {
+        const file = manifest[originalFileName]?.file
+        if (!(file && endsWithJSRE.test(file))) {
+          manifest[originalFileName] = manifestChunk
+        }
+      }
+    }
+  }
+
+  return manifest
 }
 
 export function getChunkOriginalFileName(

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -112,7 +112,7 @@ export function manifestPlugin(): Plugin {
         name: 'native:manifest-compatible',
         generateBundle(_, bundle) {
           const asset = bundle[outPath]
-          if (asset.type === 'asset') {
+          if (asset?.type === 'asset') {
             let manifest: Manifest | undefined
             for (const output of Object.values(bundle)) {
               const importedCss = output.viteMetadata?.importedCss

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -1,8 +1,7 @@
 import path from 'node:path'
-import type { OutputBundle, OutputChunk, RenderedChunk } from 'rolldown'
-import { viteManifestPlugin as nativeManifestPlugin } from 'rolldown/experimental'
+import type { OutputChunk, RenderedChunk } from 'rolldown'
 import type { Plugin } from '../plugin'
-import { normalizePath, sortObjectKeys } from '../utils'
+import { normalizePath } from '../utils'
 import { perEnvironmentState } from '../environment'
 import { type Environment, perEnvironmentPlugin } from '..'
 import { cssEntriesMap } from './asset'
@@ -69,8 +68,10 @@ export function manifestPlugin(): Plugin {
     }
   })
 
-  return perEnvironmentPlugin('native:manifest', (environment) => {
+  return perEnvironmentPlugin('native:manifest', async (environment) => {
     if (!environment.config.build.manifest) return false
+    const { viteManifestPlugin: nativeManifestPlugin } =
+      await import('rolldown/experimental')
 
     const root = environment.config.root
     const outPath =
@@ -111,184 +112,67 @@ export function manifestPlugin(): Plugin {
         name: 'native:manifest-compatible',
         generateBundle(_, bundle) {
           const asset = bundle[outPath]
-          const assetSource =
-            asset?.type === 'asset' ? asset.source.toString() : undefined
-          let manifest: Manifest | undefined = assetSource
-            ? undefined
-            : createManifestFromBundle(
-                bundle,
-                root,
-                this.environment,
-                (referenceId) => this.getFileName(referenceId),
-              )
-          for (const output of Object.values(bundle)) {
-            const importedCss = output.viteMetadata?.importedCss
-            const importedAssets = output.viteMetadata?.importedAssets
-            if (!importedCss?.size && !importedAssets?.size) continue
-            manifest ??= JSON.parse(assetSource!) as Manifest
-            if (output.type === 'chunk') {
-              const item = manifest[getChunkName(output)]
-              if (!item) continue
-              if (importedCss?.size) {
-                item.css = [...importedCss]
-              }
-              if (importedAssets?.size) {
-                item.assets = [...importedAssets]
-              }
-            } else if (output.type === 'asset' && output.names.length > 0) {
-              // Add every unique asset to the manifest, keyed by its original name
-              const keys =
-                output.originalFileNames.length > 0
-                  ? output.originalFileNames
-                  : [`_${path.basename(output.fileName)}`]
-
-              for (const key of keys) {
-                const item = manifest[key]
+          if (asset.type === 'asset') {
+            let manifest: Manifest | undefined
+            for (const output of Object.values(bundle)) {
+              const importedCss = output.viteMetadata?.importedCss
+              const importedAssets = output.viteMetadata?.importedAssets
+              if (!importedCss?.size && !importedAssets?.size) continue
+              manifest ??= JSON.parse(asset.source.toString()) as Manifest
+              if (output.type === 'chunk') {
+                const item = manifest[getChunkName(output)]
                 if (!item) continue
-                if (!(item.file && endsWithJSRE.test(item.file))) {
-                  if (importedCss?.size) {
-                    item.css = [...importedCss]
-                  }
-                  if (importedAssets?.size) {
-                    item.assets = [...importedAssets]
+                if (importedCss?.size) {
+                  item.css = [...importedCss]
+                }
+                if (importedAssets?.size) {
+                  item.assets = [...importedAssets]
+                }
+              } else if (output.type === 'asset' && output.names.length > 0) {
+                // Add every unique asset to the manifest, keyed by its original name
+                const keys =
+                  output.originalFileNames.length > 0
+                    ? output.originalFileNames
+                    : [`_${path.basename(output.fileName)}`]
+
+                for (const key of keys) {
+                  const item = manifest[key]
+                  if (!item) continue
+                  if (!(item.file && endsWithJSRE.test(item.file))) {
+                    if (importedCss?.size) {
+                      item.css = [...importedCss]
+                    }
+                    if (importedAssets?.size) {
+                      item.assets = [...importedAssets]
+                    }
                   }
                 }
               }
             }
-          }
-          const output = this.environment.config.build.rolldownOptions.output
-          const outputLength = Array.isArray(output) ? output.length : 1
-          if (manifest && outputLength === 1) {
-            const source = JSON.stringify(
-              sortObjectKeys(manifest),
-              undefined,
-              2,
-            )
-            if (asset?.type === 'asset') {
-              asset.source = source
-            } else {
-              this.emitFile({ fileName: outPath, type: 'asset', source })
+            const output = this.environment.config.build.rolldownOptions.output
+            const outputLength = Array.isArray(output) ? output.length : 1
+            if (manifest && outputLength === 1) {
+              asset.source = JSON.stringify(manifest, undefined, 2)
+              return
             }
-            return
-          }
 
-          const state = getState(this)
-          state.outputCount++
-          state.manifest = Object.assign(
-            state.manifest,
-            manifest ?? JSON.parse(assetSource!),
-          )
-          if (state.outputCount >= outputLength) {
-            const source = JSON.stringify(
-              sortObjectKeys(state.manifest),
-              undefined,
-              2,
+            const state = getState(this)
+            state.outputCount++
+            state.manifest = Object.assign(
+              state.manifest,
+              manifest ?? JSON.parse(asset.source.toString()),
             )
-            if (asset?.type === 'asset') {
-              asset.source = source
+            if (state.outputCount >= outputLength) {
+              asset.source = JSON.stringify(state.manifest, undefined, 2)
+              state.reset()
             } else {
-              this.emitFile({ fileName: outPath, type: 'asset', source })
+              delete bundle[outPath]
             }
-            state.reset()
-          } else if (asset?.type === 'asset') {
-            delete bundle[outPath]
           }
         },
       },
     ]
   })
-}
-
-function createManifestFromBundle(
-  bundle: OutputBundle,
-  root: string,
-  environment: Environment,
-  getFileName: (referenceId: string) => string,
-): Manifest {
-  const manifest: Manifest = {}
-  const entryCssAssetFileNames = new Map<string, string>()
-
-  for (const { name, referenceId } of cssEntriesMap
-    .get(environment)
-    ?.values() ?? []) {
-    try {
-      entryCssAssetFileNames.set(getFileName(referenceId), name)
-    } catch {}
-  }
-
-  function getChunkName(chunk: OutputChunk) {
-    return (
-      getChunkOriginalFileName(chunk, root, false) ??
-      `_${path.basename(chunk.fileName)}`
-    )
-  }
-
-  function getInternalImports(imports: readonly string[]) {
-    const filteredImports: string[] = []
-    for (const file of imports) {
-      const importee = bundle[file]
-      if (importee?.type === 'chunk') {
-        filteredImports.push(getChunkName(importee))
-      }
-    }
-    return filteredImports
-  }
-
-  for (const output of Object.values(bundle)) {
-    if (output.type === 'chunk') {
-      const manifestChunk: ManifestChunk = {
-        file: output.fileName,
-        name: output.name,
-      }
-      const src = getChunkOriginalFileName(output, root, false)
-      if (src) manifestChunk.src = src
-      if (output.isEntry) manifestChunk.isEntry = true
-      if (output.isDynamicEntry) manifestChunk.isDynamicEntry = true
-      if (output.imports.length) {
-        const internalImports = getInternalImports(output.imports)
-        if (internalImports.length > 0) manifestChunk.imports = internalImports
-      }
-      if (output.dynamicImports.length) {
-        const internalImports = getInternalImports(output.dynamicImports)
-        if (internalImports.length > 0) {
-          manifestChunk.dynamicImports = internalImports
-        }
-      }
-      if (output.viteMetadata?.importedCss.size) {
-        manifestChunk.css = [...output.viteMetadata.importedCss]
-      }
-      if (output.viteMetadata?.importedAssets.size) {
-        manifestChunk.assets = [...output.viteMetadata.importedAssets]
-      }
-      manifest[getChunkName(output)] = manifestChunk
-    } else if (output.names.length > 0) {
-      const src =
-        output.originalFileNames.length > 0
-          ? output.originalFileNames[0]
-          : `_${path.basename(output.fileName)}`
-      const manifestChunk: ManifestChunk = {
-        file: output.fileName,
-        src,
-      }
-      const cssEntryName = entryCssAssetFileNames.get(output.fileName)
-      if (cssEntryName) {
-        manifestChunk.isEntry = true
-        manifestChunk.name = cssEntryName
-      }
-      const file = manifest[src]?.file
-      if (!(file && endsWithJSRE.test(file))) {
-        manifest[src] = manifestChunk
-      }
-      for (const originalFileName of output.originalFileNames.slice(1)) {
-        const file = manifest[originalFileName]?.file
-        if (!(file && endsWithJSRE.test(file))) {
-          manifest[originalFileName] = manifestChunk
-        }
-      }
-    }
-  }
-
-  return manifest
 }
 
 export function getChunkOriginalFileName(


### PR DESCRIPTION
## Summary

Fixes #22485.

Vite could crash during manifest builds when `build()` was imported from a TypeScript script run by `tsx` in a CommonJS package. In that path, the native manifest plugin may not provide the manifest asset before the compatibility hook runs, so the hook now falls back to generating the manifest from the Rollup/Rolldown bundle metadata instead of reading an undefined asset.

This also keeps CSS-entry discovery tolerant when the CSS entry map is unavailable, while preserving the existing native-manifest path when the asset is emitted normally.

## Changes

- Add a JS manifest fallback for the compatibility hook when the native manifest asset is missing.
- Add a regression fixture that runs `tsx build.ts` from a CJS package and verifies `.vite/manifest.json` is written.

## Testing

- `pnpm run test-unit packages/vite/src/node/__tests__/build.spec.ts -t "manifest build works"` (failed before the fix, passed after)
- `pnpm run test-unit packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm run build`
- `pnpm exec eslint --no-warn-ignored packages/vite/src/node/plugins/manifest.ts packages/vite/src/node/__tests__/build.spec.ts packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/build.ts packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/vite.config.ts packages/vite/src/node/__tests__/fixtures/tsx-cjs-manifest/src/main.ts`
- `git diff --check`

Note: `pnpm --filter vite lint` currently exits before linting because the package script passes the ignored `src/node/__tests__/__snapshots__` directory to ESLint 9; the changed files were linted directly with the command above.

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.
