### PR TITLE
fix: preload css for nested dynamic imports

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
@@ -25,22 +25,18 @@ function markerPositions(code: string): number[] {
 // pair dynamic imports with markers the way the plugin does (see `generateBundle`)
 function match(code: string) {
   const imports = parseImports(code)[0].filter((i) => i.d > -1)
-  return {
-    imports,
-    importMarkerPos: matchImportsToPreloadMarkers(code, imports),
-  }
+  return matchImportsToPreloadMarkers(code, imports)
 }
 
 describe('matchImportsToPreloadMarkers', () => {
   test('returns an empty array when there are no imports', () => {
-    expect(matchImportsToPreloadMarkers('const a = 1', [])).toEqual([])
+    expect(matchImportsToPreloadMarkers('const a = 1', [])).toStrictEqual([])
   })
 
   test('pairs a single dynamic import with its marker', () => {
     const code = `__vitePreload(() => import('a'), ${preloadMarker})`
     const [marker] = markerPositions(code)
-    const { importMarkerPos } = match(code)
-    expect(importMarkerPos).toStrictEqual([marker])
+    expect(match(code)).toStrictEqual([marker])
   })
 
   test('gives sibling imports their own markers (Rollup-era interleaved shape)', () => {
@@ -49,9 +45,7 @@ describe('matchImportsToPreloadMarkers', () => {
       `__vitePreload(() => import('a'), ${preloadMarker})` +
       `.then(() => __vitePreload(() => import('b'), ${preloadMarker}))`
     const [markerA, markerB] = markerPositions(code)
-    const { imports, importMarkerPos } = match(code)
-    expect(imports).toHaveLength(2)
-    expect(importMarkerPos).toEqual([markerA, markerB])
+    expect(match(code)).toStrictEqual([markerA, markerB])
   })
 
   test('gives a nested `import().then(() => import())` each its own marker (#22700)', () => {
@@ -61,16 +55,13 @@ describe('matchImportsToPreloadMarkers', () => {
       `__vitePreload(() => import('a').then(() => ` +
       `__vitePreload(() => import('b'), ${preloadMarker})), ${preloadMarker})`
     const [innerMarker, outerMarker] = markerPositions(code)
-    const { imports, importMarkerPos } = match(code)
     // source order: [0] = import('a') (outer), [1] = import('b') (inner)
-    expect(imports).toHaveLength(2)
-    expect(importMarkerPos).toEqual([outerMarker, innerMarker])
+    expect(match(code)).toStrictEqual([outerMarker, innerMarker])
   })
 
   test('#3051: a lone import whose marker precedes it still pairs with that marker', () => {
     const code = `const x = ${preloadMarker};import('a')`
     const [marker] = markerPositions(code)
-    const { importMarkerPos } = match(code)
-    expect(importMarkerPos).toEqual([marker])
+    expect(match(code)).toStrictEqual([marker])
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
@@ -1,0 +1,76 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+import { init, parse as parseImports } from 'es-module-lexer'
+import {
+  matchImportsToPreloadMarkers,
+  preloadMarker,
+} from '../../plugins/importAnalysisBuild'
+
+beforeAll(async () => {
+  await init
+})
+
+// the start position of every `__VITE_PRELOAD__` marker, in source order
+function markerPositions(code: string): number[] {
+  const positions: number[] = []
+  for (
+    let pos = code.indexOf(preloadMarker);
+    pos !== -1;
+    pos = code.indexOf(preloadMarker, pos + preloadMarker.length)
+  ) {
+    positions.push(pos)
+  }
+  return positions
+}
+
+// pair dynamic imports with markers the way the plugin does (see `generateBundle`)
+function match(code: string) {
+  const imports = parseImports(code)[0].filter((i) => i.d > -1)
+  return {
+    imports,
+    importMarkerPos: matchImportsToPreloadMarkers(code, imports),
+  }
+}
+
+describe('matchImportsToPreloadMarkers', () => {
+  test('returns an empty array when there are no imports', () => {
+    expect(matchImportsToPreloadMarkers('const a = 1', [])).toEqual([])
+  })
+
+  test('pairs a single dynamic import with its marker', () => {
+    const code = `__vitePreload(() => import('a'), ${preloadMarker})`
+    const [marker] = markerPositions(code)
+    const { importMarkerPos } = match(code)
+    expect(importMarkerPos).toEqual([marker])
+  })
+
+  test('gives sibling imports their own markers (Rollup-era interleaved shape)', () => {
+    // markers stay interleaved: import a < Ma < import b < Mb
+    const code =
+      `__vitePreload(() => import('a'), ${preloadMarker})` +
+      `.then(() => __vitePreload(() => import('b'), ${preloadMarker}))`
+    const [markerA, markerB] = markerPositions(code)
+    const { imports, importMarkerPos } = match(code)
+    expect(imports).toHaveLength(2)
+    expect(importMarkerPos).toEqual([markerA, markerB])
+  })
+
+  test('gives a nested `import().then(() => import())` each its own marker (#22700)', () => {
+    // Rolldown wraps the whole `.then`, so the inner marker comes before the outer one:
+    // the outer import must NOT be paired with the inner marker it textually precedes.
+    const code =
+      `__vitePreload(() => import('a').then(() => ` +
+      `__vitePreload(() => import('b'), ${preloadMarker})), ${preloadMarker})`
+    const [innerMarker, outerMarker] = markerPositions(code)
+    const { imports, importMarkerPos } = match(code)
+    // source order: [0] = import('a') (outer), [1] = import('b') (inner)
+    expect(imports).toHaveLength(2)
+    expect(importMarkerPos).toEqual([outerMarker, innerMarker])
+  })
+
+  test('#3051: a lone import whose marker precedes it still pairs with that marker', () => {
+    const code = `const x = ${preloadMarker};import('a')`
+    const [marker] = markerPositions(code)
+    const { importMarkerPos } = match(code)
+    expect(importMarkerPos).toEqual([marker])
+  })
+})

--- a/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importAnalysisBuild.spec.ts
@@ -40,7 +40,7 @@ describe('matchImportsToPreloadMarkers', () => {
     const code = `__vitePreload(() => import('a'), ${preloadMarker})`
     const [marker] = markerPositions(code)
     const { importMarkerPos } = match(code)
-    expect(importMarkerPos).toEqual([marker])
+    expect(importMarkerPos).toStrictEqual([marker])
   })
 
   test('gives sibling imports their own markers (Rollup-era interleaved shape)', () => {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -369,6 +369,36 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
           }
 
           if (imports.length) {
+            // Each import is wrapped as `__vitePreload(factory, __VITE_PRELOAD__)`, so its
+            // marker comes right after it. Nested imports nest the wrappers — in
+            // `import('a').then(() => import('b'))` b's marker ends up before a's — so imports
+            // and markers form balanced brackets. Pairing each import with the next marker
+            // would give b's marker to both and lose a's CSS to `void 0` (#22700); instead,
+            // match them with a stack in one pass: each marker closes the innermost open import.
+            const importMarkerPos = new Array<number>(imports.length).fill(-1)
+            const openImports: number[] = []
+            let nextImport = 0
+            let markerStartPos = findPreloadMarker(code, imports[0].e)
+            while (markerStartPos !== -1) {
+              while (
+                nextImport < imports.length &&
+                imports[nextImport].e <= markerStartPos
+              ) {
+                openImports.push(nextImport++)
+              }
+              if (openImports.length) {
+                importMarkerPos[openImports.pop()!] = markerStartPos
+              }
+              markerStartPos = findPreloadMarker(
+                code,
+                markerStartPos + preloadMarker.length,
+              )
+            }
+            // #3051: a lone import whose marker isn't placed after it pairs with the only marker
+            if (imports.length === 1 && importMarkerPos[0] === -1) {
+              importMarkerPos[0] = findPreloadMarker(code)
+            }
+
             for (let index = 0; index < imports.length; index++) {
               // To handle escape sequences in specifier strings, the .n field will be provided where possible.
               const {
@@ -438,11 +468,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
                 addDeps(normalizedFile)
               }
 
-              let markerStartPos = findPreloadMarker(code, end)
-              // fix issue #3051
-              if (markerStartPos === -1 && imports.length === 1) {
-                markerStartPos = findPreloadMarker(code)
-              }
+              const markerStartPos = importMarkerPos[index]
 
               if (markerStartPos > 0) {
                 // the dep list includes the main chunk, so only need to reload when there are actual other deps.

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -378,8 +378,14 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
             const importMarkerPos = new Array<number>(imports.length).fill(-1)
             const openImports: number[] = []
             let nextImport = 0
-            let markerStartPos = findPreloadMarker(code, imports[0].e)
-            while (markerStartPos !== -1) {
+            for (
+              let markerStartPos = findPreloadMarker(code, imports[0].e);
+              markerStartPos !== -1;
+              markerStartPos = findPreloadMarker(
+                code,
+                markerStartPos + preloadMarker.length,
+              )
+            ) {
               while (
                 nextImport < imports.length &&
                 imports[nextImport].e <= markerStartPos
@@ -389,10 +395,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
               if (openImports.length) {
                 importMarkerPos[openImports.pop()!] = markerStartPos
               }
-              markerStartPos = findPreloadMarker(
-                code,
-                markerStartPos + preloadMarker.length,
-              )
             }
             // #3051: a lone import whose marker isn't placed after it pairs with the only marker
             if (imports.length === 1 && importMarkerPos[0] === -1) {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -46,6 +46,55 @@ function findPreloadMarker(str: string, pos: number = 0): number {
 }
 
 /**
+ * Pairs each dynamic `import()` with the `__VITE_PRELOAD__` marker that belongs to it.
+ *
+ * Each import is wrapped as `__vitePreload(factory, __VITE_PRELOAD__)`, so its marker
+ * comes right after it. Nested imports nest the wrappers, so the imports and markers
+ * form balanced brackets. For example, in `import('a').then(() => import('b'))`, b's
+ * marker ends up before a's. Pairing each import with the next marker would give b's
+ * marker to both imports and drop a's CSS to `void 0` (#22700). Instead the markers are
+ * matched with a stack in one pass, and each marker closes the innermost import that is
+ * still open.
+ *
+ * The returned array is parallel to `imports`. Entry `i` holds the start position of
+ * import `i`'s marker, or -1 when the import has no marker.
+ */
+export function matchImportsToPreloadMarkers(
+  code: string,
+  imports: readonly ImportSpecifier[],
+): number[] {
+  const importMarkerPos = new Array<number>(imports.length).fill(-1)
+  if (imports.length === 0) return importMarkerPos
+
+  const openImports: number[] = []
+  let nextImport = 0
+  for (
+    let markerStartPos = findPreloadMarker(code, imports[0].e);
+    markerStartPos !== -1;
+    markerStartPos = findPreloadMarker(
+      code,
+      markerStartPos + preloadMarker.length,
+    )
+  ) {
+    while (
+      nextImport < imports.length &&
+      imports[nextImport].e <= markerStartPos
+    ) {
+      openImports.push(nextImport++)
+    }
+    if (openImports.length) {
+      importMarkerPos[openImports.pop()!] = markerStartPos
+    }
+  }
+  // #3051: a lone import whose marker isn't placed after it pairs with the only marker
+  if (imports.length === 1 && importMarkerPos[0] === -1) {
+    importMarkerPos[0] = findPreloadMarker(code)
+  }
+
+  return importMarkerPos
+}
+
+/**
  * Helper for preloading CSS and direct imports of async chunks in parallel to
  * the async chunk itself.
  */
@@ -369,37 +418,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
           }
 
           if (imports.length) {
-            // Each import is wrapped as `__vitePreload(factory, __VITE_PRELOAD__)`, so its
-            // marker comes right after it. Nested imports nest the wrappers — in
-            // `import('a').then(() => import('b'))` b's marker ends up before a's — so imports
-            // and markers form balanced brackets. Pairing each import with the next marker
-            // would give b's marker to both and lose a's CSS to `void 0` (#22700); instead,
-            // match them with a stack in one pass: each marker closes the innermost open import.
-            const importMarkerPos = new Array<number>(imports.length).fill(-1)
-            const openImports: number[] = []
-            let nextImport = 0
-            for (
-              let markerStartPos = findPreloadMarker(code, imports[0].e);
-              markerStartPos !== -1;
-              markerStartPos = findPreloadMarker(
-                code,
-                markerStartPos + preloadMarker.length,
-              )
-            ) {
-              while (
-                nextImport < imports.length &&
-                imports[nextImport].e <= markerStartPos
-              ) {
-                openImports.push(nextImport++)
-              }
-              if (openImports.length) {
-                importMarkerPos[openImports.pop()!] = markerStartPos
-              }
-            }
-            // #3051: a lone import whose marker isn't placed after it pairs with the only marker
-            if (imports.length === 1 && importMarkerPos[0] === -1) {
-              importMarkerPos[0] = findPreloadMarker(code)
-            }
+            const importMarkerPos = matchImportsToPreloadMarkers(code, imports)
 
             for (let index = 0; index < imports.length; index++) {
               // To handle escape sequences in specifier strings, the .n field will be provided where possible.

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -135,6 +135,44 @@ test('should work with load ../ and contain itself directory', async () => {
     .toMatch('dynamic-import-nested-self-content')
 })
 
+// #22700: nested `import('a').then(() => import('b'))` where `a` has a CSS
+// side-effect dep — the outer import's CSS must still be loaded in build output
+test('should load css of nested dynamic import', async () => {
+  await expect
+    .poll(() => page.textContent('.then-css-outer'))
+    .toMatch('then-css-outer')
+  await expect.poll(() => getColor('.then-css-outer')).toBe('red')
+  await expect
+    .poll(() => page.textContent('.then-css-inner'))
+    .toMatch('then-css-inner')
+  await expect.poll(() => getColor('.then-css-inner')).toBe('green')
+})
+
+// #22721: each nested dynamic import must preload its OWN chunk's css. The inner
+// import is immediately followed by its own `__vite__mapDeps(...)` (its `.then`
+// callback contains no further import, so the first dep list after it is its
+// own), so we read that list back and confirm it resolves to the inner css. A
+// pairing that walks imports front-to-back and skips already-claimed markers
+// swaps the lists, putting the outer chunk's css here instead.
+test.runIf(isBuild)(
+  'should preload its own css for a nested dynamic import',
+  () => {
+    const js = findAssetFile(/index-[-\w]{8}\.js$/) ?? ''
+    const depTable = js.match(/m\.f=(\[[^\]]*\])/)
+    const innerCall = js.match(
+      /import\([^)]*\binner-[-\w]+\.js[^)]*\)[\s\S]*?__vite__mapDeps\(\[([\d,]+)\]\)/,
+    )
+    expect(depTable, 'preload dep table not found').not.toBeNull()
+    expect(innerCall, 'inner import preload call not found').not.toBeNull()
+    const files: string[] = JSON.parse(depTable![1])
+    const innerPreloads = innerCall![1].split(',').map((i) => files[Number(i)])
+    expect(innerPreloads.some((f) => /\binner-[-\w]+\.css$/.test(f))).toBe(true)
+    expect(innerPreloads.some((f) => /\bouter-[-\w]+\.css$/.test(f))).toBe(
+      false,
+    )
+  },
+)
+
 test('should work a load path that contains parentheses.', async () => {
   await expect
     .poll(() =>

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -148,31 +148,6 @@ test('should load css of nested dynamic import', async () => {
   await expect.poll(() => getColor('.then-css-inner')).toBe('green')
 })
 
-// #22721: each nested dynamic import must preload its OWN chunk's css. The inner
-// import is immediately followed by its own `__vite__mapDeps(...)` (its `.then`
-// callback contains no further import, so the first dep list after it is its
-// own), so we read that list back and confirm it resolves to the inner css. A
-// pairing that walks imports front-to-back and skips already-claimed markers
-// swaps the lists, putting the outer chunk's css here instead.
-test.runIf(isBuild)(
-  'should preload its own css for a nested dynamic import',
-  () => {
-    const js = findAssetFile(/index-[-\w]{8}\.js$/) ?? ''
-    const depTable = js.match(/m\.f=(\[[^\]]*\])/)
-    const innerCall = js.match(
-      /import\([^)]*\binner-[-\w]+\.js[^)]*\)[\s\S]*?__vite__mapDeps\(\[([\d,]+)\]\)/,
-    )
-    expect(depTable, 'preload dep table not found').not.toBeNull()
-    expect(innerCall, 'inner import preload call not found').not.toBeNull()
-    const files: string[] = JSON.parse(depTable![1])
-    const innerPreloads = innerCall![1].split(',').map((i) => files[Number(i)])
-    expect(innerPreloads.some((f) => /\binner-[-\w]+\.css$/.test(f))).toBe(true)
-    expect(innerPreloads.some((f) => /\bouter-[-\w]+\.css$/.test(f))).toBe(
-      false,
-    )
-  },
-)
-
 test('should work a load path that contains parentheses.', async () => {
   await expect
     .poll(() =>

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -45,6 +45,9 @@
 
 <div class="dynamic-import-nested-self"></div>
 
+<div class="then-css-outer">todo</div>
+<div class="then-css-inner">todo</div>
+
 <script type="module" src="./nested/index.js"></script>
 <script type="module" src="./(app)/nest/index.js"></script>
 <style>

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -201,4 +201,13 @@ import(`../nested/static.js`).then((mod) => {
   text('.dynamic-import-static', mod.self)
 })
 
+// #22700: in a nested `import().then(() => import())`, the outer import's CSS
+// dep used to be dropped to `void 0` in the build output, orphaning the CSS.
+import('./then-css/outer.js').then((outerMod) => {
+  text('.then-css-outer', outerMod.outer)
+  return import('./then-css/inner.js').then((innerMod) => {
+    text('.then-css-inner', innerMod.inner)
+  })
+})
+
 console.log('index.js')

--- a/playground/dynamic-import/nested/then-css/inner.css
+++ b/playground/dynamic-import/nested/then-css/inner.css
@@ -1,0 +1,3 @@
+.then-css-inner {
+  color: #008000;
+}

--- a/playground/dynamic-import/nested/then-css/inner.js
+++ b/playground/dynamic-import/nested/then-css/inner.js
@@ -1,0 +1,2 @@
+import './inner.css'
+export const inner = 'then-css-inner'

--- a/playground/dynamic-import/nested/then-css/outer.css
+++ b/playground/dynamic-import/nested/then-css/outer.css
@@ -1,0 +1,3 @@
+.then-css-outer {
+  color: #ff0000;
+}

--- a/playground/dynamic-import/nested/then-css/outer.js
+++ b/playground/dynamic-import/nested/then-css/outer.js
@@ -1,0 +1,2 @@
+import './outer.css'
+export const outer = 'then-css-outer'


### PR DESCRIPTION
### Description

Fixes #22700 and closes #22721

In a nested dynamic import like `import('a').then(() => import('b'))` where `a` has a CSS dependency, the production build set the outer import's preload deps to `void 0`. The stylesheet for `a` was emitted to disk and listed in the `__vite__mapDeps` table, but nothing referenced its index, so no `<link>` was created and the CSS never loaded in production. Dev is unaffected because CSS is injected by JS there.

#### Root cause

`generateBundle` in `importAnalysisBuild.ts` matched each dynamic `import()` with the next `__VITE_PRELOAD__` marker after it. Rolldown wraps the whole `import().then()` expression, so the wrappers nest and the inner marker comes before the outer one in the text:

```js
__vitePreload(() => import('a').then(() => __vitePreload(() => import('b'), ⟨inner⟩)), ⟨outer⟩)
```

Matching by the next marker gave the inner marker to both imports, where the second write overwrote the first, and left the outer marker unclaimed, so the fallback set it to `void 0` and a's deps, including its CSS, were lost.

This only surfaces with Rolldown because the dynamic-import wrapping shape changed. Rollup-era Vite wrapped each `import()` on its own and left the `.then()` outside, like `__vitePreload(() => import('a'), Ma).then(() => __vitePreload(() => import('b'), Mb))`, so the markers stayed interleaved (`import a < Ma < import b < Mb`) and the next-marker pairing landed correctly. Rolldown's native plugin wraps the whole `import().then()` for a non-destructuring `.then`, which nests the inner marker before the outer one. That whole-`.then` wrapping landed in rolldown#8328 to tree-shake `import().then((m) => m.prop)` (refs #21121), and a side effect is that `.then(() => import())` nests the markers too, which is what trips the proximity-based pairing.

#### Fix

The imports and their markers nest like balanced brackets, so they are matched with a stack in a single pass, where each marker closes the innermost import still open. Every import keeps its own deps for any nesting depth, for ternary arms like `cond ? import(a) : import(b)`, and for sibling imports inside a `.then`. It also removes a quadratic repeated scan that the old approach did once per import on deeply nested chunks.

### Tests

A build regression was added under `playground/dynamic-import/nested/then-css/`. It uses a nested `import().then(() => import())` where the outer module has a CSS side effect, and asserts that the outer module's stylesheet actually applies. It fails on `main` and passes with this change.

`pnpm --filter vite build` and `pnpm test-build dynamic-import` both pass, serve mode passes, and eslint and oxfmt are clean.

---

Thanks to @mturac for digging into this in #22721.

Co-authored-by: mehmet turac <345446+mturac@users.noreply.github.com>
