### PR TITLE
fix(importAnalysis): don't treat a method named `import` as a dynamic import (fix #22750)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, onTestFinished, test, vi } from 'vitest'
 import { transformCjsImport } from '../../plugins/importAnalysis'
+import type { Plugin } from '../../plugin'
+import { createServer } from '../../server'
 
 describe('runTransform', () => {
   const config: any = {
@@ -182,5 +184,73 @@ describe('runTransform', () => {
        export default __vite__cjsExportDefault_0;
        import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js""
     `)
+  })
+})
+
+describe('dynamic import detection', () => {
+  // Drives the real vite:import-analysis transform over virtual `.js` modules (no mocks).
+  async function transformModules(modules: Record<string, string>) {
+    const plugin: Plugin = {
+      name: 'test:virtual-import-methods',
+      resolveId(id) {
+        if (id in modules) return '\0' + id
+      },
+      load(id) {
+        if (id[0] === '\0' && id.slice(1) in modules) {
+          return modules[id.slice(1)]
+        }
+      },
+    }
+    const server = await createServer({
+      configFile: false,
+      root: import.meta.dirname,
+      logLevel: 'error',
+      plugins: [plugin],
+      server: { middlewareMode: true, ws: false },
+    })
+    onTestFinished(() => server.close())
+    const result: Record<string, string | undefined> = {}
+    for (const id of Object.keys(modules)) {
+      result[id] = (await server.transformRequest(id))?.code
+    }
+    return result
+  }
+
+  test('does not rewrite a method or shorthand named `import`', async () => {
+    const result = await transformModules({
+      'method-async.js':
+        'export class A {\n  async import(keys, values) {\n    return keys + values\n  }\n}',
+      'method-shorthand.js':
+        'export const o = {\n  import(a, b) {\n    return a + b\n  },\n}',
+      'method-block-comment.js':
+        'export class B {\n  import(a, b) /* note */ {\n    return a + b\n  }\n}',
+      'method-line-comment.js':
+        'export class C {\n  import(a, b) // note\n  {\n    return a + b\n  }\n}',
+      // string-literal first arg (not valid runtime JS, but exercises the misreport)
+      'method-string-arg.js':
+        'export class D {\n  import("key", value) {\n    return value\n  }\n}',
+      'real-dynamic-import.js':
+        'export function load(name) {\n  return import(name)\n}',
+    })
+
+    expect(result['method-async.js']).toContain('import(keys, values)')
+    expect(result['method-async.js']).not.toContain('__vite__injectQuery')
+    expect(result['method-shorthand.js']).toContain('import(a, b)')
+    expect(result['method-shorthand.js']).not.toContain('__vite__injectQuery')
+    expect(result['method-block-comment.js']).toContain(
+      'import(a, b) /* note */',
+    )
+    expect(result['method-block-comment.js']).not.toContain(
+      '__vite__injectQuery',
+    )
+    expect(result['method-line-comment.js']).toContain('import(a, b)')
+    expect(result['method-line-comment.js']).not.toContain(
+      '__vite__injectQuery',
+    )
+    expect(result['method-string-arg.js']).toContain('import("key", value)')
+    expect(result['method-string-arg.js']).not.toContain('__vite__injectQuery')
+
+    // control: a real dynamic import is still rewritten
+    expect(result['real-dynamic-import.js']).toContain('__vite__injectQuery')
   })
 })

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -105,6 +105,42 @@ export function isExplicitImportRequired(url: string): boolean {
   return !isJSRequest(url) && !isCSSRequest(url)
 }
 
+/** es-module-lexer (v2+) misreports a method/shorthand named `import` as a dynamic import; a real one is never directly followed by `{`. */
+function isImportMethodDefinition(
+  source: string,
+  importExpEnd: number,
+): boolean {
+  let i = importExpEnd
+  while (i < source.length) {
+    const code = source.charCodeAt(i)
+    if (
+      code === 32 ||
+      code === 9 ||
+      code === 10 ||
+      code === 11 ||
+      code === 12 ||
+      code === 13
+    ) {
+      i++
+      continue
+    }
+    if (code === 47 && source.charCodeAt(i + 1) === 47) {
+      const newlineIndex = source.indexOf('\n', i + 2)
+      if (newlineIndex === -1) return false
+      i = newlineIndex + 1
+      continue
+    }
+    if (code === 47 && source.charCodeAt(i + 1) === 42) {
+      const blockCommentEnd = source.indexOf('*/', i + 2)
+      if (blockCommentEnd === -1) return false
+      i = blockCommentEnd + 2
+      continue
+    }
+    return code === 123 // '{'
+  }
+  return false
+}
+
 function normalizeResolvedIdToUrl(
   environment: DevEnvironment,
   url: string,
@@ -523,6 +559,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
 
           const isDynamicImport = dynamicIndex > -1
+
+          // es-module-lexer can misreport a method named `import` as a dynamic import; skip it.
+          if (isDynamicImport && isImportMethodDefinition(source, expEnd)) {
+            return
+          }
 
           // strip import attributes as we can process them ourselves
           if (!isDynamicImport && attributeIndex > -1) {

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -22,6 +22,21 @@ test('should load full dynamic import from public', async () => {
   ).toBe(false)
 })
 
+test('should not treat a method named `import` as a dynamic import', async () => {
+  // Methods named `import` must be left untouched (es-module-lexer misreports them).
+  await expect
+    .poll(() => page.textContent('.method-named-import'))
+    .toMatch('a,b c,d e,f')
+  // The method must not be reported as an un-analyzable dynamic import.
+  expect(
+    serverLogs.some(
+      (log) =>
+        log.includes('cannot be analyzed') &&
+        log.includes('method-named-import'),
+    ),
+  ).toBe(false)
+})
+
 test('should load data URL of `blob:`', async () => {
   await page.click('.issue-2658-1')
   await expect.poll(() => page.textContent('.view')).toMatch('blob')

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -45,8 +45,12 @@
 
 <div class="dynamic-import-nested-self"></div>
 
+<p>method-named-import</p>
+<div class="method-named-import">todo</div>
+
 <script type="module" src="./nested/index.js"></script>
 <script type="module" src="./(app)/nest/index.js"></script>
+<script type="module" src="./method-named-import.js"></script>
 <style>
   p {
     color: #0088ff;

--- a/playground/dynamic-import/method-named-import.js
+++ b/playground/dynamic-import/method-named-import.js
@@ -1,0 +1,24 @@
+// Regression: methods/shorthands named `import` must not be rewritten as dynamic imports.
+export class Repo {
+  async import(keys, values) {
+    return `${keys},${values}`
+  }
+}
+
+export const repoLike = {
+  import(a, b) {
+    return `${a},${b}`
+  },
+}
+
+// comment between params and body
+export class Commented {
+  import(a, b) /* note */ {
+    return `${a},${b}`
+  }
+}
+
+new Repo().import('a', 'b').then((classResult) => {
+  document.querySelector('.method-named-import').textContent =
+    `${classResult} ${repoLike.import('c', 'd')} ${new Commented().import('e', 'f')}`
+})


### PR DESCRIPTION
### Description

In the dev server, a class/object method or shorthand named `import` with two or more parameters — e.g. `async import(a, b) {}` or `{ import(a, b) {} }` — is rewritten into invalid JS (`import(__vite__injectQuery(a, 'import'), b)`), so the browser throws `SyntaxError: Unexpected token '('` and the module never loads. `vite build` is unaffected; this only happens in `serve`.

es-module-lexer (v2, used since Vite 8.1) reports such methods as dynamic imports, and `vite:import-analysis` then applies its dynamic-import query rewrite to them.

Fixes #22750

### Fix

Before rewriting a dynamic import, skip it when it's actually a method definition. A real dynamic `import(...)` is never immediately followed by a `{` block (its options object sits inside the parens), whereas a method's parameter list always is — so a small forward scan from the import's end (skipping whitespace and comments) distinguishes the two.

Added unit tests covering class/async/static/object-shorthand methods named `import` (including comment and string-argument variants) plus a real-dynamic-import control, and an end-to-end playground fixture.