### PR TITLE
fix(dev): apply server headers to 404 responses (fix #22543)

### DIFF
--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -65,4 +65,30 @@ describe('the dev server', () => {
       network: [],
     })
   })
+
+  test('applies server headers to POST 404 responses', async () => {
+    server = await createServer({
+      root: import.meta.dirname,
+      logLevel: 'error',
+      server: {
+        ws: false,
+        headers: {
+          'X-Powered-By': 'Vite',
+        },
+      },
+      optimizeDeps: {
+        noDiscovery: true,
+        include: [],
+      },
+    })
+
+    await server.listen()
+
+    const response = await fetch(`${server.resolvedUrls!.local[0]}missing`, {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('X-Powered-By')).toBe('Vite')
+  })
 })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -943,6 +943,17 @@ export async function _createServer(
     middlewares.use(hostValidationMiddleware(allowedHosts, false))
   }
 
+  // apply server.headers to all subsequent responses
+  const { headers } = serverConfig
+  if (headers) {
+    middlewares.use(function viteHeadersMiddleware(_, res, next) {
+      for (const name in headers) {
+        res.setHeader(name, headers[name]!)
+      }
+      next()
+    })
+  }
+
   // apply configureServer hooks ------------------------------------------------
 
   const configureServerContext = new BasicMinimalPluginContext(


### PR DESCRIPTION
## Summary

Fixes #22543.

`server.headers` was applied by built-in asset, HTML, and transform response paths, but not by the dev server fallthrough 404 path. This adds a lightweight headers middleware after CORS and host validation so POST/API-style 404 responses include configured server headers too.

## Changes

- Apply configured dev `server.headers` before user and built-in response middlewares run.
- Add a unit regression test for a POST request that falls through to Vite's 404 handler.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter=./packages/vite run build-bundle`
- `pnpm test-unit packages/vite/src/node/__tests__/dev.spec.ts`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/server/index.ts packages/vite/src/node/__tests__/dev.spec.ts`
- `pnpm --filter=./packages/vite run build-types-roll`
- `pnpm --filter=./packages/vite run typecheck`
- `git diff --check`
- `pnpm exec oxfmt --check packages/vite/src/node/server/index.ts packages/vite/src/node/__tests__/dev.spec.ts`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.
