### PR TITLE
refactor: remove unused removeRawQuery util

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -331,9 +331,6 @@ export const rawRE: RegExp = /(\?|&)raw(?:&|$)/
 export function removeUrlQuery(url: string): string {
   return url.replace(urlRE, '$1').replace(trailingSeparatorRE, '')
 }
-export function removeRawQuery(url: string): string {
-  return url.replace(rawRE, '$1').replace(trailingSeparatorRE, '')
-}
 
 export function injectQuery(url: string, queryToInject: string): string {
   const { file, postfix } = splitFileAndPostfix(url)


### PR DESCRIPTION
`removeRawQuery` is exported from `node/utils.ts` but is never used.

## Change
- Remove the function. It has no call sites anywhere in the repo, is not re-exported from the public `node/index.ts` entry, and is the only one of the four sibling query-stripping helpers (`removeImportQuery`, `removeDirectQuery`, `removeUrlQuery`) without a consumer. It was introduced in #15259 and its caller was later removed.
- The `rawRE` regex it used stays (still used by `dynamicImportVars`, `asset`, and the transform middleware), as does `trailingSeparatorRE`.

## Tests
- None: this only removes dead, unreferenced internal code with no behavior change, so there is nothing to assert.
