### PR TITLE
fix: apply configured headers to 404 responses

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -274,7 +274,7 @@ export async function preview(
     app.use(indexHtmlMiddleware(normalizedDistDir, server))
 
     // handle 404s
-    app.use(notFoundMiddleware())
+    app.use(notFoundMiddleware(config.preview.headers))
   }
 
   const hostname = await resolveHostname(options.host)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1027,7 +1027,7 @@ export async function _createServer(
     middlewares.use(indexHtmlMiddleware(root, server))
 
     // handle 404s
-    middlewares.use(notFoundMiddleware())
+    middlewares.use(notFoundMiddleware(serverConfig.headers))
   }
 
   // error handler

--- a/packages/vite/src/node/server/middlewares/notFound.ts
+++ b/packages/vite/src/node/server/middlewares/notFound.ts
@@ -1,8 +1,16 @@
+import type { OutgoingHttpHeaders } from 'node:http'
 import type { Connect } from '#dep-types/connect'
 
-export function notFoundMiddleware(): Connect.NextHandleFunction {
+export function notFoundMiddleware(
+  headers?: OutgoingHttpHeaders,
+): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function vite404Middleware(_, res) {
+    if (headers) {
+      for (const name in headers) {
+        res.setHeader(name, headers[name]!)
+      }
+    }
     res.statusCode = 404
     res.end()
   }

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -306,6 +306,14 @@ describe('fetch', () => {
     const res = await fetch(viteTestUrl + '/src/')
     expect(res.headers.get('x-served-by')).toBe('vite')
   })
+
+  test.runIf(isServe)('serve 404 with configured headers', async () => {
+    const res = await fetch(viteTestUrl + '/does-not-exist', {
+      method: 'POST',
+    })
+    expect(res.status).toBe(404)
+    expect(res.headers.get('x-served-by')).toBe('vite')
+  })
 })
 
 describe('cross origin', () => {


### PR DESCRIPTION
## Summary

- apply configured `server.headers` / `preview.headers` to Vite 404 responses
- keep the existing 404 middleware behavior while setting configured headers before ending the response
- add a playground regression for POST requests that fall through to the dev-server 404 handler

Fixes #22543

## Validation

- `pnpm exec oxfmt packages/vite/src/node/server/middlewares/notFound.ts packages/vite/src/node/server/index.ts packages/vite/src/node/preview.ts playground/fs-serve/__tests__/commonTests.ts`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/server/middlewares/notFound.ts packages/vite/src/node/server/index.ts packages/vite/src/node/preview.ts playground/fs-serve/__tests__/commonTests.ts`
- `pnpm --filter vite build`
- `pnpm exec vitest run -c vitest.config.e2e.ts playground/fs-serve/__tests__/fs-serve.spec.ts`
