### PR TITLE
fix: use literal envPrefix queries for Vite Task

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -95,7 +95,7 @@
     "@vercel/detect-agent": "^1.2.3",
     "@vitejs/devtools": "^0.3.3",
     "@vitest/utils": "4.1.8",
-    "@voidzero-dev/vite-task-client": "^0.1.1",
+    "@voidzero-dev/vite-task-client": "^0.2.0",
     "artichokie": "^0.4.3",
     "baseline-browser-mapping": "^2.10.37",
     "cac": "^7.0.0",

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -88,9 +88,9 @@ export function loadEnv(
   }
 
   // Vite Task may know prefixed envs not present here; fetch them and let
-  // the runner record each glob in the build's cache key.
+  // the runner record each prefix in the build's cache key.
   for (const prefix of prefixes) {
-    Object.assign(env, getEnvs(`${prefix}*`))
+    Object.assign(env, getEnvs({ prefix }))
   }
 
   // check if there are actual env variables starting with VITE_*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,8 +294,8 @@ importers:
         specifier: 4.1.8
         version: 4.1.8
       '@voidzero-dev/vite-task-client':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.2.0
+        version: 0.2.0
       artichokie:
         specifier: ^0.4.3
         version: 0.4.3
@@ -4849,8 +4849,8 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
-  '@voidzero-dev/vite-task-client@0.1.1':
-    resolution: {integrity: sha512-9zGnSzvzUOKNoMf4zxaDeAyerkvnsXBRWfbTkwhwHsVJFug3j48Et8kr+ulHf3KRdcLr07Np+xDuCvHYVK1k7w==}
+  '@voidzero-dev/vite-task-client@0.2.0':
+    resolution: {integrity: sha512-y932hw4I0qrdlqbDhOC4VS7mtLad+MtXToSVJIZ79Cd7Ib6p4bRuoTRrx6OeedhdPm2yf9+r8ndlhJjn8LbsxQ==}
     engines: {node: '>=18'}
 
   '@voidzero-dev/vitepress-theme@4.8.4':
@@ -11006,7 +11006,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-task-client@0.1.1': {}
+  '@voidzero-dev/vite-task-client@0.2.0': {}
 
   '@voidzero-dev/vitepress-theme@4.8.4(focus-trap@8.0.1)(vite@packages+vite)(vitepress@2.0.0-alpha.17)(vue@3.5.38)':
     dependencies:


### PR DESCRIPTION
## Problem

The Vite Task integration reports `envPrefix` values to `getEnvs` as glob patterns like `${prefix}*`. That creates a corner case where an `envPrefix` containing `*` is treated as a wildcard by the task client, while Vite itself treats `envPrefix` as a literal string prefix.

## Solution

Use the literal prefix query form from `@voidzero-dev/vite-task-client@0.2.0`, added in https://github.com/voidzero-dev/vite-task/pull/472, and call `getEnvs({ prefix })` for each configured `envPrefix`.

## Compatibility

This can move to the `0.2.0` client query form without released-compatibility fallout because no Vite Task release with `vite-task-client` client support has shipped yet. There is no released Vite Task version depending on the previous client query contract.