### PR TITLE
fix: reject windows alternate paths

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -286,6 +286,8 @@ export function isFileInTargetPath(
   )
 }
 
+const windowsDriveRE = /^[A-Z]:/i
+
 /**
  * Warning: parameters are not validated, only works with normalized absolute paths
  */
@@ -296,6 +298,19 @@ export function isFileLoadingAllowed(
   const { fs } = config.server
 
   if (!fs.strict) return true
+
+  if (isWindows && filePath.includes('~')) {
+    // `~` is used for Windows 8.3 short names, which can be used to bypass the check.
+    // While is it valid to have files with `~` in the path, we disallow it to be safe.
+    return false
+  }
+
+  const hasDriveLetter = isWindows && windowsDriveRE.test(filePath)
+  const hasColon = (hasDriveLetter ? filePath.slice(2) : filePath).includes(':')
+  if (hasColon) {
+    // the `:` is included in the path which may be used for NTFS ADS
+    return false
+  }
 
   // NOTE: `fs.readFile('/foo.png/')` tries to load `'/foo.png'`
   // so we should check the path without trailing slash

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -14,6 +14,7 @@ import {
 import type { Page } from 'playwright-chromium'
 import WebSocket from 'ws'
 import testJSON from '../safe.json'
+import { getWindows83ShortNameForDotEnv as getWindows83ShortNameForDotEnv } from '../root/windows83Filename'
 import { browser, isServe, page, viteServer, viteTestUrl } from '~utils'
 
 const getViteTestIndexHtmlUrl = () => {
@@ -51,6 +52,8 @@ describe.runIf(isServe)('normal', () => {
 })
 
 describe.runIf(isServe)('matrix', () => {
+  const dotEnvWindows83ShortName = getWindows83ShortNameForDotEnv()
+
   const variants = [
     { variantId: '', variantName: 'normal' },
     { variantId: '-fs', variantName: '/@fs/' },
@@ -61,7 +64,8 @@ describe.runIf(isServe)('matrix', () => {
     testId: string
     content: string | RegExp
     status: string | string[]
-    skipVariants?: VariantId[]
+    disableVariants?: VariantId[]
+    skip?: boolean
     isSPAFallback?: boolean
   }> = [
     {
@@ -99,14 +103,14 @@ describe.runIf(isServe)('matrix', () => {
       testId: 'safe-imported',
       content: safeJsonContent,
       status: '200',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'safe fetch imported with query',
       testId: 'safe-imported-query',
       content: safeJsonContent,
       status: '200',
-      skipVariants: [''],
+      disableVariants: [''],
     },
 
     {
@@ -120,7 +124,7 @@ describe.runIf(isServe)('matrix', () => {
       testId: 'unsafe-json',
       content: /403 Restricted/,
       status: '403',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'unsafe HTML fetch',
@@ -133,7 +137,7 @@ describe.runIf(isServe)('matrix', () => {
       testId: 'unsafe-html-outside-root',
       content: /403 Restricted/,
       status: '403',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'unsafe fetch with special characters (#8498)',
@@ -164,21 +168,21 @@ describe.runIf(isServe)('matrix', () => {
       testId: 'unsafe-raw-import-raw-outside-root',
       content: /403 Restricted/,
       status: '403',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'unsafe fetch raw import raw outside root 1',
       testId: 'unsafe-raw-import-raw-outside-root1',
       content: /403 Restricted/,
       status: '403',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'unsafe fetch raw import raw outside root 2',
       testId: 'unsafe-raw-import-raw-outside-root2',
       content: /403 Restricted/,
       status: '403',
-      skipVariants: [''],
+      disableVariants: [''],
     },
     {
       name: 'unsafe fetch with ?url query',
@@ -263,6 +267,15 @@ describe.runIf(isServe)('matrix', () => {
       content: /403 Restricted/,
       status: '403',
     },
+    // On Windows, the files can be accessed through the 8.3 short name if the feature is enabled.
+    // For example, if the short name for `.env` is `ENV~1`, it can be accessed as `ENV~1`.
+    {
+      name: 'denied .env with 8.3 short name',
+      testId: 'unsafe-dotenv-83-short-name',
+      content: /403 Restricted/,
+      status: '403',
+      skip: dotEnvWindows83ShortName === undefined, // skip if 8.3 short name is not available
+    },
   ]
 
   for (const {
@@ -270,41 +283,48 @@ describe.runIf(isServe)('matrix', () => {
     testId,
     content,
     status,
-    skipVariants,
+    disableVariants,
+    skip,
     isSPAFallback,
   } of cases) {
     for (const { variantId, variantName } of variants) {
-      if (skipVariants?.includes(variantId)) {
+      if (disableVariants?.includes(variantId)) {
         continue
       }
 
-      test.concurrent(`${name} (${variantName})`, async ({ expect }) => {
-        const baseSelector = `.fetch${variantId}-${testId}`
-        const actualStatus = expect.poll(() =>
-          page.textContent(`${baseSelector}-status`),
-        )
-        const actualContent = expect.poll(() =>
-          page.textContent(`${baseSelector}-content`),
-        )
+      test.concurrent(
+        `${name} (${variantName})`,
+        { skip },
+        async ({ expect }) => {
+          const baseSelector = `.fetch${variantId}-${testId}`
+          const actualStatus = expect.poll(() =>
+            page.textContent(`${baseSelector}-status`),
+          )
+          const actualContent = expect.poll(() =>
+            page.textContent(`${baseSelector}-content`),
+          )
 
-        if (variantName === 'normal' && isSPAFallback) {
-          await actualStatus.toBe('200')
-          await actualContent.toContain('<h1>FS Serve Matrix Test Summary</h1>')
-          return
-        }
+          if (variantName === 'normal' && isSPAFallback) {
+            await actualStatus.toBe('200')
+            await actualContent.toContain(
+              '<h1>FS Serve Matrix Test Summary</h1>',
+            )
+            return
+          }
 
-        if (typeof status === 'string') {
-          await actualStatus.toBe(status)
-        } else {
-          await actualStatus.toBeOneOf(status)
-        }
+          if (typeof status === 'string') {
+            await actualStatus.toBe(status)
+          } else {
+            await actualStatus.toBeOneOf(status)
+          }
 
-        if (typeof content === 'string') {
-          await actualContent.toBe(content)
-        } else {
-          await actualContent.toMatch(content)
-        }
-      })
+          if (typeof content === 'string') {
+            await actualContent.toBe(content)
+          } else {
+            await actualContent.toMatch(content)
+          }
+        },
+      )
     }
   }
 })

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -261,11 +261,12 @@ describe.runIf(isServe)('matrix', () => {
     },
     // On NTFS, it exposes a file's default data stream through the `::$DATA` suffix,
     // so `.env::$DATA` resolves to the same content as `.env`.
+    // It is 404 on non-NTFS.
     {
       name: 'denied .env with NTFS ADS suffix',
       testId: 'unsafe-dotenv-ntfs-ads',
-      content: /403 Restricted/,
-      status: '403',
+      content: /403 Restricted|^$/,
+      status: ['403', '404'],
     },
     // On Windows, the files can be accessed through the 8.3 short name if the feature is enabled.
     // For example, if the short name for `.env` is `ENV~1`, it can be accessed as `ENV~1`.

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -255,6 +255,14 @@ describe.runIf(isServe)('matrix', () => {
       content: /403 Restricted/,
       status: '403',
     },
+    // On NTFS, it exposes a file's default data stream through the `::$DATA` suffix,
+    // so `.env::$DATA` resolves to the same content as `.env`.
+    {
+      name: 'denied .env with NTFS ADS suffix',
+      testId: 'unsafe-dotenv-ntfs-ads',
+      content: /403 Restricted/,
+      status: '403',
+    },
   ]
 
   for (const {

--- a/playground/fs-serve/root/matrixTestResultPlugin.ts
+++ b/playground/fs-serve/root/matrixTestResultPlugin.ts
@@ -32,6 +32,7 @@ const testIds = [
   'unsafe-dotenv-inline',
   'unsafe-dotenv-query-dot-svg-wasm-init',
   'unsafe-dotenv-import-raw',
+  'unsafe-dotenv-ntfs-ads',
 ]
 
 export default function matrixTestResultPlugin(): Plugin {

--- a/playground/fs-serve/root/matrixTestResultPlugin.ts
+++ b/playground/fs-serve/root/matrixTestResultPlugin.ts
@@ -33,6 +33,7 @@ const testIds = [
   'unsafe-dotenv-query-dot-svg-wasm-init',
   'unsafe-dotenv-import-raw',
   'unsafe-dotenv-ntfs-ads',
+  'unsafe-dotenv-83-short-name',
 ]
 
 export default function matrixTestResultPlugin(): Plugin {

--- a/playground/fs-serve/root/src/index.html
+++ b/playground/fs-serve/root/src/index.html
@@ -33,6 +33,7 @@
 
   const base = typeof BASE !== 'undefined' ? BASE : ''
   const fsBase = joinUrlSegments('/@fs/', ROOT)
+  const dotEnvWindows83ShortName = DOTENV83SHORTNAME
 
   function joinUrlSegments(a, b) {
     if (!a || !b) {
@@ -156,13 +157,24 @@
     { testId: 'unsafe-dotenv-import-raw', path: '/root/src/.env?import&raw' },
     // .env with NTFS ADS suffix
     { testId: 'unsafe-dotenv-ntfs-ads', path: '/root/src/.env::$DATA' },
+    // .env with 8.3 short name
+    {
+      testId: 'unsafe-dotenv-83-short-name',
+      path:
+        dotEnvWindows83ShortName === undefined
+          ? false
+          : `/root/src/${dotEnvWindows83ShortName}`,
+    },
   ]
   const variants = {
     '': (path) =>
-      path.startsWith('/root/')
-        ? joinUrlSegments(base, path.replace(/^\/root/, ''))
-        : false,
-    '-fs': (path) => joinUrlSegments(base, fsBase + path),
+      path === false
+        ? path
+        : path.startsWith('/root/')
+          ? joinUrlSegments(base, path.replace(/^\/root/, ''))
+          : false,
+    '-fs': (path) =>
+      path === false ? path : joinUrlSegments(base, fsBase + path),
   }
 
   for (const { testId, path } of paths) {

--- a/playground/fs-serve/root/src/index.html
+++ b/playground/fs-serve/root/src/index.html
@@ -154,6 +154,8 @@
     },
     // .env with ?import&raw
     { testId: 'unsafe-dotenv-import-raw', path: '/root/src/.env?import&raw' },
+    // .env with NTFS ADS suffix
+    { testId: 'unsafe-dotenv-ntfs-ads', path: '/root/src/.env::$DATA' },
   ]
   const variants = {
     '': (path) =>

--- a/playground/fs-serve/root/vite.config-base.js
+++ b/playground/fs-serve/root/vite.config-base.js
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { defineConfig } from 'vite'
 import svgVirtualModulePlugin from './svgVirtualModulePlugin'
 import matrixTestResultPlugin from './matrixTestResultPlugin'
+import { getWindows83ShortNameForDotEnv } from './windows83Filename'
 
 const BASE = '/base/'
 
@@ -35,6 +36,7 @@ export default defineConfig({
   define: {
     ROOT: JSON.stringify(path.dirname(import.meta.dirname).replace(/\\/g, '/')),
     BASE: JSON.stringify(BASE),
+    DOTENV83SHORTNAME: JSON.stringify(getWindows83ShortNameForDotEnv()),
   },
   plugins: [svgVirtualModulePlugin(), matrixTestResultPlugin()],
 })

--- a/playground/fs-serve/root/vite.config.js
+++ b/playground/fs-serve/root/vite.config.js
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { defineConfig } from 'vite'
 import svgVirtualModulePlugin from './svgVirtualModulePlugin'
 import matrixTestResultPlugin from './matrixTestResultPlugin'
+import { getWindows83ShortNameForDotEnv } from './windows83Filename'
 
 export default defineConfig({
   build: {
@@ -31,6 +32,7 @@ export default defineConfig({
   },
   define: {
     ROOT: JSON.stringify(path.dirname(import.meta.dirname).replace(/\\/g, '/')),
+    DOTENV83SHORTNAME: JSON.stringify(getWindows83ShortNameForDotEnv()),
   },
   plugins: [svgVirtualModulePlugin(), matrixTestResultPlugin()],
 })

--- a/playground/fs-serve/root/windows83Filename.ts
+++ b/playground/fs-serve/root/windows83Filename.ts
@@ -1,0 +1,23 @@
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+
+function getWindows83ShortName(inputPath: string): string | undefined {
+  try {
+    const result = execSync(
+      `powershell -Command "(New-Object -ComObject Scripting.FileSystemObject).GetFile('${inputPath}').ShortPath"`,
+      { encoding: 'utf-8' },
+    ).trim()
+    return result !== inputPath && result.includes('~') ? result : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function getWindows83ShortNameForDotEnv(): string | undefined {
+  const dotEnvPath = path.resolve(import.meta.dirname, '../root/src/.env')
+  const dotEnvWindows83ShortName = getWindows83ShortName(dotEnvPath)
+  if (dotEnvWindows83ShortName === undefined) {
+    return undefined
+  }
+  return path.basename(dotEnvWindows83ShortName)
+}


### PR DESCRIPTION
reject paths containing `:` or `~`.

Fixes GHSA-fx2h-pf6j-xcff
