### PR TITLE
fix(css): skip Rolldown lazy proxy modules in bundledDev mode

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -229,6 +229,11 @@ const directRequestRE = /[?&]direct\b/
 const htmlProxyRE = /[?&]html-proxy\b/
 const htmlProxyIndexRE = /&index=(\d+)/
 const commonjsProxyRE = /[?&]commonjs-proxy/
+// In `experimental.bundledDev` mode, Rolldown wraps lazily-bundled modules in a
+// JavaScript proxy that keeps the original id and appends a `?rolldown-lazy`
+// query. For CSS the proxy id still matches `CSS_LANGS_RE`, so it must be
+// skipped to avoid running PostCSS over the JS proxy content.
+const rolldownLazyProxyRE = /[?&]rolldown-lazy/
 const inlineRE = /[?&]inline\b/
 const inlineCSSRE = /[?&]inline-css\b/
 const styleAttrRE = /[?&]style-attr\b/
@@ -367,7 +372,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: {
           include: CSS_LANGS_RE,
-          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE],
+          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE, rolldownLazyProxyRE],
         },
       },
       async handler(raw, id) {
@@ -531,7 +536,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: {
           include: CSS_LANGS_RE,
-          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE],
+          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE, rolldownLazyProxyRE],
         },
       },
       async handler(css, id) {
@@ -1185,7 +1190,7 @@ export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: {
           include: CSS_LANGS_RE,
-          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE],
+          exclude: [commonjsProxyRE, SPECIAL_QUERY_RE, rolldownLazyProxyRE],
         },
       },
       handler(_, id) {

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
 import { expect, test } from 'vitest'
-import { editFile, isBuild, page } from '~utils'
+import { editFile, getColor, isBuild, page } from '~utils'
 
 const assetUrl = /asset-[\w-]+\.png/
 
@@ -187,5 +187,9 @@ if (isBuild) {
   test('lazy bundling', async () => {
     await page.click('#load-dynamic')
     await expect.poll(() => page.textContent('.dynamic')).toBe('loaded')
+    // `dynamic.js` lazily imports `dynamic.css`. The CSS proxy module Rolldown
+    // emits (`dynamic.css?rolldown-lazy`) must be skipped by the `vite:css`
+    // transform instead of being parsed as CSS (#22651).
+    await expect.poll(() => getColor('.dynamic')).toBe('green')
   })
 }

--- a/playground/hmr-full-bundle-mode/dynamic.css
+++ b/playground/hmr-full-bundle-mode/dynamic.css
@@ -1,0 +1,3 @@
+.dynamic {
+  color: green;
+}

--- a/playground/hmr-full-bundle-mode/dynamic.js
+++ b/playground/hmr-full-bundle-mode/dynamic.js
@@ -1,4 +1,6 @@
-text('.dynamic', 'loaded')
+import('./dynamic.css').then(() => {
+  text('.dynamic', 'loaded')
+})
 
 function text(el, text) {
   document.querySelector(el).textContent = text


### PR DESCRIPTION
### Description

Fixes #22651.

In `experimental.bundledDev` mode, Rolldown wraps each lazily-bundled module in a JavaScript proxy that keeps the original id and appends a `?rolldown-lazy` query. For a lazily-imported CSS file the proxy id (e.g. `foo.css?rolldown-lazy=1`) still matches `CSS_LANGS_RE`, while it is **not** matched by the existing skip patterns (`commonjsProxyRE`, `SPECIAL_QUERY_RE`). As a result the `vite:css` plugin ran PostCSS over the JavaScript proxy content and threw, crashing the bundle:

```
[plugin vite:css] /path/to/global.css?rolldown-lazy=1:15:41
CssSyntaxError: [postcss] Unclosed string
```

The dev server never recovers — the browser stays on the "Bundling in progress" screen.

### Fix

Add a `rolldownLazyProxyRE` (`/[?&]rolldown-lazy/`) and exclude it from the three `vite:css` `transform` filters, so the lazy proxy is handled as the JavaScript module it actually is and the real CSS is still loaded through the normal lazy re-import.

### Tests

Extended the existing `hmr-full-bundle-mode` playground so the lazily-loaded module (`dynamic.js`) dynamically imports a CSS file, and the `lazy bundling` test now asserts the stylesheet is applied (`getColor('.dynamic') === 'green'`). The test fails without this change (the dynamic import rejects and `.dynamic` is never updated) and passes with it.

### Notes for reviewers

`?rolldown-lazy` only appears in `bundledDev` mode, so the new exclusion has no effect on the normal CSS pipeline — the full `playground/css` suite still passes. If maintainers would prefer routing the lazy CSS proxy away from CSS handling at a more central point (e.g. resolve/importAnalysis) rather than per-plugin, happy to adjust.