### PR TITLE
feat: allow esbuild 0.28

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -81,7 +81,7 @@
   },
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "esbuild": "^0.27.0",
+    "esbuild": "^0.27.0 || ^0.28.0",
     "fdir": "^6.5.0",
     "picomatch": "^4.0.3",
     "postcss": "^8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,7 +244,7 @@ importers:
   packages/vite:
     dependencies:
       esbuild:
-        specifier: ^0.27.0
+        specifier: ^0.27.0 || ^0.28.0
         version: 0.27.0
       fdir:
         specifier: ^6.5.0


### PR DESCRIPTION
# for v7

close #22684

Usually we'd just bump the range, but given this is for v7, probably not worth changing too much? [0.28](https://github.com/evanw/esbuild/releases/tag/v0.28.0) also doesn't have any significant changes that could affect users.