### PR TITLE
fix(config): rewrite './' base to '/' for server environments

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1348,6 +1348,82 @@ test('preTransformRequests', async () => {
   `)
 })
 
+describe('relative base with environment API', () => {
+  test('server-consumer environment overrides relative base to "/"', async () => {
+    const resolved = await resolveConfig(
+      {
+        base: './',
+        environments: {
+          ssr: {},
+        },
+      },
+      'build',
+    )
+    expect(resolved.base).toBe('./')
+    expect(resolved.environments.ssr.consumer).toBe('server')
+    expect(resolved.environments.ssr.base).toBe('/')
+    expect(resolved.environments.ssr.rawBase).toBe('/')
+    expect(resolved.environments.ssr.decodedBase).toBe('/')
+  })
+
+  test('client-consumer environment falls back to relative base', async () => {
+    const resolved = await resolveConfig({ base: './' }, 'build')
+    expect(resolved.environments.client.consumer).toBe('client')
+    // Client doesn't override; the proxy on the environment config falls
+    // back to the top-level base.
+    expect(resolved.environments.client.base).toBeUndefined()
+  })
+
+  test('custom server environment also gets the override', async () => {
+    const resolved = await resolveConfig(
+      {
+        base: './',
+        environments: {
+          edge: { consumer: 'server' },
+        },
+      },
+      'build',
+    )
+    expect(resolved.environments.edge.base).toBe('/')
+  })
+
+  test('non-shortcut base is not overridden for server environments', async () => {
+    const resolved = await resolveConfig(
+      {
+        base: '/foo/',
+        environments: { ssr: {} },
+      },
+      'build',
+    )
+    expect(resolved.base).toBe('/foo/')
+    expect(resolved.environments.ssr.base).toBeUndefined()
+  })
+
+  test('legacy build.ssr already forces "/" so no per-env override is needed', async () => {
+    const resolved = await resolveConfig(
+      {
+        base: './',
+        build: { ssr: true },
+      },
+      'build',
+    )
+    expect(resolved.base).toBe('/')
+    expect(resolved.environments.ssr.base).toBeUndefined()
+  })
+
+  test('dev mode is unaffected (top-level already resolves to "/")', async () => {
+    const resolved = await resolveConfig(
+      {
+        base: './',
+        environments: { ssr: {} },
+      },
+      'serve',
+    )
+    expect(resolved.base).toBe('/')
+    expect(resolved.environments.ssr.base).toBeUndefined()
+  })
+})
+
 describe('loadConfigFromFile', () => {
   const fixtures = path.resolve(import.meta.dirname, './fixtures/config')
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -338,6 +338,18 @@ export type ResolvedEnvironmentOptions = {
   build: ResolvedBuildEnvironmentOptions
   isBundled: boolean
   plugins: readonly Plugin[]
+  /**
+   * Per-environment base override. Set only when the top-level `base` is
+   * resolved via the relative-base shortcut and the environment's code
+   * runs on the server, where `import.meta.url` can't resolve `./`.
+   * Read by callers via the environment `config` proxy.
+   * @internal
+   */
+  base?: string
+  /** @internal */
+  rawBase?: string
+  /** @internal */
+  decodedBase?: string
   /** @internal */
   optimizeDepsPluginNames: string[]
 }
@@ -1747,6 +1759,22 @@ export async function resolveConfig(
       ? '/'
       : './'
     : resolveBaseUrl(config.base, isBuild, logger)
+
+  // The relative-base shortcut leaves the top-level base as `./` for client
+  // builds, but `import.meta.url` can't resolve `./` on the server. For
+  // environments whose code runs on the server, surface an absolute base via
+  // the environment `config` proxy so they emit `/asset` instead of
+  // `./asset`. Legacy `config.build.ssr` already gets this for free above,
+  // since it forces the top-level base to `/`.
+  if (isBuild && relativeBaseShortcut && resolvedBase !== '/') {
+    for (const env of Object.values(resolvedEnvironments)) {
+      if (env.consumer === 'server') {
+        env.base = '/'
+        env.rawBase = '/'
+        env.decodedBase = '/'
+      }
+    }
+  }
 
   // resolve cache directory
   // pkgDir may be an ancestor directory (findNearestPackageData walks up).


### PR DESCRIPTION
closes #21812

`build.ssr: true` rewrites `base: './'` to `'/'`, but the new environment API check (`consumer === 'server'`) doesn't, so env-API server builds use `./` as the base. `import.meta.url` can't handle `./` on the server.

Extended the rewrite to any environment with `consumer: 'server'`. Client environments still get `./` from the outer check.

`toOutputFilePathWithoutRuntime` still reads `config.build.ssr` directly. Only matters for server-side HTML/CSS emit, which doesn't happen in practice, so leaving it.

Tests in `config.spec.ts` cover the env-API server case, legacy `build.ssr: true`, client fall-through, and non-shortcut bases.