### PR TITLE
docs: add ios16.4 to the documented baseline-widely-available target

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -8,7 +8,7 @@ Unless noted, the options in this section are only applied to build.
 - **Default:** `'baseline-widely-available'`
 - **Related:** [Browser Compatibility](/guide/build#browser-compatibility)
 
-Browser compatibility target for the final bundle. The default value is a Vite special value, `'baseline-widely-available'`, which targets browsers that are included in the [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2026-01-01. Specifically, it is `['chrome111', 'edge111', 'firefox114', 'safari16.4']`.
+Browser compatibility target for the final bundle. The default value is a Vite special value, `'baseline-widely-available'`, which targets browsers that are included in the [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available on 2026-01-01. Specifically, it is `['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']`.
 
 Another special value is `'esnext'` - which assumes native dynamic imports support and will only perform minimal transpiling.
 


### PR DESCRIPTION
## Description

The documented default for `build.target` lists the resolved `'baseline-widely-available'` value as a 4-entry array, but the actual source constant is a 5-entry array — it's missing `'ios16.4'`.

In `packages/vite/src/node/constants.ts`, `ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET` is:

```js
['chrome111', 'edge111', 'firefox114', 'safari16.4', 'ios16.4']
```

`'ios16.4'` was added in #21342 ("feat: add ios to default esbuild targets") but the docs list in `docs/config/build-options.md` was never updated, so it still shows 4 entries. This aligns the documented default with the actual build behavior.

Docs-only, one token.
