### PR TITLE
fix(resolve): show requested subpath in exports error

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/string-exports/index.js
+++ b/packages/vite/src/node/__tests__/fixtures/string-exports/index.js
@@ -1,0 +1,1 @@
+export default 'ok'

--- a/packages/vite/src/node/__tests__/fixtures/string-exports/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/string-exports/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-string-exports",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -4,6 +4,9 @@ import { createServer } from '../server'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
 import type { EnvironmentOptions, InlineConfig } from '../config'
 import { build } from '../build'
+import { DEFAULT_EXTENSIONS } from '../constants'
+import { tryNodeResolve } from '../plugins/resolve'
+import { nodeLikeBuiltins } from '../utils'
 
 describe('import and resolveId', () => {
   async function createTestServer() {
@@ -52,6 +55,35 @@ describe('import and resolveId', () => {
       'dir/index.default.js',
       expect.stringContaining('dir/index.module.js'),
     ])
+  })
+
+  test('tryNodeResolve reports the requested package subpath for missing string exports', () => {
+    const root = join(import.meta.dirname, 'fixtures/string-exports')
+
+    expect(() =>
+      tryNodeResolve(
+        '@vitejs/test-string-exports/missing',
+        join(root, 'index.js'),
+        {
+          root,
+          isBuild: true,
+          isProduction: true,
+          preferRelative: false,
+          tryIndex: true,
+          mainFields: [],
+          conditions: ['node'],
+          externalConditions: [],
+          external: [],
+          noExternal: [],
+          dedupe: [],
+          extensions: DEFAULT_EXTENSIONS,
+          preserveSymlinks: false,
+          tsconfigPaths: false,
+          packageCache: undefined,
+          builtins: nodeLikeBuiltins,
+        },
+      ),
+    ).toThrow(`Package subpath './missing' is not defined by "exports"`)
   })
 })
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1080,7 +1080,7 @@ function resolveDeepImport(
     }
     if (!relativeId) {
       throw new Error(
-        `Package subpath '${relativeId}' is not defined by "exports" in ` +
+        `Package subpath '${id}' is not defined by "exports" in ` +
           `${path.join(dir, 'package.json')}.`,
       )
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/scan-subpath-import-glob: {}
 
+  packages/vite/src/node/__tests__/fixtures/string-exports: {}
+
   packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}
 
   packages/vite/src/node/__tests__/fixtures/watch-rebuild-manifest: {}


### PR DESCRIPTION
### Description

When `resolveDeepImport` rejects a package deep import, it can clear the current relative id before formatting the error message. In the string-valued `exports` case, that reports `Package subpath 'undefined'` instead of the subpath that was actually requested.\n\nThis formats the exports error with the original requested `id`, so the diagnostic keeps the requested subpath. The regression test calls `tryNodeResolve` directly to cover the resolver helper without going through `nodeResolveWithVite`.\n\n### Tests\n\n- `npm exec --yes pnpm@10.34.1 -- --filter=./packages/vite run build-bundle`\n- `./node_modules/.bin/vitest run packages/vite/src/node/__tests__/resolve.spec.ts`\n- `npm exec --yes pnpm@10.34.1 -- lint`