### PR TITLE
fix: make asset handling consistent between serve and build (fix #22646)

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -117,6 +117,7 @@ export const SPECIAL_QUERY_RE: RegExp = /[?&](?:worker|sharedworker|raw|url)\b/
  * Prefix for resolved fs paths, since windows paths may not be valid as URLs.
  */
 export const FS_PREFIX = `/@fs/`
+export const FS_RAW_PREFIX = `/@fs-raw/`
 
 export const CLIENT_PUBLIC_PATH = `/@vite/client`
 export const ENV_PUBLIC_PATH = `/@vite/env`

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -10,7 +10,6 @@ import {
   flattenId,
   isBuiltin,
   isCSSRequest,
-  isDataUrl,
   isExternalUrl,
   isNodeBuiltin,
   moduleListContains,
@@ -336,7 +335,8 @@ export function rolldownDepPlugin(
             }
 
             const url = rawUrl.slice(1, -1)
-            if (isDataUrl(url) || isExternalUrl(url) || url.startsWith('/')) {
+            if (!url.startsWith('.')) {
+              // This is not a relative url
               continue
             }
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_ASSETS_INLINE_LIMIT,
   DEFAULT_ASSETS_RE,
   FS_PREFIX,
+  FS_RAW_PREFIX,
 } from '../constants'
 import {
   cleanUrl,
@@ -321,10 +322,11 @@ export async function fileToUrl(
   pluginContext: PluginContext,
   id: string,
   asFileUrl = false,
+  raw: boolean = false,
 ): Promise<string> {
   const { environment } = pluginContext
   if (!environment.config.isBundled) {
-    return fileToDevUrl(environment, id, asFileUrl)
+    return fileToDevUrl(environment, id, asFileUrl, raw)
   } else {
     return fileToBuiltUrl(pluginContext, id)
   }
@@ -334,6 +336,7 @@ export async function fileToDevUrl(
   environment: Environment,
   id: string,
   asFileUrl = false,
+  raw: boolean,
 ): Promise<string> {
   const config = environment.getTopLevelConfig()
   const publicFile = checkPublicFile(id, config)
@@ -364,6 +367,8 @@ export async function fileToDevUrl(
   if (publicFile) {
     // in public dir during dev, keep the url as-is
     rtn = id
+  } else if (raw) {
+    rtn = path.posix.join(FS_RAW_PREFIX, id)
   } else if (id.startsWith(withTrailingSlash(config.root))) {
     // in project root, infer short public path
     rtn = '/' + path.posix.relative(config.root, id)

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -144,9 +144,9 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             try {
               if (publicDir && isParentDirectory(publicDir, file)) {
                 const publicPath = '/' + path.posix.relative(publicDir, file)
-                builtUrl = await fileToUrl(this, publicPath)
+                builtUrl = await fileToUrl(this, publicPath, undefined, true)
               } else {
-                builtUrl = await fileToUrl(this, file)
+                builtUrl = await fileToUrl(this, file, undefined, true)
                 // during dev, builtUrl may point to a directory or a non-existing file
                 if (tryStatSync(file)?.isFile()) {
                   this.addWatchFile(file)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -58,6 +58,8 @@ import {
   CLIENT_DIR,
   DEFAULT_DEV_PORT,
   defaultAllowedOrigins,
+  FS_PREFIX,
+  FS_RAW_PREFIX,
 } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
@@ -1011,11 +1013,14 @@ export async function _createServer(
     middlewares.use(triggerLazyBundlingMiddleware(server))
     middlewares.use(memoryFilesMiddleware(server))
   } else {
+    // serve static files from @fs-raw before transformMiddleware so that they are served as-is without transforms.
+    middlewares.use(serveRawFsMiddleware(server, FS_RAW_PREFIX))
+
     // main transform middleware
     middlewares.use(transformMiddleware(server))
 
     // serve static files
-    middlewares.use(serveRawFsMiddleware(server))
+    middlewares.use(serveRawFsMiddleware(server, FS_PREFIX))
     middlewares.use(serveStaticMiddleware(server))
   }
 

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -6,7 +6,6 @@ import escapeHtml from 'escape-html'
 import type { Connect } from '#dep-types/connect'
 import type { ViteDevServer } from '../../server'
 import type { ResolvedConfig } from '../../config'
-import { FS_PREFIX } from '../../constants'
 import {
   decodeURIIfPossible,
   fsPathFromUrl,
@@ -200,6 +199,7 @@ export function serveStaticMiddleware(
 
 export function serveRawFsMiddleware(
   server: ViteDevServer,
+  prefix: string,
 ): Connect.NextHandleFunction {
   const serveFromRoot = sirv(
     '/',
@@ -215,14 +215,14 @@ export function serveRawFsMiddleware(
     // reference assets that are also out of served root. In such cases
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by
     // searching based from fs root.
-    if (req.url!.startsWith(FS_PREFIX)) {
+    if (req.url!.startsWith(prefix)) {
       const url = new URL(req.url!, 'http://example.com')
       const pathname = decodeURIIfPossible(url.pathname)
       if (pathname === undefined) {
         return next()
       }
 
-      let newPathname = pathname.slice(FS_PREFIX.length)
+      let newPathname = pathname.slice(prefix.length)
       if (isWindows) newPathname = newPathname.replace(/^[A-Z]:/i, '')
       url.pathname = encodeURI(newPathname)
       req.url = url.href.slice(url.origin.length)

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -13,6 +13,7 @@ import {
   page,
   readFile,
   readManifest,
+  rootDir,
   serverLogs,
   viteTestUrl,
   watcher,
@@ -27,6 +28,9 @@ const encodedAssetMatch = isBuild
   : '/foo/bar/nested/asset[small].png'
 
 const iconMatch = `/foo/bar/icon.png`
+
+const fsPath = (filename: string) =>
+  `/foo/bar/@fs-raw${path.posix.join('/', rootDir.replaceAll('\\', '/'), filename)}`
 
 const fetchPath = (p: string) => {
   return fetch(path.posix.join(viteTestUrl, p), {
@@ -571,7 +575,7 @@ describe.runIf(isBuild)('encodeURI', () => {
 test('new URL(..., import.meta.url)', async () => {
   const imgMatch = isBuild
     ? /\/foo\/bar\/assets\/img-[-\w]{8}\.png/
-    : '/foo/bar/import-meta-url/img.png'
+    : fsPath('import-meta-url/img.png')
 
   expect(await page.textContent('.import-meta-url')).toMatch(imgMatch)
   if (isServe) {
@@ -597,7 +601,9 @@ test('new URL(..., import.meta.url)', async () => {
 })
 
 test('new URL("@/...", import.meta.url)', async () => {
-  expect(await page.textContent('.import-meta-url-dep')).toMatch(assetMatch)
+  expect(await page.textContent('.import-meta-url-dep')).toMatch(
+    isBuild ? assetMatch : fsPath('nested/asset.png'),
+  )
 })
 
 test('new URL("/...", import.meta.url)', async () => {
@@ -674,7 +680,7 @@ test("new URL(/* @vite-ignore */ 'non-existent', import.meta.url)", async () => 
 test('new URL(..., import.meta.url) (multiline)', async () => {
   const assetMatch = isBuild
     ? /\/foo\/bar\/assets\/asset-[-\w]{8}\.png/
-    : '/foo/bar/nested/asset.png'
+    : fsPath('nested/asset.png')
 
   expect(await page.textContent('.import-meta-url-multiline')).toMatch(
     assetMatch,

--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type { InlineConfig } from 'vite'
 import { build, createServer, preview } from 'vite'
 import { expect, test } from 'vitest'
@@ -7,6 +8,9 @@ const baseOptions = [
   { base: '', label: 'relative' },
   { base: '/', label: 'absolute' },
 ]
+
+const fsPath = (filename: string) =>
+  `/@fs-raw${path.posix.join('/', rootDir.replaceAll('\\', '/'), filename)}`
 
 const getConfig = (base: string): InlineConfig => ({
   base,
@@ -82,7 +86,7 @@ baseOptions.forEach(({ base, label }) => {
         // in serve there is no preloading
         expect(await getLinks()).toEqual([
           {
-            pathname: '/dynamic.css',
+            pathname: fsPath('dynamic.css'),
             rel: 'preload',
             as: 'style',
           },

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -348,11 +348,9 @@ test('long file name should work', async () => {
     .toMatch(`hello world`)
 })
 
-test.runIf(isServe)('warn on incompatible dependency', () => {
+test.runIf(isServe)('warn on unresolved included dependency', () => {
   expect(serverLogs).toContainEqual(
-    expect.stringContaining(
-      'The dependency might be incompatible with the dep optimizer.',
-    ),
+    expect.stringContaining('Failed to resolve dependency'),
   )
 })
 


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

In `serve` and `build` modes, vite behaves differently regarding assets referenced via the `new URL(..., import.meta.url)`:
- css assets go though the css transformation hooks in serve mode, not in build mode
- in `serve` mode, assets referencing a node_modules asset from the outside are wrongly rewritten (`new URL('my_package/asset.ext', import.meta.url)` are replaced by a broken relative path)

fixes https://github.com/vitejs/vite/discussions/22646

The solution investigated are in the discussion, in short:
- Adding a query parameter to the css asset url can break some usages
- Relying on request headers can break in a service-worker context

So the proposed solution relies on a new `/@fs-raw` prefix, allowing to load any file by it's absolute path without any transformation