### PR TITLE
docs(blog): correct VoidZero announcement URL in announcing-vite6

### DIFF
--- a/docs/blog/announcing-vite6.md
+++ b/docs/blog/announcing-vite6.md
@@ -43,7 +43,7 @@ Vite is used by OpenAI, Google, Apple, Microsoft, NASA, Shopify, Cloudflare, Git
 
 ## Speeding up the Vite ecosystem
 
-Last month, the community gathered for the third edition of [ViteConf](https://viteconf.org/24/replay), hosted once more by [StackBlitz](https://stackblitz.com). It was the biggest Vite conference, with a broad representation of builders from the ecosystem. Among other announcements, Evan You announced [VoidZero](https://staging.voidzero.dev/posts/announcing-voidzero-inc), a company dedicated to building an open-source, high-performance, and unified development toolchain for the JavaScript ecosystem. VoidZero is behind [Rolldown](https://rolldown.rs) and [Oxc](https://oxc.rs), and their team is making significant strides, getting them rapidly ready for being adopted by Vite. Watch Evan's keynote to learn more about the next steps for Vite's rust-powered future.
+Last month, the community gathered for the third edition of [ViteConf](https://viteconf.org/24/replay), hosted once more by [StackBlitz](https://stackblitz.com). It was the biggest Vite conference, with a broad representation of builders from the ecosystem. Among other announcements, Evan You announced [VoidZero](https://voidzero.dev/posts/announcing-voidzero-inc), a company dedicated to building an open-source, high-performance, and unified development toolchain for the JavaScript ecosystem. VoidZero is behind [Rolldown](https://rolldown.rs) and [Oxc](https://oxc.rs), and their team is making significant strides, getting them rapidly ready for being adopted by Vite. Watch Evan's keynote to learn more about the next steps for Vite's rust-powered future.
 
 <YouTubeVideo videoId="EKvvptbTx6k?si=EZ-rFJn4pDW3tUvp" />
 


### PR DESCRIPTION
## Summary

Drop the now-dead `staging.` prefix from the VoidZero announcement link in the Vite 6 launch blog post.

```diff
- Last month, the community gathered for the third edition of [ViteConf]...
+ Last month, the community gathered for the third edition of [ViteConf]...
```

- `staging.voidzero.dev/posts/announcing-voidzero-inc` → `voidzero.dev/posts/announcing-voidzero-inc`

The staging hostname no longer resolves. VoidZero moved the launch post to its canonical URL after coming out of stealth. Verified the replacement returns HTTP 200.

This is a historical link in an announcement blog post that referenced VoidZero's soft-launch staging site. The 404 was a result of VoidZero's own staging → production cutover, not a change in Vite's position.