### PR TITLE
fix(server): handle malformed URI in memory files middleware

### DIFF
--- a/packages/vite/src/node/server/middlewares/memoryFiles.ts
+++ b/packages/vite/src/node/server/middlewares/memoryFiles.ts
@@ -18,7 +18,13 @@ export function memoryFilesMiddleware(
       return next()
     }
 
-    const pathname = decodeURIComponent(cleanedUrl)
+    let pathname
+    try {
+      pathname = decodeURIComponent(cleanedUrl)
+    } catch {
+      // ignore malformed URI
+      return next()
+    }
     const filePath = pathname.slice(1) // remove first /
 
     const file = memoryFiles.get(filePath)


### PR DESCRIPTION
`memoryFilesMiddleware` (used in `experimental.bundledDev` full-bundle mode) decoded the request URL without guarding against malformed input.

Wrapped the decode in try/catch and `return next()` on failure, mirroring `htmlFallback.ts`.
