### PR TITLE
chore: fix tailwind playground comments

### DIFF
--- a/playground/tailwind-v3/tailwind.config.ts
+++ b/playground/tailwind-v3/tailwind.config.ts
@@ -5,7 +5,7 @@ import type { Config } from 'tailwindcss'
 export default {
   content: [
     // Before editing this section, make sure no paths are matching with `/src/main.js`
-    // Look https://github.com/vitejs/vite/pull/6959 for more details
+    // See https://github.com/vitejs/vite/pull/6959 for more details
     __dirname + '/src/{components,views}/**/*.js',
     __dirname + '/src/main.js',
   ],

--- a/playground/tailwind/tailwind.config.ts
+++ b/playground/tailwind/tailwind.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'tailwindcss'
 export default {
   content: [
     // Before editing this section, make sure no paths are matching with `/src/main.js`
-    // Look https://github.com/vitejs/vite/pull/6959 for more details
+    // See https://github.com/vitejs/vite/pull/6959 for more details
     import.meta.dirname + '/src/{components,views}/**/*.js',
     import.meta.dirname + '/src/main.js',
     import.meta.dirname + '/index.html',


### PR DESCRIPTION
Updates the Tailwind playground config comments to use the clearer wording "See ... for more details" when pointing to the related Vite PR.

Validation:
- `git diff --check`

No tests were run because this only updates comments in playground config files.