### PR TITLE
feat(resolve): allow custom tsconfig file via resolve.tsconfigPaths.configFile

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -202,10 +202,38 @@ Enabling this setting causes vite to determine file identity by the original fil
 
 ## resolve.tsconfigPaths
 
-- **Type:** `boolean`
+- **Type:** `boolean | TsconfigPathsOptions`
 - **Default:** `false`
 
 Enables the tsconfig paths resolution feature. `paths` option in `tsconfig.json` will be used to resolve imports. See [Features](/guide/features.md#paths) for more details.
+
+Set to `true` to enable auto-discovery of the nearest `tsconfig.json`. Pass an object to pin a specific config file:
+
+```ts
+interface TsconfigPathsOptions {
+  /**
+   * Path to the tsconfig.json file to use for path resolution.
+   * Can be a relative path (resolved against the project root) or an absolute path.
+   * For auto-discovery, use `tsconfigPaths: true` instead.
+   */
+  configFile: string
+}
+```
+
+Example: load a different tsconfig in production builds:
+
+```js
+import { defineConfig } from 'vite'
+
+export default defineConfig(({ mode }) => ({
+  resolve: {
+    tsconfigPaths: {
+      configFile:
+        mode === 'production' ? './tsconfig.prod.json' : './tsconfig.json',
+    },
+  },
+}))
+```
 
 ## html.cspNonce
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -103,18 +103,32 @@ export interface EnvironmentResolveOptions {
   builtins?: (string | RegExp)[]
 }
 
+export interface TsconfigPathsOptions {
+  /**
+   * Path to the tsconfig.json file to use for path resolution.
+   * Can be a relative path (resolved against the project root) or an absolute path.
+   * For auto-discovery of the nearest tsconfig.json, use `tsconfigPaths: true`
+   * instead.
+   */
+  configFile: string
+}
+
 export interface ResolveOptions extends EnvironmentResolveOptions {
   /**
    * @default false
    */
   preserveSymlinks?: boolean
   /**
-   * Enable tsconfig paths resolution
+   * Enable tsconfig paths resolution.
+   *
+   * Set to `true` to enable auto-discovery of the nearest tsconfig.json,
+   * or pass an object to customize the behavior (e.g. specify a custom
+   * tsconfig file).
    *
    * @default false
    * @experimental
    */
-  tsconfigPaths?: boolean
+  tsconfigPaths?: boolean | TsconfigPathsOptions
 }
 
 interface ResolvePluginOptions {
@@ -178,6 +192,22 @@ export interface InternalResolveOptions
 // It is used when creating custom resolvers (for CSS, scanning, etc)
 export interface ResolvePluginOptionsWithOverrides
   extends ResolveOptions, ResolvePluginOptions {}
+
+// Maps Vite's user-facing `tsconfigPaths` option to the shape rolldown's
+// viteResolvePlugin expects. `true`/`false` pass through unchanged; for the
+// object form, we resolve a relative `configFile` against the project root
+// because oxc-resolver expects an absolute path.
+function normalizeTsconfigPathsOption(
+  tsconfigPaths: boolean | TsconfigPathsOptions,
+  root: string,
+): boolean | { configFile: string } {
+  if (typeof tsconfigPaths !== 'object') return tsconfigPaths
+  return {
+    configFile: path.isAbsolute(tsconfigPaths.configFile)
+      ? tsconfigPaths.configFile
+      : path.resolve(root, tsconfigPaths.configFile),
+  }
+}
 
 const perEnvironmentOrWorkerPlugin = (
   name: string,
@@ -277,7 +307,10 @@ export function oxcResolvePlugin(
             tryIndex: options.tryIndex ?? true,
             tryPrefix: options.tryPrefix,
             preserveSymlinks: options.preserveSymlinks,
-            tsconfigPaths: options.tsconfigPaths,
+            tsconfigPaths: normalizeTsconfigPathsOption(
+              options.tsconfigPaths,
+              options.root,
+            ),
           },
           environmentConsumer: partialEnv.config.consumer,
           environmentName: partialEnv.name,

--- a/playground/glob-import/root/follow-symlinks/linked/my-lib
+++ b/playground/glob-import/root/follow-symlinks/linked/my-lib
@@ -1,1 +1,0 @@
-../packages/my-lib

--- a/playground/glob-import/root/follow-symlinks/linked/my-lib
+++ b/playground/glob-import/root/follow-symlinks/linked/my-lib
@@ -1,0 +1,1 @@
+../packages/my-lib

--- a/playground/resolve-tsconfig-paths-config-file/__tests__/resolve.spec.ts
+++ b/playground/resolve-tsconfig-paths-config-file/__tests__/resolve.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('custom configFile is honored over auto-discovered tsconfig.json', async () => {
+  await expect.poll(() => page.textContent('.custom')).toMatch('[success]')
+})

--- a/playground/resolve-tsconfig-paths-config-file/index.html
+++ b/playground/resolve-tsconfig-paths-config-file/index.html
@@ -1,0 +1,16 @@
+<h1>Resolve: tsconfig paths (custom configFile)</h1>
+
+<h2>Import via @/ alias (custom tsconfig)</h2>
+<p class="custom"></p>
+
+<script type="module">
+  function text(selector, value) {
+    document.querySelector(selector).textContent = value
+  }
+
+  // `@/imported` resolves through tsconfig.custom.json paths
+  // (`./src/*`), not the default tsconfig.json (`./src/wrong/*`)
+  // which would 404 because `./src/wrong/imported.js` does not exist.
+  import imported from '@/imported'
+  text('.custom', imported)
+</script>

--- a/playground/resolve-tsconfig-paths-config-file/package.json
+++ b/playground/resolve-tsconfig-paths-config-file/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-resolve-tsconfig-paths-config-file",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/playground/resolve-tsconfig-paths-config-file/src/imported.js
+++ b/playground/resolve-tsconfig-paths-config-file/src/imported.js
@@ -1,0 +1,1 @@
+export default '[success] imported from custom tsconfig'

--- a/playground/resolve-tsconfig-paths-config-file/tsconfig.custom.json
+++ b/playground/resolve-tsconfig-paths-config-file/tsconfig.custom.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "exclude": ["./__tests__"]
+}

--- a/playground/resolve-tsconfig-paths-config-file/tsconfig.json
+++ b/playground/resolve-tsconfig-paths-config-file/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/wrong/*"]
+    }
+  },
+  "exclude": ["./__tests__"]
+}

--- a/playground/resolve-tsconfig-paths-config-file/vite.config.js
+++ b/playground/resolve-tsconfig-paths-config-file/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+// Use the explicit configFile to opt into `tsconfig.custom.json` rather
+// than the default `tsconfig.json`.
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: {
+      configFile: './tsconfig.custom.json',
+    },
+  },
+})


### PR DESCRIPTION
## Summary

  Widens `resolve.tsconfigPaths` from `boolean` to `boolean | TsconfigPathsOptions` so consumers can pin a specific tsconfig (e.g. `tsconfig.prod.json`) instead of relying on rolldown's
  auto-discovery.

  ```js
  export default defineConfig(({ mode }) => ({
    resolve: {
      tsconfigPaths: {
        configFile: mode === 'production' ? './tsconfig.prod.json' : './tsconfig.json',
      },
    },
  }))
  ```

  ## Motivation

  `resolve.tsconfigPaths: true` already works, but only auto-discovers the nearest `tsconfig.json`. There's no way to point it at a different file. Today users have to either:

  1. Keep the `vite-tsconfig-paths` plugin (and its `projects` option), or
  2. Re-read the tsconfig and rebuild `resolve.alias` by hand in `vite.config.ts`.

  The intended migration story from #22112 was to drop the external plugin once Vite 8 shipped native support, but `boolean` is too narrow for the cases that motivated
  `vite-tsconfig-paths.projects` in the first place.

  ## Changes

  - `packages/vite/src/node/plugins/resolve.ts`:
    - New `TsconfigPathsOptions { configFile: string }` interface.
    - `ResolveOptions.tsconfigPaths` typed as `boolean | TsconfigPathsOptions`.
    - Forward the value straight through to rolldown's `viteResolvePlugin`, resolving a relative `configFile` against the project root (oxc-resolver requires an absolute path).
  - `docs/config/shared-options.md` — documents the new shape with the prod/dev switch example.
  - `playground/resolve-tsconfig-paths-config-file/` — new e2e playground proving the custom `configFile` wins over an adjacent (wrong-mapping) `tsconfig.json`.

  ## Depends on

  - [rolldown/rolldown#9571](https://github.com/rolldown/rolldown/pull/9571) — widens the napi binding so `viteResolvePlugin` accepts the object form. Without it, passing `{ configFile }` throws `Failed to convert napi value into rust type
   'bool'` at runtime.

  The Rust side already had `TsconfigDiscovery::Manual` plumbed through `oxc_resolver`; only the vite-resolve plugin's binding hardcoded `bool`
  (`crates/rolldown_plugin_vite_resolve/src/resolver.rs:174` upstream), so the `Manual` arm was unreachable from JS. The rolldown PR exposes it; this PR forwards it.

  ## Related

  - Closes #22112
  - vitest-dev/vitest#10176 — the downstream issue where dropping `esbuild.tsconfigRaw` (vitest 4.1 moved to rolldown) left users with no way to swap tsconfigs for prod vs dev runs.

  ## Test plan

  - [ ] Type-check passes (`pnpm typecheck`)
  - [ ] All `packages/vite/src/node/__tests__/resolve.spec.ts` cases pass
  - [ ] `playground/resolve-tsconfig-paths/__tests__/resolve.spec.ts` — existing `tsconfigPaths: true` behavior unchanged
  - [ ] `playground/resolve-tsconfig-paths-config-file/__tests__/resolve.spec.ts` — new playground passes in both dev and build modes
  - [ ] `tsconfigPaths: false` still disables resolution
  - [ ] Bumped `rolldown` to a version that includes the binding widening