### PR TITLE
chore: update `create-react-app` links

### DIFF
--- a/packages/vite/bin/openChrome.js
+++ b/packages/vite/bin/openChrome.js
@@ -3,7 +3,7 @@ Copyright (c) 2015-present, Facebook, Inc.
 
 This source code is licensed under the MIT license found in the
 LICENSE file at
-https://github.com/facebook/create-react-app/blob/main/LICENSE
+https://github.com/react/create-react-app/blob/main/LICENSE
 */
 
 /* global Application */

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -1,10 +1,10 @@
 /**
  * The following is modified based on source found in
- * https://github.com/facebook/create-react-app
+ * https://github.com/react/create-react-app
  *
  * MIT Licensed
  * Copyright (c) 2015-present, Facebook, Inc.
- * https://github.com/facebook/create-react-app/blob/main/LICENSE
+ * https://github.com/react/create-react-app/blob/main/LICENSE
  *
  */
 
@@ -108,7 +108,7 @@ async function startBrowserProcess(
   // Another special case: on OS X, check if BROWSER has been set to "open".
   // In this case, instead of passing the string `open` to `open` function (which won't work),
   // just ignore it (thus ensuring the intended behavior, i.e. opening the system browser):
-  // https://github.com/facebook/create-react-app/pull/1690#issuecomment-283518768
+  // https://github.com/react/create-react-app/pull/1690#issuecomment-283518768
   if (process.platform === 'darwin' && browser === 'open') {
     browser = undefined
   }


### PR DESCRIPTION
Now `create-react-app` is (https://github.com/react/).