### PR TITLE
ci: set permissions for create-github-app-token

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -133,11 +133,14 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
+          client-id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
           private-key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
           repositories: |
             vite
             vite-ecosystem-ci
+          permission-issues: write
+          permission-pull-requests: write
+          permission-actions: write
 
       - name: Trigger Preview Release (if Package Not Found)
         if: fromJSON(steps.check-package.outputs.result).exists == false

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -138,9 +138,8 @@ jobs:
           repositories: |
             vite
             vite-ecosystem-ci
-          permission-issues: write
-          permission-pull-requests: write
-          permission-actions: write
+          permission-pull-requests: write # to add pr labels, add / delete comment reactions
+          permission-actions: write # to list workflow runs, to dispatch workflows
 
       - name: Trigger Preview Release (if Package Not Found)
         if: fromJSON(steps.check-package.outputs.result).exists == false


### PR DESCRIPTION
Set permissions to limit the permission explicitly.

https://docs.zizmor.sh/audits/#github-app

refs https://github.com/vitejs/vite/security/code-scanning/40
refs https://github.com/actions/create-github-app-token#permission-permission-name
