### PR TITLE
chore: correct `parseAst`/`parseAstAsync` deprecation hints

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -21,9 +21,9 @@ export {
   type ESTree,
 } from 'rolldown/utils'
 
-/** @deprecated - use `parse` instead */
+/** @deprecated - use `parseSync` instead */
 export const parseAst: typeof _parseAst = _parseAst
-/** @deprecated - use `parseAsync` instead */
+/** @deprecated - use `parse` instead */
 export const parseAstAsync: typeof _parseAstAsync = _parseAstAsync
 
 export {


### PR DESCRIPTION
The `@deprecated` JSDoc hints for the re-exported `parseAst` / `parseAstAsync` pointed to the wrong replacements:

```ts
// before
/** @deprecated - use `parse` instead */
export const parseAst: typeof _parseAst = _parseAst
/** @deprecated - use `parseAsync` instead */
export const parseAstAsync: typeof _parseAstAsync = _parseAstAsync
```

Two problems:

1. `parseAst` is **synchronous** (returns `Program`), but the hint pointed to `parse`, which is **async** (`Promise<ParseResult>`). The correct sync replacement is `parseSync`.
2. `parseAstAsync` is **asynchronous**, but the hint pointed to `parseAsync` — a symbol Vite does not export (and which `rolldown/utils` doesn't expose; it was renamed to `parse`). The correct async replacement is `parse`.

The two suggestions were effectively swapped, and one referenced a non-existent export. This PR corrects them:

```ts
// after
/** @deprecated - use `parseSync` instead */
export const parseAst: typeof _parseAst = _parseAst
/** @deprecated - use `parse` instead */
export const parseAstAsync: typeof _parseAstAsync = _parseAstAsync
```

| API (deprecated) | Sync/Async | Replacement |
| --- | --- | --- |
| `parseAst` | sync (`Program`) | `parseSync` |
| `parseAstAsync` | async (`Promise<Program>`) | `parse` |

Both `parse` and `parseSync` are already re-exported from `rolldown/utils` in `packages/vite/src/node/index.ts`.

Docs-only change; no runtime behavior affected.