### PR TITLE
docs: fix broken rolldown plugin options link in api-plugin.md

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -155,7 +155,7 @@ During dev, the Vite dev server creates a plugin container that invokes [Rolldow
 
 The following hooks are called once on server start:
 
-- [`options`](https://rolldown.rs/reference/interface.plugin#options)
+- [`options`](https://rolldown.rs/reference/#plugins)
 - [`buildStart`](https://rolldown.rs/reference/Interface.Plugin#buildstart)
 
 The following hooks are called on each incoming module request:


### PR DESCRIPTION
## Summary

`docs/guide/api-plugin.md` linked to `https://rolldown.rs/reference/interface.plugin#options` for the plugin `options` field, but the `/reference/interface.plugin` page was removed in the rolldown v1 docs restructure. The URL now 404s.

## Fix

Point to the new `/reference/#plugins` anchor on the consolidated options & APIs reference page, which lists the plugin options alongside other configurable inputs.

```diff
-- `options`](https://rolldown.rs/reference/interface.plugin#options)
++ `options`](https://rolldown.rs/reference/#plugins)
```

Confirmed the new URL returns 200.