### PR TITLE
fix(resolve): normalize build tsconfig path aliases

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -138,6 +138,8 @@ jobs:
           repositories: |
             vite
             vite-ecosystem-ci
+          permission-actions: write
+          permission-issues: write
 
       - name: Trigger Preview Release (if Package Not Found)
         if: fromJSON(steps.check-package.outputs.result).exists == false

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -9,13 +9,32 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-slim
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-      pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to close stale needs reproduction issues
     steps:
-      - name: needs reproduction
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Close inactive needs reproduction issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          actions: "close-issues"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "needs reproduction"
-          inactive-day: 3
+          script: |
+            const cutoff = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000)
+              .toISOString()
+              .slice(0, 10)
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:"needs reproduction" updated:<${cutoff}`
+
+            let closed = 0
+            for await (const response of github.paginate.iterator(
+              github.rest.search.issuesAndPullRequests,
+              { q, per_page: 100 },
+            )) {
+              for (const issue of response.data) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                })
+                closed++
+              }
+            }
+
+            core.info(`Closed ${closed} inactive issue(s).`)

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,34 +9,54 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-slim
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-      pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to update labels and comments
     steps:
-      - name: contribution welcome
-        if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Update labels and reproduction prompt
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          actions: "remove-labels"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: "pending triage, needs reproduction"
+          script: |
+            const issue = context.payload.issue
+            const addedLabel = context.payload.label
+            const labelNames = new Set(issue.labels.map((label) => label.name))
 
-      - name: remove pending
-        if: (github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)')) && contains(github.event.issue.labels.*.name, 'pending triage')
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
-        with:
-          actions: "remove-labels"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          labels: "pending triage"
+            async function removeLabels(labels) {
+              for (const name of labels) {
+                if (!labelNames.has(name)) continue
 
-      - name: needs reproduction
-        if: github.event.label.name == 'needs reproduction'
-        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
-        with:
-          actions: "create-comment, remove-labels"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with `needs reproduction` will be closed if they have no activity within 3 days.
-          labels: "pending triage"
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name,
+                  })
+                } catch (error) {
+                  if (error.status !== 404) throw error
+                }
+              }
+            }
+
+            if (
+              addedLabel.name === 'contribution welcome' ||
+              addedLabel.name === 'help wanted'
+            ) {
+              await removeLabels(['pending triage', 'needs reproduction'])
+            }
+
+            if (
+              (addedLabel.name === 'enhancement' ||
+                (addedLabel.description ?? '').includes('(priority)')) &&
+              labelNames.has('pending triage')
+            ) {
+              await removeLabels(['pending triage'])
+            }
+
+            if (addedLabel.name === 'needs reproduction') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Hello @${issue.user.login}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://vite.new). Issues marked with \`needs reproduction\` will be closed if they have no activity within 3 days.`,
+              })
+              await removeLabels(['pending triage'])
+            }

--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -44,7 +44,7 @@ jobs:
               core.setOutput('skip', 'true');
             }
 
-      - uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1
+      - uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12
         if: steps.detect.outputs.skip == 'false'
         id: agent
         with:

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -12,13 +12,30 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-slim
     steps:
-      - uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
+      - name: Lock inactive closed issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          actions: "lock-issues"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          #body: |
-          #  This issue has been locked since it has been closed for more than 14 days.
-          #
-          #  If you have found a concrete bug or regression related to it, please open a new [bug report](https://github.com/vitejs/vite/issues/new/choose) with a reproduction against the latest Vite version. If you have any other comments you should join the chat at [Vite Land](https://chat.vite.dev) or create a new [discussion](https://github.com/vitejs/vite/discussions).
-          issue-state: closed
-          inactive-day: 14
+          script: |
+            const cutoff = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)
+              .toISOString()
+              .slice(0, 10)
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:closed updated:<${cutoff}`
+
+            let locked = 0
+            for await (const response of github.paginate.iterator(
+              github.rest.search.issuesAndPullRequests,
+              { q, per_page: 100 },
+            )) {
+              for (const issue of response.data) {
+                if (issue.locked) continue
+
+                await github.rest.issues.lock({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                })
+                locked++
+              }
+            }
+
+            core.info(`Locked ${locked} inactive closed issue(s).`)

--- a/.github/workflows/pull-request-template-check.yml
+++ b/.github/workflows/pull-request-template-check.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1
+      - uses: warpdotdev/oz-agent-action@ce1621abf6a8ed8afdd4e4cc994545ede8fe1c6f # v1.0.12
         id: agent
         with:
           prompt: |

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -278,6 +278,25 @@ describe('build', () => {
     ) as OutputChunk
     expect(foo.code).not.contains('import "external"')
   })
+
+  test('normalizes tsconfig path aliases to avoid duplicated modules', async () => {
+    const result = (await build({
+      root: resolve(dirname, 'fixtures/tsconfig-paths-alias-duplication'),
+      logLevel: 'silent',
+      build: {
+        write: false,
+        ssr: true,
+        rollupOptions: {
+          input: '/src/main.js',
+        },
+      },
+    })) as RolldownOutput
+
+    const chunk = result.output.find(
+      (output): output is OutputChunk => output.type === 'chunk',
+    )!
+    expect(chunk.code.match(/Symbol\("shared-singleton"\)/g)).toHaveLength(1)
+  })
 })
 
 const baseLibOptions: LibraryOptions = {

--- a/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/src/main.js
+++ b/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/src/main.js
@@ -1,0 +1,4 @@
+import { TOKEN as relativeToken } from './shared/index.js'
+import { TOKEN as aliasToken } from '@shared/index'
+
+export default relativeToken === aliasToken

--- a/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/src/shared/index.js
+++ b/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/src/shared/index.js
@@ -1,0 +1,1 @@
+export const TOKEN = Symbol('shared-singleton')

--- a/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/tsconfig.json
+++ b/packages/vite/src/node/__tests__/fixtures/tsconfig-paths-alias-duplication/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["src/shared/*"]
+    }
+  }
+}

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -72,6 +72,19 @@ const debug = createDebugger('vite:resolve-details', {
   onlyWhenFocused: true,
 })
 
+function normalizeResolvedId(resolvedId: string): string | undefined {
+  if (
+    !resolvedId.includes('\\') ||
+    resolvedId.includes('\0') ||
+    isExternalUrl(resolvedId) ||
+    isDataUrl(resolvedId)
+  ) {
+    return
+  }
+  const normalizedId = normalizePath(resolvedId)
+  return normalizedId === resolvedId ? undefined : normalizedId
+}
+
 export interface EnvironmentResolveOptions {
   /**
    * @default ['browser', 'module', 'jsnext:main', 'jsnext']
@@ -276,7 +289,9 @@ export function oxcResolvePlugin(
             tryIndex: options.tryIndex ?? true,
             tryPrefix: options.tryPrefix,
             preserveSymlinks: options.preserveSymlinks,
-            tsconfigPaths: options.tsconfigPaths,
+            // Build uses Rolldown's tsconfig discovery, so route aliases through
+            // Vite's resolver first to keep resolved ids normalized.
+            tsconfigPaths: options.tsconfigPaths || options.isBuild,
           },
           environmentConsumer: partialEnv.config.consumer,
           environmentName: partialEnv.name,
@@ -289,67 +304,72 @@ export function oxcResolvePlugin(
             // eslint-disable-next-line eqeqeq
             partialEnv.config.server.watch === null,
           legacyInconsistentCjsInterop: options.legacyInconsistentCjsInterop,
-          finalizeBareSpecifier: !depsOptimizerEnabled
-            ? undefined
-            : (resolvedId, rawId, importer) => {
-                const depsOptimizer = getDepsOptimizer()
-                // if we reach here, it's a valid dep import that hasn't been optimized.
-                const isJsType = isOptimizable(
-                  resolvedId,
-                  depsOptimizer.options,
-                )
-                const exclude = depsOptimizer?.options.exclude
+          finalizeBareSpecifier: (resolvedId, rawId, importer) => {
+            const normalizedId = normalizeResolvedId(resolvedId)
+            if (!depsOptimizerEnabled) {
+              return normalizedId
+            }
+            resolvedId = normalizedId ?? resolvedId
 
-                // check for deep import, e.g. "my-lib/foo"
-                const deepMatch = deepImportRE.exec(rawId)
-                // package name doesn't include postfixes
-                // trim them to support importing package with queries (e.g. `import css from 'normalize.css?inline'`)
-                const pkgId = deepMatch
-                  ? deepMatch[1] || deepMatch[2]
-                  : cleanUrl(rawId)
+            const depsOptimizer = getDepsOptimizer()
+            // if we reach here, it's a valid dep import that hasn't been optimized.
+            const isJsType = isOptimizable(resolvedId, depsOptimizer.options)
+            const exclude = depsOptimizer?.options.exclude
 
-                const skipOptimization =
-                  depsOptimizer.options.noDiscovery ||
-                  !isJsType ||
-                  (importer && isInNodeModules(importer)) ||
-                  exclude?.includes(pkgId) ||
-                  exclude?.includes(rawId) ||
-                  SPECIAL_QUERY_RE.test(resolvedId)
+            // check for deep import, e.g. "my-lib/foo"
+            const deepMatch = deepImportRE.exec(rawId)
+            // package name doesn't include postfixes
+            // trim them to support importing package with queries (e.g. `import css from 'normalize.css?inline'`)
+            const pkgId = deepMatch
+              ? deepMatch[1] || deepMatch[2]
+              : cleanUrl(rawId)
 
-                let newId = resolvedId
-                if (skipOptimization) {
-                  // excluded from optimization
-                  // Inject a version query to npm deps so that the browser
-                  // can cache it without re-validation, but only do so for known js types.
-                  // otherwise we may introduce duplicated modules for externalized files
-                  // from pre-bundled deps.
-                  const versionHash = depsOptimizer!.metadata.browserHash
-                  if (versionHash && isJsType) {
-                    newId = injectQuery(newId, `v=${versionHash}`)
-                  }
-                } else {
-                  // this is a missing import, queue optimize-deps re-run and
-                  // get a resolved its optimized info
-                  const optimizedInfo = depsOptimizer!.registerMissingImport(
-                    rawId,
-                    newId,
-                  )
-                  newId = depsOptimizer!.getOptimizedDepId(optimizedInfo)
-                }
-                return newId
-              },
-          finalizeOtherSpecifiers: !depsOptimizerEnabled
-            ? undefined
-            : (resolvedId, rawId) => {
-                const depsOptimizer = getDepsOptimizer()
-                const newResolvedId = ensureVersionQuery(
-                  resolvedId,
-                  rawId,
-                  options,
-                  depsOptimizer,
-                )
-                return newResolvedId === resolvedId ? undefined : newResolvedId
-              },
+            const skipOptimization =
+              depsOptimizer.options.noDiscovery ||
+              !isJsType ||
+              (importer && isInNodeModules(importer)) ||
+              exclude?.includes(pkgId) ||
+              exclude?.includes(rawId) ||
+              SPECIAL_QUERY_RE.test(resolvedId)
+
+            let newId = resolvedId
+            if (skipOptimization) {
+              // excluded from optimization
+              // Inject a version query to npm deps so that the browser
+              // can cache it without re-validation, but only do so for known js types.
+              // otherwise we may introduce duplicated modules for externalized files
+              // from pre-bundled deps.
+              const versionHash = depsOptimizer!.metadata.browserHash
+              if (versionHash && isJsType) {
+                newId = injectQuery(newId, `v=${versionHash}`)
+              }
+            } else {
+              // this is a missing import, queue optimize-deps re-run and
+              // get a resolved its optimized info
+              const optimizedInfo = depsOptimizer!.registerMissingImport(
+                rawId,
+                newId,
+              )
+              newId = depsOptimizer!.getOptimizedDepId(optimizedInfo)
+            }
+            return newId
+          },
+          finalizeOtherSpecifiers: (resolvedId, rawId) => {
+            const normalizedId = normalizeResolvedId(resolvedId)
+            if (!depsOptimizerEnabled) {
+              return normalizedId
+            }
+            resolvedId = normalizedId ?? resolvedId
+
+            const depsOptimizer = getDepsOptimizer()
+            const newResolvedId = ensureVersionQuery(
+              resolvedId,
+              rawId,
+              options,
+              depsOptimizer,
+            )
+            return newResolvedId === resolvedId ? undefined : newResolvedId
+          },
           resolveSubpathImports(id, importer, isRequire, scan) {
             return resolveSubpathImports(id, importer, {
               ...options,


### PR DESCRIPTION
### Description

Fixes #22506.

On Windows builds, a file imported through both a relative path and a tsconfig `paths` alias could be emitted twice because the tsconfig-alias path reached Rolldown with backslashes while the relative path used normalized forward slashes.

This routes build-time tsconfig alias resolution through Vite's resolver before Rolldown's fallback tsconfig handling, and normalizes resolved ids from the Vite resolve finalizers so both imports key to the same module id.

While clearing the failing Zizmor workflow check, this also replaces disabled `actions-cool/issues-helper` workflow uses with pinned `actions/github-script` steps, scopes the ecosystem CI app token permissions, and corrects two action version comments reported by Zizmor.

### Additional context

Added a regression fixture that imports one `Symbol("shared-singleton")` module through both a relative path and the matching tsconfig alias; the built SSR output must contain the symbol only once.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines), and applied the [Rollback Rules](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#rollback-rules) if it's a bug fix.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves.

### Tests

- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts -t "normalizes tsconfig path aliases"`
- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm --filter=./packages/vite run typecheck`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/plugins/resolve.ts packages/vite/src/node/__tests__/build.spec.ts`
- `uvx zizmor@1.25.2 . --persona regular --format plain --no-progress --color never` with `GH_TOKEN`
- `uvx zizmor@1.25.2 . --persona regular --format sarif --no-progress --color never` with `GH_TOKEN`
- `actionlint .github/workflows/ecosystem-ci-trigger.yml .github/workflows/issue-close-require.yml .github/workflows/issue-labeled.yml .github/workflows/issue-template-check.yml .github/workflows/lock-closed-issues.yml .github/workflows/pull-request-template-check.yml`
- `git diff --check`