### PR TITLE
docs: add v7→v8 migration entry for output.experimentalMinChunkSize removal

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -292,6 +292,31 @@ The `build.rollupOptions.watch.chokidar` option was removed. Please migrate to t
 
 The object form `output.manualChunks` option is not supported anymore. The function form `output.manualChunks` is deprecated. Rolldown has the more flexible [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option. See Rolldown's docs for more details about `codeSplitting`: [Manual Code Splitting - Rolldown](https://rolldown.rs/in-depth/manual-code-splitting).
 
+### Removed `build.rollupOptions.output.experimentalMinChunkSize` option
+
+The `output.experimentalMinChunkSize` Rollup option is not available in Rolldown. Use [`build.rolldownOptions.output.codeSplitting.minSize`](https://rolldown.rs/reference/OutputOptions.codeSplitting#minsize) instead:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  build: {
+    // before (Vite v7 with Rollup)
+    // rollupOptions: {
+    //   output: { experimentalMinChunkSize: 2000 }
+    // },
+
+    // after (Vite v8 with Rolldown)
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          minSize: 2000,
+        },
+      },
+    },
+  },
+})
+```
+
 ### `build()` Throws `BundleError`
 
 _This change only affects JS API users._


### PR DESCRIPTION
## Summary

Closes #21844

The `output.experimentalMinChunkSize` Rollup option was removed in Vite v8 (which uses Rolldown). This PR adds a migration guide section explaining the equivalent Rolldown option: `build.rolldownOptions.output.codeSplitting.minSize`.

The new section follows the existing pattern of sibling sections that document removed Rollup-specific options (e.g., `manualChunks`, `watch.chokidar`) and includes a before/after code snippet for clarity.

## Changes

- `docs/guide/migration.md`: add new `### Removed build.rollupOptions.output.experimentalMinChunkSize option` section with before/after code example

## Test plan
- [ ] Docs-only change; no code modified
- [ ] Before/after example compiles correctly (TypeScript syntax verified manually)