### PR TITLE
fix(optimize-deps): ignore `ERR_CLOSED_SERVER` in scanner

### DIFF
--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -256,6 +256,35 @@ test('scan resolves build.rolldownOptions.input relative to the root', async (ct
   })
 })
 
+// regression test for `The server is being restarted or closed. Request is outdated`
+// error in the scanner. The dependency scanner runs in the background and
+// may still be crawling when the server is closed. The scan fails because resolutions
+// reject with `ERR_CLOSED_SERVER`, but this failure must be ignored (the scan result is
+// discarded on close anyway) so it doesn't escape as an unhandled rejection.
+test('scan ignores the failure when the server is closed mid-scan', async (ctx) => {
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'silent',
+    root: path.join(import.meta.dirname, 'fixtures', 'scan-build-input', 'src'),
+    optimizeDeps: {
+      entries: ['./entry-client.tsx'],
+      force: true,
+      noDiscovery: false,
+    },
+  })
+  ctx.onTestFinished(() => server.close())
+
+  // Simulate the server being torn down while the scanner is still running.
+  await server.environments.client.pluginContainer.close()
+
+  const { cancel, result } = scanImports(
+    devToScanEnvironment(server.environments.client),
+  )
+  ctx.onTestFinished(cancel)
+
+  await expect(result).resolves.toEqual({ deps: {}, missing: {} })
+})
+
 test('scan import.meta.glob package imports patterns', async (ctx) => {
   const server = await createServer({
     configFile: false,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -32,7 +32,10 @@ import {
   virtualModuleRE,
 } from '../utils'
 import type { EnvironmentPluginContainer } from '../server/pluginContainer'
-import { createEnvironmentPluginContainer } from '../server/pluginContainer'
+import {
+  ERR_CLOSED_SERVER,
+  createEnvironmentPluginContainer,
+} from '../server/pluginContainer'
 import { BaseEnvironment } from '../baseEnvironment'
 import type { DevEnvironment } from '../server/environment'
 import { transformGlobImport } from '../plugins/importMetaGlob'
@@ -165,6 +168,17 @@ export function scanImports(environment: ScanEnvironment): {
         missing,
       }
     } catch (e) {
+      // The scanner runs in the background and may still be crawling when the
+      // server is closed. In that case resolutions reject with
+      // `ERR_CLOSED_SERVER` and the scan build fails.
+      if (
+        e.errors?.some(
+          (error: { pluginCode?: string }) =>
+            error.pluginCode === ERR_CLOSED_SERVER,
+        )
+      ) {
+        return
+      }
       const prependMessage = colors.red(`\
   Failed to scan for dependencies from entries:
   ${entries.join('\n')}


### PR DESCRIPTION
This PR tries to fix flaky failures like https://github.com/vitejs/vite/actions/runs/28230863726/job/83634064856#step:11:165:
```
[plugin vite:dep-scan:resolve]
Error: The server is being restarted or closed. Request is outdated
    at throwClosedServerError (D:/a/vite/vite/packages/vite/src/node/server/pluginContainer.ts:129:20)
    at EnvironmentPluginContainer.resolveId (D:/a/vite/vite/packages/vite/src/node/server/pluginContainer.ts:395:9)
    at resolveId (D:/a/vite/vite/packages/vite/src/node/optimizer/scan.ts:362:40)
    at resolve (D:/a/vite/vite/packages/vite/src/node/optimizer/scan.ts:381:28)
    at PluginContextImpl.resolveId (D:/a/vite/vite/packages/vite/src/node/optimizer/scan.ts:616:34)
    at plugin (file:///D:/a/vite/vite/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1420:30)
    at plugin.<computed> (file:///D:/a/vite/vite/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1961:18)

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: [vitest-pool]: Worker forks emitted error.
 ❯ EventEmitter.onTaskError node_modules/.pnpm/vitest@4.1.9_@types+node@24.13.2_vite@packages+vite/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:3459:21
 ❯ EventEmitter.emit node:events:509:28
 ❯ ChildProcess.emitUnexpectedExit node_modules/.pnpm/vitest@4.1.9_@types+node@24.13.2_vite@packages+vite/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:3025:22
 ❯ ChildProcess.emit node:events:509:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:295:12

Caused by: Error: Worker exited unexpectedly
 ❯ ChildProcess.emitUnexpectedExit node_modules/.pnpm/vitest@4.1.9_@types+node@24.13.2_vite@packages+vite/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:3023:33
 ❯ ChildProcess.emit node:events:509:28
 ❯ Process.ChildProcess._handle.onexit node:internal/child_process:295:12
```

The background dependency scanner resolves through the dev plugin container, and when a test tears down the server mid-scan, resolveId throws `ERR_CLOSED_SERVER`, rejecting the scan on a promise chain nothing awaits. This triggers an unhandled rejection that crashes the vitest worker even though all assertions passed.
