### PR TITLE
feat: Scope tsconfig change invalidation to affected modules only

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -1,8 +1,11 @@
 import path from 'node:path'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import type { ResolvedConfig, UserConfig } from '../../config'
+import type { ViteDevServer } from '../../server'
 import {
   injectEsbuildHelpers,
+  registerTsconfigDependency,
+  reloadOnTsconfigChange,
   resolveEsbuildTranspileOptions,
   transformWithEsbuild,
 } from '../../plugins/esbuild'
@@ -424,6 +427,108 @@ describe('injectEsbuildHelpers', () => {
       'var $$=function(){};var MyLib=(function(){"use strict";return 42;})()'
     const result = injectEsbuildHelpers(esbuildCode, 'iife')
     expect(result).toContain('"use strict";var $$=function(){};')
+  })
+})
+
+describe('reloadOnTsconfigChange', () => {
+  function createMockConfig(): ResolvedConfig {
+    return {
+      logger: { info: vi.fn() },
+      clearScreen: false,
+    } as unknown as ResolvedConfig
+  }
+
+  function createMockServer(config: ResolvedConfig) {
+    const invalidateAll = vi.fn()
+    const invalidateModule = vi.fn()
+    const getModulesByFile = vi.fn().mockReturnValue(undefined)
+    const hotSend = vi.fn()
+
+    const server = {
+      config,
+      environments: {
+        client: {
+          moduleGraph: { invalidateAll, invalidateModule, getModulesByFile },
+          hot: { send: hotSend },
+        },
+      },
+    } as unknown as ViteDevServer
+
+    return {
+      server,
+      invalidateAll,
+      invalidateModule,
+      getModulesByFile,
+      hotSend,
+    }
+  }
+
+  test('create event: invalidates all modules', () => {
+    const config = createMockConfig()
+    const { server, invalidateAll, invalidateModule } = createMockServer(config)
+
+    reloadOnTsconfigChange(server, '/project/src/tsconfig.json', 'create')
+
+    expect(invalidateAll).toHaveBeenCalledOnce()
+    expect(invalidateModule).not.toHaveBeenCalled()
+  })
+
+  test('delete event: invalidates all modules', () => {
+    const config = createMockConfig()
+    const { server, invalidateAll, invalidateModule } = createMockServer(config)
+
+    reloadOnTsconfigChange(server, '/project/src/tsconfig.json', 'delete')
+
+    expect(invalidateAll).toHaveBeenCalledOnce()
+    expect(invalidateModule).not.toHaveBeenCalled()
+  })
+
+  test('update event with no registered dependents: invalidates all modules', () => {
+    const config = createMockConfig()
+    const { server, invalidateAll, invalidateModule } = createMockServer(config)
+
+    reloadOnTsconfigChange(server, '/project/src/tsconfig.json', 'update')
+
+    expect(invalidateAll).toHaveBeenCalledOnce()
+    expect(invalidateModule).not.toHaveBeenCalled()
+  })
+
+  test('update event with registered dependents: invalidates only affected modules', () => {
+    const config = createMockConfig()
+    const { server, invalidateAll, invalidateModule, getModulesByFile } =
+      createMockServer(config)
+
+    const tsconfigFile = '/project/src/tsconfig.json'
+    const sourceFile = '/project/src/foo.ts'
+    const mockMod = { id: sourceFile }
+
+    registerTsconfigDependency(config, tsconfigFile, sourceFile)
+    getModulesByFile.mockReturnValue(new Set([mockMod]))
+
+    reloadOnTsconfigChange(server, tsconfigFile, 'update')
+
+    expect(invalidateAll).not.toHaveBeenCalled()
+    expect(getModulesByFile).toHaveBeenCalledWith(sourceFile)
+    expect(invalidateModule).toHaveBeenCalledWith(mockMod, expect.any(Set))
+  })
+
+  test('full-reload is always sent regardless of event type', () => {
+    const config = createMockConfig()
+    const { server, hotSend } = createMockServer(config)
+
+    reloadOnTsconfigChange(server, '/project/src/tsconfig.json', 'update')
+
+    expect(hotSend).toHaveBeenCalledWith({ type: 'full-reload', path: '*' })
+  })
+
+  test('non-tsconfig json file: no invalidation or reload', () => {
+    const config = createMockConfig()
+    const { server, invalidateAll, hotSend } = createMockServer(config)
+
+    reloadOnTsconfigChange(server, '/project/src/package.json', 'update')
+
+    expect(invalidateAll).not.toHaveBeenCalled()
+    expect(hotSend).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -537,6 +537,38 @@ export function getTSConfigResolutionCache(
   return cache
 }
 
+// reverse index: tsconfig file path -> source files that referenced it.
+// used by reloadOnTsconfigChange to only invalidate affected modules.
+const tsconfigDependentFilesMap = new WeakMap<
+  ResolvedConfig,
+  Map<string, Set<string>>
+>()
+
+function getTsconfigDependentFilesMap(
+  config: ResolvedConfig,
+): Map<string, Set<string>> {
+  let map = tsconfigDependentFilesMap.get(config)
+  if (!map) {
+    map = new Map()
+    tsconfigDependentFilesMap.set(config, map)
+  }
+  return map
+}
+
+export function registerTsconfigDependency(
+  config: ResolvedConfig,
+  tsconfigFile: string,
+  sourceFile: string,
+): void {
+  const map = getTsconfigDependentFilesMap(config)
+  let files = map.get(tsconfigFile)
+  if (!files) {
+    files = new Set()
+    map.set(tsconfigFile, files)
+  }
+  files.add(sourceFile)
+}
+
 export function reloadOnTsconfigChange(
   server: ViteDevServer,
   changedFile: string,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -20,6 +20,7 @@ import {
   normalizePath,
 } from '../utils'
 import type { ViteDevServer } from '../server'
+import type { EnvironmentModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { cleanUrl } from '../../shared/utils'
@@ -580,6 +581,7 @@ export function registerTsconfigDependency(
 export function reloadOnTsconfigChange(
   server: ViteDevServer,
   changedFile: string,
+  event: 'create' | 'delete' | 'update',
 ): void {
   // any tsconfig.json that's added in the workspace could be closer to a code file than a previously cached one
   // any json file in the tsconfig cache could have been used to compile ts
@@ -591,15 +593,33 @@ export function reloadOnTsconfigChange(
         { clear: server.config.clearScreen, timestamp: true },
       )
 
-      // TODO: more finegrained invalidation than the nuclear option below
-
-      // clear module graph to remove code compiled with outdated config
-      for (const environment of Object.values(server.environments)) {
-        environment.moduleGraph.invalidateAll()
-      }
-
       // reset the cache so that recompile works with up2date configs
       cache.clear()
+
+      // On 'update' we can scope invalidation to modules that actually
+      // referenced this tsconfig (tracked during transform). On create/delete,
+      // a new/removed tsconfig may change which tsconfig other files resolve
+      // to, which the reverse index can't capture, so invalidate everything.
+      const dependentFiles =
+        event === 'update'
+          ? getTsconfigDependentFilesMap(server.config).get(changedFile)
+          : undefined
+
+      for (const environment of Object.values(server.environments)) {
+        if (dependentFiles) {
+          const seen = new Set<EnvironmentModuleNode>()
+          for (const file of dependentFiles) {
+            environment.moduleGraph
+              .getModulesByFile(file)
+              ?.forEach((mod) =>
+                environment.moduleGraph.invalidateModule(mod, seen),
+              )
+          }
+        } else {
+          // clear module graph to remove code compiled with outdated config
+          environment.moduleGraph.invalidateAll()
+        }
+      }
 
       // reload environments
       for (const environment of Object.values(server.environments)) {

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -17,6 +17,7 @@ import {
   createFilter,
   ensureWatchedFile,
   generateCodeFrame,
+  normalizePath,
 } from '../utils'
 import type { ViteDevServer } from '../server'
 import type { ResolvedConfig } from '../config'
@@ -153,8 +154,15 @@ export async function transformWithEsbuild(
         const { tsconfig: loadedTsconfig, tsconfigFilePaths } = result
         // tsconfig could be out of root, make sure it is watched on dev
         if (watcher && config) {
+          const sourceFile = cleanUrl(filename)
           for (const tsconfigFile of tsconfigFilePaths) {
-            ensureWatchedFile(watcher, tsconfigFile, config.root)
+            const normalizedTsconfigFile = normalizePath(tsconfigFile)
+            ensureWatchedFile(watcher, normalizedTsconfigFile, config.root)
+            registerTsconfigDependency(
+              config,
+              normalizedTsconfigFile,
+              sourceFile,
+            )
           }
         }
 

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -16,7 +16,11 @@ import type { Environment } from '..'
 import type { ViteDevServer } from '../server'
 import { JS_TYPES_RE } from '../constants'
 import type { Logger } from '../logger'
-import { type ESBuildOptions, getTSConfigResolutionCache } from './esbuild'
+import {
+  type ESBuildOptions,
+  getTSConfigResolutionCache,
+  registerTsconfigDependency,
+} from './esbuild'
 
 // IIFE content looks like `var MyLib = (function() {` or `this.nested.myLib = (function() {`.
 export const IIFE_BEGIN_RE: RegExp =
@@ -161,8 +165,11 @@ export async function transformWithOxc(
     result.tsconfigFilePaths &&
     result.tsconfigFilePaths.length > 0
   ) {
+    const sourceFile = cleanUrl(filename)
     for (const tsconfigFile of result.tsconfigFilePaths) {
-      ensureWatchedFile(watcher, normalizePath(tsconfigFile), config.root)
+      const normalizedTsconfigFile = normalizePath(tsconfigFile)
+      ensureWatchedFile(watcher, normalizedTsconfigFile, config.root)
+      registerTsconfigDependency(config, normalizedTsconfigFile, sourceFile)
     }
   }
 

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -4,7 +4,10 @@ import type {
   TransformResult as OxcTransformResult,
 } from 'rolldown/utils'
 import { transformSync } from 'rolldown/utils'
-import { viteTransformPlugin as nativeTransformPlugin } from 'rolldown/experimental'
+import {
+  viteTransformPlugin as nativeTransformPlugin,
+  resolveTsconfig,
+} from 'rolldown/experimental'
 import type { RolldownError, RolldownLog, SourceMap } from 'rolldown'
 import colors from 'picocolors'
 import type { FSWatcher } from '#dep-types/chokidar'
@@ -159,17 +162,18 @@ export async function transformWithOxc(
     resolvedOptions,
     getTSConfigResolutionCache(config),
   )
-  if (
-    watcher &&
-    config &&
-    result.tsconfigFilePaths &&
-    result.tsconfigFilePaths.length > 0
-  ) {
-    const sourceFile = cleanUrl(filename)
-    for (const tsconfigFile of result.tsconfigFilePaths) {
-      const normalizedTsconfigFile = normalizePath(tsconfigFile)
-      ensureWatchedFile(watcher, normalizedTsconfigFile, config.root)
-      registerTsconfigDependency(config, normalizedTsconfigFile, sourceFile)
+  if (watcher && config && (lang === 'ts' || lang === 'tsx')) {
+    const tsconfigResult = resolveTsconfig(
+      cleanUrl(filename),
+      getTSConfigResolutionCache(config),
+    )
+    if (tsconfigResult) {
+      const sourceFile = cleanUrl(filename)
+      for (const tsconfigFile of tsconfigResult.tsconfigFilePaths) {
+        const normalizedTsconfigFile = normalizePath(tsconfigFile)
+        ensureWatchedFile(watcher, normalizedTsconfigFile, config.root)
+        registerTsconfigDependency(config, normalizedTsconfigFile, sourceFile)
+      }
     }
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -857,7 +857,7 @@ export async function _createServer(
 
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
-    reloadOnTsconfigChange(server, file)
+    reloadOnTsconfigChange(server, file, isUnlink ? 'delete' : 'create')
 
     await Promise.all(
       Object.values(server.environments).map((environment) =>
@@ -895,7 +895,7 @@ export async function _createServer(
 
   const onFileChange = async (file: string) => {
     file = normalizePath(file)
-    reloadOnTsconfigChange(server, file)
+    reloadOnTsconfigChange(server, file, 'update')
 
     await Promise.all(
       Object.values(server.environments).map((environment) =>

--- a/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
+++ b/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
@@ -2,7 +2,14 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { transformWithEsbuild } from 'vite'
 import { describe, expect, test } from 'vitest'
-import { browserLogs, isServe, serverLogs } from '~utils'
+import {
+  browserLogs,
+  editFile,
+  isServe,
+  page,
+  serverLogs,
+  viteTestUrl,
+} from '~utils'
 
 test('should respected each `tsconfig.json`s compilerOptions', () => {
   // main side effect should be called (because of `"verbatimModuleSyntax": true`)
@@ -20,6 +27,49 @@ test('should respected each `tsconfig.json`s compilerOptions', () => {
   // nested-with-extends base setter should be called (because of `"useDefineForClassFields": false"`)
   expect(browserLogs).toContain('data setter in NestedWithExtendsBase')
 })
+
+test.runIf(isServe)(
+  'nested tsconfig update: only affected modules are re-transformed',
+  async () => {
+    const before = (await fetch(viteTestUrl + '/transform-counts').then((r) =>
+      r.json(),
+    )) as Record<string, number>
+
+    // both zones should have been transformed on initial load
+    expect(before['nested/main.ts']).toBeGreaterThan(0)
+    expect(before['nested-with-extends/main.ts']).toBeGreaterThan(0)
+
+    editFile('nested/tsconfig.json', (code) =>
+      code.replace(
+        '"useDefineForClassFields": false',
+        '"useDefineForClassFields": true',
+      ),
+    )
+    await page.waitForEvent('load')
+
+    const after = (await fetch(viteTestUrl + '/transform-counts').then((r) =>
+      r.json(),
+    )) as Record<string, number>
+
+    // nested modules should have been re-transformed (tsconfig changed)
+    expect(after['nested/main.ts']).toBeGreaterThan(before['nested/main.ts'])
+
+    // nested-with-extends is in a separate tsconfig zone and not in nested/'s
+    // import chain, so it should NOT be re-transformed
+    expect(after['nested-with-extends/main.ts']).toBe(
+      before['nested-with-extends/main.ts'],
+    )
+
+    // restore
+    editFile('nested/tsconfig.json', (code) =>
+      code.replace(
+        '"useDefineForClassFields": true',
+        '"useDefineForClassFields": false',
+      ),
+    )
+    await page.waitForEvent('load')
+  },
+)
 
 test.runIf(isServe)('scanner should not error with decorators', () => {
   expect(serverLogs).not.toStrictEqual(

--- a/playground/tsconfig-json/vite.config.ts
+++ b/playground/tsconfig-json/vite.config.ts
@@ -1,0 +1,42 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [transformCountPlugin()],
+})
+
+function transformCountPlugin(): Plugin {
+  const counts = new Map<string, number>()
+  let root = ''
+
+  return {
+    name: 'transform-count',
+    configResolved(config: ResolvedConfig) {
+      root = config.root
+    },
+    transform(_code, id) {
+      if (
+        !id.includes('\0') &&
+        !id.includes('node_modules') &&
+        /\.[jt]sx?$/.test(id)
+      ) {
+        const rel = path
+          .relative(root, id.split('?')[0])
+          .split(path.sep)
+          .join('/')
+        counts.set(rel, (counts.get(rel) ?? 0) + 1)
+      }
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url === '/transform-counts') {
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify(Object.fromEntries(counts)))
+          return
+        }
+        next()
+      })
+    },
+  }
+}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

## Summary

When a `tsconfig.json` changes, Vite currently invalidates every module in every environment regardless of whether the module actually referenced that tsconfig. In a monorepo with multiple `tsconfig.json` files, editing one config causes all unrelated modules to be re-transformed unnecessarily.

This PR replaces the nuclear option with scoped invalidation: only modules that actually used the changed tsconfig during their last transform are invalidated.

## Problem

Looking into the code to address this, `reloadOnTsconfigChange()` already had a `TODO` comment acknowledging the same problem.

```ts
// TODO: more finegrained invalidation than the nuclear option below

for (const environment of Object.values(server.environments)) {
  environment.moduleGraph.invalidateAll()  // invalidates everything
}
```

The root cause was the absence of a reverse index. `TsconfigResolutionCache` (a Rust native binding) only answers "which tsconfig applies to file X". It cannot be iterated from JS, so "which files referenced tsconfig Y" had no answer.

## Approach

During transform, record a reverse mapping of `tsconfig path → Set<source files>` in a `WeakMap<ResolvedConfig, Map<string, Set<string>>>`.

On tsconfig change, use that map to invalidate only the affected modules instead of calling `invalidateAll()`.

The `full-reload` signal is preserved. It's safe and appropriate since tsconfig option changes (e.g. `verbatimModuleSyntax`, `useDefineForClassFields`) affect module semantics globally. What changes is the scope of re-transformation, not the reload itself.

`create`/`delete` events still use the nuclear option. A new or removed tsconfig can silently change which config other files resolve to (tsconfig resolution walks up the directory tree). The reverse index cannot capture this, so we conservatively invalidate everything.

## Changes

- **`esbuild.ts`**: Add `tsconfigDependentFilesMap` reverse index + `registerTsconfigDependency()`. Populate it in the `transformWithEsbuild` watcher loop. Update `reloadOnTsconfigChange` to accept an `event` param and apply scoped invalidation on `update`.
- **`oxc.ts`**: Populate the same reverse index in `transformWithOxc` by calling `resolveTsconfig()` directly.
- **`server/index.ts`**: Pass the correct `event` value (`'create'` / `'delete'` / `'update'`) to `reloadOnTsconfigChange` at both call sites.

## Bug fixed along the way

`oxc.ts` already had code that appeared to populate the reverse index.

```ts
// looked correct but never executed
if (watcher && config && result.tsconfigFilePaths && result.tsconfigFilePaths.length > 0) {
  for (const tsconfigFile of result.tsconfigFilePaths) { ... }
}
```

`result` here is the return value of rolldown's `transformSync()`. rolldown only populates `tsconfigFilePaths` when `options.tsconfig === true`, but `OxcOptions` deliberately `Omit`s the `'tsconfig'` field (Vite manages tsconfig resolution itself via `TsconfigResolutionCache`). So `result.tsconfigFilePaths` was always an empty array and the block was unreachable.

Fix: call `resolveTsconfig()` from `rolldown/experimental` directly, passing the same shared cache, mirroring exactly what `esbuild.ts` does. This is a cache hit since `transformSync()` already populated the cache for the same file.

## Tests

**Unit tests** (`esbuild.spec.ts`): 6 new tests covering `reloadOnTsconfigChange`: verifying that `create`/`delete` call `invalidateAll`, `update` with registered dependents calls only `invalidateModule` for those files, `full-reload` is always sent, and non-tsconfig JSON files are ignored.

**Playground serve test** (`tsconfig-json`): Edits `nested/tsconfig.json` at runtime and asserts:
- `nested/main.ts` transform count increases (expected re-transform)
- `nested-with-extends/main.ts` transform count stays the same (proves scoped invalidation works: it lives in a separate tsconfig zone)

A `transformCountPlugin` was added to `playground/tsconfig-json/vite.config.ts` to expose per-file transform counts via `/transform-counts`, making the internal `transformResult` state observable from Playwright.

---

Feedback is welcome! Happy to hear suggestions for a better approach.