### PR TITLE
fix(server): skip fallback sourcemap for large responses to avoid OOM

### DIFF
--- a/packages/vite/src/node/server/__tests__/send.spec.ts
+++ b/packages/vite/src/node/server/__tests__/send.spec.ts
@@ -1,0 +1,48 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { describe, expect, test } from 'vitest'
+import { send } from '../send'
+
+function createReq(url = '/foo.js'): IncomingMessage {
+  return { url, method: 'GET', headers: {} } as IncomingMessage
+}
+
+function createRes(): ServerResponse & { body?: string | Buffer } {
+  const res = {
+    writableEnded: false,
+    statusCode: 0,
+    headers: {} as Record<string, unknown>,
+    setHeader(name: string, value: unknown) {
+      res.headers[name] = value
+      return res
+    },
+    end(chunk?: string | Buffer) {
+      res.body = chunk
+      res.writableEnded = true
+    },
+  }
+  return res as unknown as ServerResponse & { body?: string | Buffer }
+}
+
+describe('send fallback sourcemap', () => {
+  test('injects a fallback sourcemap for js without a map', () => {
+    const req = createReq()
+    const res = createRes()
+    send(req, res, 'const a = 1', 'js', {})
+    expect(res.body!.toString()).toContain('//# sourceMappingURL=')
+  })
+
+  test('skips the fallback sourcemap for very large js', () => {
+    const req = createReq()
+    const res = createRes()
+    const code = `export default ${JSON.stringify('x\n'.repeat(5_000_000))}`
+    send(req, res, code, 'js', {})
+    expect(res.body!.toString()).not.toContain('//# sourceMappingURL=')
+  })
+
+  test('does not inject a fallback sourcemap for non-js', () => {
+    const req = createReq('/foo.css')
+    const res = createRes()
+    send(req, res, '.a { color: red }', 'css', {})
+    expect(res.body!.toString()).not.toContain('sourceMappingURL=')
+  })
+})

--- a/packages/vite/src/node/server/send.ts
+++ b/packages/vite/src/node/server/send.ts
@@ -29,6 +29,9 @@ export interface SendOptions {
   map?: SourceMap | { mappings: '' } | null
 }
 
+// skip the fallback sourcemap for large code to avoid OOM (#22132)
+const MAX_FALLBACK_SOURCEMAP_CODE_LENGTH = 4 * 1024 * 1024
+
 export function send(
   req: IncomingMessage,
   res: ServerResponse,
@@ -76,6 +79,8 @@ export function send(
     // if the code has existing inline sourcemap, assume it's correct and skip
     if (convertSourceMap.mapFileCommentRegex.test(code)) {
       debug?.(`Skipped injecting fallback sourcemap for ${req.url}`)
+    } else if (code.length > MAX_FALLBACK_SOURCEMAP_CODE_LENGTH) {
+      debug?.(`Skipped injecting fallback sourcemap for large ${req.url}`)
     } else {
       const urlWithoutTimestamp = removeTimestampQuery(req.url!)
       const ms = new MagicString(code)


### PR DESCRIPTION
The dev server generates a fallback sourcemap with hires: 'boundary' and includeContent for JS modules that lack one. For very large modules (e.g. a big file imported via ?raw) this map amplifies memory usage enough to crash the server with an out-of-memory error. Skip the fallback sourcemap, which is only a debugging aid, once the code exceeds 4MB.

Fixes #22132

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
