### PR TITLE
fix(build): improve root URL import error

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -171,6 +171,47 @@ describe('build', () => {
     })
   })
 
+  test('root URL import error includes asset hint', async () => {
+    let error: Error | undefined
+    try {
+      await build({
+        root: resolve(dirname, 'packages/build-project'),
+        logLevel: 'silent',
+        build: {
+          write: false,
+          rollupOptions: {
+            input: 'entry.js',
+          },
+        },
+        plugins: [
+          {
+            name: 'root-url-import',
+            resolveId(id) {
+              if (id === 'entry.js') {
+                return '\0' + id
+              }
+            },
+            load(id) {
+              if (id === '\0entry.js') {
+                return `import url from '/'; console.log(url)`
+              }
+            },
+          },
+        ],
+      })
+    } catch (e) {
+      error = e
+    }
+
+    expect(error).toBeDefined()
+    const message = stripVTControlCharacters(error!.message)
+    expect(message).toContain(`Could not resolve '/'`)
+    expect(message).toContain(
+      `A root URL "/" cannot be imported from source code.`,
+    )
+    expect(message).not.toContain(`Failed to resolve entry for package`)
+  })
+
   test.for([
     [true, true],
     [true, false],

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -905,6 +905,7 @@ async function buildEnvironment(
 
 export function enhanceRollupError(e: RollupError): void {
   const stackOnly = extractStack(e)
+  augmentRootUrlImportError(e)
 
   let msg = colors.red((e.plugin ? `[${e.plugin}] ` : '') + e.message)
   if (e.loc && e.loc.file && e.loc.file !== e.id) {
@@ -930,6 +931,26 @@ export function enhanceRollupError(e: RollupError): void {
   if (stackOnly !== undefined) {
     e.stack = `${e.message}\n${stackOnly}`
   }
+}
+
+function augmentRootUrlImportError(e: RollupError): void {
+  const errors = (e as RollupError & { errors?: RollupError[] }).errors
+  if (
+    isRootUrlImportError(e) ||
+    (Array.isArray(errors) && errors.some(isRootUrlImportError))
+  ) {
+    const hint =
+      `A root URL "/" cannot be imported from source code. ` +
+      `If this was generated from an asset reference, use a concrete file path such as "/logo.svg" instead.`
+
+    if (!e.message.includes(hint)) {
+      e.message += `\n\n${hint}`
+    }
+  }
+}
+
+function isRootUrlImportError(e: RollupError & { exporter?: string }): boolean {
+  return e.code === 'UNRESOLVED_IMPORT' && e.exporter === '/'
 }
 
 /**


### PR DESCRIPTION
Fixes #10871.

### Summary
- Add a targeted hint when build fails on a root URL import (`/`).
- Cover the case with a focused build unit test.

### Details
Vue template asset references such as `<img src=/>` are transformed into an import of `/`. The resolver now reports this as an unresolved import with a code frame, but the message does not explain the asset reference problem. This keeps resolution behavior unchanged and augments the build error only for root URL imports.

### Tests
- `pnpm vitest run packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/build.ts packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec eslint --cache --max-warnings 0 packages/vite/src/node/build.ts packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm --filter vite build-bundle`