### PR TITLE
fix(worker): warn when new URL is not directly passed to Worker constructor (fix #22727)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -10,15 +10,93 @@ async function createWorkerImportMetaUrlPluginTransform() {
   const environment = new PartialEnvironment('client', config)
 
   return async (code: string) => {
+    const warnings: string[] = []
     // @ts-expect-error transform.handler should exist
     const result = await instance.transform.handler.call(
-      { environment, parse: parseAst },
+      {
+        environment,
+        parse: parseAst,
+        warn: (msg: string | { message: string }) => {
+          warnings.push(typeof msg === 'string' ? msg : msg.message)
+        },
+      },
       code,
       'foo.ts',
     )
     return result?.code || result
   }
 }
+
+async function createWorkerImportMetaUrlPluginTransformWithWarnings() {
+  const config = await resolveConfig({ configFile: false }, 'serve')
+  const instance = workerImportMetaUrlPlugin(config)
+  const environment = new PartialEnvironment('client', config)
+
+  return async (code: string) => {
+    const warnings: string[] = []
+    // @ts-expect-error transform.handler should exist
+    const result = await instance.transform.handler.call(
+      {
+        environment,
+        parse: parseAst,
+        warn: (msg: string | { message: string }) => {
+          warnings.push(typeof msg === 'string' ? msg : msg.message)
+        },
+      },
+      code,
+      'foo.ts',
+    )
+    return { code: result?.code || result, warnings }
+  }
+}
+
+describe('workerImportMetaUrlPlugin - indirect new URL warnings', async () => {
+  const transformWithWarnings =
+    await createWorkerImportMetaUrlPluginTransformWithWarnings()
+
+  test('warns when new URL is assigned to a variable before being passed to Worker', async () => {
+    const { code, warnings } = await transformWithWarnings(
+      `const url = new URL('./worker.js', import.meta.url)
+new Worker(url)`,
+    )
+    expect(code).toBeNull()
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain(
+      `\`new URL('./worker.js', import.meta.url)\` is not directly passed to a Worker constructor`,
+    )
+    expect(warnings[0]).toContain(
+      `new Worker(new URL('./worker.js', import.meta.url))`,
+    )
+  })
+
+  test('warns for each indirect URL when multiple workers use variable URLs', async () => {
+    const { warnings } = await transformWithWarnings(
+      `const url1 = new URL('./cpu.worker.js', import.meta.url)
+const url2 = new URL('./gpu.worker.js', import.meta.url)
+new Worker(url1)
+new Worker(url2)`,
+    )
+    expect(warnings).toHaveLength(2)
+  })
+
+  test('does not warn when new URL is passed directly to Worker', async () => {
+    const { warnings } = await transformWithWarnings(
+      `new Worker(new URL('./worker.js', import.meta.url))`,
+    )
+    expect(warnings).toHaveLength(0)
+  })
+
+  test('does not warn for dynamic template literal URLs', async () => {
+    const { warnings } = await transformWithWarnings(
+      'const name = "worker"\n' +
+        'const url = new URL(`./' +
+        '$' +
+        '{name}.js`, import.meta.url)\n' +
+        'new Worker(url)',
+    )
+    expect(warnings).toHaveLength(0)
+  })
+})
 
 describe('workerImportMetaUrlPlugin', async () => {
   const transform = await createWorkerImportMetaUrlPluginTransform()

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -184,6 +184,9 @@ async function getWorkerType(
 export const workerImportMetaUrlRE: RegExp =
   /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*(new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\))/dg
 
+const bareImportMetaUrlRE: RegExp =
+  /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg
+
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   let workerResolver: ResolveIdFn
 
@@ -204,17 +207,21 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     },
 
     transform: {
-      filter: { code: workerImportMetaUrlRE },
+      filter: { code: /\bnew\s+(?:Worker|SharedWorker)\s*\(/ },
       async handler(code, id) {
         const isBundled = this.environment.config.isBundled
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
         const re = new RegExp(workerImportMetaUrlRE)
 
+        const handledExpStarts = new Set<number>()
+
         let match: RegExpExecArray | null
         while ((match = re.exec(cleanString))) {
           const [[, endIndex], [expStart, expEnd], [urlStart, urlEnd]] =
             match.indices as Array<[number, number]>
+
+          handledExpStarts.add(expStart)
 
           const rawUrl = code.slice(urlStart, urlEnd)
 
@@ -279,6 +286,26 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               expEnd,
               // NOTE: add `'' +` to opt-out rolldown's transform: https://github.com/rolldown/rolldown/issues/2745
               `new URL(/* @vite-ignore */ ${JSON.stringify(builtUrl)}, '' + import.meta.url)`,
+            )
+          }
+        }
+
+        const bareRe = new RegExp(bareImportMetaUrlRE)
+        let bareMatch: RegExpExecArray | null
+        while ((bareMatch = bareRe.exec(cleanString))) {
+          const [[bareStart], [urlStart, urlEnd]] = bareMatch.indices as Array<
+            [number, number]
+          >
+          if (!handledExpStarts.has(bareStart)) {
+            const rawUrl = code.slice(urlStart, urlEnd)
+            if (rawUrl[0] === '`' && rawUrl.includes('${')) {
+              continue
+            }
+            this.warn(
+              `\`new URL(${rawUrl}, import.meta.url)\` is not directly passed to a Worker constructor and will not be processed as a worker entry point. ` +
+                `To bundle this file as a worker, pass the URL expression directly: ` +
+                `\`new Worker(new URL(${rawUrl}, import.meta.url))\``,
+              bareStart,
             )
           }
         }


### PR DESCRIPTION
### What this fixes

When `new URL('./worker.ts', import.meta.url)` is assigned to a variable before being passed to `new Worker()`, Vite's worker plugin does not recognise it as a worker entry point. The file falls through to the generic asset pipeline, gets MIME-typed as `video/mp2t` (`.ts` extension collision), and the worker fails silently at runtime — no build error, no warning.

Reproduces with the pattern from #22727:

```ts
const url = backend === 'gpu'
  ? new URL('./gpu.worker.ts', import.meta.url)
  : new URL('./cpu.worker.ts', import.meta.url)
const worker = new Worker(url, { type: 'module' })
```

### What this PR does

- Broadens the `transform` filter from the strict `workerImportMetaUrlRE` (which requires `new Worker(new URL(...))` literally) to `/\bnew\s+(?:Worker|SharedWorker)\s*\(/`, so the handler also runs for files with indirect patterns.
- After the existing main loop (which handles the direct case), a second scan finds any `new URL('...', import.meta.url)` expressions that were not consumed by the main loop and emits a `this.warn()` for each one, pointing the user to the direct form.
- Dynamic template literals (`new URL(\`./\${name}.ts\`, import.meta.url)`) are silently skipped — no actionable guidance is possible.

The existing transform behaviour is unchanged; only the filter and the post-loop warning are new.

### Tests

Added 4 unit tests to the existing `workerImportMetaUrl.spec.ts`:
- warns on single indirect URL
- warns once per URL when multiple workers use variable URLs
- does not warn when URL is already passed directly (existing path)
- does not warn for dynamic template literal URLs

All 23 tests pass (`pnpm run test-unit workerImportMetaUrl`). Lint clean (`pnpm run lint`).