### PR TITLE
docs: How to set preview port from CLI

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -35,6 +35,8 @@ See [`server.allowedHosts`](./server-options#server-allowedhosts) for more detai
 
 Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on.
 
+This can be set via the CLI using `--port 8080`.
+
 **Example:**
 
 ```js


### PR DESCRIPTION
Dear Maintainers,

Thank you very much for your great tool. 

I discovered this useful "hidden" feature (`vite preview --port 9999`) by chance.
I suspect this could be of interest to other Vite users...  Hence here is a tiny contribution to your documentation.

Best regards,

Aurélien