### PR TITLE
fix: disable lazy barrel in bundled dev (fix #22749)

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -357,6 +357,9 @@ export class BundledDev {
         this.environment.getTopLevelConfig(),
       ),
     }
+    // disable lazy barrel optimization due to a bug in Rolldown dev mode
+    // https://github.com/vitejs/vite/issues/22749
+    rolldownOptions.experimental.lazyBarrel = false
 
     // disable inlineConst optimization due to a bug in Rolldown
     // https://github.com/vitejs/vite/issues/21843

--- a/playground/bundled-dev/__tests__/bundled-dev.spec.ts
+++ b/playground/bundled-dev/__tests__/bundled-dev.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { isBuild, page } from '~utils'
+
+if (isBuild) {
+  test('should render', async () => {
+    await expect.poll(() => page.textContent('.app')).toBe('hello')
+    await expect
+      .poll(() => page.textContent('.date-fns-locale'))
+      .toBe('czerwca')
+  })
+} else {
+  test('bundles locale barrel imports', async () => {
+    const reloadPromise = page.waitForEvent('load')
+    await expect
+      .poll(() => page.textContent('body'))
+      .toContain('Bundling in progress')
+    await reloadPromise
+    await expect.poll(() => page.textContent('.app')).toBe('hello')
+    await expect
+      .poll(() => page.textContent('.date-fns-locale'))
+      .toBe('czerwca')
+  })
+}

--- a/playground/bundled-dev/index.html
+++ b/playground/bundled-dev/index.html
@@ -1,0 +1,4 @@
+<div class="app"></div>
+<div class="date-fns-locale"></div>
+
+<script type="module" src="./main.js"></script>

--- a/playground/bundled-dev/main.js
+++ b/playground/bundled-dev/main.js
@@ -1,0 +1,9 @@
+import { format } from 'date-fns'
+import { pl } from 'date-fns/locale'
+
+text('.app', 'hello')
+text('.date-fns-locale', format(new Date(2020, 5, 1), 'MMMM', { locale: pl }))
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}

--- a/playground/bundled-dev/package.json
+++ b/playground/bundled-dev/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vitejs/test-bundled-dev",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "date-fns": "4.1.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/playground/bundled-dev/vite.config.ts
+++ b/playground/bundled-dev/vite.config.ts
@@ -1,0 +1,50 @@
+import { type Plugin, defineConfig } from 'vite'
+
+export default defineConfig({
+  experimental: {
+    bundledDev: true,
+  },
+  plugins: [waitBundleCompleteUntilAccess()],
+})
+
+function waitBundleCompleteUntilAccess(): Plugin {
+  let resolvers: PromiseWithResolvers<void>
+
+  return {
+    name: 'wait-bundle-complete-until-access',
+    apply: 'serve',
+    configureServer(server) {
+      let accessCount = 0
+      resolvers = promiseWithResolvers()
+
+      server.middlewares.use((req, _res, next) => {
+        if (req.url === '/' || req.url === '/index.html') {
+          accessCount++
+          if (accessCount === 1) {
+            resolvers.resolve()
+          }
+        }
+        next()
+      })
+    },
+    async generateBundle() {
+      await resolvers.promise
+    },
+  }
+}
+
+interface PromiseWithResolvers<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+}
+
+function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,6 +611,12 @@ importers:
 
   playground/build-old: {}
 
+  playground/bundled-dev:
+    dependencies:
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
+
   playground/chunk-importmap: {}
 
   playground/cli: {}
@@ -5396,6 +5402,9 @@ packages:
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -11575,6 +11584,8 @@ snapshots:
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
+
+  date-fns@4.1.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:


### PR DESCRIPTION
### Description

Fixes #22749.

Full-bundle dev currently leaves Rolldown's lazy barrel optimization enabled. With barrel imports such as `import { pl } from 'date-fns/locale'`, the generated dev bundle can retain references to symbols that are no longer declared (for example `formatDistance$93`), which crashes the entry before the app code runs.

This disables `experimental.lazyBarrel` only for bundled dev, next to the existing `inlineConst` workaround in the same code path.

### Alternatives checked

- Checked for duplicate open PRs for #22749 and this bundled-dev/date-fns crash; none found.
- Checked the published Rolldown version; `1.1.3` is still latest, so there is no dependency bump path yet.
- Tried disabling `treeshake`; it did not fix the missing symbol output.
- Tried disabling `optimization.pifeForModuleWrappers`; it did not fix the missing symbol output.

### Tests

- `pnpm --filter vite run build`
- `pnpm run test-serve bundled-dev`
- `pnpm run test-build bundled-dev`
- `pnpm run test-serve hmr-full-bundle-mode`
- `pnpm exec oxfmt --check packages/vite/src/node/server/bundledDev.ts playground/bundled-dev/__tests__/bundled-dev.spec.ts playground/bundled-dev/main.js playground/bundled-dev/package.json playground/bundled-dev/vite.config.ts`
- `pnpm exec eslint packages/vite/src/node/server/bundledDev.ts playground/bundled-dev/__tests__/bundled-dev.spec.ts playground/bundled-dev/main.js playground/bundled-dev/vite.config.ts`
- `git diff --check`

No documentation update is needed because this is an internal workaround for experimental full-bundle dev mode.
