### PR TITLE
fix: update rolldown input messages (fix #22548)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -257,7 +257,7 @@ export interface BuildEnvironmentOptions {
   lib?: LibraryOptions | false
   /**
    * Produce SSR oriented build. Note this requires specifying SSR entry via
-   * `rollupOptions.input`.
+   * `rolldownOptions.input`.
    * @default false
    */
   ssr?: boolean | string
@@ -601,7 +601,7 @@ export function resolveRolldownOptions(
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(
-      `rollupOptions.input should not be an html file when building for SSR. ` +
+      `rolldownOptions.input should not be an html file when building for SSR. ` +
         `Please specify a dedicated SSR entry.`,
     )
   }
@@ -614,7 +614,7 @@ export function resolveRolldownOptions(
           : Object.values(input)
     if (inputs.some((input) => input.endsWith('.css'))) {
       throw new Error(
-        `When "build.cssCodeSplit: false" is set, "rollupOptions.input" should not include CSS files.`,
+        `When "build.cssCodeSplit: false" is set, "rolldownOptions.input" should not include CSS files.`,
       )
     }
   }


### PR DESCRIPTION
### Description

Updates the remaining user-facing `rollupOptions.input` references in `packages/vite/src/node/build.ts` to `rolldownOptions.input`.

These were missed after #22400 updated most messages from the deprecated `rollupOptions` name to `rolldownOptions`.

### Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --check packages/vite/src/node/build.ts`
- `pnpm exec eslint packages/vite/src/node/build.ts`
- `pnpm --dir packages/vite exec eslint --cache --ext .ts src/node/build.ts`
- `git diff --check origin/main...HEAD`
