### PR TITLE
docs: clarify tsconfig resolution for each file

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -53,7 +53,11 @@ export type { T }
 
 ### TypeScript Compiler Options
 
-Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the `tsconfig.json` in the closest parent directory. If that `tsconfig.json` contains a [`references`](https://www.typescriptlang.org/tsconfig/#references) field, Vite will use the referenced config file that satisfies the [`include`](https://www.typescriptlang.org/tsconfig/#include) and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields.
+Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the closest parent `tsconfig.json` that matches the file:
+
+- A `tsconfig.json` matches when the file satisfies its [`files`](https://www.typescriptlang.org/tsconfig/#files), [`include`](https://www.typescriptlang.org/tsconfig/#include), and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields, or those of one of the config files listed in its [`references`](https://www.typescriptlang.org/tsconfig/#references) field.
+- If a `tsconfig.json` doesn't match, Vite keeps searching parent directories upward.
+- If no `tsconfig.json` matches the file, none of these options are applied.
 
 When the options are set in both the Vite config and the `tsconfig.json`, the value in the Vite config takes precedence.
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -53,7 +53,7 @@ export type { T }
 
 ### TypeScript Compiler Options
 
-Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the closest parent `tsconfig.json` or the config referenced by the [`references`](https://www.typescriptlang.org/tsconfig/#references) field in them if that config matches the file. Vite treats the config to match a file when the file satisfies the config's [`files`](https://www.typescriptlang.org/tsconfig/#files), [`include`](https://www.typescriptlang.org/tsconfig/#include), and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields.
+Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the closest parent `tsconfig.json` that matches the file, or a config referenced by its [`references`](https://www.typescriptlang.org/tsconfig/#references) field that matches the file. Vite treats a config as matching the file when the file satisfies the config's [`files`](https://www.typescriptlang.org/tsconfig/#files), [`include`](https://www.typescriptlang.org/tsconfig/#include), and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields.
 
 When the options are set in both the Vite config and the `tsconfig.json`, the value in the Vite config takes precedence.
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -53,11 +53,7 @@ export type { T }
 
 ### TypeScript Compiler Options
 
-Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the closest parent `tsconfig.json` that matches the file:
-
-- A `tsconfig.json` matches when the file satisfies its [`files`](https://www.typescriptlang.org/tsconfig/#files), [`include`](https://www.typescriptlang.org/tsconfig/#include), and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields, or those of one of the config files listed in its [`references`](https://www.typescriptlang.org/tsconfig/#references) field.
-- If a `tsconfig.json` doesn't match, Vite keeps searching parent directories upward.
-- If no `tsconfig.json` matches the file, none of these options are applied.
+Vite respects some of the options in `tsconfig.json` and sets the corresponding Oxc Transformer options. For each file, Vite uses the closest parent `tsconfig.json` or the config referenced by the [`references`](https://www.typescriptlang.org/tsconfig/#references) field in them if that config matches the file. Vite treats the config to match a file when the file satisfies the config's [`files`](https://www.typescriptlang.org/tsconfig/#files), [`include`](https://www.typescriptlang.org/tsconfig/#include), and [`exclude`](https://www.typescriptlang.org/tsconfig/#exclude) fields.
 
 When the options are set in both the Vite config and the `tsconfig.json`, the value in the Vite config takes precedence.
 


### PR DESCRIPTION
## Description

Follow-up to #22695 (upgrade to Rolldown 1.1.2). The old wording "Vite uses the `tsconfig.json` in the closest parent directory" was inaccurate: Vite walks up the directory tree and uses the closest `tsconfig.json` that **matches** the file, not simply the closest one.

The docs now state that:

- A config matches based on its `files`, `include`, and `exclude` fields, or those of one of its `references`.
- The search continues upward when a config doesn't match.
- No options are applied when no `tsconfig.json` matches the file.

Docs-only change.

## Notes for reviewers

Reference: #22695, [Rolldown v1.1.2](https://github.com/rolldown/rolldown/releases/tag/v1.1.2), and the [`tsconfig` input option docs](https://rolldown.rs/reference/InputOptions.tsconfig).
