### PR TITLE
chore: add about AI prompt disclosure and duplicate difference to contribution guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Also, please make sure you do the following:
 
 - Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
 - Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
+- If you used AI, disclose the prompts used.
 - Update the corresponding documentation if needed.
 - Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,8 @@ For a mock dependency, make sure you add a `@vitejs/test-` prefix to the package
 
 - PR title must follow the [commit message convention](./.github/commit-convention.md) so that changelogs can be automatically generated.
 
-- If you used AI, disclose the prompts used in the pull request description. If the maintainers find a PR that is likely used AI that doesn't disclose the prompts, it may be closed without any explanation. If the prompt is generic, it may be closed with a comment.
+- If you used AI, disclose the prompts used in the pull request description. If the maintainers find a PR that likely used AI and doesn't disclose the prompts, it may be closed without any explanation. If the prompt is generic, it may be closed with a comment.
+
 
 - If there's already an existing PR that solves the same problem, make sure to link to it in the PR description and clarify what is different from it. If it is missing, the maintainers may close it without any explanation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,6 @@ For a mock dependency, make sure you add a `@vitejs/test-` prefix to the package
 
 - If you used AI, disclose the prompts used in the pull request description. If the maintainers find a PR that likely used AI and doesn't disclose the prompts, it may be closed without any explanation. If the prompt is generic, it may be closed with a comment.
 
-
 - If there's already an existing PR that solves the same problem, make sure to link to it in the PR description and clarify what is different from it. If it is missing, the maintainers may close it without any explanation.
 
 ## Maintenance Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,6 +245,10 @@ For a mock dependency, make sure you add a `@vitejs/test-` prefix to the package
 
 - PR title must follow the [commit message convention](./.github/commit-convention.md) so that changelogs can be automatically generated.
 
+- If you used AI, disclose the prompts used in the pull request description. If the maintainers find a PR that is likely used AI that doesn't disclose the prompts, it may be closed without any explanation. If the prompt is generic, it may be closed with a comment.
+
+- If there's already an existing PR that solves the same problem, make sure to link to it in the PR description and clarify what is different from it. If it is missing, the maintainers may close it without any explanation.
+
 ## Maintenance Guidelines
 
 > The following section is mostly for maintainers who have commit access, but it's helpful to go through if you intend to make non-trivial contributions to the codebase.


### PR DESCRIPTION
The pull requests that are **completely** generated by AI is not useful and takes maintainers' time unnecessarily.

This change tries to reduce that by adding two items in the Pull Request Guidelines:

- the prompts for AI should be disclosed, and if it's generic, we'll be closing the PR
- if a PR for the same problem already exists and doesn't have any explanation why there needs to be a new one, we'll be closing the PR without any explantion
