### PR TITLE
fix(server): handle malformed URI in indexHtmlMiddleware

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -465,7 +465,13 @@ export function indexHtmlMiddleware(
     // htmlFallbackMiddleware appends '.html' to URLs
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
       if (fullBundle) {
-        const pathname = decodeURIComponent(url)
+        let pathname
+        try {
+          pathname = decodeURIComponent(url)
+        } catch {
+          // ignore malformed URI
+          return next()
+        }
         const filePath = pathname.slice(1) // remove first /
 
         let file = fullBundle.memoryFiles.get(filePath)


### PR DESCRIPTION
The `fullBundle` branch of `indexHtmlMiddleware` calls `decodeURIComponent(url)` without a guard (`src/node/server/middlewares/indexHtml.ts`). A request for a malformed `.html` URL such as `/%c0.html` therefore throws `URIError: URI malformed` and crashes the middleware instead of falling through.

This is the symmetric case of #22714, which added exactly this guard to `memoryFiles.ts`. `rejectInvalidRequest` only blocks `#`, and `memoryFiles` early-returns on `.html`, so a malformed `.html` lands precisely on this unguarded decode.

The fix mirrors #22714: wrap the decode in try/catch and `return next()` on failure (this middleware already uses `return next()` in several places). Valid input is byte-identical; only the throwing path changes.