### PR TITLE
fix(serve): serve index.html from public subdirectories

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -109,13 +109,35 @@ export function servePublicMiddleware(
     // in-memory set of known public files. This set is updated on restarts.
     // also skip import request and internal requests `/@fs/ /@vite-client` etc...
     if (
-      (publicFiles && !publicFiles.has(toFilePath(req.url!))) ||
       isImportRequest(req.url!) ||
       isInternalRequest(req.url!) ||
       // for `/public-file.js?url` to be transformed
       urlRE.test(req.url!)
     ) {
       return next()
+    }
+    const filePath = toFilePath(req.url!)
+    if (publicFiles && !publicFiles.has(filePath)) {
+      // Mirror htmlFallbackMiddleware so that public files behave the same
+      // in dev and preview: `/foo/` resolves to `/foo/index.html` and
+      // `/foo` to `/foo.html` for requests that accept html.
+      const fallbackPath = filePath.endsWith('/')
+        ? filePath + 'index.html'
+        : filePath + '.html'
+      if (
+        (req.method !== 'GET' && req.method !== 'HEAD') ||
+        !(
+          req.headers.accept === undefined || // equivalent to `Accept: */*`
+          req.headers.accept === '' || // equivalent to `Accept: */*`
+          req.headers.accept.includes('text/html') ||
+          req.headers.accept.includes('*/*')
+        ) ||
+        !publicFiles.has(fallbackPath)
+      ) {
+        return next()
+      }
+      const url = cleanUrl(req.url!)
+      req.url = url.endsWith('/') ? url + 'index.html' : url + '.html'
     }
     serve(req, res, next)
   }

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -498,6 +498,28 @@ test('html serve behavior', async () => {
   expect(await bothSlashIndexHtml.text()).toContain('both/index.html')
 })
 
+test('should serve index.html from public subdirectories', async () => {
+  // /subdir/ should serve public/subdir/index.html
+  const res = await fetchHtml('/subdir/')
+  expect(res.status).toBe(200)
+  expect(await res.text()).toContain('public/subdir/index.html')
+
+  // /subdir/index.html should also work
+  const resExplicit = await fetchHtml('/subdir/index.html')
+  expect(resExplicit.status).toBe(200)
+  expect(await resExplicit.text()).toContain('public/subdir/index.html')
+
+  // extensionless requests resolve to the .html public file,
+  // consistent with the preview server's html fallback
+  const resWithoutExtension = await fetchHtml('/public-file')
+  expect(resWithoutExtension.status).toBe(200)
+  expect(await resWithoutExtension.text()).toContain('public-file.html')
+
+  const resWithExtension = await fetchHtml('/public-file.html')
+  expect(resWithExtension.status).toBe(200)
+  expect(await resWithExtension.text()).toContain('public-file.html')
+})
+
 test('html fallback works non browser accept header', async () => {
   expect((await fetch(viteTestUrl, { headers: { Accept: '' } })).status).toBe(
     200,

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -499,6 +499,28 @@ test('html serve behavior', async () => {
   expect(await bothSlashIndexHtml.text()).toContain('both/index.html')
 })
 
+test('should serve index.html from public subdirectories', async () => {
+  // /subdir/ should serve public/subdir/index.html
+  const res = await fetchHtml('/subdir/')
+  expect(res.status).toBe(200)
+  expect(await res.text()).toContain('public/subdir/index.html')
+
+  // /subdir/index.html should also work
+  const resExplicit = await fetchHtml('/subdir/index.html')
+  expect(resExplicit.status).toBe(200)
+  expect(await resExplicit.text()).toContain('public/subdir/index.html')
+
+  // extensionless requests resolve to the .html public file,
+  // consistent with the preview server's html fallback
+  const resWithoutExtension = await fetchHtml('/public-file')
+  expect(resWithoutExtension.status).toBe(200)
+  expect(await resWithoutExtension.text()).toContain('public-file.html')
+
+  const resWithExtension = await fetchHtml('/public-file.html')
+  expect(resWithExtension.status).toBe(200)
+  expect(await resWithExtension.text()).toContain('public-file.html')
+})
+
 test('html fallback works non browser accept header', async () => {
   expect((await fetch(viteTestUrl, { headers: { Accept: '' } })).status).toBe(
     200,

--- a/playground/html/public/public-file.html
+++ b/playground/html/public/public-file.html
@@ -1,0 +1,1 @@
+public-file.html

--- a/playground/html/public/subdir/index.html
+++ b/playground/html/public/subdir/index.html
@@ -1,0 +1,1 @@
+public/subdir/index.html


### PR DESCRIPTION
### Description

Fixes #6714

When `index.html` lives under a `public/` subdirectory (e.g. `public/foo/bar/index.html`), navigating to `/foo/bar/` now serves that file — matching `/foo/bar/index.html` and typical static-server directory index behavior.

Also aligns **extensionless** public HTML resolution between **dev** and **preview**:

| URL | resolves to (when present) |
|-----|----------------------------|
| `/foo/bar/` | `public/foo/bar/index.html` |
| `/foo` | `public/foo.html` |

### Approach

Update `servePublicMiddleware` to mirror `htmlFallbackMiddleware` for public files only:

- rewrite only for `GET`/`HEAD` with `Accept` containing `text/html` or `*/*`
- require the rewritten path to exist in the in-memory `publicFiles` set
- then serve with the existing `sirv` instance (`extensions: []`)

This deliberately **does not** use sirv's `extensions: ['html']`, which would also map `/foo` → `/foo/index.html` (preview does not do that).

### Tests

Playground `html` coverage (serve + build):

- `/subdir/` and `/subdir/index.html` → `public/subdir/index.html`
- `/public-file` and `/public-file.html` → `public-file.html`

### Review follow-ups addressed

- [x] Run the new test in build as well (not serve-only) — @sapphi-red
- [x] Make extensionless public HTML behavior consistent between dev and preview — @sapphi-red
- [x] Avoid broad sirv `extensions: ['html']` / document intentional `/file` → `/file.html` — @avinashkamat48

### Verification

```bash
pnpm test-serve html   # 65 passed
# new case also verified under:
VITE_TEST_BUILD=1 vitest run -c vitest.config.e2e.ts html -t "should serve index.html from public subdirectories"
```

Rebased onto latest `main`.