### PR TITLE
fix(build): register TypeScript extensions in registerCustomMime as text/javascript

### DIFF
--- a/packages/vite/src/node/__tests__/registerCustomMime.spec.ts
+++ b/packages/vite/src/node/__tests__/registerCustomMime.spec.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import * as mrmime from 'mrmime'
+import { registerCustomMime } from '../plugins/asset'
+
+const TS_EXTENSIONS = ['ts', 'tsx', 'mts', 'cts'] as const
+
+describe('registerCustomMime', () => {
+  let savedMimes: Partial<Record<string, string>>
+
+  beforeEach(() => {
+    savedMimes = Object.fromEntries(
+      TS_EXTENSIONS.map((ext) => [ext, mrmime.mimes[ext]]),
+    )
+  })
+
+  afterEach(() => {
+    for (const ext of TS_EXTENSIONS) {
+      const saved = savedMimes[ext]
+      if (saved === undefined) {
+        delete mrmime.mimes[ext]
+      } else {
+        mrmime.mimes[ext] = saved
+      }
+    }
+  })
+
+  test('overrides .ts from video/mp2t to text/javascript', () => {
+    // mrmime maps .ts to video/mp2t (MPEG-2 transport stream); wrong when inlining compiled worker files
+    expect(mrmime.lookup('worker.ts')).toBe('video/mp2t')
+    registerCustomMime()
+    expect(mrmime.lookup('worker.ts')).toBe('text/javascript')
+    expect(mrmime.lookup('worker.tsx')).toBe('text/javascript')
+    expect(mrmime.lookup('worker.mts')).toBe('text/javascript')
+    expect(mrmime.lookup('worker.cts')).toBe('text/javascript')
+  })
+})

--- a/packages/vite/src/node/__tests__/registerCustomMime.spec.ts
+++ b/packages/vite/src/node/__tests__/registerCustomMime.spec.ts
@@ -11,6 +11,12 @@ describe('registerCustomMime', () => {
     savedMimes = Object.fromEntries(
       TS_EXTENSIONS.map((ext) => [ext, mrmime.mimes[ext]]),
     )
+    // Reset to mrmime's original defaults — registerCustomMime() may have already
+    // been called by other test files that share this module graph (e.g. via assetPlugin()).
+    mrmime.mimes.ts = 'video/mp2t'
+    delete mrmime.mimes.tsx
+    delete mrmime.mimes.mts
+    delete mrmime.mimes.cts
   })
 
   afterEach(() => {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -71,6 +71,12 @@ export function registerCustomMime(): void {
   mrmime.mimes.flac = 'audio/flac'
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
   mrmime.mimes.eot = 'application/vnd.ms-fontobject'
+  // mrmime maps .ts to video/mp2t (MPEG-2 transport stream); TypeScript files compile to JavaScript in Vite
+  // https://github.com/vitejs/vite/issues/11823
+  mrmime.mimes.ts = 'text/javascript'
+  mrmime.mimes.tsx = 'text/javascript'
+  mrmime.mimes.mts = 'text/javascript'
+  mrmime.mimes.cts = 'text/javascript'
 }
 
 export function renderAssetUrlInJS(


### PR DESCRIPTION
mrmime maps `.ts` to `video/mp2t` (MPEG-2 transport stream) rather than a JavaScript type. When Vite inlines a `.ts`-origin file as a data URL — compiled worker scripts being the most visible case — it produces `data:video/mp2t;base64,...`, which browsers reject for worker and module scripts.

`registerCustomMime()` already overrides a handful of incorrect mrmime mappings (`.ico`, `.cur`, `.flac`, `.eot`). This adds overrides for `.ts`, `.tsx`, `.mts`, and `.cts` using `text/javascript`, the IANA-standardized JavaScript MIME type per RFC 9239. (`application/javascript` was deprecated by the same RFC.)

A unit test in `registerCustomMime.spec.ts` confirms the overrides take effect. Existing playground tests for worker inlining cover the full inlining path.

Fixes #11823