### PR TITLE
docs: correct `ssr.resolve.externalConditions` default value

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -42,7 +42,7 @@ These conditions are used in the plugin pipeline, and only affect non-externaliz
 ## ssr.resolve.externalConditions
 
 - **Type:** `string[]`
-- **Default:** `['node']`
+- **Default:** `['node', 'module-sync']`
 
 Conditions that are used during ssr import (including `ssrLoadModule`) of externalized direct dependencies (external dependencies imported by Vite).
 


### PR DESCRIPTION
## Description

The documented default for `ssr.resolve.externalConditions` is out of date.

The docs list:

```
- **Default:** `['node']`
```

But the source constant is `['node', 'module-sync']`:

```ts
// packages/vite/src/node/constants.ts
export const DEFAULT_EXTERNAL_CONDITIONS: readonly string[] = Object.freeze([
  'node',
  'module-sync',
])
```

and it's applied verbatim as the resolved default in `packages/vite/src/node/config.ts`:

```ts
externalConditions: [...DEFAULT_EXTERNAL_CONDITIONS],
```

`'module-sync'` was added to the default in #20409 (merged 2025-07-29) but the docs for this option were never updated. This PR brings the documented default back in sync with the actual runtime default — matching how the sibling `ssr.resolve.conditions` option documents its source constant.

Docs-only change.
