### PR TITLE
refactor(client): inline dev-id value in CSS selector

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -588,13 +588,9 @@ export function removeStyle(id: string): void {
     // re-select elements since HMR can replace links
     document
       .querySelectorAll<HTMLLinkElement>(
-        `link[rel="stylesheet"][data-vite-dev-id]`,
+        `link[rel="stylesheet"][data-vite-dev-id="${CSS.escape(id)}"]`,
       )
-      .forEach((el) => {
-        if (el.getAttribute('data-vite-dev-id') === id) {
-          el.remove()
-        }
-      })
+      .forEach((el) => el.remove())
     linkSheetsMap.delete(id)
   }
   const style = sheetsMap.get(id)


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
Use `data-vite-dev-id="\${CSS.escape(id)}"` as the CSS selector instead of selecting all `link[data-vite-dev-id]` elements and filtering by ID in JavaScript. This lets the browser's native selector engine do the matching, making the code simpler and slightly more efficient.
https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static