### PR TITLE
fix(ssr): convert bundled CJS require() of node builtins for webworker SSR (fix #22618)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -55,6 +55,7 @@ import {
   joinUrlSegments,
   mergeConfig,
   mergeWithDefaults,
+  nodeLikeBuiltins,
   partialEncodeURIPath,
   setupRollupOptionCompat,
   unique,
@@ -667,8 +668,13 @@ export function resolveRolldownOptions(
 
   // For webworker SSR with platform: 'browser', external CJS require() calls
   // need to be converted to ESM imports since createRequire is not available.
+  // Without an `external` list the plugin matches nothing, so a bundled CJS
+  // dependency calling `require("<node builtin>")` (e.g. node-forge requiring
+  // "crypto") falls through to Rolldown's throwing `__require` stub. Pass the
+  // node-like builtins so those requires become ESM imports the runtime
+  // (e.g. workerd's nodejs_compat) can resolve.
   if (isSsrTargetWebworkerEnvironment) {
-    plugins.push(esmExternalRequirePlugin())
+    plugins.push(esmExternalRequirePlugin({ external: nodeLikeBuiltins }))
   }
 
   const buildOutputOptions = (output: OutputOptions = {}): OutputOptions => {

--- a/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
+++ b/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
@@ -30,11 +30,30 @@ test('supports nodejs_compat', async () => {
   )
 })
 
+test('converts require() of node builtins in bundled CJS deps', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.cjs-node-builtin')).toMatch(
+    '[success] cjs node builtin require',
+  )
+})
+
 test.runIf(isBuild)('build output does not contain createRequire', async () => {
   const workerContent = findAssetFile(/entry-worker/, 'worker', '')
   expect(workerContent).toBeDefined()
   expect(workerContent).not.toContain('createRequire')
 })
+
+test.runIf(isBuild)(
+  'converts bundled CJS require() of node builtins to ESM imports',
+  async () => {
+    const workerContent = findAssetFile(/entry-worker/, 'worker', '')
+    expect(workerContent).toBeDefined()
+    // `require("node:util")` nested in a bundled CJS module must become an ESM
+    // import, not Rolldown's throwing `__require` stub (fix for empty `external`)
+    expect(workerContent).not.toContain('__require("node:util")')
+    expect(workerContent).toContain('node:util')
+  },
+)
 
 test.runIf(isBuild)('codeSplitting: false', () => {
   const dynamicJsContent = findAssetFile(/dynamic-[-\w]+\.js/, 'worker')

--- a/playground/ssr-webworker/src/cjs-node-builtin.cjs
+++ b/playground/ssr-webworker/src/cjs-node-builtin.cjs
@@ -1,0 +1,7 @@
+// A bundled CommonJS module that internally `require()`s a Node builtin, the way
+// dependencies like node-forge do. Under `ssr.target: 'webworker'` this require
+// must be converted to an ESM import; otherwise it falls through to Rolldown's
+// throwing `__require` stub. Regression test for the empty-`external` gap.
+const util = require('node:util')
+module.exports.format = () =>
+  util.format('[success] %s', 'cjs node builtin require')

--- a/playground/ssr-webworker/src/entry-worker.jsx
+++ b/playground/ssr-webworker/src/entry-worker.jsx
@@ -3,6 +3,7 @@ import { msg as linkedMsg } from '@vitejs/test-resolve-linked'
 import browserExportsMessage from '@vitejs/test-browser-exports'
 import workerExportsMessage from '@vitejs/test-worker-exports'
 import React from 'react'
+import { format as cjsBuiltinRequire } from './cjs-node-builtin.cjs'
 
 let loaded = false
 import('./dynamic').then(({ foo }) => {
@@ -20,6 +21,7 @@ addEventListener('fetch', function (event) {
     <p class="browser-exports">${browserExportsMessage}</p>
     <p class="worker-exports">${workerExportsMessage}</p>
     <p class="nodejs-compat">${equal('a', 'a') || '[success] nodejs compat'}</p>
+    <p class="cjs-node-builtin">${cjsBuiltinRequire()}</p>
     `,
       {
         headers: {


### PR DESCRIPTION
### Description

Follow-up to #21963 (fix #21969), which added `esmExternalRequirePlugin()` for `ssr.target: 'webworker'` builds so external CJS `require()` becomes ESM imports (avoiding `createRequire(import.meta.url)`, which throws on workerd).

The plugin was invoked **with no `external` option**, so it matched nothing. A bundled CommonJS dependency that internally calls `require("<node builtin>")` — e.g. `node-forge` doing `require("crypto")` — therefore fell through to Rolldown's throwing `__require` stub:

```
Calling `require` for "crypto" in an environment that doesn't expose the `require` function.
```

This breaks on Cloudflare Workers (workerd), and fails the build outright when the SSR output is evaluated during analysis (e.g. SvelteKit `adapter-cloudflare`). Vite 7 / Rollup converted the same nested require to a static `import nodeCrypto from "crypto"`, so this is a regression for the webworker target.

Fixes #22618.

### Change

Pass `nodeLikeBuiltins` (the existing helper in `utils.ts`) as the plugin's `external`, so nested builtin `require()` in bundled CJS is converted to ESM imports that the runtime (workerd's `nodejs_compat`) resolves:

```ts
plugins.push(esmExternalRequirePlugin({ external: nodeLikeBuiltins }))
```

### Alternatives explored

- Setting `ssr.target: 'webworker'` alone — insufficient (this is exactly the gap).
- `ssr.noExternal: true` — builds, but `crypto` resolves to a browser stub missing `randomBytes` at runtime.
- Externalizing the offending dep (`ssr.external`) — the nested `require()` inside the bundled CJS wrapper still hits the throwing stub.

### Tests

Extends the `ssr-webworker` playground with a bundled CJS fixture that `require("node:util")`, plus a runtime assertion (executes under miniflare) and a build-output assertion (`require("node:util")` must become an import, not a `__require` stub). Verified these fail on `main` (`var util = __require("node:util")` + throwing stub) and pass with the change. Full `ssr-webworker` suite green in both serve and build modes.
