### PR TITLE
fix(html): preserve inline module scripts with sideEffects allowlists (fix #22620)

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -111,10 +111,9 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
     resolveId: {
       filter: { id: isHtmlProxyRE },
       handler(id) {
-        return id
+        return { id, moduleSideEffects: 'no-treeshake' }
       },
     },
-
     load: {
       filter: { id: isHtmlProxyRE },
       handler(id) {
@@ -126,7 +125,7 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
           const result = htmlProxyMap.get(config)!.get(url)?.[index]
           if (result) {
             // set moduleSideEffects to keep the module even if `treeshake.moduleSideEffects=false` is set
-            return { ...result, moduleSideEffects: true }
+            return { ...result, moduleSideEffects: 'no-treeshake' }
           } else {
             throw new Error(`No matching HTML proxy module found from ${id}`)
           }

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -406,8 +406,18 @@ describe('side-effects', () => {
     await page.goto(viteTestUrl + '/side-effects/')
   })
 
-  test('console.log is not tree-shaken', async () => {
+  test('allowlisted external module script is not tree-shaken', async () => {
     expect(browserLogs).toContain('message from sideEffects script')
+  })
+
+  test('inline module script omitted from the sideEffects allowlist is not tree-shaken', async () => {
+    // Reproduces the Rollup -> Rolldown regression from #22620: the
+    // package.json sideEffects allowlist only includes ./sideEffects.js, but
+    // the generated HTML proxy module for this inline script must still run.
+    expect(browserLogs).toContain('message from inline sideEffects script')
+    expect(
+      await page.evaluate(() => globalThis.__inlineSideEffectsScript),
+    ).toBe('executed')
   })
 })
 

--- a/playground/html/side-effects/index.html
+++ b/playground/html/side-effects/index.html
@@ -1,2 +1,6 @@
 <h1>sideEffects false</h1>
 <script type="module" src="./sideEffects.js"></script>
+<script type="module">
+  console.log('message from inline sideEffects script')
+  globalThis.__inlineSideEffectsScript = 'executed'
+</script>

--- a/playground/html/side-effects/package.json
+++ b/playground/html/side-effects/package.json
@@ -2,5 +2,7 @@
   "name": "@vitejs/test-html-side-effects",
   "private": true,
   "version": "0.0.0",
-  "sideEffects": false
+  "sideEffects": [
+    "./sideEffects.js"
+  ]
 }


### PR DESCRIPTION
Closes #22620.

## Summary

- Mark generated HTML `?html-proxy` modules as `no-treeshake` during resolve and load so package `sideEffects` allowlists cannot prune inline module scripts.
- Add a playground regression that keeps an inline `<script type="module">` alongside an external module script under a restrictive `sideEffects` allowlist.

## Root cause

Inline HTML module scripts are represented as virtual `?html-proxy` modules. With Rolldown, the package `sideEffects` allowlist can be applied to that virtual module during resolution before the existing load-time side-effect marker is enough to protect it, so the inline script body can be treated as removable and dropped from the build.

The fix keeps the side-effect marker at the generated HTML proxy boundary. This matches the existing treatment for HTML entry modules and stays local to code Vite creates from HTML.

## Validation

- [x] `pnpm run build`
- [x] `pnpm run test-build html`
- [x] `pnpm run test-serve html`
- [x] `pnpm exec eslint --cache packages/vite/src/node/plugins/html.ts playground/html/__tests__/html.spec.ts --concurrency auto`
- [x] `git diff --check`

No documentation update is included because this restores expected build behavior and is covered by the regression test.

## Disclosure

Prepared with assistance from OpenAI Codex. I reviewed the final diff and ran the tests listed above locally.
