### PR TITLE
fix: skip compression wrapper for SSE responses

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -236,7 +236,24 @@ export async function preview(
     app.use(proxyMiddleware(httpServer, proxy, config))
   }
 
-  app.use(compression())
+  // @polka/compression wraps response methods before it decides whether
+  // to actually compress. For SSE (`text/event-stream`) this wrapping breaks
+  // HTTP/2 stream lifecycle when the client aborts the connection.
+  // Skip installing the wrapper for SSE.
+  app.use((req, res, next) => {
+    const contentType = (res as any).getHeader?.('Content-Type') as
+      | string
+      | undefined
+    const accept = req.headers['accept'] || ''
+
+    const isSSE =
+      contentType === 'text/event-stream' ||
+      (typeof accept === 'string' && accept.includes('text/event-stream'))
+
+    if (isSSE) return next()
+
+    return compression()(req, res, next)
+  })
 
   // base
   if (config.base !== '/') {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -240,10 +240,13 @@ export async function preview(
   // to actually compress. For SSE (`text/event-stream`) this wrapping breaks
   // HTTP/2 stream lifecycle when the client aborts the connection.
   // Skip installing the wrapper for SSE.
+  const compressionMiddleware = compression()
+
   app.use((req, res, next) => {
     const contentType = (res as any).getHeader?.('Content-Type') as
       | string
       | undefined
+
     const accept = req.headers['accept'] || ''
 
     const isSSE =
@@ -252,9 +255,8 @@ export async function preview(
 
     if (isSSE) return next()
 
-    return compression()(req, res, next)
+    return compressionMiddleware(req, res, next)
   })
-
   // base
   if (config.base !== '/') {
     app.use(baseMiddleware(config.rawBase, false))


### PR DESCRIPTION
Change is in packages/vite/src/node/preview.ts: preview now skips installing @polka/compression for SSE (text/event-stream) requests, preventing HTTP/2 stream lifecycle issues that caused concurrent fetches to stall.