### PR TITLE
fix(ssr): register export * getters next to earlier same-source import to fix cyclic facade namespace

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -279,6 +279,67 @@ test('export then import minified', async () => {
   `)
 })
 
+test('dedupes export star from an already imported source', async () => {
+  expect(
+    await ssrTransformSimpleCode(`
+import { createApp } from 'vue'
+export { client } from './client'
+export * from 'vue'
+export { createApp }
+`),
+  ).toMatchInlineSnapshot(`
+    "__vite_ssr_exportName__("client", () => { try { return __vite_ssr_import_1__.client } catch {} });
+    __vite_ssr_exportName__("createApp", () => { try { return __vite_ssr_import_0__.createApp } catch {} });
+    const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["createApp"]});
+    __vite_ssr_exportAll__(__vite_ssr_import_0__);
+    const __vite_ssr_import_1__ = await __vite_ssr_import__("./client", {"importedNames":["client"]});
+    ;
+
+
+    ;
+
+    "
+  `)
+})
+
+test('dedupes export star from an already re-exported source', async () => {
+  expect(
+    await ssrTransformSimpleCode(`
+export { createApp } from 'vue'
+export { client } from './client'
+export * from 'vue'
+`),
+  ).toMatchInlineSnapshot(`
+    "__vite_ssr_exportName__("createApp", () => { try { return __vite_ssr_import_0__.createApp } catch {} });
+    __vite_ssr_exportName__("client", () => { try { return __vite_ssr_import_1__.client } catch {} });
+    const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["createApp"]});
+    __vite_ssr_exportAll__(__vite_ssr_import_0__);
+    ;const __vite_ssr_import_1__ = await __vite_ssr_import__("./client", {"importedNames":["client"]});
+    ;
+
+
+
+    "
+  `)
+})
+
+test('does not dedupe export namespace from an already imported source', async () => {
+  expect(
+    await ssrTransformSimpleCode(`
+import { createApp } from 'vue'
+export * as ns from 'vue'
+`),
+  ).toMatchInlineSnapshot(`
+    "__vite_ssr_exportName__("ns", () => { try { return __vite_ssr_import_1__ } catch {} });
+    const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["createApp"]});
+    const __vite_ssr_import_1__ = await __vite_ssr_import__("vue");
+
+
+
+    "
+  `)
+})
+
 test('hoist import to top', async () => {
   expect(
     await ssrTransformSimpleCode(

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/client.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/client.js
@@ -1,0 +1,3 @@
+import { start } from './start.js'
+
+export const client = start()

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/core.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/core.js
@@ -1,0 +1,7 @@
+export var createThing = (value) => {
+  return value
+}
+
+export var createStart = () => {
+  return { started: true }
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/facade.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/facade.js
@@ -1,0 +1,5 @@
+import { createStart } from './core.js'
+
+export { client } from './client.js'
+export * from './core.js'
+export { createStart }

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/middleware.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/middleware.js
@@ -1,0 +1,3 @@
+import { createThing } from './facade.js'
+
+export const middleware = createThing('middleware')

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/start.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic-reexport-facade/start.js
@@ -1,0 +1,6 @@
+import { createStart } from './facade.js'
+import { middleware } from './middleware.js'
+
+export function start() {
+  return { ...createStart(), middleware }
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -350,6 +350,19 @@ describe('module runner initialization', async () => {
     `)
   })
 
+  it('resolves export star bindings through a cyclic facade', async ({
+    runner,
+  }) => {
+    const mod = await runner.import(
+      '/fixtures/cyclic-reexport-facade/facade.js',
+    )
+
+    expect(mod.client).toEqual({
+      started: true,
+      middleware: 'middleware',
+    })
+  })
+
   it(`live binding (export default function f)`, async ({ runner }) => {
     const mod = await runner.import('/fixtures/live-binding/test1/index.js')
     expect(mod.default).toMatchInlineSnapshot(`

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -156,6 +156,8 @@ async function ssrTransformScript(
     ESTree.ExportNamedDeclaration | ESTree.ExportAllDeclaration,
     string
   >()
+  const sourceToImportMap = new Map<string, { id: string; end: number }>()
+  const earlyExportAllDeclarations = new Set<ESTree.ExportAllDeclaration>()
 
   for (const node of ast.body) {
     if (node.type === 'ImportDeclaration') {
@@ -189,14 +191,31 @@ async function ssrTransformScript(
           },
         )
         reExportImportIdMap.set(node, importId)
+        sourceToImportMap.set(node.source.value, {
+          id: importId,
+          end: node.end,
+        })
       }
       continue
     }
     if (node.type === 'ExportAllDeclaration') {
       if (node.source) {
         // export * from './foo'
-        const importId = defineImport(hoistIndex, node)
-        reExportImportIdMap.set(node, importId)
+        const existingImport = !node.exported
+          ? sourceToImportMap.get(node.source.value)
+          : undefined
+        if (existingImport) {
+          reExportImportIdMap.set(node, existingImport.id)
+          earlyExportAllDeclarations.add(node)
+          s.remove(node.start, node.end)
+          s.appendLeft(
+            existingImport.end,
+            `${ssrExportAllKey}(${existingImport.id});\n`,
+          )
+        } else {
+          const importId = defineImport(hoistIndex, node)
+          reExportImportIdMap.set(node, importId)
+        }
       }
       continue
     }
@@ -213,6 +232,7 @@ async function ssrTransformScript(
         })
         .filter(isDefined),
     })
+    sourceToImportMap.set(node.source.value, { id: importId, end: node.end })
     for (const spec of node.specifiers) {
       if (spec.type === 'ImportSpecifier') {
         if (spec.imported.type === 'Identifier') {
@@ -320,6 +340,8 @@ async function ssrTransformScript(
       if (node.exported) {
         const exportedAs = getIdentifierNameOrLiteralValue(node.exported)
         defineExport(exportedAs, `${importId}`)
+      } else if (earlyExportAllDeclarations.has(node)) {
+        // Already emitted next to the earlier same-source import.
       } else {
         s.appendLeft(node.end, `${ssrExportAllKey}(${importId});\n`)
       }


### PR DESCRIPTION
Fixes #22491.

## Fix
Transform-level change in `ssrTransform.ts`. When `export * from 'x'` reuses a source already imported earlier in the same module:
- Track earlier import ids by source (`sourceToImportMap`).
- Reuse the existing import id for the `export *`.
- Emit `__vite_ssr_exportAll__(existingImportId)` immediately after the earlier import (via `s.appendLeft(existingImport.end, ...)`).
- Remove the later duplicate `export *` statement.
- Skip the pass-2 `appendLeft` for those nodes via an `earlyExportAllDeclarations` Set to avoid double-emission.
- Negative-guarded by `!node.exported`, so `export * as ns from 'x'` is left untouched.
This restores link-time `export *` semantics for the common facade pattern: the wildcard getters are registered before any subsequent cycle-triggering import awaits.
## Tests
- `runtime/__tests__/fixtures/cyclic-reexport-facade/*` — fixtures mirroring the reduced repro in the issue.
- `server-runtime.spec.ts > resolves export star bindings through a cyclic facade` — fails on `main` with `TypeError: createThing is not a function`, passes with this patch.
- `ssrTransform.spec.ts` — three inline-snapshot tests
## Scope (in this PR)
Only `export * from 'x'` where `'x'` was already imported earlier in the same module (`import …` or `export … from`). The reported real-world case (TanStack Start) matches this shape.

## Out of scope (can extend if maintainers want)
These are adjacent cyclic-`export *` deviations from spec link-time semantics that this PR does **not** address, to keep the diff minimal:
### 1. No prior same-source import
```js
// facade.js
export { client } from './client.js'  // triggers cycle into facade
export * from './core.js'             // no earlier import of ./core.js
// client.js -> ... -> middleware.js
import { createThing } from './facade.js'  // sees partial namespace
```
Both the hoisted `__vite_ssr_import__("./core.js")` and its `__vite_ssr_exportAll__` end up *after* the `./client.js` import in the hoisted block, so the cycle observes the facade before `core`'s wildcard is registered. A fix would hoist plain `export *` imports ahead of any cycle-capable preceding import, but that requires broader reordering.
### 2. Cycle during the anchor import's own await
```js
// facade.js
import { a } from './x.js'   // anchor; ./x.js cycles back to ./facade.js
export * from './x.js'
// x.js
import { b } from './facade.js'  // cycle returns here, before exportAll(x) runs
```
The patched `__vite_ssr_exportAll__(x)` is appended *after* the anchor import resolves. While we're still awaiting `./x.js`, the facade namespace does not yet have the wildcard getters. A fix would need to register `exportAll` *before* awaiting the anchor — but at that point the imported module reference does not exist yet, so it requires a different runtime shape (e.g. a deferred-getter proxy).
### 3. Multiple `export *` from the same anchored source
```js
// facade.js
import { a } from './x.js'
export * from './x.js'
export * from './x.js'
```
Both deduped `export *` statements emit `__vite_ssr_exportAll__(__vite_ssr_import_0__)` at the same anchor — idempotent at runtime, but redundant. Trivially dedupable with a per-anchor `Set<sourceValue>` if desired.
### 4. `export * as ns` is left at its textual position
```js
// facade.js
import { a } from './x.js'
export * as ns from './x.js'   // creates named export `ns`, kept in place
```
A more general fix could also hoist the `ns` named-export registration next to the anchor import, but `export * as ns` is a namespace *snapshot* with different semantics from `export *` and is not in the reported failure mode.
