### PR TITLE
fix(css): preserve layer order statements during minification

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2232,7 +2232,8 @@ async function minifyCSS(
         )
       }
       // esbuild output does return a linebreak at the end
-      return inlined ? code.trimEnd() : code
+      const minifiedCss = restoreCssLayerOrderStatements(css, code)
+      return inlined ? minifiedCss.trimEnd() : minifiedCss
     } catch (e) {
       if (e.errors) {
         e.message = '[esbuild css minify] ' + e.message
@@ -2267,7 +2268,11 @@ async function minifyCSS(
     // Deno res.code = Uint8Array
     // For correct decode compiled css need to use TextDecoder
     // LightningCSS output does not return a linebreak at the end
-    return decoder.decode(code) + (inlined ? '' : '\n')
+    const minifiedCss = restoreCssLayerOrderStatements(
+      css,
+      decoder.decode(code),
+    )
+    return minifiedCss + (inlined ? '' : '\n')
   } catch (e) {
     e.message = `[lightningcss minify] ${e.message}`
     const friendlyMessage = getLightningCssErrorMessageForIeSyntaxes(css)
@@ -3199,6 +3204,31 @@ const absoluteOrProtocolRelativeUrlRE = /^(?:[a-z]+:)?\/\//i
 const importEsbuild = createCachedImport(() => import('esbuild'))
 
 const importLightningCSS = createCachedImport(() => import('lightningcss'))
+
+const cssLayerOrderStatementRE = /@layer[^;{}]*;/g
+
+function restoreCssLayerOrderStatements(
+  css: string,
+  minifiedCss: string,
+): string {
+  const statements = css.match(cssLayerOrderStatementRE)
+  if (!statements) {
+    return minifiedCss
+  }
+
+  const missingStatements = statements
+    .filter((statement) => /^@layer\s/.test(statement))
+    .map((statement) =>
+      statement.replace(/\s*,\s*/g, ',').replace(/\s+;/g, ';'),
+    )
+    .filter((statement) => !minifiedCss.includes(statement))
+
+  if (missingStatements.length === 0) {
+    return minifiedCss
+  }
+
+  return `${missingStatements.join('')}${minifiedCss}`
+}
 async function compileLightningCSS(
   environment: PartialEnvironment,
   id: string,

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -1,1 +1,13 @@
 import './tests'
+import { expect, test } from 'vitest'
+import { findAssetFile, isBuild } from '~utils'
+
+test.runIf(isBuild)(
+  'keeps CSS layer order statements across imported files',
+  () => {
+    const cssFile = findAssetFile(/index-[-\w]+\.css$/)
+    expect(cssFile).toContain(
+      '@layer layer-order-base,layer-order-reset,layer-order-utilities;',
+    )
+  },
+)

--- a/playground/css/layer-order/order.css
+++ b/playground/css/layer-order/order.css
@@ -1,0 +1,7 @@
+@layer layer-order-base, layer-order-reset, layer-order-utilities;
+
+@layer layer-order-base {
+  .layer-order-base {
+    color: green;
+  }
+}

--- a/playground/css/layer-order/vendor.css
+++ b/playground/css/layer-order/vendor.css
@@ -1,0 +1,11 @@
+@layer layer-order-reset {
+  .layer-order-reset {
+    color: red;
+  }
+}
+
+@layer layer-order-utilities {
+  .layer-order-utilities {
+    color: blue;
+  }
+}

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -52,6 +52,8 @@ import charset from './charset.css?inline'
 text('.charset-css', charset)
 
 import './layered/index.css'
+import './layer-order/vendor.css'
+import './layer-order/order.css'
 import './external.css'
 
 import './dep.css'


### PR DESCRIPTION
Fixes #22705

This keeps bare CSS `@layer` order statements when CSS minification drops them. Those statements are order-bearing across imported files, so losing them can change cascade precedence after build output is concatenated.

The regression fixture imports layer blocks and the order statement from separate CSS files, then checks that the built CSS still includes the minified order statement.

Tested with:

```sh
pnpm exec oxfmt --no-error-on-unmatched-pattern packages/vite/src/node/plugins/css.ts playground/css/__tests__/css.spec.ts playground/css/main.js playground/css/layer-order/vendor.css playground/css/layer-order/order.css
pnpm exec eslint --cache --concurrency auto packages/vite/src/node/plugins/css.ts playground/css/__tests__/css.spec.ts playground/css/__tests__/tests.ts
pnpm run build
VITE_TEST_BUILD=1 pnpm exec vitest run -c vitest.config.e2e.ts playground/css/__tests__/css.spec.ts playground/css/__tests__/lightningcss/lightningcss.spec.ts -- --runInBand
```