### PR TITLE
ci: use head commit date for ecosystem-ci freshness check

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -67,10 +67,16 @@ jobs:
             })
 
             const commentCreatedAt = new Date(context.payload.comment.created_at)
-            const commitPushedAt = new Date(pr.head.repo.pushed_at)
+
+            const { data: headCommit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha,
+            })
+            const commitPushedAt = new Date(headCommit.commit.committer.date)
 
             console.log(`Comment created at: ${commentCreatedAt.toISOString()}`)
-            console.log(`PR last pushed at: ${commitPushedAt.toISOString()}`)
+            console.log(`Head commit (${pr.head.sha}) date: ${commitPushedAt.toISOString()}`)
 
             // Check if any commits were pushed after the comment was created
             if (commitPushedAt > commentCreatedAt) {
@@ -78,7 +84,7 @@ jobs:
                 '⚠️ Security warning: PR was updated after the trigger command was posted.',
                 '',
                 `Comment posted at: ${commentCreatedAt.toISOString()}`,
-                `PR last pushed at: ${commitPushedAt.toISOString()}`,
+                `Head commit (${pr.head.sha}) date: ${commitPushedAt.toISOString()}`,
                 '',
                 'This could indicate an attempt to inject code after approval.',
                 'Please review the latest changes and re-run /ecosystem-ci run if they are acceptable.'


### PR DESCRIPTION
`pr.head.repo.pushed_at` is the repository-wide push timestamp of the repository, so a push to any unrelated branch bumps it. This causes a false "PR was updated after the trigger command was posted" security warning.

https://github.com/vitejs/vite/pull/22691#issuecomment-4716955550
