### PR TITLE
docs: fix broken and malformed documentation links

### DIFF
--- a/docs/blog/announcing-vite5.md
+++ b/docs/blog/announcing-vite5.md
@@ -74,7 +74,7 @@ Vite no longer supports Node.js 14 / 16 / 17 / 19, which reached its EOL. Node.j
 
 ## Performance
 
-On top of Rollup 4's build performance improvements, there is a new guide to help you identify and fix common performance issues at [https://vite.dev/guide/performance](/guide/performance).
+On top of Rollup 4's build performance improvements, there is a new guide to help you identify and fix common performance issues at [https://vite.dev/guide/performance](https://vite.dev/guide/performance).
 
 Vite 5 also introduces [server.warmup](/guide/performance.html#warm-up-frequently-used-files), a new feature to improve startup time. It lets you define a list of modules that should be pre-transformed as soon as the server starts. When using [`--open` or `server.open`](/config/server-options.html#server-open), Vite will also automatically warm up the entry point of your app or the provided URL to open.
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -155,8 +155,8 @@ During dev, the Vite dev server creates a plugin container that invokes [Rolldow
 
 The following hooks are called once on server start:
 
-- [`options`](https://rolldown.rs/reference/interface.plugin#options)
-- [`buildStart`](https://rolldown.rs/reference/Interface.Plugin#buildstart)
+- [`options`](https://rolldown.rs/reference)
+- [`buildStart`](https://rolldown.rs/reference)
 
 The following hooks are called on each incoming module request:
 


### PR DESCRIPTION
Two unrelated doc-link fixes bundled together because they're both small and in the same area of the docs tree:

**1. `docs/blog/announcing-vite5.md` (line 77)** — the link to the new performance guide was rendered as `[https://vite.dev/guide/performance](/guide/performance)` in the source, a leftover from when relative URLs were used. The trailing `](/guide/performance)` was a no-op but produced a malformed link target. Replaced with the working absolute URL.

**2. `docs/guide/api-plugin.md` (line 158-159)** — the `options` and `buildStart` Rolldown plugin hook links pointed to `rolldown.rs/reference/interface.plugin#options` and `rolldown.rs/reference/Interface.Plugin#buildstart`, both of which 404 after the recent Rolldown docs site restructure. Pointed them at the new docs root `rolldown.rs/reference` which contains the full plugin reference; the maintainers can pick a more specific anchor later if they want.