### PR TITLE
refactor: use pre-defined environments variable to avoid duplicate `Object.values` calls

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -478,7 +478,7 @@ export async function handleHMRUpdate(
     { options: HotUpdateOptions; error?: Error }
   >()
 
-  for (const environment of Object.values(server.environments)) {
+  for (const environment of environments) {
     const mods = new Set(environment.moduleGraph.getModulesByFile(file))
     if (type === 'create') {
       for (const mod of environment.moduleGraph._hasResolveFailedErrorModules) {
@@ -593,7 +593,7 @@ export async function handleHMRUpdate(
     hotMap.get(server.environments.client)!.error = error
   }
 
-  for (const environment of Object.values(server.environments)) {
+  for (const environment of environments) {
     if (environment.name === 'client') continue
     const hot = hotMap.get(environment)!
     const context = environment.pluginContainer.minimalContext


### PR DESCRIPTION

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
The result of `Object.values(server.environments)` has already been stored in the variable `environments`, and this variable can be reused directly within the same scope.