### PR TITLE
fix(css): preserve source-import order in CSS cascade (#4890)

### DIFF
--- a/packages/vite/src/node/__tests__/html.spec.ts
+++ b/packages/vite/src/node/__tests__/html.spec.ts
@@ -1,17 +1,31 @@
 import { describe, expect, test } from 'vitest'
-import type { OutputBundle, OutputChunk } from 'rolldown'
+import type {
+  GetModuleInfo,
+  ModuleInfo,
+  OutputBundle,
+  OutputChunk,
+} from 'rolldown'
 import { getCssFilesForChunk } from '../plugins/html'
 
 function createChunk(
   fileName: string,
   imports: string[],
   importedCss: string[],
+  options: { facadeModuleId?: string; modules?: string[] } = {},
 ): OutputChunk {
+  const modules: Record<string, unknown> = {}
+  if (options.modules) {
+    for (const id of options.modules) {
+      modules[id] = {}
+    }
+  }
   return {
     type: 'chunk',
     fileName,
     imports,
     viteMetadata: { importedCss: new Set(importedCss) },
+    facadeModuleId: options.facadeModuleId,
+    modules,
   } as unknown as OutputChunk
 }
 
@@ -21,6 +35,13 @@ function createBundle(...chunks: OutputChunk[]): OutputBundle {
     bundle[chunk.fileName] = chunk
   }
   return bundle as unknown as OutputBundle
+}
+
+function createModuleInfoMap(edges: Record<string, string[]>): GetModuleInfo {
+  return ((id: string) => {
+    if (!(id in edges)) return null
+    return { importedIds: edges[id] } as ModuleInfo
+  }) as GetModuleInfo
 }
 
 describe('getCssFilesForChunk', () => {
@@ -72,7 +93,6 @@ describe('getCssFilesForChunk', () => {
 
     const result = getCssFilesForChunk(entry, bundle, cache)
     expect(result).toStrictEqual(['dep.css', 'entry.css'])
-    expect(cache.has(dep)).toBe(true)
     expect(cache.has(entry)).toBe(true)
 
     expect(getCssFilesForChunk(entry, bundle, cache)).toStrictEqual(result)
@@ -238,5 +258,150 @@ describe('getCssFilesForChunk', () => {
       'b.css',
       'a.css',
     ])
+  })
+
+  describe('source-import order (#4890)', () => {
+    // Models a chunk that imports two pure-CSS chunks via two of its modules
+    // (one nested through `vendor.js`, one direct). `chunk.imports` order
+    // does NOT match source-import order, so the previous algorithm - which
+    // walked `chunk.imports` - placed the override stylesheet before the
+    // baseline stylesheet, inverting the cascade.
+    function buildOpRepro() {
+      const vendorCss = createChunk('vendor.css.js', [], ['vendor.css'])
+      const overrideCss = createChunk('override.css.js', [], ['override.css'])
+      // Note: chunk.imports lists override BEFORE vendor on purpose, to
+      // demonstrate that the chunk-import order does not reflect source.
+      const shared = createChunk(
+        'shared.js',
+        ['override.css.js', 'vendor.css.js'],
+        [],
+        {
+          facadeModuleId: '/src/main.js',
+          modules: ['/src/main.js', '/src/vendor.js'],
+        },
+      )
+      const entry = createChunk('entry.js', ['shared.js'], [], {
+        facadeModuleId: '/src/main.js',
+        modules: ['/src/main.js'],
+      })
+      const bundle = createBundle(entry, shared, vendorCss, overrideCss)
+
+      // Source code:
+      //   main.js: `import './vendor.js'; import './override.css';`
+      //   vendor.js: `import './vendor.css';`
+      const getModuleInfo = createModuleInfoMap({
+        '/src/main.js': ['/src/vendor.js', '/src/override.css'],
+        '/src/vendor.js': ['/src/vendor.css'],
+        '/src/vendor.css': [],
+        '/src/override.css': [],
+      })
+      const cssModuleFileMap = new Map<string, string>([
+        ['/src/vendor.css', 'vendor.css'],
+        ['/src/override.css', 'override.css'],
+      ])
+
+      return { entry, bundle, getModuleInfo, cssModuleFileMap }
+    }
+
+    test('chunk-import-only walk produces wrong order', () => {
+      // Without module info we fall back to the old chunk-import walk; this
+      // is the bug we are fixing. The override stylesheet is emitted before
+      // the vendor stylesheet because that is the order chunk.imports lists
+      // them in.
+      const { entry, bundle } = buildOpRepro()
+      const cache = new Map<OutputChunk, string[]>()
+      expect(getCssFilesForChunk(entry, bundle, cache)).toStrictEqual([
+        'override.css',
+        'vendor.css',
+      ])
+    })
+
+    test('module-graph walk places vendor.css before override.css (fix)', () => {
+      // Regression for https://github.com/vitejs/vite/issues/4890: with module
+      // info, the `<link>` tags follow source-import order, so the override
+      // stylesheet loads after the vendor stylesheet it is meant to override.
+      const { entry, bundle, getModuleInfo, cssModuleFileMap } = buildOpRepro()
+      const cache = new Map<OutputChunk, string[]>()
+      expect(
+        getCssFilesForChunk(
+          entry,
+          bundle,
+          cache,
+          cssModuleFileMap,
+          getModuleInfo,
+        ),
+      ).toStrictEqual(['vendor.css', 'override.css'])
+    })
+
+    test('two entries that share a chunk both get the corrected order', () => {
+      // Regression for https://github.com/vitejs/vite/issues/4890 - the
+      // multi-entry shape originally reported there: two entries sharing the
+      // same imports must both emit CSS in source-import order.
+      const { bundle, cssModuleFileMap } = buildOpRepro()
+      const entry2 = createChunk('entry2.js', ['shared.js'], [], {
+        facadeModuleId: '/src/entry2/main.js',
+        modules: ['/src/entry2/main.js'],
+      })
+      ;(bundle as Record<string, OutputChunk>)['entry2.js'] = entry2
+      // entry2/main.js imports the same vendor + override in the same order.
+      const getModuleInfo = createModuleInfoMap({
+        '/src/main.js': ['/src/vendor.js', '/src/override.css'],
+        '/src/entry2/main.js': ['/src/vendor.js', '/src/override.css'],
+        '/src/vendor.js': ['/src/vendor.css'],
+        '/src/vendor.css': [],
+        '/src/override.css': [],
+      })
+      const cache = new Map<OutputChunk, string[]>()
+      const entry = (bundle as Record<string, OutputChunk>)['entry.js']
+      expect(
+        getCssFilesForChunk(
+          entry,
+          bundle,
+          cache,
+          cssModuleFileMap,
+          getModuleInfo,
+        ),
+      ).toStrictEqual(['vendor.css', 'override.css'])
+      expect(
+        getCssFilesForChunk(
+          entry2,
+          bundle,
+          cache,
+          cssModuleFileMap,
+          getModuleInfo,
+        ),
+      ).toStrictEqual(['vendor.css', 'override.css'])
+    })
+
+    test('falls back to chunk-import walk for CSS not in cssModuleFileMap', () => {
+      // If a chunk has CSS files that aren't covered by cssModuleFileMap
+      // (e.g., emitted outside the normal `renderChunk` flow), they should
+      // still appear via the fallback walk so we don't drop links.
+      const helper = createChunk('helper.js', [], ['helper.css'], {
+        facadeModuleId: '/src/helper.js',
+        modules: ['/src/helper.js'],
+      })
+      const entry = createChunk('entry.js', ['helper.js'], [], {
+        facadeModuleId: '/src/main.js',
+        modules: ['/src/main.js'],
+      })
+      const bundle = createBundle(entry, helper)
+      const getModuleInfo = createModuleInfoMap({
+        '/src/main.js': ['/src/helper.js'],
+        '/src/helper.js': [],
+      })
+      // Empty map - helper.css is not registered.
+      const cssModuleFileMap = new Map<string, string>()
+      const cache = new Map<OutputChunk, string[]>()
+      expect(
+        getCssFilesForChunk(
+          entry,
+          bundle,
+          cache,
+          cssModuleFileMap,
+          getModuleInfo,
+        ),
+      ).toStrictEqual(['helper.css'])
+    })
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -279,6 +279,18 @@ export const removedPureCssFilesCache: WeakMap<
 // Used only if the config doesn't code-split CSS (builds a single CSS file)
 export const cssBundleNameCache: WeakMap<ResolvedConfig, string> = new WeakMap()
 
+/**
+ * Maps the id of every CSS module that contributes to an emitted CSS file
+ * to that emitted CSS file's final filename. Built up while chunks are
+ * rendered (and again as pure-CSS chunks are absorbed into their importers).
+ * Consumed by the build-html plugin to order `<link rel="stylesheet">` tags
+ * by the source-import position of the CSS modules.
+ */
+export const cssModuleFileMapCache: WeakMap<
+  ResolvedConfig,
+  Map<string, string>
+> = new WeakMap()
+
 const postcssConfigCache = new WeakMap<
   ResolvedConfig,
   PostCSSConfigResult | null | Promise<PostCSSConfigResult | null>
@@ -525,6 +537,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       hasEmitted = false
       chunkCSSMap = new Map()
       codeSplitEmitQueue = createSerialPromiseQueue()
+      cssModuleFileMapCache.set(config, new Map())
     },
 
     transform: {
@@ -948,9 +961,15 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                       .get(this.environment)!
                       .set(chunk.fileName, { referenceId, name: chunk.name })
                   }
-                  chunk.viteMetadata!.importedCss.add(
-                    this.getFileName(referenceId),
-                  )
+                  const emittedCssFile = this.getFileName(referenceId)
+                  chunk.viteMetadata!.importedCss.add(emittedCssFile)
+                  // Record each contributing CSS module's id -> emitted file
+                  // so the html plugin can place `<link>` tags in source
+                  // import order.
+                  const cssModuleFileMap = cssModuleFileMapCache.get(config)!
+                  for (const id of orderedCssIds) {
+                    cssModuleFileMap.set(id, emittedCssFile)
+                  }
                 } else if (this.environment.config.consumer === 'client') {
                   // legacy build and inline css
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -664,23 +664,39 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
             const isJsChunkEmpty = code === '' && !chunk.isEntry
             let isPureCssChunk = chunk.exports.length === 0
-            const ids = Object.keys(chunk.modules)
-            for (const id of ids) {
+            const moduleIds = Object.keys(chunk.modules)
+            // Walk the chunk's modules in source-import order so that, when
+            // multiple CSS modules end up in the same chunk, their content is
+            // concatenated in the order the source code imports them.
+            const moduleIdSet = new Set(moduleIds)
+            const visitedIds = new Set<string>()
+            const orderedCssIds: string[] = []
+            const walk = (id: string): void => {
+              if (visitedIds.has(id)) return
+              visitedIds.add(id)
+              // Only walk modules owned by this chunk; cross-chunk imports
+              // are emitted by their own chunk's renderChunk call.
+              if (!moduleIdSet.has(id)) return
+              const info = this.getModuleInfo(id)
+              if (info) {
+                for (const importedId of info.importedIds) {
+                  walk(importedId)
+                }
+              }
               if (styles.has(id)) {
                 // ?transform-only is used for ?url and shouldn't be included in normal CSS chunks
                 if (transformOnlyRE.test(id)) {
-                  continue
+                  return
                 }
 
                 // If this CSS is scoped to its importers exports, check if those importers exports
                 // are rendered in the chunks. If they are not, we can skip bundling this CSS.
-                const cssScopeTo =
-                  this.getModuleInfo(id)?.meta?.vite?.cssScopeTo
+                const cssScopeTo = info?.meta?.vite?.cssScopeTo
                 if (
                   cssScopeTo &&
                   !isCssScopeToRendered(cssScopeTo, renderedModules)
                 ) {
-                  continue
+                  return
                 }
 
                 // a css module contains JS, so it makes this not a pure css chunk
@@ -688,13 +704,27 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   isPureCssChunk = false
                 }
 
-                chunkCSS = (chunkCSS || '') + styles.get(id)
+                orderedCssIds.push(id)
               } else if (!isJsChunkEmpty) {
                 // if the module does not have a style, then it's not a pure css chunk.
                 // this is true because in the `transform` hook above, only modules
                 // that are css gets added to the `styles` map.
                 isPureCssChunk = false
               }
+            }
+
+            if (chunk.facadeModuleId && moduleIdSet.has(chunk.facadeModuleId)) {
+              walk(chunk.facadeModuleId)
+            }
+            // Fallback for modules not reached from the facade (e.g.,
+            // side-effect-only auto-injected modules, or manualChunks output
+            // without a facade). Preserves the chunk-record order for those.
+            for (const id of moduleIds) {
+              walk(id)
+            }
+
+            for (const id of orderedCssIds) {
+              chunkCSS = (chunkCSS || '') + styles.get(id)
             }
 
             const publicAssetUrlMap = publicAssetUrlCache.get(config)!

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { URL } from 'node:url'
 import type {
+  GetModuleInfo,
   OutputAsset,
   OutputBundle,
   OutputChunk,
@@ -47,7 +48,7 @@ import {
   publicAssetUrlRE,
   urlToBuiltUrl,
 } from './asset'
-import { cssBundleNameCache } from './css'
+import { cssBundleNameCache, cssModuleFileMapCache } from './css'
 import { modulePreloadPolyfillId } from './modulePreloadPolyfill'
 
 interface ScriptAssetsUrl {
@@ -348,63 +349,94 @@ function handleParseError(
 }
 
 /**
- * Collects CSS files for a chunk by traversing its imports depth-first,
- * using a cache to avoid re-analyzing chunks while still returning the
- * correct files when the same chunk is reached via different entry points.
+ * Collects CSS files needed by an entry chunk, ordered by the source-import
+ * position of the CSS modules that produced them.
+ *
+ * Walks the module graph from the entry chunk's facade module in DFS
+ * source-import order. Each CSS module's emitted file (looked up in
+ * `cssModuleFileMap`) is registered at the position in the walk where its
+ * importing module references it. Post-order DFS means a module's
+ * dependencies' CSS is loaded before its own.
+ *
+ * Falls back to the chunk-import post-order walk for any CSS files that
+ * aren't reached via the module graph (e.g., CSS-only chunks with no
+ * facade-reachable module, or implicit Rollup imports).
  */
 export function getCssFilesForChunk(
-  chunk: OutputChunk,
+  entryChunk: OutputChunk,
   bundle: OutputBundle,
   analyzedImportedCssFiles: Map<OutputChunk, string[]>,
-  seenChunks: Set<string> = new Set(),
-  seenCss: Set<string> = new Set(),
+  cssModuleFileMap?: Map<string, string>,
+  getModuleInfo?: GetModuleInfo,
 ): string[] {
-  if (seenChunks.has(chunk.fileName)) {
-    return []
-  }
-  seenChunks.add(chunk.fileName)
-
-  if (analyzedImportedCssFiles.has(chunk)) {
-    const files = analyzedImportedCssFiles.get(chunk)!
-    const additionals = files.filter((file) => !seenCss.has(file))
-    additionals.forEach((file) => seenCss.add(file))
-    return additionals
+  if (analyzedImportedCssFiles.has(entryChunk)) {
+    return analyzedImportedCssFiles.get(entryChunk)!
   }
 
-  // Collect all CSS from imports (unfiltered for caching, filtered for return)
-  const allFiles: string[] = []
-  const filteredFiles: string[] = []
-  chunk.imports.forEach((file) => {
-    const importee = bundle[file]
-    if (importee?.type === 'chunk') {
-      const importeeCss = getCssFilesForChunk(
-        importee,
-        bundle,
-        analyzedImportedCssFiles,
-        seenChunks,
-        seenCss,
-      )
-      filteredFiles.push(...importeeCss)
-      // For cache: use the importee's full cached list
-      if (analyzedImportedCssFiles.has(importee)) {
-        allFiles.push(...analyzedImportedCssFiles.get(importee)!)
-      } else {
-        allFiles.push(...importeeCss)
-      }
-    }
-  })
+  const result: string[] = []
+  const seenCss = new Set<string>()
+  const visitedModules = new Set<string>()
 
-  chunk.viteMetadata!.importedCss.forEach((file) => {
-    allFiles.push(file)
+  const addCssFile = (file: string) => {
     if (!seenCss.has(file)) {
       seenCss.add(file)
-      filteredFiles.push(file)
+      result.push(file)
     }
-  })
+  }
 
-  analyzedImportedCssFiles.set(chunk, unique(allFiles))
+  // DFS the module graph in source-import order. Post-order - register a
+  // module's CSS file after walking its imports - so dependencies' CSS
+  // comes first (preserves the existing cascade priority).
+  const walkModule = (id: string) => {
+    if (visitedModules.has(id)) return
+    visitedModules.add(id)
 
-  return filteredFiles
+    const info = getModuleInfo!(id)
+    if (info) {
+      for (const importedId of info.importedIds) {
+        walkModule(importedId)
+      }
+    }
+
+    const cssFile = cssModuleFileMap!.get(id)
+    if (cssFile !== undefined) addCssFile(cssFile)
+  }
+
+  if (cssModuleFileMap && getModuleInfo) {
+    if (entryChunk.facadeModuleId) {
+      walkModule(entryChunk.facadeModuleId)
+    }
+    // Cover modules in the chunk that aren't reached from the facade (e.g.,
+    // side-effect-only auto-injected modules, or chunks without a facade).
+    if (entryChunk.modules) {
+      for (const id of Object.keys(entryChunk.modules)) {
+        walkModule(id)
+      }
+    }
+  }
+
+  // Fallback for CSS files that aren't associated with any walked module -
+  // e.g., chunks introduced via implicit Rollup edges, or callers that
+  // didn't supply module-graph info. Post-order chunk traversal preserves
+  // the previous behavior for these.
+  const visitedChunks = new Set<OutputChunk>()
+  const walkChunkPostOrder = (chunk: OutputChunk) => {
+    if (visitedChunks.has(chunk)) return
+    visitedChunks.add(chunk)
+    for (const file of chunk.imports) {
+      const imp = bundle[file]
+      if (imp?.type === 'chunk') walkChunkPostOrder(imp)
+    }
+    if (chunk.viteMetadata?.importedCss) {
+      for (const file of chunk.viteMetadata.importedCss) {
+        addCssFile(file)
+      }
+    }
+  }
+  walkChunkPostOrder(entryChunk)
+
+  analyzedImportedCssFiles.set(entryChunk, result)
+  return result
 }
 
 /**
@@ -814,6 +846,9 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
     async generateBundle(options, bundle) {
       const analyzedImportedCssFiles = new Map<OutputChunk, string[]>()
+      const cssModuleFileMap =
+        cssModuleFileMapCache.get(config) ?? new Map<string, string>()
+      const getModuleInfo = this.getModuleInfo.bind(this)
       const inlineEntryChunk = new Set<string>()
       const getImportedChunks = (
         chunk: OutputChunk,
@@ -889,9 +924,13 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         chunk: OutputChunk,
         toOutputPath: (filename: string) => string,
       ) =>
-        getCssFilesForChunk(chunk, bundle, analyzedImportedCssFiles).map(
-          (file) => toStyleSheetLinkTag(file, toOutputPath),
-        )
+        getCssFilesForChunk(
+          chunk,
+          bundle,
+          analyzedImportedCssFiles,
+          cssModuleFileMap,
+          getModuleInfo,
+        ).map((file) => toStyleSheetLinkTag(file, toOutputPath))
 
       for (const [normalizedId, html] of processedHtml(this)) {
         const relativeUrlPath = normalizePath(

--- a/playground/css-import-order/__tests__/css-import-order.spec.ts
+++ b/playground/css-import-order/__tests__/css-import-order.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { getBgColor, isBuild, readFile } from '~utils'
+
+test('source-import order wins in the cascade', async () => {
+  // `main.js` does `import './vendor.js'` (which imports vendor.css with
+  // background: red) and then `import './override.css'` (background: blue).
+  // If link tags load in source order, override wins -> blue.
+  expect(await getBgColor('.box')).toBe('blue')
+})
+
+describe.runIf(isBuild)('build', () => {
+  // Regression for https://github.com/vitejs/vite/issues/4890. With two
+  // entries sharing the same imports, the historical bug placed the
+  // override stylesheet before the vendor stylesheet in the built HTML -
+  // reversing the cascade so vendor's red defeated override's blue.
+  for (const htmlPath of ['dist/index.html', 'dist/entry2/index.html']) {
+    test(`${htmlPath} lists vendor.css before override.css`, () => {
+      const html = readFile(htmlPath)
+      const vendorIdx = html.search(
+        /<link[^>]+href=["'][^"']*\/vendor-[^"']+\.css["']/,
+      )
+      const overrideIdx = html.search(
+        /<link[^>]+href=["'][^"']*\/override-[^"']+\.css["']/,
+      )
+      expect(vendorIdx, 'vendor link should be present').toBeGreaterThanOrEqual(
+        0,
+      )
+      expect(
+        overrideIdx,
+        'override link should be present',
+      ).toBeGreaterThanOrEqual(0)
+      expect(vendorIdx).toBeLessThan(overrideIdx)
+    })
+  }
+})

--- a/playground/css-import-order/entry2/index.html
+++ b/playground/css-import-order/entry2/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>css-import-order: entry2</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/entry2/main.js"></script>
+  </body>
+</html>

--- a/playground/css-import-order/entry2/main.js
+++ b/playground/css-import-order/entry2/main.js
@@ -1,0 +1,7 @@
+// Mirrors ../main.js so the two entries share a chunk and exercise the
+// multi-entry pure-CSS-absorption ordering path.
+import { vendor } from '../vendor.js'
+import '../override.css'
+
+document.querySelector('#app').innerHTML =
+  `<div class="box">entry2 ${vendor}</div>`

--- a/playground/css-import-order/index.html
+++ b/playground/css-import-order/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>css-import-order: main</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/playground/css-import-order/main.js
+++ b/playground/css-import-order/main.js
@@ -1,0 +1,5 @@
+import { vendor } from './vendor.js'
+import './override.css'
+
+document.querySelector('#app').innerHTML =
+  `<div class="box">main ${vendor}</div>`

--- a/playground/css-import-order/override.css
+++ b/playground/css-import-order/override.css
@@ -1,0 +1,4 @@
+/* App override; same specificity as vendor.css, relies on source order. */
+.box {
+  background: rgb(0, 0, 255);
+}

--- a/playground/css-import-order/package.json
+++ b/playground/css-import-order/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-css-import-order",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/playground/css-import-order/vendor.css
+++ b/playground/css-import-order/vendor.css
@@ -1,0 +1,9 @@
+/*
+ * Baseline that the app override must beat in the cascade. If the
+ * `<link>` tags end up in the wrong order (override before this), the
+ * red background wins and the regression test fails.
+ */
+.box {
+  background: rgb(255, 0, 0);
+  padding: 20px;
+}

--- a/playground/css-import-order/vendor.js
+++ b/playground/css-import-order/vendor.js
@@ -1,0 +1,2 @@
+import './vendor.css'
+export const vendor = 'vendor'

--- a/playground/css-import-order/vite.config.js
+++ b/playground/css-import-order/vite.config.js
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+const dirname = import.meta.dirname
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(dirname, './index.html'),
+        entry2: resolve(dirname, './entry2/index.html'),
+      },
+      output: {
+        // Force vendor.css into its own chunk so it is absorbed into the
+        // shared chunk's importedCss - this is the configuration that
+        // historically reversed the cascade order (#4890).
+        manualChunks(id) {
+          if (id.endsWith('/vendor.css')) return 'vendor'
+        },
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -660,6 +660,8 @@ importers:
 
   playground/css-dynamic-import: {}
 
+  playground/css-import-order: {}
+
   playground/css-lightningcss:
     devDependencies:
       lightningcss:


### PR DESCRIPTION
This PR fixes #4890: CSS `<link>` tags being emitted in the wrong order in production builds, which reverses the CSS cascade so the wrong rules win.

Two things could scramble the CSS order:

1. **Within a chunk**. When multiple CSS modules landed in the same output chunk, their contents were concatenated in `Object.keys(chunk.modules)` order (roughly Rollup's internal order), rather than in source-import order.
2. **Across chunks / in the HTML**. `getCssFilesForChunk` collected `<link>` tags by walking the chunk import graph. When two CSS modules with a definite source-import order ended up in different emitted CSS files (e.g. one pulled into its own chunk and absorbed as a pure-CSS chunk into a shared chunk's importedCss), the chunk-level walk could emit their link tags in the wrong relative order.

The fix in this PR is:

* `css.ts`: In `renderChunk` we walk the chunk's modules via the module graph (`importedIds`) in DFS source-import order. (post-order, so a module's dependencies' CSS is concatenated before its own) and concatenate CSS in that order. We also build a new `cssModuleFileMapCache` mapping each CSS module id to its emitted CSS filename, which the `html.ts` change below consumes.
* `html.ts`: We rewrite `getCssFilesForChunk` to DFS the module graph from the entry's facade module (same post-order), looking up each module's emitted file in the map built above. A chunk-import post-order walk remains as a fallback for CSS not reachable via the module graph.

There's also a new playground to demonstrate the fix and test for regressions, and unit tests in `html.spec.ts` were updated and extended.