### PR TITLE
fix(server): guard decodeURIComponent on the non-bundle indexHtml path

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
 import path from 'node:path'
 import { describe, expect, onTestFinished, test } from 'vitest'
 import { createServer } from '../../../server'
@@ -28,6 +30,27 @@ async function createTestServer(rootDir?: string) {
   onTestFinished(() => server.close())
   return server
 }
+
+describe('indexHtml middleware — malformed URI guard (non-fullBundle path)', () => {
+  test('request with malformed URI falls through to next() rather than throwing URIError', async () => {
+    const server = await createTestServer()
+
+    // Wrap the Vite middleware stack in a real HTTP server so we can observe the
+    // HTTP status code instead of catching an unhandled async exception.
+    const httpServer = http.createServer(server.middlewares)
+    await new Promise<void>((resolve) =>
+      httpServer.listen(0, '127.0.0.1', resolve),
+    )
+    onTestFinished(() => httpServer.close())
+
+    const { port } = httpServer.address() as AddressInfo
+
+    // /%c0.html → decodeURIComponent would throw URIError without the guard.
+    // With the guard it calls next() and the request falls through to a 404.
+    const response = await fetch(`http://127.0.0.1:${port}/%c0.html`)
+    expect(response.status).not.toBe(500)
+  })
+})
 
 describe('indexHtml middleware — /@fs/ inline script proxy cache', () => {
   test('inline <script type="module"> in an /@fs/ HTML file is loadable via the html-proxy module', async () => {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -505,13 +505,19 @@ export function indexHtmlMiddleware(
         return send(req, res, html, 'html', { headers, etag: file.etag })
       }
 
+      let pathname: string
+      try {
+        pathname = decodeURIComponent(url)
+      } catch {
+        // ignore malformed URI
+        return next()
+      }
+
       let filePath: string
       if (isDev && url.startsWith(FS_PREFIX)) {
-        filePath = decodeURIComponent(fsPathFromId(url))
+        filePath = fsPathFromId(pathname)
       } else {
-        filePath = normalizePath(
-          path.resolve(path.join(root, decodeURIComponent(url))),
-        )
+        filePath = normalizePath(path.resolve(path.join(root, pathname)))
       }
 
       if (isDev) {


### PR DESCRIPTION
## What

The non-`fullBundle` branch of `indexHtmlMiddleware` called `decodeURIComponent(url)` unguarded in two places (`packages/vite/src/node/server/middlewares/indexHtml.ts`).  A request for a malformed `.html` URL such as `GET /%c0.html` passes `rejectInvalidRequest` (which only blocks `#`), passes the `fullBundle` guard (which calls `next()` immediately for out-of-scope files), and then lands on the unguarded decode — throwing `URIError: URI malformed` and crashing the middleware.

## Relation to #22781

#22781 (my previous contribution, merged by @sapphi-red) added exactly this guard to the **`fullBundle`** branch:

```ts
// fullBundle path — already guarded (#22781)
let pathname
try {
  pathname = decodeURIComponent(url)
} catch {
  return next()
}
```

This PR mirrors that **identical pattern** onto the **regular dev-server (non-`fullBundle`) path**, which is the symmetric sibling left unguarded:

```ts
// non-fullBundle path — this PR
let pathname: string
try {
  pathname = decodeURIComponent(url)
} catch {
  // ignore malformed URI
  return next()
}

let filePath: string
if (isDev && url.startsWith(FS_PREFIX)) {
  filePath = fsPathFromId(pathname)
} else {
  filePath = normalizePath(path.resolve(path.join(root, pathname)))
}
```

`decodeURIComponent(fsPathFromId(url))` and `fsPathFromId(decodeURIComponent(url))` are equivalent for any URI where `FS_PREFIX` (`/@fs/`) is not itself percent-encoded (it cannot be, since it comes from `cleanUrl`).  Valid input is byte-identical to the previous behaviour; only the throwing path changes.

## Test

Added a test in `packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts` that wraps the Vite middleware stack in a real HTTP server and asserts that `GET /%c0.html` returns a non-500 response (falls through to 404 rather than crashing).

---

> **AI-assist disclosure**: this patch was drafted with Claude Code assistance. The logic, file identification, and guard pattern are derived directly from the already-merged #22781; no novel design decisions were required.