### PR TITLE
feat(create-vite): support Vite+ (vp) package manager

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -300,6 +300,23 @@ test('accepts immediate flag', () => {
   expect(stdout).toContain('Installing dependencies')
 })
 
+test('uses vp commands in the done message when run via vp dlx', () => {
+  const { stdout } = run([projectName, '--template', 'vue', '--no-immediate'], {
+    cwd: import.meta.dirname,
+    env: {
+      ...process.env,
+      _VITE_TEST_CLI: 'true',
+      // `vp dlx` sets VP_USER_AGENT; the underlying package manager overwrites
+      // npm_config_user_agent, so VP_USER_AGENT must take precedence.
+      VP_USER_AGENT: 'vp/0.2.1',
+      npm_config_user_agent: 'pnpm/10.0.0 npm/? node/v24.18.0 darwin arm64',
+    },
+  })
+  expect(stdout).toContain('Done. Now run:')
+  expect(stdout).toContain('vp install')
+  expect(stdout).toContain('vp dev')
+})
+
 test('accepts immediate flag and skips install prompt', () => {
   const { stdout } = run([projectName, '--template', 'vue', '--no-immediate'], {
     cwd: import.meta.dirname,

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -463,7 +463,11 @@ async function init() {
     )
   }
 
-  const pkgInfo = pkgFromUserAgent(process.env.npm_config_user_agent)
+  // Vite+ (`vp`) exposes its own `VP_USER_AGENT` because the underlying package
+  // manager overwrites `npm_config_user_agent` when running `vp dlx create-vite`.
+  const pkgInfo = pkgFromUserAgent(
+    process.env.VP_USER_AGENT ?? process.env.npm_config_user_agent,
+  )
   const cancel = () => prompts.cancel('Operation cancelled')
 
   // 1. Get project name and target dir
@@ -1064,6 +1068,10 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
         if (pkgManager === 'pnpm') {
           return 'pnpm create '
         }
+        // Vite+ uses `vp dlx create-` directly on the package
+        if (pkgManager === 'vp') {
+          return 'vp dlx create-'
+        }
         // For other package managers, preserve the original format
         return customCommand.startsWith('npm create -- ')
           ? `${pkgManager} create -- `
@@ -1085,6 +1093,10 @@ function getFullCustomCommand(customCommand: string, pkgInfo?: PkgInfo) {
         }
         if (pkgManager === 'deno') {
           return 'deno run -A npm:'
+        }
+        // Vite+ uses `vp dlx` to execute package binaries
+        if (pkgManager === 'vp') {
+          return 'vp dlx '
         }
         // Use `npm exec` in all other cases,
         // including Yarn 1.x and other custom npm clients.
@@ -1117,6 +1129,7 @@ function getRunCommand(agent: string, script: string) {
     case 'yarn':
     case 'pnpm':
     case 'bun':
+    case 'vp':
       return [agent, script]
     case 'deno':
       return [agent, 'task', script]


### PR DESCRIPTION
### Description

When `create-vite` is run via `vp dlx create-vite` (Vite+), it currently falls back to `npm` commands because the underlying package manager (pnpm/npm/yarn/bun) overwrites `npm_config_user_agent`, hiding that vp launched it.

This teaches `create-vite` to recognize vp:

- Detect vp from a dedicated `VP_USER_AGENT` env var that vp sets (falls back to `npm_config_user_agent` as before).
- `getRunCommand` emits `vp dev`; `getInstallCommand` already yields `vp install`.
- `getFullCustomCommand` maps `npm create` to `vp dlx create-` and `npm exec` to `vp dlx` (same shape as the existing bun/pnpm/deno branches).

Result: a `vp dlx create-vite` run finishes with `vp install` / `vp dev`, and template custom commands use `vp dlx`.

### Why `vp dlx create-` and not `vp create`

`npm create X` is defined as `npm exec create-X`, and `vp dlx create-X` is the exact structural equivalent (`dlx` = `exec`), forwarding all positionals and flags straight to the create-* binary. `vp create` was considered but is unsuitable here: it consumes the target-dir positional itself (uses its own `--directory` flag), so the `TARGET_DIR` convention is dropped, and the `npm create -- vike@latest --vue TARGET_DIR` templates need their template flags after a `--` separator that a prefix-only replacement cannot produce. `vp create` is also a richer, opinionated flow (adds agent/editor/git/hooks setup) rather than a transparent passthrough.

> [!NOTE]
> The companion change that makes vp set `VP_USER_AGENT` ships in the vite-plus repo (voidzero-dev/vite-plus#1958). Until that lands, behavior is unchanged for all existing package managers.

### Test

Added a `create-vite` CLI test asserting that `VP_USER_AGENT` takes precedence over `npm_config_user_agent` and produces `vp install` / `vp dev`.