### PR TITLE
fix(html): emit HTML when root is symlinked

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,5 +1,6 @@
-import { basename, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { stripVTControlCharacters } from 'node:util'
+import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import colors from 'picocolors'
 import { afterEach, describe, expect, test, vi } from 'vitest'
@@ -277,6 +278,37 @@ describe('build', () => {
       (chunk) => chunk.fileName === 'foo.js',
     ) as OutputChunk
     expect(foo.code).not.contains('import "external"')
+  })
+
+  test('html entry should not escape root when root is symlinked', async () => {
+    // The bundler resolves the HTML entry id to its real path (symlinks
+    // resolved), while `config.root` is not. When the root is a symlink, the
+    // emitted file name would escape the root with `../`. See #21955.
+    const realRoot = resolve(dirname, 'fixtures/symlink-root')
+    // Create the symlink on the same drive as the fixture. On Windows,
+    // `path.relative` between different drives returns an absolute path, which
+    // is unrelated to the symlink resolution being tested here.
+    const tmp = join(dirname, 'fixtures', '.tmp-symlink-root')
+    fs.rmSync(tmp, { recursive: true, force: true })
+    fs.mkdirSync(tmp)
+    const linkedRoot = join(tmp, 'linked')
+    fs.symlinkSync(
+      realRoot,
+      linkedRoot,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    )
+
+    try {
+      const bundle = (await build({
+        root: linkedRoot,
+        logLevel: 'silent',
+        build: { write: false },
+      })) as RolldownOutput
+      const html = bundle.output.find((o) => o.fileName.endsWith('index.html'))
+      expect(html?.fileName).toBe('index.html')
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/vite/src/node/__tests__/fixtures/symlink-root/index.html
+++ b/packages/vite/src/node/__tests__/fixtures/symlink-root/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="module" src="/main.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/packages/vite/src/node/__tests__/fixtures/symlink-root/main.js
+++ b/packages/vite/src/node/__tests__/fixtures/symlink-root/main.js
@@ -1,0 +1,1 @@
+console.log('hello')

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -31,6 +31,7 @@ import {
   partialEncodeURIPath,
   processSrcSet,
   removeLeadingSlash,
+  safeRealpathSync,
   unique,
 } from '../utils'
 import type { ResolvedConfig } from '../config'
@@ -424,6 +425,24 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const isExcludedUrl = (url: string) =>
     url[0] === '#' || isExternalUrl(url) || isDataUrl(url)
 
+  // The `id` of an HTML file may be a real path while `config.root` is not.
+  // For example, this happens when the project root is symlinked.
+  // In that case, `path.relative(config.root, id)` returns a path with `../`.
+  // To handle this, retry the relative path against the real path of the root
+  // so that the result stays inside the root.
+  let realRoot: string | undefined
+  const relativePathFromRoot = (id: string): string => {
+    const relativePath = normalizePath(path.relative(config.root, id))
+    if (!relativePath.startsWith('../')) {
+      return relativePath
+    }
+    realRoot ??= normalizePath(safeRealpathSync(config.root))
+    const relativePathFromRealRoot = normalizePath(path.relative(realRoot, id))
+    return relativePathFromRealRoot.startsWith('../')
+      ? relativePath
+      : relativePathFromRealRoot
+  }
+
   // Same reason with `htmlInlineProxyPlugin`
   isAsyncScriptMap.set(config, new Map())
 
@@ -438,7 +457,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       filter: { id: /\.html$/ },
       async handler(html, id) {
         id = normalizePath(id)
-        const relativeUrlPath = normalizePath(path.relative(config.root, id))
+        const relativeUrlPath = relativePathFromRoot(id)
         const publicPath = `/${relativeUrlPath}`
         const publicBase = getBaseInHTML(relativeUrlPath, config)
 
@@ -899,9 +918,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         )
 
       for (const [normalizedId, html] of processedHtml(this)) {
-        const relativeUrlPath = normalizePath(
-          path.relative(config.root, normalizedId),
-        )
+        const relativeUrlPath = relativePathFromRoot(normalizedId)
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
         const toOutputFilePath = (
           filename: string,
@@ -1059,9 +1076,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           inlineEntryChunk.add(chunk.fileName)
         }
 
-        const shortEmitName = normalizePath(
-          path.relative(config.root, normalizedId),
-        )
+        const shortEmitName = relativePathFromRoot(normalizedId)
         this.emitFile({
           type: 'asset',
           originalFileName: normalizedId,


### PR DESCRIPTION
When the `root` was a symlinked directory, Vite failed to emit the HTML, because it calculates the relative path from the symlinked root directory to the real path of the HTML file. When the relative path ends up with `../`, `this.emitFile` errored.

This PR fixes that by try to calculate the relative path again from the realpath of the `root`. This isn't completely true because the symlink might be nested (e.g. `foo/bar/baz.html` and both `foo` and `bar` is a symlink), but this should cover most cases.

fixes #21955 that can be fixed on Vite side
