### PR TITLE
fix: update rolldown input messages

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -28,6 +28,42 @@ const dirname = import.meta.dirname
 type FormatsToFileNames = [LibraryFormats, string][]
 
 describe('build', () => {
+  test('SSR html entry error refers to rolldownOptions.input', async () => {
+    await expect(
+      build({
+        root: resolve(dirname, 'packages/build-project'),
+        logLevel: 'silent',
+        build: {
+          ssr: true,
+          write: false,
+          rollupOptions: {
+            input: 'index.html',
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'rolldownOptions.input should not be an html file when building for SSR.',
+    )
+  })
+
+  test('CSS entry with cssCodeSplit false error refers to rolldownOptions.input', async () => {
+    await expect(
+      build({
+        root: resolve(dirname, 'packages/build-project'),
+        logLevel: 'silent',
+        build: {
+          cssCodeSplit: false,
+          write: false,
+          rollupOptions: {
+            input: 'style.css',
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'When "build.cssCodeSplit: false" is set, "rolldownOptions.input" should not include CSS files.',
+    )
+  })
+
   test('file hash should change when css changes for dynamic entries', async () => {
     const buildProject = async (cssColor: string) => {
       return (await build({

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -257,7 +257,7 @@ export interface BuildEnvironmentOptions {
   lib?: LibraryOptions | false
   /**
    * Produce SSR oriented build. Note this requires specifying SSR entry via
-   * `rollupOptions.input`.
+   * `rolldownOptions.input`.
    * @default false
    */
   ssr?: boolean | string
@@ -601,7 +601,7 @@ export function resolveRolldownOptions(
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(
-      `rollupOptions.input should not be an html file when building for SSR. ` +
+      `rolldownOptions.input should not be an html file when building for SSR. ` +
         `Please specify a dedicated SSR entry.`,
     )
   }
@@ -614,7 +614,7 @@ export function resolveRolldownOptions(
           : Object.values(input)
     if (inputs.some((input) => input.endsWith('.css'))) {
       throw new Error(
-        `When "build.cssCodeSplit: false" is set, "rollupOptions.input" should not include CSS files.`,
+        `When "build.cssCodeSplit: false" is set, "rolldownOptions.input" should not include CSS files.`,
       )
     }
   }


### PR DESCRIPTION
### Description

Closes #22548.

Updates the remaining user-facing `rollupOptions.input` references in `build.ts` to `rolldownOptions.input`, matching the Vite 8 option naming used by the surrounding messages.

### Additional context

This covers the SSR HTML entry error, the `cssCodeSplit: false` CSS input error, and the JSDoc for `build.ssr`.

### Tests

- `pnpm --filter vite build-bundle`
- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts`