### PR TITLE
fix(css): provide friendly hint when lightningcss native binding is missing

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -10,6 +10,7 @@ import {
   cssPlugin,
   cssUrlRE,
   getEmptyChunkReplacer,
+  getLightningCssNativeBindingErrorMessage,
   hoistAtRules,
   injectInlinedCSS,
   preprocessCSS,
@@ -828,5 +829,59 @@ exports.foo = foo;
       //#endregion
       })();"
     `)
+  })
+})
+
+describe('getLightningCssNativeBindingErrorMessage', () => {
+  test('returns hint when lightningcss native binding is missing', () => {
+    const e = {
+      code: 'MODULE_NOT_FOUND',
+      message:
+        "Cannot find module '../lightningcss.linux-arm64-musl.node'\nRequire stack:\n- /app/node_modules/lightningcss/node/index.js",
+    }
+    const msg = getLightningCssNativeBindingErrorMessage(e)
+    expect(msg).toBeDefined()
+    expect(msg).toContain('Lightning CSS native binding')
+    expect(msg).toContain("build.cssMinify: 'esbuild'")
+    expect(msg).toContain('build.cssMinify: false')
+    expect(msg).toContain('lightningcss-linux-arm64-musl')
+  })
+
+  test('matches other platform native bindings (e.g. darwin-arm64)', () => {
+    const e = {
+      code: 'MODULE_NOT_FOUND',
+      message: "Cannot find module '../lightningcss.darwin-arm64.node'",
+    }
+    expect(getLightningCssNativeBindingErrorMessage(e)).toBeDefined()
+  })
+
+  test('returns undefined when error code is not MODULE_NOT_FOUND', () => {
+    const e = {
+      code: 'ERR_OTHER',
+      message: "Cannot find module '../lightningcss.linux-arm64-musl.node'",
+    }
+    expect(getLightningCssNativeBindingErrorMessage(e)).toBeUndefined()
+  })
+
+  test('returns undefined when message does not match lightningcss .node', () => {
+    const e = {
+      code: 'MODULE_NOT_FOUND',
+      message: "Cannot find module 'some-other-package'",
+    }
+    expect(getLightningCssNativeBindingErrorMessage(e)).toBeUndefined()
+  })
+
+  test('returns undefined for unrelated lightningcss errors (e.g. CSS syntax)', () => {
+    const e = {
+      code: 'MODULE_NOT_FOUND',
+      message: 'Unexpected token in CSS',
+    }
+    expect(getLightningCssNativeBindingErrorMessage(e)).toBeUndefined()
+  })
+
+  test('returns undefined when message is missing', () => {
+    expect(
+      getLightningCssNativeBindingErrorMessage({ code: 'MODULE_NOT_FOUND' }),
+    ).toBeUndefined()
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2270,7 +2270,9 @@ async function minifyCSS(
     return decoder.decode(code) + (inlined ? '' : '\n')
   } catch (e) {
     e.message = `[lightningcss minify] ${e.message}`
-    const friendlyMessage = getLightningCssErrorMessageForIeSyntaxes(css)
+    const friendlyMessage =
+      getLightningCssNativeBindingErrorMessage(e) ??
+      getLightningCssErrorMessageForIeSyntaxes(css)
     if (friendlyMessage) {
       e.message += friendlyMessage
     }
@@ -3315,7 +3317,10 @@ async function compileLightningCSS(
         })
   } catch (e) {
     e.message = `[lightningcss] ${e.message}`
-    if (e.loc) {
+    const nativeBindingMessage = getLightningCssNativeBindingErrorMessage(e)
+    if (nativeBindingMessage) {
+      e.message += nativeBindingMessage
+    } else if (e.loc) {
       e.loc = {
         file: e.fileName.replace(NULL_BYTE_PLACEHOLDER, '\0'),
         line: e.loc.line,
@@ -3399,6 +3404,37 @@ async function compileLightningCSS(
     map: 'map' in res ? res.map?.toString() : undefined,
     modules,
   }
+}
+
+// Friendly hint when the platform-specific Lightning CSS native binding is
+// missing (e.g. linux-arm64-musl on Gentoo/Alpine, or unusual containers where
+// the lightningcss optional platform package was not installed by the package
+// manager). Without this, users only see a low-level
+// `Cannot find module '../lightningcss.<platform>.node'` stack trace.
+const lightningCssNativeBindingMissingRE =
+  /Cannot find module '[^']*lightningcss[^']*\.node'/
+
+export function getLightningCssNativeBindingErrorMessage(e: {
+  message?: string
+  code?: string
+}): string | undefined {
+  if (
+    e.code === 'MODULE_NOT_FOUND' &&
+    typeof e.message === 'string' &&
+    lightningCssNativeBindingMissingRE.test(e.message)
+  ) {
+    return (
+      '\n\nThe Lightning CSS native binding for your platform is not installed. ' +
+      'This usually happens on musl libc, uncommon CPU architectures, or in containers ' +
+      'where the platform-specific optional dependency was skipped during install.\n\n' +
+      'You can either:\n' +
+      "  - Switch the CSS minifier to esbuild: set `build.cssMinify: 'esbuild'` " +
+      '(and install `esbuild` as a devDependency), or\n' +
+      '  - Disable CSS minification: set `build.cssMinify: false`, or\n' +
+      '  - Install the missing platform package manually, e.g. `lightningcss-linux-arm64-musl`.\n'
+    )
+  }
+  return undefined
 }
 
 // friendly error for https://github.com/parcel-bundler/lightningcss/issues/39


### PR DESCRIPTION
fixes #22494
Reported case: musl libc on Gentoo arm64, but the same situation reproduces on other less common architectures or in containers where `optionalDependencies` are skipped.

This PR detects `MODULE_NOT_FOUND` errors that reference a lightningcss native binding inside both `minifyCSS` and `compileLightningCSS` catch blocks, and appends actionable guidance to the error message:

- switch the CSS minifier to esbuild: `build.cssMinify: 'esbuild'` (and install `esbuild`)
- disable CSS minification: `build.cssMinify: false`
- install the missing platform package manually, e.g. `lightningcss-linux-arm64-musl`

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (`fixes #22494`).
- [x] Ideally, include relevant tests that fail without this PR. Bug fixes and new features should include tests.