### PR TITLE
perf(hmr): avoid eager subChain allocation in propagateUpdate

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -850,8 +850,6 @@ function propagateUpdate(
   }
 
   for (const importer of node.importers) {
-    const subChain = currentChain.concat(importer)
-
     if (importer.acceptedHmrDeps.has(node)) {
       // acceptedHmrDeps has value only for js and css
       const boundary = importer as EnvironmentModuleNode & {
@@ -860,7 +858,10 @@ function propagateUpdate(
       boundaries.push({
         boundary,
         acceptedVia: node,
-        isWithinCircularImport: isNodeWithinCircularImports(importer, subChain),
+        isWithinCircularImport: isNodeWithinCircularImports(
+          importer,
+          currentChain.concat(importer),
+        ),
       })
       continue
     }
@@ -877,7 +878,12 @@ function propagateUpdate(
 
     if (
       !currentChain.includes(importer) &&
-      propagateUpdate(importer, traversedModules, boundaries, subChain)
+      propagateUpdate(
+        importer,
+        traversedModules,
+        boundaries,
+        currentChain.concat(importer),
+      )
     ) {
       return true
     }


### PR DESCRIPTION
In `propagateUpdate`, `subChain` was allocated at the top of the importer loop for every importer, but it is only used in two branches.

## Problem
- `const subChain = currentChain.concat(importer)` runs for every importer edge during HMR propagation.
- It is only consumed by the `acceptedHmrDeps` branch and the recursive call. The `acceptedHmrExports` branch `continue`s without ever using it — so for modules accepted via export bindings (e.g. barrel/re-export files with many importers), each allocation is immediately discarded.

## Fix
- Inline `currentChain.concat(importer)` at the two sites that actually use it, so the export-accepting `continue` path allocates nothing. The two sites are mutually exclusive, so this computes the chain at most once per importer. No behavior change.

## Tests
- No test is included: this is a behavior-preserving change that only defers an allocation, so there is no observable behavior difference to assert (a fails-without/passes-with test isn't possible). `propagateUpdate` correctness remains covered by the existing HMR tests and the `playground/hmr` e2e suite.
