### PR TITLE
fix(optimizer): close the rolldown bundle when write() rejects

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -855,15 +855,17 @@ async function prepareRolldownOptimizerRun(
       await bundle.close()
       throw new Error('The build was canceled')
     }
-    const result = await bundle.write({
-      ...rolldownOptions.output,
-      format: 'esm',
-      sourcemap: true,
-      dir: processingCacheDir,
-      entryFileNames: '[name].js',
-    })
-    await bundle.close()
-    return result
+    try {
+      return await bundle.write({
+        ...rolldownOptions.output,
+        format: 'esm',
+        sourcemap: true,
+        dir: processingCacheDir,
+        entryFileNames: '[name].js',
+      })
+    } finally {
+      await bundle.close()
+    }
   }
 
   function cancel() {


### PR DESCRIPTION
## Problem

In `packages/vite/src/node/optimizer/index.ts`, the optimizer's `build()` does:

```ts
const result = await bundle.write({ /* ... */ })
await bundle.close()
return result
```

If `bundle.write()` rejects, `bundle.close()` is skipped and the rolldown bundle leaks (native handles / fds / worker threads). The cancel path just above already closes the bundle before throwing:

```ts
if (canceled) {
  await bundle.close()
  throw new Error('The build was canceled')
}
```

So `close()` is clearly meant to run on every exit — only the `write()`-rejection path misses it.

## Fix

Wrap the write in `try { … } finally { await bundle.close() }` so the bundle is always closed. The success path is unchanged.

## Tests

I did not add a unit test, and want to be upfront about why: the optimizer build pipeline isn't unit-tested in the repo (the `src/node/__tests__/optimizer` specs cover plugin converters), and `build()` is a closure over an internally-created `rolldown()` bundle with no injection seam — a faithful test would need either a `rolldown` mock driven through `runOptimizeDeps` (no precedent in the repo) or a refactor to inject the bundle. The change itself is a behaviour-preserving `try/finally`. Happy to add a test in whatever form you'd prefer.

---
*AI Disclosure: This contribution was proposed by Prodia, an autonomous TypeScript evolution system (https://prodia.dev). Human review was applied before submission. The change is behaviour-preserving on the success path.*
