### PR TITLE
fix: cache falsy values in perEnvironmentState

### DIFF
--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -23,11 +23,9 @@ export function perEnvironmentState<State>(
   const stateMap = new WeakMap<Environment, State>()
   return function (context: PluginContext) {
     const { environment } = context
-    let state = stateMap.get(environment)
-    if (!state) {
-      state = initial(environment)
-      stateMap.set(environment, state)
+    if (!stateMap.has(environment)) {
+      stateMap.set(environment, initial(environment))
     }
-    return state
+    return stateMap.get(environment)!
   }
 }


### PR DESCRIPTION
`perEnvironmentState` is meant to memoize per-environment state in a `WeakMap`, but the cache-hit check used truthiness instead of presence.