### PR TITLE
feat: customize bundled dev loading page

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -225,7 +225,7 @@ cli
           server: cleanGlobalCLIOptions(options),
           forceOptimizeDeps: options.force,
           experimental: {
-            bundledDev: options.experimentalBundle,
+            bundledDev: options.experimentalBundle ? true : undefined,
           },
         })
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -67,7 +67,11 @@ import {
   resolveBuildEnvironmentOptions,
   resolveBuilderOptions,
 } from './build'
-import type { ResolvedServerOptions, ServerOptions } from './server'
+import type {
+  ResolvedServerOptions,
+  ServerOptions,
+  ViteDevServer,
+} from './server'
 import { resolveServerOptions, serverConfigDefaults } from './server'
 import { DevEnvironment } from './server/environment'
 import { createRunnableDevEnvironment } from './server/environments/runnableEnvironment'
@@ -573,6 +577,52 @@ export interface FutureOptions {
   removeSsrLoadModule?: 'warn'
 }
 
+export interface BundledDevLoadingHtmlContext {
+  /**
+   * The default loading page HTML. Does NOT include the HMR runtime script;
+   * Vite always injects it into the returned HTML so the page reloads
+   * automatically when the bundle is ready.
+   */
+  defaultHtml: string
+  /** Decoded URL path being requested, e.g. `/index.html` */
+  path: string
+  server: ViteDevServer
+}
+
+export interface BundledDevOptions {
+  /**
+   * Custom HTML served while the bundle is being generated.
+   *
+   * A string replaces the default page. A function receives the default HTML and
+   * can tweak or replace it. Vite always injects the HMR runtime script into the
+   * returned HTML so the page reloads automatically when the bundle is ready.
+   *
+   * @example
+   * ```ts
+   * experimental: {
+   *   bundledDev: {
+   *     loadingHtml: '<!doctype html><h1>Loading...</h1>',
+   *   },
+   * }
+   * ```
+   *
+   * @example
+   * ```ts
+   * experimental: {
+   *   bundledDev: {
+   *     loadingHtml: ({ defaultHtml }) =>
+   *       defaultHtml.replace('Bundling in progress', 'Hold tight...'),
+   *   },
+   * }
+   * ```
+   *
+   * @experimental
+   */
+  loadingHtml?:
+    | string
+    | ((ctx: BundledDevLoadingHtmlContext) => string | Promise<string>)
+}
+
 export interface ExperimentalOptions {
   /**
    * Append fake `&lang.(ext)` when queries are specified, to preserve the file extension for following plugins to process.
@@ -603,10 +653,32 @@ export interface ExperimentalOptions {
    *
    * This is highly experimental.
    *
+   * Pass an object to customize the HTML served while the bundle is being
+   * generated. The HMR runtime script is always injected by Vite afterwards.
+   *
+   * @example
+   * ```ts
+   * experimental: {
+   *   bundledDev: {
+   *     loadingHtml: '<!doctype html><h1>Loading...</h1>',
+   *   },
+   * }
+   * ```
+   *
+   * @example
+   * ```ts
+   * experimental: {
+   *   bundledDev: {
+   *     loadingHtml: ({ defaultHtml }) =>
+   *       defaultHtml.replace('Bundling in progress', 'Hold tight...'),
+   *   },
+   * }
+   * ```
+   *
    * @experimental
    * @default false
    */
-  bundledDev?: boolean
+  bundledDev?: boolean | BundledDevOptions
 }
 
 export interface LegacyOptions {

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -108,6 +108,8 @@ export { loadEnv, resolveEnvPrefix } from './env'
 // additional types
 export type {
   AppType,
+  BundledDevLoadingHtmlContext,
+  BundledDevOptions,
   ConfigEnv,
   ExperimentalOptions,
   HTMLOptions,

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -120,7 +120,7 @@ async function createClientConfigValueReplacer(
     config.server.forwardConsole as any,
   )
   const bundleDevReplacement = escapeReplacement(
-    config.experimental.bundledDev || false,
+    !!config.experimental.bundledDev,
   )
 
   return (code) =>

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1484,11 +1484,11 @@ const bodyPrependInjectRE = /([ \t]*)<body[^>]*>/i
 
 const doctypePrependInjectRE = /<!doctype html>/i
 
-function injectToHead(
+export function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],
   prepend = false,
-) {
+): string {
   if (tags.length === 0) return html
 
   if (prepend) {

--- a/packages/vite/src/node/server/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/__tests__/indexHtml.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BundledDevOptions } from '../../config'
+import type { ViteDevServer } from '../index'
+import { generateFallbackHtml } from '../middlewares/indexHtml'
+
+vi.mock('../../plugins/clientInjections', () => ({
+  getHmrImplementation: () => 'console.log("</script>")',
+}))
+
+function createTestServer(bundledDev: true | BundledDevOptions): {
+  server: ViteDevServer
+  loggerError: ReturnType<typeof vi.fn>
+} {
+  const loggerError = vi.fn()
+
+  return {
+    server: {
+      config: {
+        logger: {
+          error: loggerError,
+        },
+        experimental: {
+          bundledDev,
+        },
+      },
+    } as ViteDevServer,
+    loggerError,
+  }
+}
+
+describe('bundled dev loading HTML', () => {
+  it('replaces the default page with a string option', async () => {
+    const { server } = createTestServer({
+      loadingHtml:
+        '<!doctype html><html><head></head><body>Custom</body></html>',
+    })
+
+    const html = await generateFallbackHtml(server)
+
+    expect(html).toContain('<body>Custom</body>')
+    expect(html).not.toContain('Bundling in progress')
+  })
+
+  it('injects the runtime script when custom HTML has no head', async () => {
+    const { server } = createTestServer({
+      loadingHtml: '<main>Custom</main>',
+    })
+
+    const html = await generateFallbackHtml(server)
+
+    expect(html).toContain('<script type="module">')
+    expect(html).toContain('console.log("<\\/script>")')
+    expect(html.indexOf('<script type="module">')).toBeLessThan(
+      html.indexOf('<main>Custom</main>'),
+    )
+  })
+
+  it('falls back to the default page when the function option throws', async () => {
+    const { server, loggerError } = createTestServer({
+      loadingHtml: () => {
+        throw new Error('broken loading page')
+      },
+    })
+
+    const html = await generateFallbackHtml(server, '/nested/index.html')
+
+    expect(html).toContain('Bundling in progress')
+    expect(loggerError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to generate bundled dev loading HTML'),
+    )
+  })
+})

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -15,6 +15,7 @@ import {
   htmlEnvHook,
   htmlProxyResult,
   injectCspNonceMetaTagHook,
+  injectToHead,
   injectNonceAttributeTagHook,
   nodeIsElement,
   overwriteAttrValue,
@@ -485,7 +486,12 @@ export function indexHtmlMiddleware(
           ((await fullBundle.triggerBundleRegenerationIfStale()) ||
             file === undefined)
         ) {
-          file = { source: await generateFallbackHtml(server as ViteDevServer) }
+          file = {
+            source: await generateFallbackHtml(
+              server as ViteDevServer,
+              pathname,
+            ),
+          }
         }
         if (!file) {
           return next()
@@ -559,15 +565,10 @@ function preTransformRequest(
   server.warmupRequest(decodedUrl)
 }
 
-async function generateFallbackHtml(server: ViteDevServer) {
-  const hmrRuntime = await getHmrImplementation(server.config)
-  return /* html */ `
+export const defaultBundledDevLoadingHtml = /* html */ `
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script type="module">
-    ${hmrRuntime.replaceAll('</script>', '<\\/script>')}
-  </script>
   <style>
     :root {
       --page-bg: #ffffff;
@@ -620,4 +621,44 @@ async function generateFallbackHtml(server: ViteDevServer) {
 </body>
 </html>
 `
+
+export async function generateFallbackHtml(
+  server: ViteDevServer,
+  path = '/index.html',
+): Promise<string> {
+  const { bundledDev } = server.config.experimental
+  const loadingHtml =
+    typeof bundledDev === 'object' ? bundledDev.loadingHtml : undefined
+
+  let html = defaultBundledDevLoadingHtml
+
+  if (typeof loadingHtml === 'string') {
+    html = loadingHtml
+  } else if (typeof loadingHtml === 'function') {
+    try {
+      html = await loadingHtml({
+        defaultHtml: defaultBundledDevLoadingHtml,
+        path,
+        server,
+      })
+    } catch (error) {
+      server.config.logger.error(
+        `Failed to generate bundled dev loading HTML. Falling back to the default page.\n${error instanceof Error ? error.stack || error.message : error}`,
+      )
+    }
+  }
+
+  const hmrRuntime = await getHmrImplementation(server.config)
+  return injectToHead(
+    html,
+    [
+      {
+        tag: 'script',
+        attrs: { type: 'module' },
+        children: hmrRuntime.replaceAll('</script>', '<\\/script>'),
+        injectTo: 'head-prepend',
+      },
+    ],
+    true,
+  )
 }

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -17,6 +17,7 @@ if (isBuild) {
     await expect
       .poll(() => page.textContent('body'))
       .toContain('Bundling in progress')
+    await expect.poll(() => page.textContent('h1')).toContain('(custom)')
     await reloadPromise // page shown after reload
     await expect.poll(() => page.textContent('h1')).toBe('HMR Full Bundle Mode')
     await expect.poll(() => page.textContent('.app')).toBe('hello')

--- a/playground/hmr-full-bundle-mode/vite.config.ts
+++ b/playground/hmr-full-bundle-mode/vite.config.ts
@@ -2,7 +2,10 @@ import { type Plugin, defineConfig } from 'vite'
 
 export default defineConfig({
   experimental: {
-    bundledDev: true,
+    bundledDev: {
+      loadingHtml: ({ defaultHtml }) =>
+        defaultHtml.replace('</h1>', ' (custom)</h1>'),
+    },
   },
   plugins: [waitBundleCompleteUntilAccess(), delayTransformComment()],
 })


### PR DESCRIPTION
Adds an `loadingHtml` option to `experimental.bundledDev` so apps can customize the temporary loading page while the dev bundle is generated.

Vite still injects the HMR runtime after resolving the custom HTML, so auto-reload keeps working.

Fixes #22665
