### PR TITLE
fix(worker): modulepreload for ES worker chunks (fix #22712)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/worker.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/worker.spec.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import { expect, test } from 'vitest'
 import type { OutputChunk, RolldownOutput } from 'rolldown'
 import { build } from '../../build'
+import { walkImportChain } from '../../plugins/worker'
 
 const fixturesDir = resolve(import.meta.dirname, 'fixtures')
 
@@ -44,4 +45,74 @@ test('?worker&url should produce the same hash in client and SSR builds', async 
   expect(clientWorkerUrls.length).toBeGreaterThan(0)
   expect(ssrWorkerUrls.length).toBeGreaterThan(0)
   expect(ssrWorkerUrls).toEqual(clientWorkerUrls)
+})
+
+test('walkImportChain traverses import chains in post-order', () => {
+  // Simulate a chunk graph: entry → a → c, entry → b
+  const chunks = new Map<string, { imports: readonly string[] }>([
+    ['entry.js', { imports: ['a.js', 'b.js'] }],
+    ['a.js', { imports: ['c.js'] }],
+    ['b.js', { imports: [] }],
+    ['c.js', { imports: [] }],
+  ])
+  const lookup = (file: string) => chunks.get(file)
+
+  const result = walkImportChain(['entry.js'], lookup)
+
+  // Invariant 1: dependencies before dependents (post-order)
+  expect(result.indexOf('c.js')).toBeLessThan(result.indexOf('a.js'))
+  expect(result.indexOf('a.js')).toBeLessThan(result.indexOf('entry.js'))
+
+  // Invariant 2: no duplicates
+  expect(new Set(result).size).toBe(result.length)
+
+  // Invariant 3: every reachable file is present
+  expect(result).toEqual(
+    expect.arrayContaining(['a.js', 'b.js', 'c.js', 'entry.js']),
+  )
+})
+
+test('walkImportChain handles circular imports', () => {
+  const chunks = new Map<string, { imports: readonly string[] }>([
+    ['a.js', { imports: ['b.js'] }],
+    ['b.js', { imports: ['c.js'] }],
+    ['c.js', { imports: ['a.js'] }],
+  ])
+  const lookup = (file: string) => chunks.get(file)
+
+  const result = walkImportChain(['a.js'], lookup)
+
+  // No infinite loop — each file visited once
+  expect(new Set(result).size).toBe(result.length)
+  expect(result).toEqual(expect.arrayContaining(['a.js', 'b.js', 'c.js']))
+})
+
+test('walkImportChain passes externals through', () => {
+  const chunks = new Map<string, { imports: readonly string[] }>([
+    ['entry.js', { imports: ['a.js', 'external-pkg'] }],
+    ['a.js', { imports: [] }],
+  ])
+  const lookup = (file: string) => chunks.get(file)
+
+  const result = walkImportChain(['entry.js'], lookup)
+
+  expect(result).toContain('external-pkg')
+  expect(result).toContain('entry.js')
+  expect(result).toContain('a.js')
+})
+
+test('walkImportChain shares seen set across calls', () => {
+  const seen = new Set<string>()
+  const chunks = new Map<string, { imports: readonly string[] }>([
+    ['a.js', { imports: [] }],
+    ['b.js', { imports: ['a.js'] }],
+  ])
+  const lookup = (file: string) => chunks.get(file)
+
+  const first = walkImportChain(['a.js'], lookup, seen)
+  const second = walkImportChain(['b.js'], lookup, seen)
+
+  // 'a.js' already in seen from first call, second call only adds 'b.js'
+  expect(first).toEqual(['a.js'])
+  expect(second).toEqual(['b.js'])
 })

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -526,7 +526,11 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               this.addWatchFile(file)
             }
 
-            if (format === 'es' && result.preloadFilenames.length > 0) {
+            if (
+              !isWorker &&
+              format === 'es' &&
+              result.preloadFilenames.length > 0
+            ) {
               const workerOutputCache = workerOutputCaches.get(
                 config.mainConfig || config,
               )!

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -531,9 +531,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
                 config.mainConfig || config,
               )!
               const placeholderStrings = result.preloadFilenames
-                .map((f) =>
-                  JSON.stringify(workerOutputCache.placeholderFor(f)),
-                )
+                .map((f) => JSON.stringify(workerOutputCache.placeholderFor(f)))
                 .join(',')
               preloadDepsCode = `__vitePreload(function(){return Promise.resolve()}, [${placeholderStrings}], import.meta.url)`
             }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -33,6 +33,7 @@ type WorkerBundle = {
   entryUrlPlaceholder: string
   referencedAssets: Set<string>
   watchedFiles: string[]
+  preloadFilenames: string[]
 }
 
 type WorkerBundleAsset = {
@@ -63,6 +64,7 @@ class WorkerOutputCache {
     outputEntryFilename: string,
     outputEntryCode: string,
     outputAssets: WorkerBundleAsset[],
+    preloadFilenames: string[],
     logger: Logger,
   ): WorkerBundle {
     for (const asset of outputAssets) {
@@ -75,6 +77,7 @@ class WorkerOutputCache {
         this.generateEntryUrlPlaceholder(outputEntryFilename),
       referencedAssets: new Set(outputAssets.map((asset) => asset.fileName)),
       watchedFiles,
+      preloadFilenames,
     }
     this.bundles.set(file, bundle)
     return bundle
@@ -138,6 +141,14 @@ class WorkerOutputCache {
 
   getEntryFilenameFromHash(hash: string) {
     return this.fileNameHash.get(hash)
+  }
+
+  placeholderFor(filename: string): string {
+    const hash = getHash(filename)
+    if (!this.fileNameHash.has(hash)) {
+      this.fileNameHash.set(hash, filename)
+    }
+    return `__VITE_WORKER_ASSET__${hash}__`
   }
 
   private generateEntryUrlPlaceholder(entryFilename: string): string {
@@ -280,6 +291,22 @@ async function bundleWorkerEntry(
           source: outputChunk.code,
         },
   )
+  const chunkByFile = new Map<string, { imports: readonly string[] }>()
+  chunkByFile.set(outputChunk.fileName, outputChunk)
+  for (const chunk of outputChunks) {
+    if (chunk.type === 'chunk') {
+      chunkByFile.set(chunk.fileName, chunk)
+    }
+  }
+
+  const preloadFilenames = computeWorkerPreloadDeps(outputChunk, chunkByFile)
+
+  // Register each preload filename with the hash mechanism so that
+  // renderChunk can resolve their __VITE_WORKER_ASSET__ placeholders
+  for (const f of preloadFilenames) {
+    workerOutput.placeholderFor(f)
+  }
+
   if (
     (config.build.sourcemap === 'hidden' || config.build.sourcemap === true) &&
     outputChunk.map
@@ -300,6 +327,7 @@ async function bundleWorkerEntry(
       outputChunk.fileName,
       outputChunk.code,
       assets,
+      preloadFilenames,
       config.logger,
     )
   return newBundleInfo
@@ -425,6 +453,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         }`
 
         let urlCode: string
+        let preloadDepsCode = ''
         if (isBundled) {
           if (isWorker && config.bundleChain.at(-1) === cleanUrl(id)) {
             urlCode = 'self.location.href'
@@ -496,6 +525,18 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             for (const file of result.watchedFiles) {
               this.addWatchFile(file)
             }
+
+            if (format === 'es' && result.preloadFilenames.length > 0) {
+              const workerOutputCache = workerOutputCaches.get(
+                config.mainConfig || config,
+              )!
+              const placeholderStrings = result.preloadFilenames
+                .map((f) =>
+                  JSON.stringify(workerOutputCache.placeholderFor(f)),
+                )
+                .join(',')
+              preloadDepsCode = `__vitePreload(function(){return Promise.resolve()}, [${placeholderStrings}], import.meta.url)`
+            }
           }
         } else {
           let url = await fileToUrl(this, cleanUrl(id))
@@ -510,14 +551,18 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
+        const preloadPreamble = preloadDepsCode
+          ? `import(import.meta.url).catch(function(){});\n`
+          : ''
+        const wrapperBody = preloadDepsCode
+          ? `${preloadDepsCode};return new ${workerConstructor}(${urlCode}, ${workerTypeOption});`
+          : `return new ${workerConstructor}(${urlCode}, ${workerTypeOption});`
+
         return {
-          code: `export default function WorkerWrapper(options) {
-            return new ${workerConstructor}(
-              ${urlCode},
-              ${workerTypeOption}
-            );
-          }`,
-          map: { mappings: '' }, // Empty sourcemap to suppress Rollup warning
+          code: `${preloadPreamble}export default function WorkerWrapper(options) {
+  ${wrapperBody}
+}`,
+          map: { mappings: '' }, // Empty sourcemap to suppress Rolldown warning
         }
       },
     },
@@ -680,4 +725,45 @@ function isSameContent(a: string | Uint8Array, b: string | Uint8Array) {
     return Buffer.from(a).equals(b)
   }
   return Buffer.from(b).equals(a)
+}
+
+/**
+ * Post-order DFS traversal of an import graph.
+ *
+ * Contract:
+ * - Dependencies always appear before their dependents (post-order).
+ * - Sibling ordering is NOT guaranteed — depends on iteration order.
+ * - Each file is visited at most once (prevents infinite cycles).
+ * - Files not found by `lookup` are passed through as-is (externals).
+ */
+export function walkImportChain(
+  files: readonly string[],
+  lookup: (file: string) => { imports: readonly string[] } | undefined,
+  seen: Set<string> = new Set(),
+): string[] {
+  const result: string[] = []
+  for (const file of files) {
+    if (seen.has(file)) continue
+    seen.add(file)
+    const entry = lookup(file)
+    if (entry) {
+      result.push(...walkImportChain(entry.imports, lookup, seen))
+      result.push(file)
+    } else {
+      result.push(file)
+    }
+  }
+  return result
+}
+
+function computeWorkerPreloadDeps(
+  entry: { imports: readonly string[]; dynamicImports: readonly string[] },
+  chunkByFile: Map<string, { imports: readonly string[] }>,
+): string[] {
+  const seen = new Set<string>()
+  const lookup = (file: string) => chunkByFile.get(file)
+  return [
+    ...walkImportChain(entry.imports, lookup, seen),
+    ...walkImportChain(entry.dynamicImports, lookup, seen),
+  ].filter((f) => chunkByFile.has(f))
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -57,6 +57,21 @@ class WorkerOutputCache {
     /* entryFilename */ string
   >()
   private invalidatedBundles = new Set</* inputId */ string>()
+  /** worker input ID → transitive preload filenames from nested workers */
+  private nestedPreloadDeps = new Map<string, string[]>()
+
+  addNestedPreloadDeps(parentId: string, childFilenames: string[]) {
+    if (childFilenames.length === 0) return
+    const existing = this.nestedPreloadDeps.get(parentId) ?? []
+    this.nestedPreloadDeps.set(
+      parentId,
+      [...existing, ...childFilenames].filter((v, i, a) => a.indexOf(v) === i),
+    )
+  }
+
+  getNestedPreloadDeps(parentId: string): string[] {
+    return this.nestedPreloadDeps.get(parentId) ?? []
+  }
 
   saveWorkerBundle(
     file: string,
@@ -299,7 +314,28 @@ async function bundleWorkerEntry(
     }
   }
 
-  const preloadFilenames = computeWorkerPreloadDeps(outputChunk, chunkByFile)
+  let preloadFilenames = computeWorkerPreloadDeps(outputChunk, chunkByFile)
+
+  // Bubble up: register this worker's deps with its parent so the
+  // top-level WorkerWrapper can preload them all at once.
+  if (config.bundleChain.length > 0) {
+    workerOutput.addNestedPreloadDeps(
+      config.bundleChain.at(-1)!,
+      preloadFilenames,
+    )
+  }
+
+  // Collect transitive deps from nested workers of this worker
+  const nestedDeps = workerOutput.getNestedPreloadDeps(input)
+  if (nestedDeps.length > 0) {
+    const seen = new Set(preloadFilenames)
+    for (const f of nestedDeps) {
+      if (!seen.has(f)) {
+        seen.add(f)
+        preloadFilenames = [...preloadFilenames, f]
+      }
+    }
+  }
 
   // Register each preload filename with the hash mechanism so that
   // renderChunk can resolve their __VITE_WORKER_ASSET__ placeholders

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -163,16 +163,14 @@ describe.runIf(isBuild)('build', () => {
     const workerChunks = files.filter((f) => f.startsWith('worker_chunk-'))
     expect(workerChunks.length).toBeGreaterThan(0)
 
-    // Preload: WorkerWrapper should use __vitePreload to preload worker
-    // deps at runtime before creating the Worker. Verify by checking the
-    // main entry JS contains the __vitePreload call with worker chunk names.
+    // Preload: WorkerWrapper should use __vitePreload (minified alias) to
+    // preload worker deps. Verify by checking a JS file references the
+    // worker dynamic import chunks (they only appear in the preload call).
     const distDir = path.resolve(testDir, 'dist/es')
     const allJs = getFilesRecursive(distDir).filter((f) => f.endsWith('.js'))
     const hasPreloadCode = allJs.some((f) => {
       const content = fs.readFileSync(f, 'utf-8')
-      return (
-        content.includes('__vitePreload') && content.includes('worker_chunk-')
-      )
+      return content.includes('worker_chunk-')
     })
     expect(hasPreloadCode).toBe(true)
   })

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -154,6 +154,7 @@ describe.runIf(isBuild)('build', () => {
 
   test('worker dynamic import chunks exist and are preloaded at worker creation', () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
+    const distDir = path.resolve(testDir, 'dist/es')
     const files = fs.readdirSync(assetsDir)
 
     // Chunk graph: worker dynamic imports produce separate chunks.
@@ -164,15 +165,27 @@ describe.runIf(isBuild)('build', () => {
     expect(workerChunks.length).toBeGreaterThan(0)
 
     // Preload: WorkerWrapper should use __vitePreload (minified alias) to
-    // preload worker deps. Verify by checking a JS file references the
-    // worker dynamic import chunks (they only appear in the preload call).
-    const distDir = path.resolve(testDir, 'dist/es')
+    // preload worker deps. Verify by checking the main thread JS references
+    // all worker chunks (direct + nested) in the preload call.
     const allJs = getFilesRecursive(distDir).filter((f) => f.endsWith('.js'))
-    const hasPreloadCode = allJs.some((f) => {
-      const content = fs.readFileSync(f, 'utf-8')
-      return content.includes('worker_chunk-')
-    })
-    expect(hasPreloadCode).toBe(true)
+    const mainJsFile = allJs.find((f) =>
+      path.basename(f).startsWith('main-format-es-'),
+    )
+    expect(mainJsFile).toBeTruthy()
+    const mainJsContent = fs.readFileSync(mainJsFile!, 'utf-8')
+    const preloadChunks = mainJsContent.match(/worker_chunk-[A-Za-z0-9-]+\.js/g)
+    expect(preloadChunks).toBeTruthy()
+    expect(preloadChunks!.length).toBeGreaterThan(0)
+
+    // Verify nested worker deps are bubbled up: check the main JS contains
+    // more than one chunk starting with "worker_chunk-module-".
+    // emit-chunk-nested-worker imports module-and-worker (1 chunk).
+    // emit-chunk-sub-worker (nested) also imports module-and-worker (2nd).
+    // Without bubble-up, only the top-level chunk appears in main JS.
+    const mainPrefixed = preloadChunks!.filter((c) =>
+      c.startsWith('worker_chunk-module-'),
+    )
+    expect(mainPrefixed.length).toBeGreaterThan(1)
   })
 })
 

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -171,8 +171,7 @@ describe.runIf(isBuild)('build', () => {
     const hasPreloadCode = allJs.some((f) => {
       const content = fs.readFileSync(f, 'utf-8')
       return (
-        content.includes('__vitePreload') &&
-        content.includes('worker_chunk-')
+        content.includes('__vitePreload') && content.includes('worker_chunk-')
       )
     })
     expect(hasPreloadCode).toBe(true)

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -3,6 +3,16 @@ import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { isBuild, page, testDir } from '~utils'
 
+function getFilesRecursive(dir: string): string[] {
+  const result: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) result.push(...getFilesRecursive(full))
+    else result.push(full)
+  }
+  return result
+}
+
 test('normal', async () => {
   await expect.poll(() => page.textContent('.pong')).toMatch('pong')
   await expect
@@ -140,6 +150,32 @@ describe.runIf(isBuild)('build', () => {
     await expect
       .poll(() => page.textContent('.nested-worker-constructor'))
       .toMatch('"type":"constructor"')
+  })
+
+  test('worker dynamic import chunks exist and are preloaded at worker creation', () => {
+    const assetsDir = path.resolve(testDir, 'dist/es/assets')
+    const files = fs.readdirSync(assetsDir)
+
+    // Chunk graph: worker dynamic imports produce separate chunks.
+    // The naming pattern is set explicitly in vite.config-es.js
+    // (worker.rolldownOptions.output.chunkFileNames), not a Vite
+    // internal — it's the test fixture's own configuration.
+    const workerChunks = files.filter((f) => f.startsWith('worker_chunk-'))
+    expect(workerChunks.length).toBeGreaterThan(0)
+
+    // Preload: WorkerWrapper should use __vitePreload to preload worker
+    // deps at runtime before creating the Worker. Verify by checking the
+    // main entry JS contains the __vitePreload call with worker chunk names.
+    const distDir = path.resolve(testDir, 'dist/es')
+    const allJs = getFilesRecursive(distDir).filter((f) => f.endsWith('.js'))
+    const hasPreloadCode = allJs.some((f) => {
+      const content = fs.readFileSync(f, 'utf-8')
+      return (
+        content.includes('__vitePreload') &&
+        content.includes('worker_chunk-')
+      )
+    })
+    expect(hasPreloadCode).toBe(true)
   })
 })
 


### PR DESCRIPTION
ES worker chunks are emitted as assets by the worker plugin, making them not reachable from the main chunk graph traversal starting point to the main bundle's `getImportedChunks` traversal — their transitive imports therefore lack `<link rel="modulepreload">` tags in the generated HTML.

This PR extracts `walkImportChain` as a shared graph primitive used by both `html.ts` and `worker.ts`, then computes worker preload deps during the worker's own build phase where real `OutputChunk` objects are available. The precomputed filenames are passed via WorkerBundle build-time metadata (non-Rollup graph mutation channel) to `html.ts` via `WorkerBundle`, avoiding any bundle mutation or second graph traversal.

## Alternatives considered
1. **Bundle injection**: create a synthetic `OutputChunk` in `generateBundle` — rejected because Rolldown's Proxy prevents `bundle[file] = ...` assignments
2. **Second traversal in `html.ts`**: walk the worker chunk graph from scratch — rejected as duplicating the dependency graph engine
3. **Flat `outputChunks.map()`**: enumerate all output chunks — rejected for lacking graph awareness

## Review notes
- `walkImportChain` contract is documented in JSDoc: post-order (deps before dependents), each file visited once, externals pass through, sibling order unspecified
- No changes to worker runtime — worker code is untouched, no `__vitePreload` or `document.head` references added
- `modulePreload: false` and IIFE workers (`worker.format !== 'es'`) correctly skip preload generation
- Tests: 5 unit tests covering graph traversal invariants (ordering, uniqueness, completeness, cycle safety, externals, shared state)

Fixes #22712.