### PR TITLE
chore: enable options enabled by default in pnpm v11

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,10 @@
       "pinDigests": true,
     },
     {
+      "matchDepTypes": ["npm"],
+      "minimumReleaseAge": "1440 minutes",
+    },
+    {
       "groupName": "rolldown-related dependencies",
       "matchDepNames": [
         "rolldown",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,8 @@ allowBuilds:
   unrs-resolver: true
   workerd: true
 
+minimumReleaseAge: 1440
+blockExoticSubdeps: true
 trustPolicy: no-downgrade
 trustPolicyExclude:
   - chokidar@4.0.3 # https://github.com/paulmillr/chokidar/issues/1440


### PR DESCRIPTION
pnpm v11 requires Node 22+ but we still support Node 20. Using Node 22+ just for `pnpm i` won't work because `pnpm run` may require Node 22+ as well.

This PR enables the options enabled by default in pnpm v11:

- `minimumReleaseAge: 1440` (also added the corresponding renovate option)
- `blockExoticSubdeps: true`

close #22425
