### PR TITLE
fix(resolve): show requested subpath in exports error message

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1080,7 +1080,7 @@ function resolveDeepImport(
     }
     if (!relativeId) {
       throw new Error(
-        `Package subpath '${relativeId}' is not defined by "exports" in ` +
+        `Package subpath '${id}' is not defined by "exports" in ` +
           `${path.join(dir, 'package.json')}.`,
       )
     }


### PR DESCRIPTION
The "Package subpath is not defined by exports" error in `resolveDeepImport` always printed the literal string `undefined` instead of the requested subpath.

## Problem
- At the point the error is thrown, `relativeId` has just been set to `undefined` (no matching `exports` entry, or `exports` is a string/array).
- The message interpolated `${relativeId}`, so it always read `Package subpath 'undefined' is not defined by "exports" in ...`, never naming the path that actually failed.

## Fix
- Interpolate the `id` parameter, which holds the requested subpath (e.g. `./internal/foo`). The message now matches Node's own `ERR_PACKAGE_PATH_NOT_EXPORTED` wording and points at the real path. Diagnostic-only change.
