### PR TITLE
chore(create-vite): reword linter prompt to "Which linter to use?"

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -102,7 +102,7 @@ test('prompts to use ESLint for React templates in interactive mode', () => {
     '--template',
     'react-ts',
   ])
-  expect(stdout).toContain('Use ESLint instead of Oxlint?')
+  expect(stdout).toContain('Which linter to use?')
 })
 
 test('asks to overwrite non-empty target directory', () => {

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -633,10 +633,10 @@ async function init() {
   if (isReactTemplate && eslint === undefined) {
     if (interactive) {
       const eslintResult = await prompts.select({
-        message: 'Use ESLint instead of Oxlint?',
+        message: 'Which linter to use?',
         options: [
-          { label: 'No (Oxlint)', value: false },
-          { label: 'Yes (ESLint)', value: true },
+          { label: 'Oxlint', value: false },
+          { label: 'ESLint', value: true },
         ],
       })
       if (prompts.isCancel(eslintResult)) return cancel()


### PR DESCRIPTION
## Description

Rewords the linter selection prompt shown by `create-vite` for React templates.

Previously the prompt was framed as a yes/no question (`Use ESLint instead of Oxlint?` with `No (Oxlint)` / `Yes (ESLint)` options), which biases the choice toward Oxlint and reads awkwardly. This changes it to a neutral `Which linter to use?` with plain `Oxlint` / `ESLint` options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)