### PR TITLE
refactor: consolidate query regex patterns (fix #22625)

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -113,6 +113,9 @@ export const OPTIMIZABLE_ENTRY_RE: RegExp = /\.[cm]?[jt]s$/
 
 export const SPECIAL_QUERY_RE: RegExp = /[?&](?:worker|sharedworker|raw|url)\b/
 
+export const inlineRE: RegExp = /[?&]inline\b/
+export const noInlineRE: RegExp = /[?&]no-inline\b/
+
 /**
  * Prefix for resolved fs paths, since windows paths may not be valid as URLs.
  */

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -34,6 +34,8 @@ import {
   DEFAULT_ASSETS_INLINE_LIMIT,
   DEFAULT_ASSETS_RE,
   FS_PREFIX,
+  inlineRE,
+  noInlineRE,
 } from '../constants'
 import {
   cleanUrl,
@@ -47,9 +49,6 @@ import type { PartialEnvironment } from '../baseEnvironment'
 export const assetUrlRE: RegExp = /__VITE_ASSET__([\w$]+)__(?:\$_(.*?)__)?/g
 
 const jsSourceMapRE = /\.[cm]?js\.map$/
-
-export const noInlineRE: RegExp = /[?&]no-inline\b/
-export const inlineRE: RegExp = /[?&]inline\b/
 
 const assetCache = new WeakMap<Environment, Map<string, string>>()
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -51,6 +51,7 @@ import {
   DEV_PROD_CONDITION,
   ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET,
   SPECIAL_QUERY_RE,
+  inlineRE,
 } from '../constants'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
@@ -229,7 +230,6 @@ const directRequestRE = /[?&]direct\b/
 const htmlProxyRE = /[?&]html-proxy\b/
 const htmlProxyIndexRE = /&index=(\d+)/
 const commonjsProxyRE = /[?&]commonjs-proxy/
-const inlineRE = /[?&]inline\b/
 const inlineCSSRE = /[?&]inline-css\b/
 const styleAttrRE = /[?&]style-attr\b/
 const functionCallRE = /^[A-Z_][.\w-]*\(/i

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -6,7 +6,7 @@ import { type ImportSpecifier, init, parse } from 'es-module-lexer'
 import { viteWebWorkerPostPlugin as nativeWebWorkerPostPlugin } from 'rolldown/experimental'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
-import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
+import { ENV_ENTRY, ENV_PUBLIC_PATH, inlineRE } from '../constants'
 import {
   encodeURIPath,
   getHash,
@@ -154,7 +154,6 @@ export type WorkerType = 'classic' | 'module' | 'ignore'
 export const workerOrSharedWorkerRE: RegExp =
   /(?:\?|&)(worker|sharedworker)(?:&|$)/
 const workerFileRE = /(?:\?|&)worker_file&type=(\w+)(?:&|$)/
-const inlineRE = /[?&]inline\b/
 
 export const WORKER_FILE_ID = 'worker_file'
 const workerOutputCaches = new WeakMap<ResolvedConfig, WorkerOutputCache>()

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -15,6 +15,8 @@ import {
   prettifyUrl,
   removeImportQuery,
   removeTimestampQuery,
+  rawRE,
+  urlRE,
 } from '../../utils'
 import { send } from '../send'
 import { ERR_DENIED_ID, ERR_LOAD_URL } from '../transformRequest'
@@ -25,6 +27,7 @@ import {
   ERR_FILE_NOT_FOUND_IN_OPTIMIZED_DEP_DIR,
   ERR_OPTIMIZE_DEPS_PROCESSING_ERROR,
   FS_PREFIX,
+  inlineRE,
 } from '../../constants'
 import { isDirectCSSRequest, isDirectRequest } from '../../plugins/css'
 import { ERR_CLOSED_SERVER } from '../pluginContainer'
@@ -51,10 +54,6 @@ function isDocumentFetchDest(req: Connect.IncomingMessage) {
   return fetchDest !== undefined && documentFetchDests.has(fetchDest)
 }
 
-// TODO: consolidate this regex pattern with the url, raw, and inline checks in plugins
-const urlRE = /[?&]url\b/
-const rawRE = /[?&]raw\b/
-const inlineRE = /[?&]inline\b/
 const svgRE = /\.svg\b/
 
 export function isServerAccessDeniedForTransform(


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

<!-- What is this PR solving? Write a clear and concise description. -->
This PR resolves an outstanding `TODO` inside `packages/vite/src/node/server/middlewares/transform.ts`:
`// TODO: consolidate this regex pattern with the url, raw, and inline checks in plugins`

Previously, `urlRE`, `rawRE`, `inlineRE`, and `noInlineRE` were defined locally and duplicated across the transform middleware and multiple internal plugins (`asset.ts`, `css.ts`, and `worker.ts`).

This PR DRYs up the codebase by:
1. Moving `inlineRE` and `noInlineRE` to `packages/vite/src/node/constants.ts`.
2. Removing local regex definitions in `transform.ts`, `asset.ts`, `css.ts`, and `worker.ts`.
3. Importing the centralized versions from `constants.ts` and `utils.ts`.

<!-- Reference the issues it solves (e.g. `fixes #123`). -->
fixes #22625

<!-- What other alternatives have you explored? -->
Instead of adding `inlineRE` to `constants.ts`, I considered adding it to `utils.ts` alongside the existing `urlRE` and `rawRE` definitions. However, since `constants.ts` is explicitly designed for global Regex variables (e.g., `SPECIAL_QUERY_RE`, `CSS_LANGS_RE`), exporting them from `constants.ts` felt more semantically correct.

<!-- Are there any parts you think require more attention from reviewers? -->
No, this is a straightforward refactoring chore. All 800+ unit tests pass successfully.

---

### Checklist:
- [x] Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- [x] Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- [ ] Update the corresponding documentation if needed. *(N/A - internal code refactor)*
- [ ] Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why. *(N/A - this is a pure refactor; existing test suites cover these paths and pass successfully).*