### PR TITLE
fix(glob): respect caseSensitive option in hmr matcher

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -86,11 +86,13 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
             const affirmedMatcher = picomatch(affirmed, {
               noextglob: true,
               dot: !!i.options.exhaustive,
+              nocase: !(i.options.caseSensitive ?? true),
               ignore: i.options.exhaustive ? [] : ['**/node_modules/**'],
             })
             const negatedMatcher = picomatch(negated, {
               noextglob: true,
               dot: !!i.options.exhaustive,
+              nocase: !(i.options.caseSensitive ?? true),
               ignore: i.options.exhaustive ? [] : ['**/node_modules/**'],
             })
 


### PR DESCRIPTION
Follow up to #21707.

The HMR glob matchers in `importGlobPlugin` are meant to stay in sync with the file enumeration in `transformGlobImport`, but the `caseSensitive` option was only wired into the enumeration, not the matchers.

The tests are not added as this is an edge case.
