### PR TITLE
test: cover a constant prefix before the first variable in dynamic import vars

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
@@ -12,6 +12,8 @@ exports[`parse positives > alias path with multi ../ 1`] = `"__variableDynamicIm
 
 exports[`parse positives > basic 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js")), \`./mods/\${base}.js\`)"`;
 
+exports[`parse positives > constant before variable 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js")), \`./\${'mods'}/\${base}.js\`)"`;
+
 exports[`parse positives > with ../ and itself 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("../dynamicImportVar/*.js")), \`./\${name}.js\`)"`;
 
 exports[`parse positives > with multi ../ and itself 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("../../plugins/dynamicImportVar/*.js")), \`./\${name}.js\`)"`;

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -25,6 +25,10 @@ describe('parse positives', () => {
     expect(await run('`./mods/${base}.js`')).toMatchSnapshot()
   })
 
+  it('constant before variable', async () => {
+    expect(await run("`./${'mods'}/${base}.js`")).toMatchSnapshot()
+  })
+
   it('alias path', async () => {
     expect(await run('`@/${base}.js`')).toMatchSnapshot()
   })

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -70,6 +70,12 @@ test('should load dynamic import with vars', async () => {
     .toMatch('hello')
 })
 
+test('should load dynamic import with vars and a constant prefix', async () => {
+  await expect
+    .poll(() => page.textContent('.dynamic-import-with-vars-const-prefix'))
+    .toMatch('Foo view')
+})
+
 test('should load dynamic import with vars ignored', async () => {
   await expect
     .poll(() => page.textContent('.dynamic-import-with-vars-ignored'))

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -13,6 +13,9 @@
 <p>dynamic-import-with-vars</p>
 <div class="dynamic-import-with-vars">todo</div>
 
+<p>dynamic-import-with-vars-const-prefix</p>
+<div class="dynamic-import-with-vars-const-prefix">todo</div>
+
 <p>dynamic-import-with-vars-ignored</p>
 <div class="dynamic-import-with-vars-ignored">todo</div>
 

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -135,6 +135,13 @@ import(`../nested/${base}.js`).then((mod) => {
 import(`../nested/nested/${base}.js`).then((mod) => {
   text('.dynamic-import-nested-self', mod.self)
 })
+
+base = 'foo'
+// a constant (`${'views'}`) before the first variable must not be duplicated
+import(`../${'views'}/${base}.js`).then((mod) => {
+  text('.dynamic-import-with-vars-const-prefix', mod.msg)
+})
+
 ;(async function () {
   const { foo } = await import('./treeshaken/treeshaken.js')
   const { bar, default: tree } = await import('./treeshaken/treeshaken.js')


### PR DESCRIPTION
Related to rolldown/rolldown#10004

### What this adds

Tests for a variable dynamic import where a constant expression precedes the first variable, such as `import(`./${'views'}/${name}.js`)`. The resolved constant prefix must not be duplicated into the runtime path: it has to stay `./views/${name}.js`, not `./views/views/${name}.js`, otherwise the computed path matches no `import.meta.glob` key and the import rejects at runtime with "Unknown variable dynamic import".

### Coverage

Two layers, because `vite:dynamic-import-vars` runs a different implementation per environment:

- Dev / non-bundled uses the JS transform. Added a unit test in `packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts` whose snapshot shows the glob `./mods/*.js` and the raw pattern `` `./${'mods'}/${base}.js` `` (the constant is kept in the source, not spliced and duplicated).
- Bundled builds delegate to rolldown's native `viteDynamicImportVarsPlugin` (`applyToEnvironment` returns it when `isBundled`). Added a `playground/dynamic-import` case (`index.html`, `nested/index.js`, `__tests__/dynamic-import.spec.ts`) that builds through that native plugin and asserts the import resolves to the real view ("Foo view").

### Note on the rolldown dependency

The playground build test passes only with the rolldown fix that stops splicing the resolved prefix for relative specifiers. With rolldown 1.1.3 the build emits `../views/views/${name}.js` and the test fails, so this playground case should land after that rolldown change is released and Vite's rolldown dependency is bumped. The `parse.spec.ts` unit test is independent of rolldown and passes today.