### PR TITLE
test(dynamic-import): cover object rest destructuring of dynamic import

### DIFF
--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -148,6 +148,12 @@ test('should load css of nested dynamic import', async () => {
   await expect.poll(() => getColor('.then-css-inner')).toBe('green')
 })
 
+test('should handle object rest destructuring of a dynamic import', async () => {
+  await expect
+    .poll(() => page.textContent('.dynamic-import-rest'))
+    .toMatch('a rest-b rest-c')
+})
+
 test('should work a load path that contains parentheses.', async () => {
   await expect
     .poll(() =>

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -48,6 +48,8 @@
 <div class="then-css-outer">todo</div>
 <div class="then-css-inner">todo</div>
 
+<div class="dynamic-import-rest"></div>
+
 <script type="module" src="./nested/index.js"></script>
 <script type="module" src="./(app)/nest/index.js"></script>
 <style>

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -210,4 +210,8 @@ import('./then-css/outer.js').then((outerMod) => {
   })
 })
 
+import('./rest-destructure.js').then(({ a, ...rest }) => {
+  text('.dynamic-import-rest', `${a} ${rest.b} ${rest.c}`)
+})
+
 console.log('index.js')

--- a/playground/dynamic-import/nested/rest-destructure.js
+++ b/playground/dynamic-import/nested/rest-destructure.js
@@ -1,0 +1,3 @@
+export const a = 'a'
+export const b = 'rest-b'
+export const c = 'rest-c'


### PR DESCRIPTION
### What this solves

Adds a regression test for object rest destructuring of a dynamic import. With the build-time `__vitePreload` rewrite, `import('./m').then(({ a, ...rest }) => ...)` dropped the sibling exports from `rest` (it was nested one level deeper, `{ rest: {...} }`), silently producing wrong output. The underlying bug and fix are in rolldown: https://github.com/rolldown/rolldown/pull/9976.

The new case in `playground/dynamic-import` imports a module with several named exports via object-rest destructuring and asserts that `rest` keeps its sibling keys. It fails against the buggy build output and passes once Vite picks up the fixed rolldown.

### Notes for reviewers

The test exercises the build-mode `__vitePreload` path (the native `viteBuildImportAnalysisPlugin` from `rolldown/experimental`). It turns green after the rolldown fix (rolldown/rolldown#9976) is released and the `rolldown` dependency is bumped.