### PR TITLE
fix(css): resolve tsconfig paths in CSS and Sass @import

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -207,6 +207,18 @@ Enabling this setting causes vite to determine file identity by the original fil
 
 Enables the tsconfig paths resolution feature. `paths` option in `tsconfig.json` will be used to resolve imports. See [Features](/guide/features.md#paths) for more details.
 
+`paths` only applies to a file matched by a `tsconfig.json` through its `files` or `include`. CSS and Sass files (`.css`, `.scss`, `.sass`) are not matched by the usual TS/JS globs, since a bare `"src"` or `"**/*"` `include` only matches TS/JS extensions. To use a `paths` alias inside them (such as `@import '@/foo.css'`), list those files in `files`, or add an explicit extension to `include`:
+
+```json [tsconfig.json]
+{
+  "include": ["src", "src/**/*.css", "src/**/*.scss"]
+}
+```
+
+::: warning Less is not supported
+`resolve.tsconfigPaths` does not apply inside `.less` files. Less only gives Vite the importing file's directory, not the file itself, so Vite cannot find the `tsconfig.json` that matches it. Use a relative path or [`resolve.alias`](#resolve-alias) for `@import` in Less.
+:::
+
 ## html.cspNonce
 
 - **Type:** `string`

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -207,7 +207,7 @@ Enabling this setting causes vite to determine file identity by the original fil
 
 Enables the tsconfig paths resolution feature. `paths` option in `tsconfig.json` will be used to resolve imports. See [Features](/guide/features.md#paths) for more details.
 
-`paths` only applies to a file matched by a `tsconfig.json` through its `files` or `include`. CSS and Sass files (`.css`, `.scss`, `.sass`) are not matched by the usual TS/JS globs, since a bare `"src"` or `"**/*"` `include` only matches TS/JS extensions. To use a `paths` alias inside them (such as `@import '@/foo.css'`), list those files in `files`, or add an explicit extension to `include`:
+`paths` only applies to a file matched by a `tsconfig.json` through its `files` or `include`. Non-JS extension files should be explicitly listed in them, since a bare `"src"` or `"**/*"` `include` only matches TS/JS extensions, aligning with TypeScript's behavior. For example, to use a `paths` alias inside a CSS file (such as `@import '@/foo.css'`), list those files in `files`, or add an explicit extension to `include`:
 
 ```json [tsconfig.json]
 {

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -101,7 +101,7 @@ This option is only partially supported. Full support requires type inference by
 
 - [TypeScript documentation](https://www.typescriptlang.org/tsconfig/#paths)
 
-`resolve.tsconfigPaths: true` can be specified to tell Vite to use the `paths` option in `tsconfig.json` to resolve imports.
+[`resolve.tsconfigPaths: true`](/config/shared-options.md#resolve-tsconfigpaths) can be specified to tell Vite to use the `paths` option in `tsconfig.json` to resolve imports.
 
 Note that this feature has a performance cost and is [discouraged by the TypeScript team to use this option to change the behavior of the external tools](https://www.typescriptlang.org/tsconfig/#paths:~:text=Note%20that%20this%20feature%20does%20not%20change%20how%20import%20paths%20are%20emitted%20by%20tsc%2C%20so%20paths%20should%20only%20be%20used%20to%20inform%20TypeScript%20that%20another%20tool%20has%20this%20mapping%20and%20will%20use%20it%20at%20runtime%20or%20when%20bundling.).
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1547,7 +1547,7 @@ async function compilePostCSS(
   if (needInlineImport) {
     postcssPlugins.unshift(
       (await importPostcssImport()).default({
-        async resolve(id, basedir) {
+        async resolve(id, basedir, _importOptions, atRule) {
           const publicFile = checkPublicFile(
             id,
             environment.getTopLevelConfig(),
@@ -1556,10 +1556,15 @@ async function compilePostCSS(
             return publicFile
           }
 
+          // Resolve from the real importing file (the `@import` AtRule's source)
+          // so `resolve.tsconfigPaths` can find the tsconfig that owns it. The
+          // source is only absent for an `@import` injected by another plugin
+          // (a node with no source), in which case the resolver falls back to
+          // the project root.
           const resolved = await atImportResolvers.css(
             environment,
             id,
-            path.join(basedir, '*'),
+            atRule.source?.input.file,
           )
 
           if (resolved) {
@@ -2787,6 +2792,9 @@ const makeLessWorker = (
     const resolved = await resolvers.less(
       environment,
       filename,
+      // Less only exposes the importer's directory, not the file, so Vite can't
+      // pass a real importer like CSS/Sass do. `resolve.tsconfigPaths` therefore
+      // does not apply inside `.less` files. See the `resolve.tsconfigPaths` docs.
       path.join(dir, '*'),
     )
     if (!resolved) return undefined

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1556,14 +1556,12 @@ async function compilePostCSS(
             return publicFile
           }
 
-          // Resolve from the real importing file (the `@import` AtRule's source)
-          // so `resolve.tsconfigPaths` can find the tsconfig that owns it. The
-          // source is only absent for an `@import` injected by another plugin
-          // (a node with no source), in which case the resolver falls back to
-          // the project root.
           const resolved = await atImportResolvers.css(
             environment,
             id,
+            // The `source` is only absent for an `@import` injected by another plugin
+            // (a node with no source), in which case the resolver falls back to
+            // the project root.
             atRule.source?.input.file,
           )
 

--- a/packages/vite/src/types/shims.d.ts
+++ b/packages/vite/src/types/shims.d.ts
@@ -15,6 +15,7 @@ declare module 'postcss-import' {
       id: string,
       basedir: string,
       importOptions: any,
+      atRule: import('postcss').AtRule,
     ) => string | string[] | Promise<string | string[]>
     load: (id: string) => Promise<string>
     nameLayer: (index: number, rootFilename: string) => string

--- a/playground/resolve-tsconfig-paths/__tests__/resolve.spec.ts
+++ b/playground/resolve-tsconfig-paths/__tests__/resolve.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { page } from '~utils'
+import { getColor, page } from '~utils'
 
 test('import from .ts', async () => {
   await expect.poll(() => page.textContent('.ts')).toMatch('[success]')
@@ -20,4 +20,19 @@ test('fallback works', async () => {
 test('nested tsconfig.json & references / include works', async () => {
   await expect.poll(() => page.textContent('.nested-a')).toMatch('[success]')
   await expect.poll(() => page.textContent('.nested-b')).toMatch('[success]')
+})
+
+test('css @import resolves tsconfig paths', async () => {
+  await expect.poll(() => getColor('.tsconfig-paths-css')).toBe('darkcyan')
+})
+
+test('sass @use resolves tsconfig paths', async () => {
+  await expect.poll(() => getColor('.tsconfig-paths-scss')).toBe('seagreen')
+})
+
+// `resolve.tsconfigPaths` is not supported inside `.less` files. The aliased
+// `@import (optional) '@/less-imported.less'` cannot resolve (even with
+// `**/*.less` in `include`), so it is skipped and the color stays `navy`.
+test('less @import does not resolve tsconfig paths (unsupported)', async () => {
+  await expect.poll(() => getColor('.tsconfig-paths-less')).toBe('navy')
 })

--- a/playground/resolve-tsconfig-paths/index.html
+++ b/playground/resolve-tsconfig-paths/index.html
@@ -16,7 +16,18 @@
 <p class="nested-a"></p>
 <p class="nested-b"></p>
 
+<h2>CSS / Sass @import resolves tsconfig paths (Less does not)</h2>
+<p class="tsconfig-paths-css">This text should be darkcyan</p>
+<p class="tsconfig-paths-scss">This text should be seagreen</p>
+<p class="tsconfig-paths-less">
+  This text should stay navy (Less is unsupported)
+</p>
+
 <script type="module">
+  import '@/style.css'
+  import '@/style.scss'
+  import '@/style.less'
+
   function text(selector, text) {
     document.querySelector(selector).textContent = text
   }

--- a/playground/resolve-tsconfig-paths/package.json
+++ b/playground/resolve-tsconfig-paths/package.json
@@ -8,5 +8,9 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
+  },
+  "devDependencies": {
+    "less": "^4.6.6",
+    "sass": "^1.101.0"
   }
 }

--- a/playground/resolve-tsconfig-paths/src/imported.css
+++ b/playground/resolve-tsconfig-paths/src/imported.css
@@ -1,0 +1,3 @@
+.tsconfig-paths-css {
+  color: darkcyan;
+}

--- a/playground/resolve-tsconfig-paths/src/less-imported.less
+++ b/playground/resolve-tsconfig-paths/src/less-imported.less
@@ -1,0 +1,4 @@
+// Only applied if the `@/less-imported.less` alias resolves, which it must not.
+.tsconfig-paths-less {
+  color: tomato;
+}

--- a/playground/resolve-tsconfig-paths/src/scss-imported.scss
+++ b/playground/resolve-tsconfig-paths/src/scss-imported.scss
@@ -1,0 +1,3 @@
+.tsconfig-paths-scss {
+  color: seagreen;
+}

--- a/playground/resolve-tsconfig-paths/src/style.css
+++ b/playground/resolve-tsconfig-paths/src/style.css
@@ -1,0 +1,2 @@
+/* `@import` with a tsconfig `paths` alias must resolve from a CSS importer */
+@import '@/imported.css';

--- a/playground/resolve-tsconfig-paths/src/style.less
+++ b/playground/resolve-tsconfig-paths/src/style.less
@@ -1,0 +1,9 @@
+.tsconfig-paths-less {
+  color: navy;
+}
+
+// `resolve.tsconfigPaths` does NOT apply inside `.less` files (Less only gives
+// Vite the importer's directory, not the file). Even though `**/*.less` is in
+// the tsconfig `include`, this aliased import cannot resolve, so it is skipped
+// via `(optional)` and the color stays `navy` instead of becoming `tomato`.
+@import (optional) '@/less-imported.less';

--- a/playground/resolve-tsconfig-paths/src/style.scss
+++ b/playground/resolve-tsconfig-paths/src/style.scss
@@ -1,0 +1,2 @@
+// `@use` with a tsconfig `paths` alias must resolve from a Sass importer
+@use '@/scss-imported' as *;

--- a/playground/resolve-tsconfig-paths/tsconfig.json
+++ b/playground/resolve-tsconfig-paths/tsconfig.json
@@ -8,6 +8,6 @@
       "#/*": ["./src/*"]
     }
   },
-  "include": ["**/*", "index.html"],
+  "include": ["**/*", "**/*.css", "**/*.scss", "**/*.less", "index.html"],
   "exclude": ["./__tests__"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1447,7 +1447,14 @@ importers:
 
   playground/resolve-linked: {}
 
-  playground/resolve-tsconfig-paths: {}
+  playground/resolve-tsconfig-paths:
+    devDependencies:
+      less:
+        specifier: ^4.6.6
+        version: 4.6.7
+      sass:
+        specifier: ^1.101.0
+        version: 1.101.0
 
   playground/resolve/browser-field:
     dependencies:


### PR DESCRIPTION
### Description

close #22766

Since the oxc-resolver upgrade in Vite 8.1, `resolve.tsconfigPaths` stopped resolving `paths` aliases inside CSS `@import` and Sass `@use`, such as `@import "@/styles/main.css"`.

oxc-resolver only applies a tsconfig's `paths` to a file that tsconfig owns through its `files` or `include`. For CSS `@import`, Vite passed a synthetic `<dir>/*` importer that has no file extension, so no tsconfig ever owns it and the `paths` aliases are skipped.

The fix passes the real importing file as the importer: CSS (postcss-import) uses the `@import` AtRule's source file, and Sass already uses `context.containingUrl`. Because tsconfig matches by extension, CSS/Sass files must be declared explicitly to receive `paths`, for example `include: ["src", "src/**/*.css", "src/**/*.scss"]`. This is documented under `resolve.tsconfigPaths`.

Less is not supported: its plugin API only exposes the importer's directory, not the file, so Vite cannot tell the resolver which tsconfig owns it. Use a relative path or `resolve.alias` for `@import` in Less. This is documented and locked in by a negative test.

`playground/resolve-tsconfig-paths` gains CSS `@import` and Sass `@use` cases that resolve via `paths`, plus a Less case asserting the alias stays unresolved.

### Additional

I looked into supporting Less by overriding `getPath` in its file-manager plugin so the importer's file (not just its directory) is exposed to Vite, but that repurposes a method Less relies on internally for directory derivation and is too hacky, so Less is left unsupported for now.