### PR TITLE
docs: mention polling for network file watches

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -300,6 +300,24 @@ To fix it, you could either:
 
 :::
 
+::: tip Watching files on network drives
+
+If your project is on a network drive or mounted file share, file system events may be unreliable depending on the underlying watcher implementation. You can try enabling polling:
+
+```js
+export default defineConfig({
+  server: {
+    watch: {
+      usePolling: true,
+    },
+  },
+})
+```
+
+Note that polling can increase CPU usage. If the issue is caused by a directory with many files, you can combine this with [`server.watch.ignored`](#server-watch) to exclude that directory.
+
+:::
+
 ## server.middlewareMode
 
 - **Type:** `boolean`


### PR DESCRIPTION
### Description

Documents the `server.watch.usePolling` workaround for projects hosted on network drives or mounted file shares, where file system events may be unreliable.

This follows the workaround discussed in #10835 and points users at `server.watch.ignored` when the issue is tied to a directory with many files.

### Validation

- `git diff --check`
- `pnpm run docs-build` fails in this checkout due existing twoslash errors in unrelated pages (`docs/guide/api-javascript.md`, `docs/guide/build.md`, and local search), not from this `server-options.md` change.