### PR TITLE
fix(css): handle dynamic CSS manual chunks

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -663,7 +663,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             )
             // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
             const isJsChunkEmpty = code === '' && !chunk.isEntry
-            let isPureCssChunk = chunk.exports.length === 0
+            // Rolldown may synthesize facade exports for CSS-only chunks.
+            // Classify by rendered module content instead of chunk exports.
+            let isPureCssChunk = true
             const ids = Object.keys(chunk.modules)
             for (const id of ids) {
               if (styles.has(id)) {

--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -1,7 +1,15 @@
 import type { InlineConfig } from 'vite'
 import { build, createServer, preview } from 'vite'
 import { expect, test } from 'vitest'
-import { getColor, isBuild, isServe, page, ports, rootDir } from '~utils'
+import {
+  findAssetFile,
+  getColor,
+  isBuild,
+  isServe,
+  page,
+  ports,
+  rootDir,
+} from '~utils'
 
 const baseOptions = [
   { base: '', label: 'relative' },
@@ -14,7 +22,18 @@ const getConfig = (base: string): InlineConfig => ({
   logLevel: 'silent',
   server: { port: ports['css/dynamic-import'] },
   preview: { port: ports['css/dynamic-import'] },
-  build: { assetsInlineLimit: 0 },
+  build: {
+    assetsInlineLimit: 0,
+    rolldownOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.endsWith('/manual.css')) {
+            return 'manual-css'
+          }
+        },
+      },
+    },
+  },
 })
 
 async function withBuild(base: string, fn: () => Promise<void>) {
@@ -63,11 +82,17 @@ baseOptions.forEach(({ base, label }) => {
     async () => {
       await withBuild(base, async () => {
         await page.waitForSelector('.loaded', { state: 'attached' })
+        await page.waitForSelector('.manual-css-loaded', {
+          state: 'attached',
+        })
 
         expect(await getColor('.css-dynamic-import')).toBe('green')
+        expect(await getColor('.manual-css-dynamic-import')).toBe('purple')
         const linkUrls = (await getLinks()).map((link) => link.pathname)
         const uniqueLinkUrls = [...new Set(linkUrls)]
         expect(linkUrls).toStrictEqual(uniqueLinkUrls)
+
+        expect(findAssetFile(/manual-css.*\.js$/)).toBeUndefined()
       })
     },
   )

--- a/playground/css-dynamic-import/index.html
+++ b/playground/css-dynamic-import/index.html
@@ -1,3 +1,4 @@
 <p class="css-dynamic-import">This should be green</p>
+<p class="manual-css-dynamic-import">This should be purple</p>
 
 <script type="module" src="./index.js"></script>

--- a/playground/css-dynamic-import/index.js
+++ b/playground/css-dynamic-import/index.js
@@ -8,3 +8,9 @@ link.href = new URL('./dynamic.css', import.meta.url).href
 import('./dynamic.js').then(async ({ lazyLoad }) => {
   await lazyLoad()
 })
+
+if (import.meta.env.PROD) {
+  import('./manual.css').then(() => {
+    document.body.classList.add('manual-css-loaded')
+  })
+}

--- a/playground/css-dynamic-import/manual.css
+++ b/playground/css-dynamic-import/manual.css
@@ -1,0 +1,3 @@
+.manual-css-dynamic-import {
+  color: purple;
+}


### PR DESCRIPTION
### What is this PR solving?

Fixes #22244.

A dynamic import of a plain CSS file can be forced into a manual chunk. With Rolldown, that CSS-only chunk may get synthetic facade exports. Vite was using `chunk.exports.length === 0` to decide whether a chunk was pure CSS, so this case stayed in the JS bundle and could emit code that referenced an undeclared binding such as `lib_exports`.

This PR classifies pure CSS chunks from their rendered module content instead. CSS modules and chunks with real JS still stay out of the pure CSS removal path.

### Alternatives considered

I considered handling this in the import-analysis replacement path, but the bad chunk is created before that step. Keeping the fix in CSS chunk classification also preserves the existing flow where Vite removes pure CSS JS placeholders, records them in `removedPureCssFilesCache`, and lets build import analysis replace the dynamic import with `Promise.resolve({})` while preserving CSS preload deps.

### Tests

Added a `css-dynamic-import` playground case that dynamically imports `manual.css` in production and forces it into a manual chunk. The test checks that the CSS loads and that the built JS does not contain the bad generated export.

Manual inspection of the playground build shows the CSS file is emitted, the dynamic import is rewritten to `Promise.resolve({})`, and the CSS file remains in the preload dependency list.

Checks run locally:

- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm run build`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm run test-build css-dynamic-import`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm run test-serve css-dynamic-import`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm run test-unit css`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm lint`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm typecheck`
- `PATH=/tmp/codex-pnpm-bin:$PATH pnpm exec oxfmt --check packages/vite/src/node/plugins/css.ts playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts playground/css-dynamic-import/index.js`

Local note: `pnpm` was not on PATH in my shell, so I ran these through a temporary Corepack wrapper.

### Reviewer notes

The main behavior change is that pure CSS chunk detection no longer treats synthetic exports as proof that a chunk contains JS. The existing per-module checks still reject CSS modules and real JS chunks.
