### PR TITLE
fix: backport #22572, reject windows alternate paths

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -266,6 +266,8 @@ export function isUriInFilePath(uri: string, filePath: string): boolean {
   return isSameFileUri(uri, filePath) || isParentDirectory(uri, filePath)
 }
 
+const windowsDriveRE = /^[A-Z]:/i
+
 export function isFileLoadingAllowed(
   config: ResolvedConfig,
   filePath: string,
@@ -273,6 +275,19 @@ export function isFileLoadingAllowed(
   const { fs } = config.server
 
   if (!fs.strict) return true
+
+  if (isWindows && filePath.includes('~')) {
+    // `~` is used for Windows 8.3 short names, which can be used to bypass the check.
+    // While is it valid to have files with `~` in the path, we disallow it to be safe.
+    return false
+  }
+
+  const hasDriveLetter = isWindows && windowsDriveRE.test(filePath)
+  const hasColon = (hasDriveLetter ? filePath.slice(2) : filePath).includes(':')
+  if (hasColon) {
+    // the `:` is included in the path which may be used for NTFS ADS
+    return false
+  }
 
   // NOTE: `fs.readFile('/foo.png/')` tries to load `'/foo.png'`
   // so we should check the path without trailing slash

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -237,9 +237,10 @@ describe.runIf(isServe)('main', () => {
   })
 
   test('denied .env with NTFS ADS suffix', async () => {
+    // It is 403 on NTFS, 404 on others
     await expect
       .poll(() => page.textContent('.unsafe-dotenv-ntfs-ads'))
-      .toBe('403')
+      .toStrictEqual(expect.toBeOneOf(['403', '404']))
   })
 
   const dotEnvWindows83ShortName = getWindows83ShortNameForDotEnv()

--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -13,6 +13,7 @@ import {
 import type { Page } from 'playwright-chromium'
 import WebSocket from 'ws'
 import testJSON from '../safe.json'
+import { getWindows83ShortNameForDotEnv as getWindows83ShortNameForDotEnv } from '../root/windows83Filename'
 import { browser, isServe, page, viteServer, viteTestUrl } from '~utils'
 
 const getViteTestIndexHtmlUrl = () => {
@@ -234,6 +235,22 @@ describe.runIf(isServe)('main', () => {
       .poll(() => page.textContent('.unsafe-dotenv-query-dot-svg-wasm-init'))
       .toBe('403')
   })
+
+  test('denied .env with NTFS ADS suffix', async () => {
+    await expect
+      .poll(() => page.textContent('.unsafe-dotenv-ntfs-ads'))
+      .toBe('403')
+  })
+
+  const dotEnvWindows83ShortName = getWindows83ShortNameForDotEnv()
+  test.skipIf(dotEnvWindows83ShortName === undefined)(
+    'denied .env with 8.3 short name',
+    async () => {
+      await expect
+        .poll(() => page.textContent('.unsafe-dotenv-83-short-name'))
+        .toBe('403')
+    },
+  )
 })
 
 describe('fetch', () => {

--- a/playground/fs-serve/root/src/index.html
+++ b/playground/fs-serve/root/src/index.html
@@ -64,6 +64,8 @@
 <pre class="unsafe-dotenv"></pre>
 <pre class="unsafe-dotEnV-casing"></pre>
 <pre class="unsafe-dotenv-query-dot-svg-wasm-init"></pre>
+<pre class="unsafe-dotenv-ntfs-ads"></pre>
+<pre class="unsafe-dotenv-83-short-name"></pre>
 
 <script type="module">
   import '../../entry'
@@ -87,6 +89,7 @@
   text('.named', msg)
 
   const base = typeof BASE !== 'undefined' ? BASE : ''
+  const dotEnvWindows83ShortName = DOTENV83SHORTNAME
 
   // inside allowed dir, safe fetch
   fetch(joinUrlSegments(base, '/src/safe.txt'))
@@ -444,6 +447,33 @@
   )
     .then((r) => {
       text('.unsafe-dotenv-query-dot-svg-wasm-init', r.status)
+    })
+    .catch((e) => {
+      console.error(e)
+    })
+
+  fetch(
+    joinUrlSegments(
+      base,
+      joinUrlSegments('/@fs/', ROOT) + '/root/src/.env::$DATA',
+    ),
+  )
+    .then((r) => {
+      text('.unsafe-dotenv-ntfs-ads', r.status)
+    })
+    .catch((e) => {
+      console.error(e)
+    })
+
+  fetch(
+    joinUrlSegments(
+      base,
+      joinUrlSegments('/@fs/', ROOT) +
+        `/root/src/${dotEnvWindows83ShortName}.json`,
+    ),
+  )
+    .then((r) => {
+      text('.unsafe-dotenv-83-short-name', r.status)
     })
     .catch((e) => {
       console.error(e)

--- a/playground/fs-serve/root/vite.config-base.js
+++ b/playground/fs-serve/root/vite.config-base.js
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { defineConfig } from 'vite'
+import { getWindows83ShortNameForDotEnv } from './windows83Filename'
 
 const BASE = '/base/'
 
@@ -33,5 +34,6 @@ export default defineConfig({
   define: {
     ROOT: JSON.stringify(path.dirname(__dirname).replace(/\\/g, '/')),
     BASE: JSON.stringify(BASE),
+    DOTENV83SHORTNAME: JSON.stringify(getWindows83ShortNameForDotEnv()),
   },
 })

--- a/playground/fs-serve/root/vite.config.js
+++ b/playground/fs-serve/root/vite.config.js
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { defineConfig } from 'vite'
+import { getWindows83ShortNameForDotEnv } from './windows83Filename'
 
 export default defineConfig({
   build: {
@@ -29,5 +30,6 @@ export default defineConfig({
   },
   define: {
     ROOT: JSON.stringify(path.dirname(__dirname).replace(/\\/g, '/')),
+    DOTENV83SHORTNAME: JSON.stringify(getWindows83ShortNameForDotEnv()),
   },
 })

--- a/playground/fs-serve/root/windows83Filename.ts
+++ b/playground/fs-serve/root/windows83Filename.ts
@@ -1,0 +1,23 @@
+import { execSync } from 'node:child_process'
+import path from 'node:path'
+
+function getWindows83ShortName(inputPath: string): string | undefined {
+  try {
+    const result = execSync(
+      `powershell -Command "(New-Object -ComObject Scripting.FileSystemObject).GetFile('${inputPath}').ShortPath"`,
+      { encoding: 'utf-8' },
+    ).trim()
+    return result !== inputPath && result.includes('~') ? result : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function getWindows83ShortNameForDotEnv(): string | undefined {
+  const dotEnvPath = path.resolve(__dirname, '../root/src/.env')
+  const dotEnvWindows83ShortName = getWindows83ShortName(dotEnvPath)
+  if (dotEnvWindows83ShortName === undefined) {
+    return undefined
+  }
+  return path.basename(dotEnvWindows83ShortName)
+}


### PR DESCRIPTION
backport of https://github.com/vitejs/vite/pull/22572 for v6