### PR TITLE
fix: capitalize error messages and remove spurious space in parse error

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1156,7 +1156,7 @@ export async function extractExportsData(
       `Unable to parse: ${filePath}.\n Trying again with a ${lang} transform.`,
     )
     if (lang !== 'jsx' && lang !== 'tsx' && lang !== 'ts') {
-      throw new Error(`Unable to parse : ${filePath}.`)
+      throw new Error(`Unable to parse: ${filePath}.`)
     }
     const transformed = await transformWithOxc(
       entryContent,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -183,7 +183,7 @@ export async function preview(
       if (server.resolvedUrls) {
         printServerUrls(server.resolvedUrls, options.host, logger.info)
       } else {
-        throw new Error('cannot print server URLs before server is listening.')
+        throw new Error('Cannot print server URLs before server is listening.')
       }
     },
     bindCLIShortcuts(options) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -781,10 +781,10 @@ export async function _createServer(
           config.logger.info,
         )
       } else if (middlewareMode) {
-        throw new Error('cannot print server URLs in middleware mode.')
+        throw new Error('Cannot print server URLs in middleware mode.')
       } else {
         throw new Error(
-          'cannot print server URLs before server.listen is called.',
+          'Cannot print server URLs before server.listen is called.',
         )
       }
     },


### PR DESCRIPTION
The three `printUrls()` error messages in `packages/vite/src/node/server/index.ts` and `packages/vite/src/node/preview.ts` were using lowercase `cannot`, inconsistent with the capitalized style used by the neighbouring error at `server/index.ts:1092` (`Cannot call server.listen in middleware mode.`).

Also removed a stray space before the colon in the error message `Unable to parse : ${filePath}` in `packages/vite/src/node/optimizer/index.ts`; the debug log immediately above it already had the correct form `Unable to parse: ${filePath}`.

No behaviour change - error message text only.