### PR TITLE
fix: return sourcemap field from some plugins that were lacking

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -554,7 +554,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `${getHash(cleanUrl(id))}_${Number.parseInt(index)}`,
             css,
           )
-          return `export default ''`
+          return {
+            code: `export default ''`,
+            map: { mappings: '' },
+          }
         }
 
         const inlined = inlineRE.test(id)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -813,7 +813,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         // Force rollup to keep this module from being shared between other entry points.
         // If the resulting chunk is empty, it will be removed in generateBundle.
-        return { code: js, moduleSideEffects: 'no-treeshake' }
+        return {
+          code: js,
+          map: { mappings: '' },
+          moduleSideEffects: 'no-treeshake',
+        }
       },
     },
 


### PR DESCRIPTION
Some plugins were not returning the `map` field correctly and was causing "Sourcemap is likely to be incorrect" warning.
This PR fixes that by adding the `map` field.

`{ mappings: '' }` is used for both of these because they completely replaces the content.
