### PR TITLE
test(resolve): add test for sass @use with node builtin name

### DIFF
--- a/playground/resolve/__tests__/sass-node-builtin-clash/resolve-sass-node-builtin-clash.spec.ts
+++ b/playground/resolve/__tests__/sass-node-builtin-clash/resolve-sass-node-builtin-clash.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+import { findAssetFile, isBuild } from '~utils'
+
+test.runIf(isBuild)('sass @use with node builtin name does not panic', () => {
+  const css = findAssetFile(/entry/, 'sass-node-builtin-clash')
+  expect(css).toContain('cursor:pointer')
+})

--- a/playground/resolve/sass-node-builtin-clash/component/button.scss
+++ b/playground/resolve/sass-node-builtin-clash/component/button.scss
@@ -1,0 +1,5 @@
+@use 'util' as *;
+
+.sass-node-builtin-clash {
+  @include reset-btn;
+}

--- a/playground/resolve/sass-node-builtin-clash/entry.scss
+++ b/playground/resolve/sass-node-builtin-clash/entry.scss
@@ -1,0 +1,1 @@
+@forward 'component/button';

--- a/playground/resolve/sass-node-builtin-clash/util/_index.scss
+++ b/playground/resolve/sass-node-builtin-clash/util/_index.scss
@@ -1,0 +1,4 @@
+@mixin reset-btn {
+  all: unset;
+  cursor: pointer;
+}

--- a/playground/resolve/vite.config-sass-node-builtin-clash.js
+++ b/playground/resolve/vite.config-sass-node-builtin-clash.js
@@ -1,0 +1,23 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist/sass-node-builtin-clash',
+    rollupOptions: {
+      input: {
+        entry: path.join(
+          import.meta.dirname,
+          'sass-node-builtin-clash/entry.scss',
+        ),
+      },
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        loadPaths: [path.join(import.meta.dirname, 'sass-node-builtin-clash')],
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Follow-up to #22509. Add e2e test covering the panic where `vite build` crashed with `Can't call 'warn' on PluginContext::Napi` when SCSS `@use`s a name clashing with a Node built-in (e.g. `@use 'util'`).

The fixture mirrors the original reproduction (rolldown/rolldown#9414): `component/button.scss` does `@use 'util' as *` while `util/` lives in a parent directory, so `preferRelative` cannot resolve it and the resolve plugin's node-builtin warn path is hit.
