### PR TITLE
fix(css): resolve path for css modules imported via html

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -657,6 +657,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 if (
                   node.nodeName === 'link' &&
                   isCSSRequest(url) &&
+                  !url.includes('.module.') &&
                   // should not be converted if following attributes are present (#6748)
                   !('media' in attr.attributes || 'disabled' in attr.attributes)
                 ) {


### PR DESCRIPTION
## What is this PR solving?

This PR fixes a regression in Vite 8 where CSS Modules explicitly imported via an HTML file (e.g., `index.html`) fail to compile correctly during a production build. 

While the modules load perfectly fine in development mode, the production bundle fails to resolve the asset paths accurately. Instead, it injects an incorrect path reference (a ghost `test.module.css` file), leading to a `404 Not Found` error in the browser and broken styles in production. Regular `.css` files are unaffected.

This changes ensures that the HTML asset compilation pipeline properly intercepts, builds, and hashes CSS Module paths identically to standard CSS imports.

### Related Issues

Fixes #22242

### What other alternatives have you explored?

* **Alternative 1:** Forcing users to import CSS Modules inside JS/TS files rather than HTML. *Discarded* because importing global stylesheets or module configurations directly in `index.html` is a valid use case supported in Vite 7.
* **Alternative 2:** Standardizing the HTML plugin to treat `.module.css` exactly like `.css` without isolating the module compilation hooks. *Discarded* as it stripped out the scoped class hash features of CSS modules.

### Are there any parts you think require more attention from reviewers?

Reviewers should verify that this does not inadvertently affect CSS module scoping when elements inside `index.html` rely on the generated class mappings, or if any edge-case configurations in `css.modules` options are skipped during the HTML pre-processing step.

---

### Checklist

- [x] Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- [x] Check that there isn't already a PR that solves the problem the same way.
- [ ] Update the corresponding documentation if needed. *(Check this if you changed docs)*
- [x] Include relevant tests that fail without this PR but pass with it.
