### PR TITLE
fix(css): resolve sass partial package imports from file urls

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import type { InternalModuleFormat } from 'rolldown'
 import MagicString from 'magic-string'
@@ -447,6 +448,26 @@ describe('sass package resolution', () => {
         path.resolve(
           fixtureRoot,
           'node_modules/sass-pkg-with-index/index.scss',
+        ),
+      ),
+    )
+  })
+
+  test('resolves package exports when Sass first passes a file URL for a partial', async () => {
+    const resolve = await getSassResolver()
+    const resolved = await resolve(
+      pathToFileURL(
+        path.resolve(
+          path.dirname(importer),
+          'sass-pkg-with-wildcard-partial/styles/mixins',
+        ),
+      ).href,
+    )
+    expect(resolved).toBe(
+      normalizePath(
+        path.resolve(
+          fixtureRoot,
+          'node_modules/sass-pkg-with-wildcard-partial/dist/styles/_mixins.scss',
         ),
       ),
     )

--- a/packages/vite/src/node/__tests__/plugins/fixtures/sass-package-resolution/node_modules/sass-pkg-with-wildcard-partial/dist/styles/_mixins.scss
+++ b/packages/vite/src/node/__tests__/plugins/fixtures/sass-package-resolution/node_modules/sass-pkg-with-wildcard-partial/dist/styles/_mixins.scss
@@ -1,0 +1,3 @@
+@mixin text {
+  color: red;
+}

--- a/packages/vite/src/node/__tests__/plugins/fixtures/sass-package-resolution/node_modules/sass-pkg-with-wildcard-partial/package.json
+++ b/packages/vite/src/node/__tests__/plugins/fixtures/sass-package-resolution/node_modules/sass-pkg-with-wildcard-partial/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sass-pkg-with-wildcard-partial",
+  "private": true,
+  "version": "1.0.0",
+  "exports": {
+    "./styles/*.scss": "./dist/styles/*.scss",
+    "./styles/*": {
+      "sass": "./dist/styles/*.scss"
+    }
+  }
+}

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -59,6 +59,7 @@ import {
   _dirname,
   arraify,
   asyncReplace,
+  bareImportRE,
   combineSourcemaps,
   createSerialPromiseQueue,
   emptyCssComments,
@@ -1283,6 +1284,20 @@ export function getEmptyChunkReplacer(
 
 const fileURLWithWindowsDriveRE = /^file:\/\/\/[a-zA-Z]:\//
 
+function getSassPartialSpecifier(id: string): string | undefined {
+  const parts = id.split('/')
+  if (id.startsWith('@') ? parts.length <= 2 : parts.length <= 1) {
+    return
+  }
+
+  const index = id.lastIndexOf('/')
+  const basename = id.slice(index + 1)
+  if (!basename || basename.startsWith('_')) {
+    return
+  }
+  return `${id.slice(0, index + 1)}_${basename}`
+}
+
 export interface CSSAtImportResolvers {
   css: ResolveIdFn
   sass: ResolveIdFn
@@ -1317,19 +1332,71 @@ export function createCSSResolvers(
           preferRelative: true,
           skipMainField: true,
         })
-        sassResolve = async (...args) => {
+        sassResolve = async (environment, id, importer, aliasOnly) => {
           // the modern API calls `canonicalize` with resolved file URLs
           // for relative URLs before raw specifiers
-          if (args[1].startsWith('file://')) {
-            args[1] = fileURLToPath(args[1], {
+          let fileUrlPath: string | undefined
+          if (id.startsWith('file://')) {
+            fileUrlPath = fileURLToPath(id, {
               windows:
                 // file:///foo cannot be converted to path with windows mode
-                isWindows && !fileURLWithWindowsDriveRE.test(args[1])
+                isWindows && !fileURLWithWindowsDriveRE.test(id)
                   ? false
                   : undefined,
             })
+            id = fileUrlPath
           }
-          return resolver(...args)
+
+          const resolved = await resolver(environment, id, importer, aliasOnly)
+          if (resolved || !fileUrlPath || !importer) {
+            return resolved
+          }
+
+          // Sass can turn `pkg/path` into a file URL before retrying the raw
+          // specifier. Recover the package id after the relative lookup misses.
+          const bareSpecifier = normalizePath(
+            path.relative(path.dirname(importer), fileUrlPath),
+          )
+          if (bareImportRE.test(bareSpecifier)) {
+            let resolutionError: unknown
+            try {
+              const resolved = await resolver(
+                environment,
+                bareSpecifier,
+                importer,
+                aliasOnly,
+              )
+              if (resolved) {
+                return resolved
+              }
+            } catch (e) {
+              resolutionError = e
+            }
+
+            const partialSpecifier = getSassPartialSpecifier(bareSpecifier)
+            if (partialSpecifier) {
+              try {
+                const resolved = await resolver(
+                  environment,
+                  partialSpecifier,
+                  importer,
+                  aliasOnly,
+                )
+                if (resolved) {
+                  return resolved
+                }
+              } catch (e) {
+                if (resolutionError) {
+                  throw resolutionError
+                }
+                throw e
+              }
+            }
+
+            if (resolutionError) {
+              throw resolutionError
+            }
+          }
         }
       }
       return sassResolve


### PR DESCRIPTION
Fixes #22294.

When Sass uses the modern importer API, it can call `canonicalize` with a `file://` URL before the raw specifier. For imports like `@vite-sass-bug/example/styles/mixins`, that first URL looks like a non-existent relative file under the importer directory. Vite currently tries that path and then lets Sass fall through to package resolution, which fails on Windows for package-exported partials because the partial subpath is checked with a backslash.

This PR keeps the existing relative-path attempt first. If that misses, it recovers the bare package specifier from the file URL and retries through Vite's Sass resolver. For Sass partials, it also retries the underscore-prefixed partial form so package exports like `./styles/*: { sass: ./dist/styles/*.scss }` can resolve `styles/mixins` to `dist/styles/_mixins.scss` on Windows.

Added a regression fixture that simulates the Sass file URL canonicalization path for a package-exported partial.

Validation:
- `git diff --check`
- `pnpm dlx oxfmt@0.51.0 --check packages/vite/src/node/plugins/css.ts packages/vite/src/node/__tests__/plugins/css.spec.ts`
- Verified the reporter's repro on Windows: before the patch, `vite build` fails with `./styles\\_mixins is not exported`; after applying the same resolver change to the installed Vite package, the original `@use '@vite-sass-bug/example/styles/mixins'` build passes.

I couldn't complete a full local Vite workspace install on this machine because the available D: drive is exFAT and pnpm workspace symlinks fail there, so I kept validation to formatting, diff checks, and the focused Windows repro.