### PR TITLE
fix: build manifest from tsx cjs scripts (fix #22485)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,5 +1,6 @@
+import { execFile } from 'node:child_process'
 import { basename, resolve } from 'node:path'
-import { stripVTControlCharacters } from 'node:util'
+import { promisify, stripVTControlCharacters } from 'node:util'
 import fsp from 'node:fs/promises'
 import colors from 'picocolors'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -24,6 +25,7 @@ import { createLogger } from '../logger'
 import { BuildEnvironment, resolveConfig } from '..'
 
 const dirname = import.meta.dirname
+const execFileAsync = promisify(execFile)
 
 type FormatsToFileNames = [LibraryFormats, string][]
 
@@ -168,6 +170,31 @@ describe('build', () => {
     })
     expect(manifest['b/index.css']).toMatchObject({
       isEntry: true,
+    })
+  })
+
+  test('manifest builds from a tsx CommonJS TypeScript script', async (ctx) => {
+    const root = resolve(dirname, 'fixtures/manifest-tsx-cjs')
+    ctx.onTestFinished(() =>
+      fsp.rm(resolve(root, 'dist'), { recursive: true, force: true }),
+    )
+
+    await execFileAsync(
+      process.execPath,
+      [
+        resolve(dirname, '../../../../../node_modules/tsx/dist/cli.mjs'),
+        'build.ts',
+      ],
+      { cwd: root },
+    )
+
+    const manifest = JSON.parse(
+      await fsp.readFile(resolve(root, 'dist/.vite/manifest.json'), 'utf-8'),
+    )
+    expect(manifest['index.ts']).toMatchObject({
+      file: expect.stringMatching(/^assets\/index-.*\.js$/),
+      isEntry: true,
+      src: 'index.ts',
     })
   })
 

--- a/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/build.ts
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/build.ts
@@ -1,0 +1,17 @@
+import { build } from 'vite'
+
+async function runBuild() {
+  await build({
+    build: {
+      manifest: true,
+      outDir: 'dist',
+      rollupOptions: {
+        input: {
+          index: './index.ts',
+        },
+      },
+    },
+  })
+}
+
+runBuild()

--- a/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/index.ts
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/index.ts
@@ -1,0 +1,1 @@
+console.log('Hello Vite')

--- a/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { OutputChunk, RenderedChunk } from 'rolldown'
+import type { OutputAsset, OutputChunk, RenderedChunk } from 'rolldown'
 import { viteManifestPlugin as nativeManifestPlugin } from 'rolldown/experimental'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
@@ -111,63 +111,189 @@ export function manifestPlugin(): Plugin {
       {
         name: 'native:manifest-compatible',
         generateBundle(_, bundle) {
-          const asset = bundle[outPath]
-          if (asset.type === 'asset') {
-            let manifest: Manifest | undefined
-            for (const output of Object.values(bundle)) {
-              const importedCss = output.viteMetadata?.importedCss
-              const importedAssets = output.viteMetadata?.importedAssets
-              if (!importedCss?.size && !importedAssets?.size) continue
-              manifest ??= JSON.parse(asset.source.toString()) as Manifest
-              if (output.type === 'chunk') {
-                const item = manifest[getChunkName(output)]
-                if (!item) continue
-                if (importedCss?.size) {
-                  item.css = [...importedCss]
-                }
-                if (importedAssets?.size) {
-                  item.assets = [...importedAssets]
-                }
-              } else if (output.type === 'asset' && output.names.length > 0) {
-                // Add every unique asset to the manifest, keyed by its original name
-                const keys =
-                  output.originalFileNames.length > 0
-                    ? output.originalFileNames
-                    : [`_${path.basename(output.fileName)}`]
+          const createFallbackManifest = (): Manifest => {
+            const manifest: Manifest = {}
+            const entryCssReferenceIds = cssEntriesMap.get(this.environment)
+            const entryCssAssetFileNames = new Set(entryCssReferenceIds?.keys())
+            for (const { referenceId } of entryCssReferenceIds?.values() ??
+              []) {
+              try {
+                entryCssAssetFileNames.add(this.getFileName(referenceId))
+              } catch {
+                // The asset was generated as part of a different output option.
+              }
+            }
 
-                for (const key of keys) {
-                  const item = manifest[key]
-                  if (!item) continue
-                  if (!(item.file && endsWithJSRE.test(item.file))) {
-                    if (importedCss?.size) {
-                      item.css = [...importedCss]
-                    }
-                    if (importedAssets?.size) {
-                      item.assets = [...importedAssets]
-                    }
+            for (const file in bundle) {
+              const output = bundle[file]
+              if (output.type === 'chunk') {
+                manifest[getChunkName(output)] = createChunk(output)
+              } else if (output.type === 'asset' && output.names.length > 0) {
+                const src =
+                  output.originalFileNames.length > 0
+                    ? output.originalFileNames[0]
+                    : `_${path.basename(output.fileName)}`
+                const isEntry = entryCssAssetFileNames.has(output.fileName)
+                const asset = createAsset(output, src, isEntry)
+
+                const file = manifest[src]?.file
+                if (!(file && endsWithJSRE.test(file))) {
+                  manifest[src] = asset
+                }
+
+                for (const originalFileName of output.originalFileNames.slice(
+                  1,
+                )) {
+                  const file = manifest[originalFileName]?.file
+                  if (!(file && endsWithJSRE.test(file))) {
+                    manifest[originalFileName] = asset
                   }
                 }
               }
             }
-            const output = this.environment.config.build.rolldownOptions.output
-            const outputLength = Array.isArray(output) ? output.length : 1
-            if (manifest && outputLength === 1) {
-              asset.source = JSON.stringify(manifest, undefined, 2)
-              return
-            }
 
-            const state = getState(this)
-            state.outputCount++
-            state.manifest = Object.assign(
-              state.manifest,
-              manifest ?? JSON.parse(asset.source.toString()),
-            )
-            if (state.outputCount >= outputLength) {
-              asset.source = JSON.stringify(state.manifest, undefined, 2)
-              state.reset()
+            return manifest
+          }
+
+          const asset = bundle[outPath]
+          if (asset && asset.type !== 'asset') return
+          const manifest = asset
+            ? (JSON.parse(asset.source.toString()) as Manifest)
+            : createFallbackManifest()
+          for (const output of Object.values(bundle)) {
+            const importedCss = output.viteMetadata?.importedCss
+            const importedAssets = output.viteMetadata?.importedAssets
+            if (!importedCss?.size && !importedAssets?.size) continue
+            if (output.type === 'chunk') {
+              const item = manifest[getChunkName(output)]
+              if (!item) continue
+              if (importedCss?.size) {
+                item.css = [...importedCss]
+              }
+              if (importedAssets?.size) {
+                item.assets = [...importedAssets]
+              }
+            } else if (output.type === 'asset' && output.names.length > 0) {
+              // Add every unique asset to the manifest, keyed by its original name
+              const keys =
+                output.originalFileNames.length > 0
+                  ? output.originalFileNames
+                  : [`_${path.basename(output.fileName)}`]
+
+              for (const key of keys) {
+                const item = manifest[key]
+                if (!item) continue
+                if (!(item.file && endsWithJSRE.test(item.file))) {
+                  if (importedCss?.size) {
+                    item.css = [...importedCss]
+                  }
+                  if (importedAssets?.size) {
+                    item.assets = [...importedAssets]
+                  }
+                }
+              }
+            }
+          }
+          const output = this.environment.config.build.rolldownOptions.output
+          const outputLength = Array.isArray(output) ? output.length : 1
+          if (outputLength === 1) {
+            const source = JSON.stringify(manifest, undefined, 2)
+            if (asset) {
+              asset.source = source
             } else {
+              this.emitFile({
+                fileName: outPath,
+                type: 'asset',
+                source,
+              })
+            }
+            return
+          }
+
+          const state = getState(this)
+          state.outputCount++
+          state.manifest = Object.assign(state.manifest, manifest)
+          if (state.outputCount >= outputLength) {
+            const source = JSON.stringify(state.manifest, undefined, 2)
+            if (asset) {
+              asset.source = source
+            } else {
+              this.emitFile({
+                fileName: outPath,
+                type: 'asset',
+                source,
+              })
+            }
+            state.reset()
+          } else {
+            if (asset) {
               delete bundle[outPath]
             }
+          }
+
+          function getInternalImports(imports: string[]): string[] {
+            const filteredImports: string[] = []
+
+            for (const file of imports) {
+              const output = bundle[file]
+              if (output?.type !== 'chunk') continue
+              filteredImports.push(getChunkName(output))
+            }
+
+            return filteredImports
+          }
+
+          function createChunk(chunk: OutputChunk): ManifestChunk {
+            const manifestChunk: ManifestChunk = {
+              file: chunk.fileName,
+              name: chunk.name,
+            }
+
+            if (chunk.facadeModuleId) {
+              manifestChunk.src = getChunkName(chunk)
+            }
+            if (chunk.isEntry) {
+              manifestChunk.isEntry = true
+            }
+            if (chunk.isDynamicEntry) {
+              manifestChunk.isDynamicEntry = true
+            }
+
+            if (chunk.imports.length) {
+              const internalImports = getInternalImports(chunk.imports)
+              if (internalImports.length > 0) {
+                manifestChunk.imports = internalImports
+              }
+            }
+
+            if (chunk.dynamicImports.length) {
+              const internalImports = getInternalImports(chunk.dynamicImports)
+              if (internalImports.length > 0) {
+                manifestChunk.dynamicImports = internalImports
+              }
+            }
+
+            if (chunk.viteMetadata?.importedCss.size) {
+              manifestChunk.css = [...chunk.viteMetadata.importedCss]
+            }
+            if (chunk.viteMetadata?.importedAssets.size) {
+              manifestChunk.assets = [...chunk.viteMetadata.importedAssets]
+            }
+
+            return manifestChunk
+          }
+
+          function createAsset(
+            asset: OutputAsset,
+            src: string,
+            isEntry?: boolean,
+          ): ManifestChunk {
+            const manifestChunk: ManifestChunk = {
+              file: asset.fileName,
+              src,
+            }
+            if (isEntry) manifestChunk.isEntry = true
+            return manifestChunk
           }
         },
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/file-url: {}
 
+  packages/vite/src/node/__tests__/fixtures/manifest-tsx-cjs: {}
+
   packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob: {}
 
   packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}


### PR DESCRIPTION
### Description

When Vite is imported from a `.ts` build script executed by `tsx` in a package without `"type": "module"`, the native manifest plugin may not emit the manifest asset. The compatibility pass then tried to read `.vite/manifest.json` unconditionally and crashed before the build could finish.

This keeps the existing native manifest path when the asset is present, and falls back to constructing the manifest from the output bundle when it is missing. That matches the metadata Vite already has for chunks/assets and lets the build still emit `.vite/manifest.json`.

### Additional context

Added a regression fixture that runs a CommonJS-package `build.ts` through `tsx`, then checks that `dist/.vite/manifest.json` contains the entry for `index.ts`.

### Tests

- `pnpm --filter vite run build-bundle`
- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/plugins/manifest.ts packages/vite/src/node/__tests__/build.spec.ts`