### PR TITLE
fix(resolve): provide onWarn for viteResolvePlugin in JS plugin containers

### DIFF
--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -74,6 +74,7 @@ export function createIdResolver(
               idOnly: true,
             },
             environment.config,
+            true,
           ),
         ],
         undefined,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -362,6 +362,8 @@ export function oxcResolvePlugin(
           ...(partialEnv.config.command === 'serve' || isJsPluginContainer
             ? {
                 async onWarn(msg) {
+                  // use `partialEnv` instead of `getEnv()` because `buildStart` is
+                  // not called for plugin container used by `createIdResolver`
                   partialEnv.config.logger.warn(`warning: ${msg}`, {
                     clear: true,
                     timestamp: true,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -358,16 +358,14 @@ export function oxcResolvePlugin(
             })
           },
 
-          ...(partialEnv.config.command === 'serve'
-            ? {
-                async onWarn(msg) {
-                  getEnv().logger.warn(`warning: ${msg}`, {
-                    clear: true,
-                    timestamp: true,
-                  })
-                },
-              }
-            : {}),
+          async onWarn(msg) {
+            // getEnv() is unset on side containers (createIdResolver builds them with autoStart:false, skipping the buildStart that populates envs).
+            const logger = getEnv()?.logger ?? partialEnv.config.logger
+            logger.warn(`warning: ${msg}`, {
+              clear: true,
+              timestamp: true,
+            })
+          },
           ...(debug
             ? {
                 async onDebug(message) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -223,6 +223,7 @@ const perEnvironmentOrWorkerPlugin = (
 export function oxcResolvePlugin(
   resolveOptions: ResolvePluginOptionsWithOverrides,
   overrideEnvConfig: (ResolvedConfig & ResolvedEnvironmentOptions) | undefined,
+  isJsPluginContainer = false,
 ): Plugin[] {
   return [
     ...(resolveOptions.optimizeDeps && !resolveOptions.isBuild
@@ -358,14 +359,16 @@ export function oxcResolvePlugin(
             })
           },
 
-          async onWarn(msg) {
-            // getEnv() is unset on side containers (createIdResolver builds them with autoStart:false, skipping the buildStart that populates envs).
-            const logger = getEnv()?.logger ?? partialEnv.config.logger
-            logger.warn(`warning: ${msg}`, {
-              clear: true,
-              timestamp: true,
-            })
-          },
+          ...(partialEnv.config.command === 'serve' || isJsPluginContainer
+            ? {
+                async onWarn(msg) {
+                  partialEnv.config.logger.warn(`warning: ${msg}`, {
+                    clear: true,
+                    timestamp: true,
+                  })
+                },
+              }
+            : {}),
           ...(debug
             ? {
                 async onDebug(message) {


### PR DESCRIPTION
closes https://github.com/rolldown/rolldown/issues/9414

## Summary

- Add `isJsPluginContainer` parameter to `oxcResolvePlugin` to distinguish JS plugin container usage from the main bundler path
- Always register `onWarn` callback when used as a JS plugin container (`createIdResolver`), using `partialEnv.config.logger` which is always available
- Main bundler build path is unaffected (warnings still go through rolldown's native `ctx.warn()`)

## Context

When SCSS files use `@use 'util'`, the sass importer resolves `util` through vite's `createIdResolver`, which calls `viteResolvePlugin` via `BindingCallableBuiltinPlugin` (the JS callable path). In build mode with `isProduction=true`, the resolver identifies `util` as a Node built-in and attempts to emit a "Module externalized for browser compatibility" warning.

The warning path calls `ViteResolvePlugin::warn`, which checks for an `on_warn` JS callback first, then falls back to `ctx.warn()`. Since `onWarn` was only registered for `serve` mode, build mode had no callback, and `ctx.warn()` panicked because the Napi `PluginContext` variant does not support `warn`.

The fix ensures `onWarn` is always registered when the plugin is used inside a JS plugin container, using `partialEnv.config.logger` instead of `getEnv().logger` (the latter is unavailable in side containers built with `autoStart: false`).

## How the panic happens

```
SCSS @use 'util' as *
  |
  v
sass importer.canonicalize('util')
  |
  v
resolvers.sass(env, 'util', importer)
  |
  v
createBackCompatIdResolver -> config.createResolver -> createIdResolver
  |
  v
createEnvironmentPluginContainer(env, [oxcResolvePlugin(...)], autoStart=false)
  |  ^^^^^^^^^^^^^^^^^^^^^^^^^
  |  Side container: PluginContext is Napi (no bundler attached)
  v
pluginContainer.resolveId('util', importer)
  |
  v
BindingCallableBuiltinPlugin.resolveId  (JS -> napi -> Rust)
  |
  v
ViteResolvePlugin::resolve_id
  |  id = "util", is_node_like_builtin = true
  |  environment_consumer = "client", as_src = true, is_production = true
  v
ViteResolvePlugin::warn(ctx, "Module externalized for browser compatibility...")
  |
  +---> self.on_warn is Some?
  |       |
  |       +-- Yes: on_warn(message).await  --> vite logger (OK)
  |       |
  |       +-- No:  ctx.warn(...)
  |                  |
  |                  +-- Native ctx: bundler warn channel (OK)
  |                  |
  |                  +-- Napi ctx: unimplemented!() --> PANIC  <-- bug is here
  |
  v
on_warn was only registered for serve mode.
In build mode, on_warn = None, falls through to ctx.warn().
ctx is Napi (JS plugin container path) --> panic.
```

## The fix

```
oxcResolvePlugin(resolveOptions, overrideEnvConfig, isJsPluginContainer)
                                                    ^^^^^^^^^^^^^^^^^^^
                                                    new parameter (default: false)

createIdResolver calls with isJsPluginContainer = true
  |
  v
onWarn registered when: command === 'serve' || isJsPluginContainer
  |
  v
ViteResolvePlugin::warn -> self.on_warn is Some -> partialEnv.config.logger.warn(...)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                   Always available, no getEnv() needed
```