### PR TITLE
fix: add deprecation warning for config.envFile

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1675,6 +1675,12 @@ export async function resolveConfig(
 
   // load .env files
   // Backward compatibility: set envDir to false when envFile is false
+  if (config.envFile === false) {
+    logger.warn(
+      'config.envFile is deprecated. Use config.envDir instead. ' +
+        'For example, replace { envFile: false } with { envDir: false }.',
+    )
+  }
   let envDir = config.envFile === false ? false : config.envDir
   if (envDir !== false) {
     envDir = config.envDir


### PR DESCRIPTION
## Description

Fixes #22547

`InlineConfig.envFile` is marked as `@deprecated` in the TypeScript definition, but no runtime deprecation warning is emitted when it is used. This means users calling the programmatic API with `{ envFile: false }` receive no guidance to migrate to `{ envDir: false }`.

## What This PR Does

Adds a `logger.warn()` call in `packages/vite/src/node/config.ts` (L1678-1683) that emits a deprecation warning when `config.envFile === false` is used:

```
config.envFile is deprecated. Use config.envDir instead. For example, replace { envFile: false } with { envDir: false }.
```

This follows the existing pattern used by other deprecation/warning messages in the same file (e.g., L1696, L1497).

## How to Test

1. Create a Vite config with `{ envFile: false }`
2. Run Vite dev server or build
3. Observe the deprecation warning in the console output

Before this fix: No warning is emitted.
After this fix: A clear migration guide is shown to the user.
