### PR TITLE
fix: hide console window when running 'net use' on Windows

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -721,7 +721,7 @@ function optimizeSafeRealPathSync() {
       return
     }
   }
-  exec('net use', (error, stdout) => {
+  exec('net use', { windowsHide: true }, (error, stdout) => {
     if (error) return
     const lines = stdout.split('\n')
     // OK           Y:        \\NETWORKA\Foo         Microsoft Windows Network


### PR DESCRIPTION
On Windows, `optimizeSafeRealPathSync()` in `packages/vite/src/node/utils.ts` runs `exec('net use', cb)` to detect mapped network drives during path resolution. The call passes no options, and Node's `child_process.exec` defaults `windowsHide` to `false`. When Vite's config is loaded by a **console-less** parent process, Windows allocates a new console for the `net use` child, and the default-terminal handoff renders it as a **visible terminal window that flashes up and steals focus**.

### Real-world impact
This is constantly triggered when running a Vite project inside an **Nx** workspace (`nx serve`). Nx's project-graph daemon reloads the Vite config in a console-less plugin worker on **every file save**, so `optimizeSafeRealPathSync` re-runs and a terminal window flashes on screen *every single time you save a file*. It steals focus mid-typing and makes the dev experience genuinely painful on Windows. Originally surfaced here: https://github.com/nrwl/nx-console/issues/2906#issuecomment-4322011244. There's a few other places where this issue is raised.

### Fix
Pass `{ windowsHide: true }` to the `exec` call so the spawned console is hidden. No behavioural change otherwise; `windowsHide` does nothing on macOS/Linux. The call is not `detached`, so it's unaffected by nodejs/node#21825.

### Tests
No automated test added: the symptom is Windows-only console-window creation, which isn't observable from Vitest. The `net use` output parsing is unchanged.

### Scope / other call sites
A few other `child_process` calls in the source also omit `windowsHide` (`execSync('yarn config get …')` in `server/index.ts`; the `spawn`/`exec` browser launch in `server/openBrowser.ts`).

I did not include fixes for those in this PR to keep this PR minimal? They only run once on dev server start up so it's not nearly as annoying. But happy to fix those as well if required.


EDIT: I guess additionally - we are running this patch on our own repositories within UQ and all popups are gone, no other impacts. Huge relief.