### PR TITLE
test: mock vite.dev to avoid flaky failure

### DIFF
--- a/playground/fs-serve/__tests__/commonTests.ts
+++ b/playground/fs-serve/__tests__/commonTests.ts
@@ -463,6 +463,14 @@ describe('cross origin', () => {
     let page2: Page
     beforeEach(async () => {
       page2 = await browser.newPage()
+      // Serve the navigation locally so the tests don't depend on reaching the
+      // public `vite.dev` site (flaky from CI runners).
+      await page2.route('http://vite.dev/**', (route) =>
+        route.fulfill({
+          contentType: 'text/html',
+          body: '<!doctype html><title>404</title>',
+        }),
+      )
       await page2.goto('http://vite.dev/404')
     })
     afterEach(async () => {


### PR DESCRIPTION
This PR tries to fix flaky failure like these:
```
 FAIL  playground/fs-serve/__tests__/base/fs-serve-base.spec.ts > cross origin > denied for different origin > fetch HTML file
 FAIL  playground/fs-serve/__tests__/base/fs-serve-base.spec.ts > cross origin > denied for different origin > fetch JS file
TimeoutError: page.goto: Timeout 30000ms exceeded.
Call log:
  - navigating to "http://vite.dev/404", waiting until "load"

 ❯ playground/fs-serve/__tests__/commonTests.ts:466:19
    464|     beforeEach(async () => {
    465|       page2 = await browser.newPage()
    466|       await page2.goto('http://vite.dev/404')
       |                   ^
    467|     })
    468|     afterEach(async () => {
```
https://github.com/vitejs/vite/actions/runs/27607943660/job/81624677447#step:12:62
