### PR TITLE
refactor(server): index imported modules by url in soft invalidation

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -481,6 +481,15 @@ async function handleModuleSoftInvalidation(
     const s = new MagicString(source)
     const [imports] = parseImports(source, mod.id || undefined)
 
+    // index imported modules by url so the lookup below is O(1) per import
+    // instead of scanning the whole importedModules set each time
+    const importedModulesByUrl = new Map<string, EnvironmentModuleNode>()
+    for (const importedMod of mod.importedModules) {
+      if (!importedModulesByUrl.has(importedMod.url)) {
+        importedModulesByUrl.set(importedMod.url, importedMod)
+      }
+    }
+
     for (const imp of imports) {
       let rawUrl = source.slice(imp.s, imp.e)
       if (rawUrl === 'import.meta') continue
@@ -498,8 +507,8 @@ async function handleModuleSoftInvalidation(
           environment.config.base,
         ),
       )
-      for (const importedMod of mod.importedModules) {
-        if (importedMod.url !== hmrUrl) continue
+      const importedMod = importedModulesByUrl.get(hmrUrl)
+      if (importedMod) {
         if (importedMod.lastHMRTimestamp > 0) {
           const replacedUrl = injectQuery(
             urlWithoutTimestamp,
@@ -514,8 +523,6 @@ async function handleModuleSoftInvalidation(
           // pre-transform known direct imports
           environment.warmupRequest(hmrUrl)
         }
-
-        break
       }
     }
 


### PR DESCRIPTION
`handleModuleSoftInvalidation` rewrites import timestamps by scanning the whole `mod.importedModules` set for every parsed import, i.e. O(imports × importedModules).

## Change
- Build a `Map<url, EnvironmentModuleNode>` from `mod.importedModules` once, then look up each import's `hmrUrl` in O(1). The map keeps the first node per url, matching the previous `break`-on-first-match behavior.

This is a readability / scalability cleanup (linear instead of quadratic for modules with many imports, e.g. barrels). Behavior is unchanged.

## Tests
- No fails-without/passes-with test is included: this is a behavior-preserving change with identical output, so there is nothing new to assert. Soft-invalidation behavior is exercised by the `playground/hmr` e2e suite, and the existing `transformRequest` unit tests pass.
