### PR TITLE
fix(glob): error on relative glob in virtual module when no files match

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
@@ -67,19 +67,16 @@ describe('fixture', async () => {
     // Regression test for vitejs/vite#22345: even when the relative glob
     // matches zero files, virtual modules must still surface the error
     // instead of silently returning `{}`.
-    try {
+    await expect(async () => {
       await transformGlobImport(
         "import.meta.glob('./no-such-dir/*.ts')",
         'virtual:module',
         root,
         resolveId,
       )
-      expect('no error').toBe('should throw an error')
-    } catch (err) {
-      expect(err).toMatchInlineSnapshot(
-        "[Error: In virtual modules, all globs must start with '/']",
-      )
-    }
+    }).rejects.toMatchInlineSnapshot(
+      `[Error: In virtual modules, all globs must start with '/']`,
+    )
   })
 
   it('transform with restoreQueryExtension', async () => {

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
@@ -25,12 +25,12 @@ describe('fixture', async () => {
         .toString()
         .split('\n').length
 
-    expect(await getTransformedLineCount("import.meta.glob('./*.js')")).toBe(1)
+    expect(await getTransformedLineCount("import.meta.glob('/*.js')")).toBe(1)
     expect(
       await getTransformedLineCount(
         `
           import.meta.glob(
-            './*.js'
+            '/*.js'
           )
         `.trim(),
       ),
@@ -53,6 +53,23 @@ describe('fixture', async () => {
     try {
       await transformGlobImport(
         "import.meta.glob('./modules/*.ts')",
+        'virtual:module',
+        root,
+        resolveId,
+      )
+      expect('no error').toBe('should throw an error')
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(
+        "[Error: In virtual modules, all globs must start with '/']",
+      )
+    }
+
+    // Regression test for vitejs/vite#22345: even when the relative glob
+    // matches zero files, virtual modules must still surface the error
+    // instead of silently returning `{}`.
+    try {
+      await transformGlobImport(
+        "import.meta.glob('./no-such-dir/*.ts')",
         'virtual:module',
         root,
         resolveId,

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -450,6 +450,10 @@ export async function transformGlobImport(
           onlyKeys,
           onlyValues,
         }) => {
+          if (!dir && !options.base && isRelative) {
+            throw new Error("In virtual modules, all globs must start with '/'")
+          }
+
           const cwd = getCommonBase(globsResolved) ?? root
           const files = (
             await glob(globsResolved, {
@@ -469,10 +473,6 @@ export async function transformGlobImport(
 
           const resolvePaths = (file: string) => {
             if (!dir) {
-              if (!options.base && isRelative)
-                throw new Error(
-                  "In virtual modules, all globs must start with '/'",
-                )
               const importPath = `/${relative(root, file)}`
               let filePath = options.base
                 ? `${relative(posix.join(root, options.base), file)}`


### PR DESCRIPTION
## Summary

Closes #22345.

In a virtual module, `import.meta.glob('./...')` silently returned `{}` instead of erroring. The documented `"In virtual modules, all globs must start with '/'"` guard was unreachable whenever the relative pattern matched zero files, so the failure mode was completely silent — no log, no warning, no thrown error.

## Root cause

`transformGlobImport` passes `importer: undefined` for virtual modules. In `toAbsoluteGlob`, when both `importer` and `base` are unset, `dir` falls back to `root`, so `./*.js` is resolved against the project root rather than rejected. The validation that *should* have rejected it lived inside `resolvePaths`, which is only invoked per matched file. With zero matches, the guard never ran — leaving an empty object as the silent result.