### PR TITLE
fix: allow symlinked dev server roots

### DIFF
--- a/packages/vite/src/node/server/__tests__/server-options.spec.ts
+++ b/packages/vite/src/node/server/__tests__/server-options.spec.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { createLogger } from '../../logger'
+import { normalizePath, safeRealpathSync } from '../../utils'
+import { createServer, resolveServerOptions } from '../index'
+
+describe('resolveServerOptions', () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  test('allows the symlink target for the project root', async () => {
+    const realRoot = makeTempDir()
+    const symlinkParent = makeTempDir()
+    const symlinkRoot = path.join(symlinkParent, 'linked-root')
+    fs.symlinkSync(realRoot, symlinkRoot, 'junction')
+
+    const server = await resolveServerOptions(
+      symlinkRoot,
+      undefined,
+      createLogger('silent'),
+    )
+
+    expect(server.fs.allow).toContain(realpath(realRoot))
+  })
+
+  test('loads modules resolved through a symlinked project root', async () => {
+    const realRoot = makeTempDir()
+    fs.mkdirSync(path.join(realRoot, 'src'))
+    fs.writeFileSync(
+      path.join(realRoot, 'index.html'),
+      '<script type="module" src="/src/main.ts"></script>',
+    )
+    fs.writeFileSync(path.join(realRoot, 'src/main.ts'), 'export const msg = 1')
+
+    const symlinkParent = makeTempDir()
+    const symlinkRoot = path.join(symlinkParent, 'linked-root')
+    fs.symlinkSync(realRoot, symlinkRoot, 'junction')
+
+    const server = await createServer({
+      root: symlinkRoot,
+      logLevel: 'silent',
+      server: {
+        middlewareMode: true,
+      },
+    })
+
+    try {
+      const result =
+        await server.environments.client.transformRequest('/src/main.ts')
+
+      expect(result?.code).toContain('const msg = 1')
+    } finally {
+      await server.close()
+    }
+  })
+
+  test('allows symlink targets from explicit fs.allow entries', async () => {
+    const root = makeTempDir()
+    const realAllowedDir = makeTempDir()
+    const symlinkParent = makeTempDir()
+    const symlinkAllowedDir = path.join(symlinkParent, 'allowed')
+    fs.symlinkSync(realAllowedDir, symlinkAllowedDir, 'junction')
+
+    const server = await resolveServerOptions(
+      root,
+      {
+        fs: {
+          allow: [symlinkAllowedDir],
+        },
+      },
+      createLogger('silent'),
+    )
+
+    expect(server.fs.allow).toContain(realpath(realAllowedDir))
+  })
+
+  function makeTempDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-fs-allow-'))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  function realpath(dir: string): string {
+    return normalizePath(safeRealpathSync(dir))
+  }
+})

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -42,6 +42,7 @@ import {
   normalizePath,
   resolveHostname,
   resolveServerUrls,
+  safeRealpathSync,
   setupSIGTERMListener,
   teardownSIGTERMListener,
 } from '../utils'
@@ -1154,6 +1155,26 @@ function resolvedAllowDir(root: string, dir: string): string {
   return normalizePath(path.resolve(root, dir))
 }
 
+function addRealpathAllowDirs(allowDirs: string[]): string[] {
+  const seen = new Set(allowDirs)
+
+  for (const dir of allowDirs) {
+    let realDir: string
+    try {
+      realDir = normalizePath(safeRealpathSync(dir))
+    } catch {
+      continue
+    }
+
+    if (!seen.has(realDir)) {
+      seen.add(realDir)
+      allowDirs.push(realDir)
+    }
+  }
+
+  return allowDirs
+}
+
 const _serverConfigDefaults = Object.freeze({
   port: DEFAULT_DEV_PORT,
   strictPort: false,
@@ -1249,7 +1270,7 @@ export async function resolveServerOptions(
     allowDirs.push(resolvedClientDir)
   }
 
-  server.fs.allow = allowDirs
+  server.fs.allow = addRealpathAllowDirs(allowDirs)
 
   if (server.origin?.endsWith('/')) {
     server.origin = server.origin.slice(0, -1)


### PR DESCRIPTION
## Summary
- include realpath counterparts for server.fs.allow directories so symlinked project roots can load files resolved through their target path
- add coverage for symlinked root module loading and explicit fs.allow symlink entries

Fixes #16257

## Tests
- pnpm --filter vite build-bundle
- pnpm exec vitest run packages/vite/src/node/server/__tests__/server-options.spec.ts
- pnpm --filter vite exec oxfmt --check src/node/server/index.ts src/node/server/__tests__/server-options.spec.ts
- pnpm --filter vite exec eslint src/node/server/index.ts src/node/server/__tests__/server-options.spec.ts
- pnpm --filter vite build-types
- pnpm --filter vite typecheck
- git diff --check