### PR TITLE
fix: respect html accept header for fallback routes

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fsp from 'node:fs/promises'
+import type { ServerResponse } from 'node:http'
 import colors from 'picocolors'
 import type { ExistingRawSourceMap } from 'rolldown'
 import type { Connect } from '#dep-types/connect'
@@ -51,6 +52,26 @@ function isDocumentFetchDest(req: Connect.IncomingMessage) {
   return fetchDest !== undefined && documentFetchDests.has(fetchDest)
 }
 
+function acceptsHtml(req: Connect.IncomingMessage) {
+  return req.headers.accept?.includes('text/html')
+}
+
+function isDocumentRequest(req: Connect.IncomingMessage) {
+  return isDocumentFetchDest(req) || acceptsHtml(req)
+}
+
+function appendDocumentRequestVaryHeaders(
+  req: Connect.IncomingMessage,
+  res: ServerResponse,
+) {
+  if (isDocumentFetchDest(req)) {
+    res.appendHeader('Vary', 'Sec-Fetch-Dest')
+  }
+  if (acceptsHtml(req)) {
+    res.appendHeader('Vary', 'Accept')
+  }
+}
+
 // TODO: consolidate this regex pattern with the url, raw, and inline checks in plugins
 const urlRE = /[?&]url\b/
 const rawRE = /[?&]raw\b/
@@ -80,8 +101,8 @@ export function cachedTransformMiddleware(
   return function viteCachedTransformMiddleware(req, res, next) {
     const environment = server.environments.client
 
-    if (isDocumentFetchDest(req)) {
-      res.appendHeader('Vary', 'Sec-Fetch-Dest')
+    if (isDocumentRequest(req)) {
+      appendDocumentRequestVaryHeaders(req, res)
       return next()
     }
 
@@ -125,7 +146,7 @@ export function transformMiddleware(
     if (
       (req.method !== 'GET' && req.method !== 'HEAD') ||
       knownIgnoreList.has(req.url!) ||
-      isDocumentFetchDest(req)
+      isDocumentRequest(req)
     ) {
       return next()
     }

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -281,6 +281,15 @@ describe.runIf(isServe)('SPA fallback', () => {
     expect(content).toContain('Transformed')
     expect(content).not.toContain('This is test.js')
   })
+
+  test('should serve index.html for html requests when path matches file basename', async () => {
+    const response = await fetchHtml('/test')
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/html')
+    const content = await response.text()
+    expect(content).toContain('Transformed')
+    expect(content).not.toContain('This is test.js')
+  })
 })
 
 describe.runIf(isServe)('invalid', () => {


### PR DESCRIPTION
### Description

Fixes #3502.

Requests that explicitly accept `text/html` should be treated as document requests by the dev transform middleware. Without this, an extensionless SPA route such as `/test` can be transformed as `test.js` before the HTML fallback middleware gets a chance to serve `index.html`.

This also applies the same document-request check to the cached transform middleware so conditional HTML requests do not return cached module responses.

### Checks

- Checked open PRs for issue #3502 and related route/file-basename fallback coverage before opening this.
- Added a serve-mode HTML playground regression test for `Accept: text/html,*/*` on `/test`.

### Tests

- `pnpm --filter vite run build`
- `pnpm run test-serve html`
- `pnpm exec eslint --cache --concurrency auto packages/vite/src/node/server/middlewares/transform.ts playground/html/__tests__/html.spec.ts`