### PR TITLE
fix(resolve): disable rolldown native tsconfig paths to prevent windows duplication

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,7 +24,7 @@ You can learn more about the rationale behind the project in the [Why Vite](./wh
 
 During development, Vite assumes that a modern browser is used. This means the browser supports most of the latest JavaScript and CSS features. For that reason, Vite sets [`esnext` as the transform target](https://oxc.rs/docs/guide/usage/transformer/lowering.html#target). This prevents syntax lowering, letting Vite serve modules as close as possible to the original source code. Vite injects some runtime code to make the development server work. This code uses features included in [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available at the time of each major release (2026-01-01 for this major).
 
-For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. These are browsers that were released at least 2.5 years ago. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
+For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. That means it only uses features which have been available across browsers for at least 2.5 years. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
 
 ## Trying Vite Online
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -643,6 +643,7 @@ export function resolveRolldownOptions(
         ? 'strict'
         : false,
     // cache: options.watch ? undefined : false,
+    tsconfig: false,
     ...options.rolldownOptions,
     output: options.rolldownOptions.output,
     input,


### PR DESCRIPTION
Fixes #22506.

As suggested by @sapphi-red in #22513, disabling Rolldown's native tsconfig paths support prevents the issue where Windows builds duplicate modules when they are imported both relatively and via a `tsconfig.json` paths alias. Vite's own native `tsconfig.json` resolver already handles this, and leaving Rolldown's native support enabled causes a clash on Windows.