### PR TITLE
docs: fix Environment API framework examples

### DIFF
--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -180,7 +180,7 @@ If your code can run in the same runtime as the user modules (i.e., it does not 
 // code using the Vite's APIs
 import { createServer } from 'vite'
 
-const server = createServer({
+const server = await createServer({
   plugins: [
     // a plugin that handles `virtual:entrypoint`
     {
@@ -189,7 +189,7 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environment.ssr
+const ssrEnvironment = server.environments.ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code
@@ -252,7 +252,7 @@ If your code requires Node.js APIs, you can use `hot.send` to communicate with t
 // code using the Vite's APIs
 import { createServer } from 'vite'
 
-const server = createServer({
+const server = await createServer({
   plugins: [
     // a plugin that handles `virtual:entrypoint`
     {
@@ -261,13 +261,13 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environment.ssr
+const ssrEnvironment = server.environments.ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code
 // check for each environment factories what they provide
 if (ssrEnvironment instanceof RunnableDevEnvironment) {
-  ssrEnvironment.runner.import('virtual:entrypoint')
+  await ssrEnvironment.runner.import('virtual:entrypoint')
 } else if (ssrEnvironment instanceof CustomDevEnvironment) {
   ssrEnvironment.runEntrypoint('virtual:entrypoint')
 } else {
@@ -277,9 +277,9 @@ if (ssrEnvironment instanceof RunnableDevEnvironment) {
 const req = new Request('http://example.com/')
 
 const uniqueId = 'a-unique-id'
-ssrEnvironment.send('request', serialize({ req, uniqueId }))
+ssrEnvironment.hot.send('request', serialize({ req, uniqueId }))
 const response = await new Promise((resolve) => {
-  ssrEnvironment.on('response', (data) => {
+  ssrEnvironment.hot.on('response', (data) => {
     data = deserialize(data)
     if (data.uniqueId === uniqueId) {
       resolve(data.res)


### PR DESCRIPTION
  ### Description

  Fix outdated examples in the Environment API for Frameworks guide.

  The examples were still using older API shapes:

  - `createServer()` without `await`
  - `server.environment.ssr` instead of `server.environments.ssr`
  - direct `send` / `on` calls instead of the environment `hot` channel
  - `runner.import()` without `await`

  No linked issue; no runtime test was added because this is documentation-only.

  ### Verification

  - `pnpm exec oxfmt --check docs/guide/api-environment-frameworks.md`
  - `pnpm --filter vite run build`
  - `pnpm docs-build`
  - `git diff --check`