### PR TITLE
feat: expose resolveTsconfig util for plugins and frameworks

### DIFF
--- a/packages/vite/rolldown.dts.config.ts
+++ b/packages/vite/rolldown.dts.config.ts
@@ -121,6 +121,7 @@ const ignoreConfusingTypeNames = [
   // temporary variables for types
   'parseAst$1',
   'parseAstAsync$1',
+  'resolveTsconfig$1',
 ]
 
 /**

--- a/packages/vite/src/node/__tests__/tsconfig.spec.ts
+++ b/packages/vite/src/node/__tests__/tsconfig.spec.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { resolveTsconfig } from '../tsconfig'
+
+const fixtureDir = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../plugins/fixtures/oxc-tsconfigs',
+)
+
+describe('resolveTsconfig', () => {
+  test('resolves the nearest tsconfig for a file', () => {
+    const result = resolveTsconfig(
+      path.join(fixtureDir, 'target-es2022', 'index.ts'),
+    )
+    expect(result).not.toBeNull()
+    expect(result!.tsconfig.compilerOptions?.target).toBe('es2022')
+    expect(
+      result!.tsconfigFilePaths.some((p) => p.endsWith('tsconfig.json')),
+    ).toBe(true)
+  })
+
+  test('returns null when no tsconfig is found', () => {
+    const root = path.parse(process.cwd()).root
+    expect(resolveTsconfig(path.join(root, 'vite-no-tsconfig', 'a.ts'))).toBe(
+      null,
+    )
+  })
+})

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -44,6 +44,7 @@ export { createIdResolver } from './idResolver'
 export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
 export { transformWithEsbuild } from './plugins/esbuild'
 export { transformWithOxc } from './plugins/oxc'
+export { resolveTsconfig, type ResolveTsconfigResult } from './tsconfig'
 export { buildErrorMessage } from './server/middlewares/error'
 
 export {

--- a/packages/vite/src/node/tsconfig.ts
+++ b/packages/vite/src/node/tsconfig.ts
@@ -1,0 +1,16 @@
+import { resolveTsconfig as resolveTsconfigImpl } from 'rolldown/experimental'
+
+export type ResolveTsconfigResult = NonNullable<
+  ReturnType<typeof resolveTsconfigImpl>
+>
+
+/**
+ * Resolve the `tsconfig.json` that applies to a file, using the same resolution
+ * Vite uses internally. Returns the merged tsconfig and the list of config files
+ * involved (useful for watching), or `null` if none is found.
+ */
+export function resolveTsconfig(
+  filename: string,
+): ResolveTsconfigResult | null {
+  return resolveTsconfigImpl(filename)
+}


### PR DESCRIPTION
Vite 8 dropped tsconfck, so plugins and frameworks that relied on it for tsconfig resolution need an alternative. Expose a resolveTsconfig util that wraps the same resolution Vite uses internally, returning the merged tsconfig and the config files involved, so the ecosystem can resolve tsconfig consistently with Vite.

Closes #22336

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
