### PR TITLE
chore: clean up eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -88,29 +88,8 @@ export default defineConfig(
           tryExtensions: ['.ts', '.js', '.jsx', '.tsx', '.d.ts'],
         },
       ],
-      'n/no-extraneous-import': [
-        'error',
-        {
-          allowModules: [
-            'vite',
-            'esbuild',
-            'rolldown',
-            'less',
-            'sass',
-            'sass-embedded',
-            'terser',
-            'lightningcss',
-            'vitest',
-            'unbuild',
-          ],
-        },
-      ],
-      'n/no-extraneous-require': [
-        'error',
-        {
-          allowModules: ['vite'],
-        },
-      ],
+      'n/no-extraneous-import': 'error',
+      'n/no-extraneous-require': 'error',
       'n/prefer-node-protocol': 'error',
 
       '@typescript-eslint/ban-ts-comment': 'error',
@@ -276,17 +255,6 @@ export default defineConfig(
     },
   },
   {
-    name: 'disables/vite/types',
-    files: [
-      'packages/vite/src/types/**/*.{,c,m}[jt]s{,x}',
-      'packages/vite/scripts/**/*.{,c,m}[jt]s{,x}',
-      '**/*.spec.ts',
-    ],
-    rules: {
-      'n/no-extraneous-import': 'off',
-    },
-  },
-  {
     name: 'disables/vite/cjs',
     files: ['packages/vite/index.cjs'],
     rules: {
@@ -303,8 +271,6 @@ export default defineConfig(
     rules: {
       'no-undef': 'off',
       'n/no-missing-import': 'off',
-      'n/no-extraneous-import': 'off',
-      'n/no-extraneous-require': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
@@ -349,6 +315,7 @@ export default defineConfig(
     name: 'disables/dts',
     files: ['**/*.d.ts'],
     rules: {
+      'n/no-extraneous-import': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/triple-slash-reference': 'off',
     },
@@ -359,6 +326,7 @@ export default defineConfig(
     rules: {
       'no-console': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
+      'n/no-extraneous-import': 'off',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,9 +69,7 @@ export default defineConfig(
       'n/hashbang': 'error',
 
       eqeqeq: ['warn', 'always', { null: 'never' }],
-      'no-debugger': ['error'],
       'no-empty': ['warn', { allowEmptyCatch: true }],
-      'no-process-exit': 'off',
       'prefer-const': [
         'warn',
         {
@@ -92,7 +90,6 @@ export default defineConfig(
       'n/no-extraneous-require': 'error',
       'n/prefer-node-protocol': 'error',
 
-      '@typescript-eslint/ban-ts-comment': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': [
         'error',
@@ -106,11 +103,8 @@ export default defineConfig(
         'error',
         { allowInterfaces: 'with-single-extends' },
       ],
-      '@typescript-eslint/no-empty-interface': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      'no-extra-semi': 'off',
-      '@typescript-eslint/no-extra-semi': 'off', // conflicts with prettier
-      '@typescript-eslint/no-inferrable-types': 'off',
+      '@typescript-eslint/no-inferrable-types': 'off', // incompatible with `isolatedDeclarations`
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -123,7 +117,6 @@ export default defineConfig(
           ignoreRestSiblings: true,
         },
       ],
-      '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/consistent-type-imports': [
         'error',
         { prefer: 'type-imports', disallowTypeAnnotations: false },
@@ -239,6 +232,7 @@ export default defineConfig(
       'n/no-unsupported-features/es-builtins': 'off',
       'n/no-unsupported-features/node-builtins': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'no-undef': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -169,12 +169,6 @@ export default defineConfig(
           ],
         },
       ],
-      'sort-imports': [
-        'error',
-        {
-          ignoreDeclarationSort: true,
-        },
-      ],
 
       'regexp/prefer-regexp-exec': 'error',
       'regexp/prefer-regexp-test': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,6 @@ import pluginRegExp from 'eslint-plugin-regexp'
 import tseslint from 'typescript-eslint'
 import { defineConfig } from 'eslint/config'
 import globals from 'globals'
-import pkgVite from './packages/vite/package.json' with { type: 'json' }
 
 // Some rules work better with typechecking enabled, but as enabling it is slow,
 // we only do so when linting in IDEs for now. If you want to lint with typechecking
@@ -79,6 +78,7 @@ export default defineConfig(
           destructuring: 'all',
         },
       ],
+      'no-restricted-globals': ['error', 'require', '__dirname', '__filename'],
 
       'n/no-missing-require': [
         'error',
@@ -177,28 +177,10 @@ export default defineConfig(
     },
   },
   {
-    name: 'vite/globals',
-    files: ['packages/**/*.{,c,m}[jt]s{,x}'],
-    ignores: ['**/__tests__/**'],
-    rules: {
-      'no-restricted-globals': ['error', 'require', '__dirname', '__filename'],
-    },
-  },
-  {
     name: 'vite/node',
     files: ['packages/vite/src/node/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'no-console': ['error'],
-      'n/no-restricted-require': [
-        'error',
-        Object.keys(pkgVite.devDependencies).map((d) => ({
-          name: d,
-          message:
-            `devDependencies can only be imported using ESM syntax so ` +
-            `that they are included in the rolldown bundle. If you are trying to ` +
-            `lazy load a dependency, use (await import('dependency')).default instead.`,
-        })),
-      ],
     },
   },
   {
@@ -262,6 +244,7 @@ export default defineConfig(
       'no-undef': 'off',
       'no-empty': 'off',
       'no-constant-condition': 'off',
+      'no-restricted-globals': 'off',
       '@typescript-eslint/no-empty-function': 'off',
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -249,11 +249,7 @@ export default defineConfig(
     rules: {
       'n/no-unsupported-features/node-builtins': [
         'error',
-        {
-          // ideally we would like to allow all experimental features
-          // https://github.com/eslint-community/eslint-plugin-n/issues/199
-          ignores: ['fetch', 'import.meta.dirname'],
-        },
+        { allowExperimental: true },
       ],
     },
   },
@@ -266,11 +262,7 @@ export default defineConfig(
     rules: {
       'n/no-unsupported-features/node-builtins': [
         'error',
-        {
-          // ideally we would like to allow all experimental features
-          // https://github.com/eslint-community/eslint-plugin-n/issues/199
-          ignores: ['fetch', 'import.meta.dirname'],
-        },
+        { allowExperimental: true },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -249,33 +249,11 @@ export default defineConfig(
     },
   },
   {
-    name: 'disables/vite/cjs',
-    files: ['packages/vite/index.cjs'],
-    rules: {
-      'no-restricted-globals': 'off',
-      'n/no-missing-require': 'off',
-    },
-  },
-  {
-    name: 'disables/create-vite/templates',
-    files: [
-      'packages/create-vite/template-*/**/*.{,c,m}[jt]s{,x}',
-      '**/build.config.ts',
-    ],
-    rules: {
-      'no-undef': 'off',
-      'n/no-missing-import': 'off',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-    },
-  },
-  {
     name: 'disables/playground',
     files: ['playground/**/*.{,c,m}[jt]s{,x}', 'docs/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'n/no-extraneous-import': 'off',
       'n/no-extraneous-require': 'off',
-      'n/no-missing-import': 'off',
-      'n/no-missing-require': 'off',
       'n/no-unsupported-features/es-builtins': 'off',
       'n/no-unsupported-features/node-builtins': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -205,7 +205,7 @@ export default defineConfig(
   },
   {
     name: 'vite/globals',
-    files: ['packages/**/*.?([cm])[jt]s?(x)'],
+    files: ['packages/**/*.{,c,m}[jt]s{,x}'],
     ignores: ['**/__tests__/**'],
     rules: {
       'no-restricted-globals': ['error', 'require', '__dirname', '__filename'],
@@ -213,7 +213,7 @@ export default defineConfig(
   },
   {
     name: 'vite/node',
-    files: ['packages/vite/src/node/**/*.?([cm])[jt]s?(x)'],
+    files: ['packages/vite/src/node/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'no-console': ['error'],
       'n/no-restricted-require': [
@@ -230,7 +230,7 @@ export default defineConfig(
   },
   {
     name: 'playground/enforce-esm',
-    files: ['playground/**/*.?([cm])[jt]s?(x)'],
+    files: ['playground/**/*.{,c,m}[jt]s{,x}'],
     ignores: [
       'playground/ssr-resolve/**',
       'playground/**/*{commonjs,cjs}*/**',
@@ -245,7 +245,7 @@ export default defineConfig(
   },
   {
     name: 'tests',
-    files: ['**/__tests__/**/*.?([cm])[jt]s?(x)'],
+    files: ['**/__tests__/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'n/no-unsupported-features/node-builtins': [
         'error',
@@ -277,7 +277,7 @@ export default defineConfig(
 
   {
     name: 'disables/vite/client',
-    files: ['packages/vite/src/client/**/*.?([cm])[jt]s?(x)'],
+    files: ['packages/vite/src/client/**/*.{,c,m}[jt]s{,x}'],
     ignores: ['**/__tests__/**'],
     rules: {
       'n/no-unsupported-features/node-builtins': 'off',
@@ -286,8 +286,8 @@ export default defineConfig(
   {
     name: 'disables/vite/types',
     files: [
-      'packages/vite/src/types/**/*.?([cm])[jt]s?(x)',
-      'packages/vite/scripts/**/*.?([cm])[jt]s?(x)',
+      'packages/vite/src/types/**/*.{,c,m}[jt]s{,x}',
+      'packages/vite/scripts/**/*.{,c,m}[jt]s{,x}',
       '**/*.spec.ts',
     ],
     rules: {
@@ -305,7 +305,7 @@ export default defineConfig(
   {
     name: 'disables/create-vite/templates',
     files: [
-      'packages/create-vite/template-*/**/*.?([cm])[jt]s?(x)',
+      'packages/create-vite/template-*/**/*.{,c,m}[jt]s{,x}',
       '**/build.config.ts',
     ],
     rules: {
@@ -318,7 +318,7 @@ export default defineConfig(
   },
   {
     name: 'disables/playground',
-    files: ['playground/**/*.?([cm])[jt]s?(x)', 'docs/**/*.?([cm])[jt]s?(x)'],
+    files: ['playground/**/*.{,c,m}[jt]s{,x}', 'docs/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'n/no-extraneous-import': 'off',
       'n/no-extraneous-require': 'off',
@@ -338,8 +338,8 @@ export default defineConfig(
   {
     name: 'disables/playground/tsconfig-json',
     files: [
-      'playground/tsconfig-json/**/*.?([cm])[jt]s?(x)',
-      'playground/tsconfig-json-load-error/**/*.?([cm])[jt]s?(x)',
+      'playground/tsconfig-json/**/*.{,c,m}[jt]s{,x}',
+      'playground/tsconfig-json-load-error/**/*.{,c,m}[jt]s{,x}',
     ],
     ignores: ['**/__tests__/**'],
     rules: {
@@ -363,7 +363,7 @@ export default defineConfig(
   },
   {
     name: 'disables/test',
-    files: ['**/__tests__/**/*.?([cm])[jt]s?(x)'],
+    files: ['**/__tests__/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       'no-console': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
@@ -371,7 +371,7 @@ export default defineConfig(
   },
   {
     name: 'disables/test-dts',
-    files: ['**/__tests_dts__/**/*.?([cm])[jt]s?(x)'],
+    files: ['**/__tests_dts__/**/*.{,c,m}[jt]s{,x}'],
     rules: {
       // disable typecheck-specific rules
       '@typescript-eslint/no-duplicate-type-constituents': 'off',

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -506,8 +506,10 @@ describe('isFileReadable', () => {
     expect(isFileReadable('/does_not_exist')).toBe(false)
   })
 
-  const testFile =
-    require.resolve('./utils/isFileReadable/permission-test-file')
+  const testFile = path.resolve(
+    import.meta.dirname,
+    './utils/isFileReadable/permission-test-file',
+  )
   test('file with normal permission', async () => {
     expect(isFileReadable(testFile)).toBe(true)
   })

--- a/playground/optimize-deps/dep-with-optional-peer-dep-cjs/index.js
+++ b/playground/optimize-deps/dep-with-optional-peer-dep-cjs/index.js
@@ -4,6 +4,7 @@ exports.callItself = function () {
 
 exports.callPeerDep = function () {
   try {
+    // eslint-disable-next-line n/no-missing-require
     return require('foobar')
   } catch {
     return 'fallback'


### PR DESCRIPTION
- chore: avoid extglob syntax (https://github.com/vitejs/vite/commit/59fd9a0cc987ff4f7d5acd510bc4e8ad423895f8)
  - extglobs are not supported by oxlint. this change makes it easier to migrate to it later on
- chore: use allowExperimental (https://github.com/vitejs/vite/commit/a488a9331536f991a775f5394462d1dc7022440d)
  - `allowExperimental` for `n/no-unsupported-features/node-builtins` was implemented (https://github.com/eslint-community/eslint-plugin-n/issues/199)
- chore: simplify n/no-extraneous-* (https://github.com/vitejs/vite/commit/f7978670113d6aee317a3908a98caee2f4d80502)
  - disable these in tests and enable completely in other places
- chore: remove sort-imports (https://github.com/vitejs/vite/commit/669f8d97ed46dc87718252fa11b80eb58a9ec19f)
  - [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) conflicts [`import-x/order`](https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/order.md)
- chore: remove unused rules (https://github.com/vitejs/vite/commit/e5f3f4e4189309cc01efc975009ddfa8602acc12)
  - `packages/vite/index.cjs` does not exist
  - `build.config.ts` does not exist
  - `packages/create-vite/template-*/**` is already ignored
  - `n/no-missing-import` is not enabled anywhere
  - `n/no-missing-require` is better to be caught as it's rarely intentional
- chore: ban CJS globals globally (https://github.com/vitejs/vite/commit/d93455ae7744ccfbb32d33cc9cdedafd715cd1c5)
  - the codebase is ESM except for test fixtures now, so this would simplify the config
  - removed `n/no-restricted-require` because `require` it self is now banned
- chore: remove default value rule options (https://github.com/vitejs/vite/commit/a3bffb255eb053e2dacd5d275672c369ac309166)
  - removed `rules` entries that was no-op (e.g. specifying the default value)