### PR TITLE
refactor: correct logic in `collectAllModules` function

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2520,10 +2520,22 @@ function collectAllModules(
   bundle: Record<string, OutputChunk>,
   fileName: string,
   allModules: Set<string>,
+  analyzedModules = new Set<string>(),
 ) {
-  const chunk = bundle[fileName]!
+  if (analyzedModules.has(fileName)) return
+  analyzedModules.add(fileName)
+
+  const chunk = bundle[fileName]
+  if (!chunk) return // external modules
+
   for (const mod of chunk.moduleIds) {
     allModules.add(mod)
+  }
+  for (const i of chunk.imports) {
+    collectAllModules(bundle, i, allModules, analyzedModules)
+  }
+  for (const i of chunk.dynamicImports) {
+    collectAllModules(bundle, i, allModules, analyzedModules)
   }
 }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2520,22 +2520,10 @@ function collectAllModules(
   bundle: Record<string, OutputChunk>,
   fileName: string,
   allModules: Set<string>,
-  analyzedModules = new Set<string>(),
 ) {
-  if (analyzedModules.has(fileName)) return
-  analyzedModules.add(fileName)
-
   const chunk = bundle[fileName]!
   for (const mod of chunk.moduleIds) {
     allModules.add(mod)
-  }
-  for (const i of chunk.imports) {
-    analyzedModules.add(i)
-    collectAllModules(bundle, i, allModules, analyzedModules)
-  }
-  for (const i of chunk.dynamicImports) {
-    analyzedModules.add(i)
-    collectAllModules(bundle, i, allModules, analyzedModules)
   }
 }
 


### PR DESCRIPTION
Hi team,

While going through the source code, I came across this function:

https://github.com/vitejs/vite/blob/646dbedd2870f8ec48df0321177d8aa64bbd1575/packages/vite/src/node/config.ts#L2519

I noticed one thing about the collectAllModules implementation. Inside the for loops, we are adding the imported chunk filename to analyzedModules before calling collectAllModules recursively.

But because there is a early return at the start of collectAllModules, the recursive call looks like it will return immediately and it will not process that chunk modules.

So does it make more sense to either remove the recursive call there, or not add the filename to analyzedModules before calling collectAllModules?

Also, since codeSplitting: false is used here:

https://github.com/vitejs/vite/blob/646dbedd2870f8ec48df0321177d8aa64bbd1575/packages/vite/src/node/config.ts#L2498

My understanding is that only one chunk will be generated. So I was thinking recursive collection may not be needed here.