### PR TITLE
docs(api-javascript): fix build() return type and loadConfigFromFile description for Rolldown

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -200,7 +200,7 @@ interface ViteDevServer {
 ```ts
 async function build(
   inlineConfig?: InlineConfig,
-): Promise<RollupOutput | RollupOutput[]>
+): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher>
 ```
 
 **Example Usage:**
@@ -435,7 +435,7 @@ async function loadConfigFromFile(
 } | null>
 ```
 
-Load a Vite config file manually with esbuild.
+Load a Vite config file manually with Rolldown.
 
 ## `preprocessCSS`
 


### PR DESCRIPTION
### Description

Two stale references in the JavaScript API docs, updated for Vite 8 (current `main` is `8.1.0`), which builds and bundles the config file with **Rolldown**.

**1. `build()` return type**

The documented signature was:
```ts
async function build(
  inlineConfig?: InlineConfig,
): Promise<RollupOutput | RollupOutput[]>
```
The actual signature in [`packages/vite/src/node/build.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts) is:
```ts
export async function build(
  inlineConfig: InlineConfig = {},
): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher>
```
`RollupOutput` is now a deprecated alias of `RolldownOutput`, and the watch-mode return type `RolldownWatcher` was missing.

**2. `loadConfigFromFile` description**

It said *"Load a Vite config file manually with esbuild."* The default config loader bundles with Rolldown — `bundleConfigFile` in [`packages/vite/src/node/config.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts) calls `await rolldown({ ... })`. Updated the wording to "with Rolldown".

Docs-only change.

### Checklist

- [x] Docs-only; no code or tests affected.
