### PR TITLE
fix(html): omit nonce on import map when cspNonce is unset

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1233,7 +1233,7 @@ export function postImportMapHook(
       const importMap = bundle![getImportMapFilename(config)] as OutputAsset
       const importMapHtml = serializeTag({
         tag: 'script',
-        attrs: { type: 'importmap', nonce },
+        attrs: { type: 'importmap', ...(nonce ? { nonce } : {}) },
         children:
           typeof importMap.source === 'string'
             ? importMap.source


### PR DESCRIPTION
When `build.chunkImportMap` is enabled and `html.cspNonce` is not set, the generated `<script type="importmap">` was serialized with a literal `nonce="undefined"` attribute in the output HTML.

