### PR TITLE
docs: fix broken Rolldown Plugin reference link in api-plugin.md

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -155,7 +155,7 @@ During dev, the Vite dev server creates a plugin container that invokes [Rolldow
 
 The following hooks are called once on server start:
 
-- [`options`](https://rolldown.rs/reference/interface.plugin#options)
+- [`options`](https://rolldown.rs/reference/Interface.Plugin#options)
 - [`buildStart`](https://rolldown.rs/reference/Interface.Plugin#buildstart)
 
 The following hooks are called on each incoming module request:


### PR DESCRIPTION
## Summary

Fixes a single broken external documentation link in `docs/guide/api-plugin.md`.

The link to Rolldown's plugin interface reference was using a lowercase `interface.plugin` path that returns HTTP 404. The correct URL (matching every other plugin-hook link in this same file: `buildStart`, `resolveId`, `load`, `transform`, `buildEnd`, `closeBundle`, `moduleParsed`) is the capitalized `Interface.Plugin` path on the same docs site.

## Diff

```diff
- - [`options`](https://rolldown.rs/reference/interface.plugin#options)
+ - [`options`](https://rolldown.rs/reference/Interface.Plugin#options)
```

## Verification

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://rolldown.rs/reference/interface.plugin#options
404

$ curl -s -o /dev/null -w "%{http_code}\n" -L https://rolldown.rs/reference/Interface.Plugin#options
200
```

The replacement URL is the canonical reference path used throughout the rest of `api-plugin.md` (lines for `buildStart`, `resolveId`, etc.).