### PR TITLE
fix: respect resolve.external during dev import analysis

### DIFF
--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -1,7 +1,10 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { resolveConfig } from '../config'
-import { createIsConfiguredAsExternal } from '../external'
+import {
+  createIsConfiguredAsExternal,
+  isExplicitlyExternal,
+} from '../external'
 import { PartialEnvironment } from '../baseEnvironment'
 
 describe('createIsConfiguredAsExternal', () => {
@@ -13,6 +16,21 @@ describe('createIsConfiguredAsExternal', () => {
   test('force external', async () => {
     const isExternal = await createIsExternal(true)
     expect(isExternal('@vitejs/cjs-ssr-dep')).toBe(true)
+  })
+})
+
+describe('isExplicitlyExternal', () => {
+  test('matches only explicitly configured bare imports', () => {
+    expect(isExplicitlyExternal('vue', ['vue'])).toBe(true)
+    expect(isExplicitlyExternal('vue/server-renderer', ['vue'])).toBe(true)
+    expect(isExplicitlyExternal('react/jsx-runtime', ['react/jsx-runtime'])).toBe(
+      true,
+    )
+    expect(isExplicitlyExternal('@scope/pkg/subpath', ['@scope/pkg'])).toBe(
+      true,
+    )
+    expect(isExplicitlyExternal('@vitejs/dep', [])).toBe(false)
+    expect(isExplicitlyExternal('./local.js', true)).toBe(false)
   })
 })
 

--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -1,10 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { resolveConfig } from '../config'
-import {
-  createIsConfiguredAsExternal,
-  isExplicitlyExternal,
-} from '../external'
+import { createIsConfiguredAsExternal, isExplicitlyExternal } from '../external'
 import { PartialEnvironment } from '../baseEnvironment'
 
 describe('createIsConfiguredAsExternal', () => {
@@ -23,9 +20,9 @@ describe('isExplicitlyExternal', () => {
   test('matches only explicitly configured bare imports', () => {
     expect(isExplicitlyExternal('vue', ['vue'])).toBe(true)
     expect(isExplicitlyExternal('vue/server-renderer', ['vue'])).toBe(true)
-    expect(isExplicitlyExternal('react/jsx-runtime', ['react/jsx-runtime'])).toBe(
-      true,
-    )
+    expect(
+      isExplicitlyExternal('react/jsx-runtime', ['react/jsx-runtime']),
+    ).toBe(true)
     expect(isExplicitlyExternal('@scope/pkg/subpath', ['@scope/pkg'])).toBe(
       true,
     )

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -32,6 +32,26 @@ export function shouldExternalize(
   return isExternal(id, importer)
 }
 
+export function isExplicitlyExternal(
+  id: string,
+  external: true | string[] | undefined,
+): boolean {
+  if (!bareImportRE.test(id) || id.includes('\0')) {
+    return false
+  }
+  if (external === true) {
+    return true
+  }
+  if (!external?.length) {
+    return false
+  }
+  if (external.includes(id)) {
+    return true
+  }
+  const pkgName = getNpmPackageName(id)
+  return !!pkgName && external.includes(pkgName)
+}
+
 export function createIsConfiguredAsExternal(
   environment: PartialEnvironment,
 ): (id: string, importer?: string) => boolean {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -60,7 +60,7 @@ import { checkPublicFile } from '../publicDir'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import type { DevEnvironment } from '../server/environment'
-import { shouldExternalize } from '../external'
+import { isExplicitlyExternal, shouldExternalize } from '../external'
 import {
   optimizedDepInfoFromFile,
   optimizedDepNeedsInterop,
@@ -540,9 +540,16 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             ) {
               return
             }
-            // skip configured externals, ssr externals and builtins
+            // skip configured client externals, ssr externals and builtins
             if (!matchAlias(specifier)) {
-              if (shouldExternalize(environment, specifier, importer)) {
+              if (
+                ssr
+                  ? shouldExternalize(environment, specifier, importer)
+                  : isExplicitlyExternal(
+                      specifier,
+                      environment.config.resolve.external,
+                    )
+              ) {
                 return
               }
               if (

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -540,12 +540,15 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             ) {
               return
             }
-            // skip ssr externals and builtins
-            if (ssr && !matchAlias(specifier)) {
+            // skip configured externals, ssr externals and builtins
+            if (!matchAlias(specifier)) {
               if (shouldExternalize(environment, specifier, importer)) {
                 return
               }
-              if (isBuiltin(environment.config.resolve.builtins, specifier)) {
+              if (
+                ssr &&
+                isBuiltin(environment.config.resolve.builtins, specifier)
+              ) {
                 return
               }
             }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -93,7 +93,8 @@ export interface EnvironmentResolveOptions {
   noExternal?: string | RegExp | (string | RegExp)[] | true
   /**
    * Externalize the given dependencies and their transitive dependencies.
-   * Only works in server environments for now. Previously this was `ssr.external`.
+   * Also skips import analysis for externalized client imports during dev.
+   * Previously this was `ssr.external`.
    * @experimental
    */
   external?: string[] | true

--- a/playground/external/__tests__/external.spec.ts
+++ b/playground/external/__tests__/external.spec.ts
@@ -8,6 +8,7 @@ test('importmap', () => {
 })
 
 test('should have default exports', async () => {
+  expect(await page.textContent('#direct-vue-version')).toBe('3.4.38')
   expect(await page.textContent('#imported-slash5-exists')).toBe('true')
   expect(await page.textContent('#imported-slash3-exists')).toBe('true')
   expect(await page.textContent('#required-slash3-exists')).toBe('true')

--- a/playground/external/index.html
+++ b/playground/external/index.html
@@ -16,6 +16,7 @@
   </head>
   <body>
     <p>Imported Vue version: <span id="imported-vue-version"></span></p>
+    <p>Direct Vue version: <span id="direct-vue-version"></span></p>
     <p>Required Vue version: <span id="required-vue-version"></span></p>
     <p>Imported slash5 exists: <span id="imported-slash5-exists"></span></p>
     <p>Imported slash3 exists: <span id="imported-slash3-exists"></span></p>

--- a/playground/external/src/main.js
+++ b/playground/external/src/main.js
@@ -1,3 +1,6 @@
 import './require-polyfill'
+import { version } from 'vue'
 import '@vitejs/test-dep-that-imports'
 import '@vitejs/test-dep-that-requires'
+
+document.querySelector('#direct-vue-version').textContent = version

--- a/playground/external/vite.config.js
+++ b/playground/external/vite.config.js
@@ -22,6 +22,9 @@ const serveNpmCodeDirectlyMiddleware = async (req, res, next) => {
 }
 
 export default defineConfig({
+  resolve: {
+    external: ['vue'],
+  },
   optimizeDeps: {
     include: ['dep-that-imports', 'dep-that-requires'],
     exclude: ['vue', 'slash5'],


### PR DESCRIPTION
`resolve.external` already feeds Vite's externalization decision, but dev import analysis only skipped that path for SSR. That meant a client import configured as external could still be resolved and transformed by the dev server.

This lets configured externals bypass client import analysis too, while still preserving alias handling and the existing SSR builtin skip. The external playground now imports `vue` directly through an import map while `resolve.external` keeps it out of import analysis.

Validation: `node --check playground/external/vite.config.js`, `node --check playground/external/src/main.js`, and `git diff --check`.

Refs: https://github.com/vitejs/vite/issues/6582
