### PR TITLE
fix(assets): allow ?raw imports of public files

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -166,6 +166,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: [
           urlRE,
+          rawRE,
           DEFAULT_ASSETS_RE,
           ...makeIdFiltersToMatchWithQuery(config.rawAssetsInclude).map((v) =>
             typeof v === 'string' ? picomatch.makeRe(v, { dot: true }) : v,
@@ -173,7 +174,11 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
         ],
       },
       handler(id) {
-        if (!config.assetsInclude(cleanUrl(id)) && !urlRE.test(id)) {
+        if (
+          !config.assetsInclude(cleanUrl(id)) &&
+          !urlRE.test(id) &&
+          !rawRE.test(id)
+        ) {
           return
         }
         // imports to absolute urls pointing to files in /public

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -48,6 +48,7 @@ import {
   moduleListContains,
   normalizePath,
   prettifyUrl,
+  rawRE,
   removeImportQuery,
   removeTimestampQuery,
   stripBase,
@@ -559,7 +560,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               specifier[0] === '/' &&
               !(
                 config.assetsInclude(cleanUrl(specifier)) ||
-                urlRE.test(specifier)
+                urlRE.test(specifier) ||
+                rawRE.test(specifier)
               ) &&
               checkPublicFile(specifier, config)
             ) {

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -16,6 +16,7 @@ import {
   isParentDirectory,
   isSameFilePath,
   normalizePath,
+  rawRE,
   removeLeadingSlash,
   urlRE,
 } from '../../utils'
@@ -112,8 +113,9 @@ export function servePublicMiddleware(
       (publicFiles && !publicFiles.has(toFilePath(req.url!))) ||
       isImportRequest(req.url!) ||
       isInternalRequest(req.url!) ||
-      // for `/public-file.js?url` to be transformed
-      urlRE.test(req.url!)
+      // for `/public-file.js?url` and `/public-file.js?raw` to be transformed
+      urlRE.test(req.url!) ||
+      rawRE.test(req.url!)
     ) {
       return next()
     }

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -205,6 +205,15 @@ describe('asset imports from js', () => {
       )
     }
   })
+
+  test('?raw from /public', async () => {
+    expect(await page.textContent('.public-js-raw-import-content'))
+      .toMatchInlineSnapshot(`
+        "document.querySelector('.raw-js').textContent =
+          '[success] Raw js from /public loaded'
+        "
+      `)
+  })
 })
 
 describe('css url() references', () => {

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -51,6 +51,10 @@
     <code class="public-mts-import-content"></code> Content-Type:
     <code class="public-mts-import-content-type"></code>
   </li>
+  <li>
+    From publicDir (?raw):
+    <code class="public-js-raw-import-content"></code>
+  </li>
 </ul>
 
 <h2>CSS url references</h2>
@@ -546,6 +550,9 @@
       await res.headers.get('Content-Type'),
     )
   })()
+
+  import publicJsRaw from '/raw.js?raw'
+  text('.public-js-raw-import-content', publicJsRaw)
 
   import svgFrag from './nested/fragment.svg'
   text('.svg-frag-import-path', svgFrag)


### PR DESCRIPTION
## Description

Importing a non-asset file from `publicDir` with `?raw` currently throws a hard error during import analysis:

```js
import redirects from '/_redirects?raw'
// Error: Cannot import non-asset file /_redirects?raw which is inside /public ...
```

This is inconsistent: the asset plugin's `load` hook already knows how to read public files for `?raw` requests (`checkPublicFile(id, config) || cleanUrl(id)`), so `?raw` is a legitimate way to inline a public file's contents. The error even suggests `?url&raw` as a workaround, which doesn't actually make sense (you get the raw text, not a URL).

There were two reasons `?raw` didn't work for public files:

1. `importAnalysis` only exempted `?url` (and asset types) from the "non-asset file inside /public" guard, so `?raw` on a non-asset public file (e.g. `/_redirects`, `/foo.js`) threw before the asset plugin ran.
2. Even past that, the dev public middleware served such files statically (it only let `?url` fall through to be transformed), so the import resolved to the raw source served as a module rather than a string.

## Fix

Treat `?raw` the same way `?url` is already treated for public files:

- `importAnalysis`: don't throw the non-asset error when the request has `?raw`.
- asset plugin `resolveId`: resolve public files for `?raw` so the existing `load` handler picks them up.
- dev public middleware: let `?raw` requests fall through to the transform pipeline.

The existing hard error is preserved for plain public imports without `?raw`/`?url` (e.g. `import x from '/foo.js'`), which remain genuine mistakes.

## Testing

Added a `?raw` public-file import to the `assets` playground (`/raw.js?raw`) asserting the file contents are inlined. Verified it fails before the change and passes after, in both serve and build modes. Also manually checked extensionless (`/_redirects?raw`), asset-extension (`/foo.txt?raw`), and additional-query (`?raw&v=1`) cases all return `export default "<content>"`.

Fixes #21277