### PR TITLE
feat(wasm): support source phase imports

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -663,7 +663,7 @@ These rules are enforced to prevent accidentally importing files that are not in
 
 ## WebAssembly
 
-Vite supports importing pre-compiled `.wasm` files in two ways: directly as an [ES module](#esm-integration) when you only need the module's exports, or with [`?init`](#manual-initialization) when you need explicit control over instantiation.
+Vite supports importing pre-compiled `.wasm` files directly as an [ES module](#esm-integration) when you only need the module's exports. When you need explicit control over instantiation, import the compiled module with a [source phase import](#source-phase-imports), or use [`?init`](#manual-initialization).
 
 ### ESM Integration
 
@@ -679,6 +679,8 @@ If the WebAssembly module declares imports of its own, Vite resolves them from J
 
 This follows the [WebAssembly/ES Module Integration proposal](https://github.com/WebAssembly/esm-integration). Because a WebAssembly module is instantiated asynchronously, a directly imported `.wasm` file behaves as an async module and requires top-level `await` support.
 
+Modules are compiled with the [JS String Builtins](https://github.com/WebAssembly/js-string-builtins) and [Imported String Constants](https://github.com/WebAssembly/js-string-builtins) proposals enabled, matching the WebAssembly/ES Module Integration loader.
+
 ::: tip TypeScript support
 
 Since the types of `.wasm` files are unknown, TypeScript will report errors like `Module '"*.wasm"' has no exported member 'add'`. To fix this, enable [`allowArbitraryExtensions`](https://www.typescriptlang.org/tsconfig/#allowArbitraryExtensions) in your `tsconfig.json` and create a declaration file next to your `.wasm` file. With `allowArbitraryExtensions` enabled, TypeScript will look for a declaration file named `{filename}.d.wasm.ts` when resolving a `.wasm` import. For example, for `add.wasm`, create `add.d.wasm.ts`:
@@ -688,6 +690,38 @@ export function add(a: number, b: number): number
 ```
 
 :::
+
+#### Source Phase Imports
+
+The ESM Integration proposal also defines [source phase imports](https://github.com/tc39/proposal-source-phase-imports) for `.wasm` files, giving you the compiled [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) without instantiating it, leaving instantiation entirely to you. This is the standard way to take control over instantiation and is the recommended alternative to [`?init`](#manual-initialization):
+
+```js
+import source mod from './example.wasm'
+
+// `mod` is a `WebAssembly.Module`; instantiate it whenever (and however) you like
+const instance = await WebAssembly.instantiate(mod)
+instance.exports.test()
+```
+
+Because you own the `WebAssembly.Instance`, you can satisfy the module's own imports and instantiate it as many times as needed:
+
+```js
+import source mod from './example.wasm'
+
+const instance = await WebAssembly.instantiate(mod, {
+  './imports.js': {
+    someFunc: () => {
+      /* ... */
+    },
+  },
+})
+```
+
+The dynamic form resolves to the `WebAssembly.Module` as well:
+
+```js
+const mod = await import.source('./example.wasm')
+```
 
 ### Manual Initialization
 
@@ -724,7 +758,7 @@ In the production build, `.wasm` files smaller than `assetsInlineLimit` will be 
 
 ::: warning For SSR build, Node.js compatible runtimes are only supported
 
-Due to the lack of a universal way to load a file, the internal implementation for both direct `.wasm` imports and `.wasm?init` relies on the `node:fs` module. This means that these features will only work in Node.js compatible runtimes for SSR builds.
+Due to the lack of a universal way to load a file, the internal implementation for direct `.wasm` imports, source phase imports, and `.wasm?init` relies on the `node:fs` module. This means that these features will only work in Node.js compatible runtimes for SSR builds.
 
 :::
 

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,15 +1,21 @@
 import fsp from 'node:fs/promises'
 import MagicString from 'magic-string'
+import {
+  init as esModuleLexerInit,
+  parse as parseImports,
+} from 'es-module-lexer'
 import { exactRegex } from 'rolldown/filter'
 import type { RolldownMagicString } from 'rolldown'
 import { createToImportMetaURLBasedRelativeRuntime } from '../build'
 import { type Plugin, perEnvironmentPlugin } from '../plugin'
 import { cleanUrl } from '../../shared/utils'
+import { injectQuery } from '../utils'
 import { assetUrlRE, fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper.js'
 
 const wasmInitRE = /(?<![?#].*)\.wasm\?init/
+const wasmSourceRE = /(?<![?#].*)\.wasm\?source/
 const wasmDirectRE = /(?<![?#].*)\.wasm$/
 
 // Lower "instance" layer of a directly imported `.wasm` module that exports a
@@ -19,6 +25,10 @@ const wasmDirectRE = /(?<![?#].*)\.wasm$/
 // thin wrapper around this layer that unwraps globals for JS consumers.
 const wasmInstanceSuffix = '?vite-wasm-instance'
 const wasmInstanceRE = /[?&]vite-wasm-instance(?:&|$)/
+
+// Detects the `import source` / `import.source(...)` phase forms cheaply so we
+// only run the full lexer pass over modules that actually use them.
+const wasmSourcePhaseRE = /\bimport\s+source\b|\bimport\s*\.\s*source\b/
 
 const wasmInitUrlRE: RegExp = /__VITE_WASM_INIT__([\w$]+)__/g
 
@@ -37,25 +47,34 @@ const wasmReservedModules = new Set<string>([
   wasmCompileOptions.importedStringConstants,
 ])
 
+// Decodes a base64 wasm data URL to bytes in both browser and SSR runtimes.
+const dataUrlToBytes = (url: string) => {
+  const urlContent = url.replace(/^data:.*?base64,/, '')
+  if (typeof Buffer === 'function' && typeof Buffer.from === 'function') {
+    return Buffer.from(urlContent, 'base64')
+  } else if (typeof atob === 'function') {
+    const binaryString = atob(urlContent)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i)
+    }
+    return bytes
+  }
+  throw new Error(
+    'Failed to decode base64-encoded data URL, Buffer and atob are not supported',
+  )
+}
+
+const dataUrlToBytesCode = dataUrlToBytes.toString()
+
 const wasmHelper = async (opts = {}, url: string) => {
   let result
   if (url.startsWith('data:')) {
-    const urlContent = url.replace(/^data:.*?base64,/, '')
-    let bytes
-    if (typeof Buffer === 'function' && typeof Buffer.from === 'function') {
-      bytes = Buffer.from(urlContent, 'base64')
-    } else if (typeof atob === 'function') {
-      const binaryString = atob(urlContent)
-      bytes = new Uint8Array(binaryString.length)
-      for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i)
-      }
-    } else {
-      throw new Error(
-        'Failed to decode base64-encoded data URL, Buffer and atob are not supported',
-      )
-    }
-    result = await WebAssembly.instantiate(bytes, opts, wasmCompileOptions)
+    result = await WebAssembly.instantiate(
+      dataUrlToBytes(url),
+      opts,
+      wasmCompileOptions,
+    )
   } else {
     result = await instantiateFromUrl(url, opts)
   }
@@ -63,6 +82,18 @@ const wasmHelper = async (opts = {}, url: string) => {
 }
 
 const wasmHelperCode = wasmHelper.toString()
+
+// Compiles a `.wasm` to a `WebAssembly.Module` without instantiating it, backing
+// the source phase import (`import source mod from './mod.wasm'`). Callers own
+// instantiation, mirroring the native source phase import semantics.
+const compileWasm = async (url: string) => {
+  if (url.startsWith('data:')) {
+    return WebAssembly.compile(dataUrlToBytes(url), wasmCompileOptions)
+  }
+  return compileFromUrl(url)
+}
+
+const compileWasmCode = compileWasm.toString()
 
 const instantiateFromUrl = async (url: string, opts?: WebAssembly.Imports) => {
   // https://github.com/mdn/webassembly-examples/issues/5
@@ -85,6 +116,22 @@ const instantiateFromUrl = async (url: string, opts?: WebAssembly.Imports) => {
 
 const instantiateFromUrlCode = instantiateFromUrl.toString()
 
+const compileFromUrl = async (url: string) => {
+  const response = await fetch(url)
+  const contentType = response.headers.get('Content-Type') || ''
+  if (
+    'compileStreaming' in WebAssembly &&
+    contentType.startsWith('application/wasm')
+  ) {
+    return WebAssembly.compileStreaming(response, wasmCompileOptions)
+  } else {
+    const buffer = await response.arrayBuffer()
+    return WebAssembly.compile(buffer, wasmCompileOptions)
+  }
+}
+
+const compileFromUrlCode = compileFromUrl.toString()
+
 const instantiateFromFile = async (
   fileUrlString: string,
   opts?: WebAssembly.Imports,
@@ -96,6 +143,15 @@ const instantiateFromFile = async (
 }
 
 const instantiateFromFileCode = instantiateFromFile.toString()
+
+const compileFromFile = async (fileUrlString: string) => {
+  const { readFile } = await import('node:fs/promises')
+  const fileUrl = new URL(fileUrlString, /** #__KEEP__ */ import.meta.url)
+  const buffer = await readFile(fileUrl)
+  return WebAssembly.compile(buffer, wasmCompileOptions)
+}
+
+const compileFromFileCode = compileFromFile.toString()
 
 export const wasmHelperPlugin = (): Plugin => {
   return perEnvironmentPlugin('vite:wasm-helper', (env) => {
@@ -109,11 +165,63 @@ export const wasmHelperPlugin = (): Plugin => {
         },
       },
 
+      // Rewrite source phase imports (`import source mod from './mod.wasm'` and
+      // the dynamic `import.source('./mod.wasm')`) to a plain import of the
+      // `?source` module, which resolves to a compiled `WebAssembly.Module`.
+      // This polyfills the proposal on top of Vite's existing module pipeline.
+      transform: {
+        filter: { code: wasmSourcePhaseRE },
+        async handler(code) {
+          await esModuleLexerInit
+          let imports: ReturnType<typeof parseImports>[0]
+          try {
+            ;[imports] = parseImports(code)
+          } catch {
+            return
+          }
+
+          let s: MagicString | undefined
+          for (const imp of imports) {
+            // 4 = `import source ...`, 5 = `import.source(...)`
+            if (imp.t !== 4 && imp.t !== 5) continue
+            const specifier = imp.n
+            if (specifier === undefined) continue
+            // Source phase imports are only meaningful for `.wasm` in Vite.
+            if (!wasmDirectRE.test(cleanUrl(specifier))) continue
+
+            s ??= new MagicString(code)
+            const sourced = injectQuery(specifier, 'source')
+            if (imp.t === 5) {
+              // `import.source(spec)` resolves to the module source object (the
+              // `WebAssembly.Module`), whereas `import(spec)` resolves to the
+              // namespace, so rewrite to `import(spec?source).then(m => m.default)`.
+              s.remove(imp.ss + 'import'.length, imp.d)
+              // For dynamic imports the specifier span includes the quotes.
+              s.update(imp.s, imp.e, JSON.stringify(sourced))
+              s.appendLeft(imp.se, '.then((m) => m.default)')
+            } else {
+              // Drop the `source` phase keyword, keeping `import x from ...`.
+              const keyword = imp.ss + 'import'.length
+              const offset = code.slice(keyword, imp.s).indexOf('source')
+              s.remove(keyword + offset, keyword + offset + 'source'.length + 1)
+              s.update(imp.s, imp.e, sourced)
+            }
+          }
+
+          if (!s) return
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: 'boundary' }),
+          }
+        },
+      },
+
       load: {
         filter: {
           id: [
             exactRegex(wasmHelperId),
             wasmInitRE,
+            wasmSourceRE,
             wasmDirectRE,
             wasmInstanceRE,
           ],
@@ -124,18 +232,22 @@ export const wasmHelperPlugin = (): Plugin => {
           if (id === wasmHelperId) {
             return `
 const wasmCompileOptions = ${JSON.stringify(wasmCompileOptions)}
+const dataUrlToBytes = ${dataUrlToBytesCode}
 const instantiateFromUrl = ${ssr ? instantiateFromFileCode : instantiateFromUrlCode}
+const compileFromUrl = ${ssr ? compileFromFileCode : compileFromUrlCode}
 export default ${wasmHelperCode}
+export const compileWasm = ${compileWasmCode}
 `
           }
 
           const isInit = wasmInitRE.test(id)
+          const isSource = wasmSourceRE.test(id)
           const isInstance = wasmInstanceRE.test(id)
           const cleanedId = isInstance ? cleanUrl(id) : id.split('?')[0]
 
           // Direct .wasm import (WASM ESM Integration)
           let wasmInfo: WasmInfo | undefined
-          if (!isInit) {
+          if (!isInit && !isSource) {
             wasmInfo = await parseWasm(cleanedId)
             // The user-facing module of a wasm that exports a global is a thin
             // wrapper that re-exports the instance layer, unwrapping globals for JS.
@@ -158,6 +270,13 @@ export default ${wasmHelperCode}
   import initWasm from "${wasmHelperId}"
   export default opts => initWasm(opts, ${JSON.stringify(url)})
   `
+          }
+
+          if (isSource) {
+            return `
+import { compileWasm } from "${wasmHelperId}"
+export default await compileWasm(${JSON.stringify(url)})
+`
           }
 
           const glueCode = generateInstanceGlue(wasmInfo!, {

--- a/playground/wasm/__tests__/wasm.spec.ts
+++ b/playground/wasm/__tests__/wasm.spec.ts
@@ -65,3 +65,21 @@ test('wasm using js-string builtins and imported string constants', async () => 
     .poll(() => page.textContent('.direct-wasm-string-builtins .result'))
     .toMatch('5')
 })
+
+test('source phase import yields a WebAssembly.Module', async () => {
+  await expect
+    .poll(() => page.textContent('.source-phase-wasm .result'))
+    .toMatch('3')
+})
+
+test('dynamic source phase import yields a WebAssembly.Module', async () => {
+  await expect
+    .poll(() => page.textContent('.source-phase-wasm-dynamic .result'))
+    .toMatch('7')
+})
+
+test('source phase import instantiated with imports', async () => {
+  await expect
+    .poll(() => page.textContent('.source-phase-wasm-with-imports .result'))
+    .toMatch('42')
+})

--- a/playground/wasm/index.html
+++ b/playground/wasm/index.html
@@ -63,6 +63,21 @@
   <span class="result"></span>
 </div>
 
+<div class="source-phase-wasm">
+  <h3>Source phase import, result should be 3</h3>
+  <span class="result"></span>
+</div>
+
+<div class="source-phase-wasm-dynamic">
+  <h3>Dynamic source phase import, result should be 7</h3>
+  <span class="result"></span>
+</div>
+
+<div class="source-phase-wasm-with-imports">
+  <h3>Source phase import instantiated with imports, result should be 42</h3>
+  <span class="result"></span>
+</div>
+
 <script type="module">
   import light from './light.wasm?init'
   import heavy from './heavy.wasm?init'
@@ -74,6 +89,9 @@
   import { getAnswerPlusOne, readCounter } from './global-consumer.wasm'
   import { bumpCounter } from './global.wasm'
   import { helloLength } from './string-constants.wasm'
+  import source addModule from './add.wasm'
+  import source lightWithImportsModule from './light-with-imports.wasm'
+  import { imported_func } from './imports.js'
 
   const w = new myWorker()
   w.addEventListener('message', (ev) => {
@@ -139,4 +157,24 @@
 
   import lightUrl from './light.wasm?url'
   text('.url', lightUrl)
+
+  // Source phase tests use top-level await, so they run after the listeners
+  // above are registered to avoid racing the test clicks.
+
+  // Source phase import: `addModule` is the compiled WebAssembly.Module, the
+  // consumer owns instantiation.
+  const addInstance = await WebAssembly.instantiate(addModule)
+  text('.source-phase-wasm .result', addInstance.exports.add(1, 2))
+
+  // Dynamic source phase import also yields a WebAssembly.Module.
+  const dynamicModule = await import.source('./add.wasm')
+  const dynamicInstance = await WebAssembly.instantiate(dynamicModule)
+  text('.source-phase-wasm-dynamic .result', dynamicInstance.exports.add(3, 4))
+
+  // Source phase import instantiated with the wasm's own imports satisfied.
+  const lwiInstance = await WebAssembly.instantiate(lightWithImportsModule, {
+    './imports.js': { imported_func },
+  })
+  lwiInstance.exports.exported_func()
+  text('.source-phase-wasm-with-imports .result', getResult())
 </script>


### PR DESCRIPTION
Follow-on to the WASM ESM Integration work, adding support for the [source phase import proposal](https://github.com/tc39/proposal-source-phase-imports) for `.wasm` files. A source phase import hands you the compiled `WebAssembly.Module` without instantiating it, so you own instantiation entirely — the standard alternative to `?init` for instantiation control:

```js
import source mod from './mod.wasm'

const instance = await WebAssembly.instantiate(mod, {
  './imports.js': { someFunc: () => {} },
})
```

The dynamic `import.source('./mod.wasm')` form resolves to the `WebAssembly.Module` as well.

Rather than rely on native `import source` support (which isn't available across all supported browsers or Node versions yet), this polyfills the proposal on top of Vite's existing module pipeline:

* `import source x from './m.wasm'` is rewritten to a plain `import x from './m.wasm?source'`, whose module resolves to a compiled `WebAssembly.Module`.
* `import.source('./m.wasm')` becomes `import('./m.wasm?source').then((m) => m.default)`, unwrapping the namespace default to match the native semantics where the promise resolves to the module source object.
* In SSR the `?source` module compiles via `node:fs`, so it works on every supported Node version regardless of whether the runtime understands the syntax. We can drop the polyfill and pass `import source` through natively once Node 22 reaches EOL (April 2027).

Source phase imports use the [JS String Builtins](https://github.com/WebAssembly/js-string-builtins) and Imported String Constants proposals on compile/instantiate, matching the WebAssembly/ES Module Integration loader.

Tests cover static and dynamic source phase imports, and source phase imports instantiated with the wasm module's own imports, in both serve and build. Docs are updated with a new "Source Phase Imports" section.
