### PR TITLE
docs: recommend vite-env.ts for TypeScript env types

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -54,13 +54,17 @@ export default defineConfig({
 ```
 
 ::: tip NOTE
-For TypeScript users, make sure to add the type declarations in the `vite-env.d.ts` file to get type checks and Intellisense.
+For TypeScript users, make sure to add the type declarations in the `vite-env.ts` file to get type checks and Intellisense.
 
 Example:
 
 ```ts
-// vite-env.d.ts
-declare const __APP_VERSION__: string
+// vite-env.ts
+declare global {
+  const __APP_VERSION__: string
+}
+
+export {}
 ```
 
 :::

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -126,23 +126,28 @@ To avoid interop issues, it is recommended to avoid relying on this behavior. Vi
 
 By default, Vite provides type definitions for `import.meta.env` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables that are prefixed with `VITE_`.
 
-To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augment `ImportMetaEnv` like this:
+To achieve this, you can create a `vite-env.ts` in `src` directory, then augment `ImportMetaEnv` like this:
 
-```typescript [vite-env.d.ts]
-interface ViteTypeOptions {
-  // By adding this line, you can make the type of ImportMetaEnv strict
-  // to disallow unknown keys.
-  // strictImportMetaEnv: unknown
+```typescript [vite-env.ts]
+declare global {
+  interface ViteTypeOptions {
+    // By adding this line, you can make the type of ImportMetaEnv strict
+    // to disallow unknown keys.
+    // strictImportMetaEnv: unknown
+  }
+
+  interface ImportMetaEnv {
+    readonly VITE_APP_TITLE: string
+    // more env variables...
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv
+  }
 }
 
-interface ImportMetaEnv {
-  readonly VITE_APP_TITLE: string
-  // more env variables...
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv
-}
+// Explicitly mark this file as a module.
+export {}
 ```
 
 If your code relies on types from browser environments such as [DOM](https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts) and [WebWorker](https://github.com/microsoft/TypeScript/blob/main/src/lib/webworker.generated.d.ts), you can update the [lib](https://www.typescriptlang.org/tsconfig#lib) field in `tsconfig.json`.
@@ -153,9 +158,9 @@ If your code relies on types from browser environments such as [DOM](https://git
 }
 ```
 
-:::warning Imports will break type augmentation
+:::warning Imports require global augmentation
 
-If the `ImportMetaEnv` augmentation does not work, make sure you do not have any `import` statements in `vite-env.d.ts`. See the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined) for more information.
+If `vite-env.ts` contains `import` statements, TypeScript treats the file as a module. Wrap custom `ImportMetaEnv` declarations in `declare global` and add `export {}` so the augmentation applies globally. See the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined) for more information.
 
 :::
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -172,6 +172,7 @@ For example, to make the default import of `*.svg` a React component:
   }
   ```
 - If you are using triple-slash directives, update the file containing the reference to `vite/client` (normally `vite-env.ts`):
+
   ```ts
   /// <reference types="./vite-env-override.d.ts" />
   /// <reference types="vite/client" />

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -137,10 +137,12 @@ Note that if [`compilerOptions.types`](https://www.typescriptlang.org/tsconfig#t
 
 ::: details Using triple-slash directive
 
-Alternatively, you can add a `d.ts` declaration file:
+Alternatively, you can add a TypeScript file for Vite environment types:
 
-```typescript [vite-env.d.ts]
+```typescript [vite-env.ts]
 /// <reference types="vite/client" />
+
+export {}
 ```
 
 :::
@@ -169,10 +171,12 @@ For example, to make the default import of `*.svg` a React component:
     "include": ["src", "./vite-env-override.d.ts"]
   }
   ```
-- If you are using triple-slash directives, update the file containing the reference to `vite/client` (normally `vite-env.d.ts`):
+- If you are using triple-slash directives, update the file containing the reference to `vite/client` (normally `vite-env.ts`):
   ```ts
   /// <reference types="./vite-env-override.d.ts" />
   /// <reference types="vite/client" />
+
+  export {}
   ```
 
 :::


### PR DESCRIPTION
### Description

Updates the TypeScript environment type docs to recommend `vite-env.ts` instead of an authored `vite-env.d.ts` file.

This follows the discussion in #19693: user-authored source files are type-checked normally, while declaration files are easy to accidentally skip with common TypeScript settings like `skipLibCheck`.

### Changes

- Replaces user-facing `vite-env.d.ts` examples with `vite-env.ts`.
- Uses `declare global` + `export {}` for module-safe global augmentation examples.
- Updates the related triple-slash directive and shared `define` examples.

Fixes #19693.