### PR TITLE
fix(optimizer): scanner should resolve `input` from `root`

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/scan-build-input/src/entry-client.tsx
+++ b/packages/vite/src/node/__tests__/fixtures/scan-build-input/src/entry-client.tsx
@@ -1,0 +1,3 @@
+import * as vue from 'vue'
+
+export default vue

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -218,6 +218,44 @@ test('scan import.meta.glob respects rolldown transform jsx options', async (ctx
   expect(scanResult.deps).not.toHaveProperty('react/jsx-runtime')
 })
 
+// regression test for https://github.com/vitejs/vite/issues/22752
+// `resolveRolldownOptions` resolves `build.rolldownOptions.input` relative to the root,
+// so the scanner needs to resolve a relative bare entry from the root
+test('scan resolves build.rolldownOptions.input relative to the root', async (ctx) => {
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'error',
+    // root differs from process.cwd(); the entry lives at `<root>/entry-client.tsx`
+    root: path.join(import.meta.dirname, 'fixtures', 'scan-build-input', 'src'),
+    environments: {
+      client: {
+        build: {
+          rolldownOptions: {
+            input: 'entry-client.tsx',
+          },
+        },
+      },
+    },
+    optimizeDeps: {
+      force: true,
+      noDiscovery: false,
+    },
+  })
+  ctx.onTestFinished(() => server.close())
+
+  const { cancel, result } = scanImports(
+    devToScanEnvironment(server.environments.client),
+  )
+  ctx.onTestFinished(cancel)
+
+  await expect(result).resolves.toMatchObject({
+    deps: {
+      vue: expect.any(String),
+    },
+    missing: {},
+  })
+})
+
 test('scan import.meta.glob package imports patterns', async (ctx) => {
   const server = await createServer({
     configFile: false,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -202,16 +202,13 @@ async function computeEntries(environment: ScanEnvironment) {
     entries = await globEntries(explicitEntryPatterns, environment)
   } else if (buildInput) {
     const resolvePath = async (p: string) => {
-      // rollup resolves the input from process.cwd()
+      // `build.rollupOptions.input` is resolved from the root (not `process.cwd()`)
+      // by the build, so resolve it from the root here too by not passing an importer.
       const id = (
-        await environment.pluginContainer.resolveId(
-          p,
-          path.join(process.cwd(), '*'),
-          {
-            isEntry: true,
-            scan: true,
-          },
-        )
+        await environment.pluginContainer.resolveId(p, undefined, {
+          isEntry: true,
+          scan: true,
+        })
       )?.id
       if (id === undefined) {
         throw new Error(


### PR DESCRIPTION
fixes #22752 

This PR is essentially reverts #20080 as I was wrong there. cc @CyberAP (as you mentioned the issue in https://github.com/vitejs/vite/discussions/15834#discussioncomment-13207937)

In build, Vite resolves `build.rolldownOptions.input` from the `root` in `resolveRolldownOptions` before it reaches Rolldown (/ Rollup). 
