### PR TITLE
fix: invert `esbuild.jsxSideEffects` when converting to `oxc.jsx.pure`

### DIFF
--- a/packages/vite/src/node/__tests__/oxc.spec.ts
+++ b/packages/vite/src/node/__tests__/oxc.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { convertEsbuildConfigToOxcConfig } from '../plugins/oxc'
+import { createLogger } from '../logger'
+
+describe('convertEsbuildConfigToOxcConfig', () => {
+  const logger = createLogger('silent')
+
+  // esbuild's `jsxSideEffects` is the inverse of oxc's `jsx.pure`:
+  // `jsxSideEffects: true` means JSX has side effects, i.e. it is NOT pure.
+  test('inverts jsxSideEffects when mapping to jsx.pure', () => {
+    expect(
+      convertEsbuildConfigToOxcConfig({ jsxSideEffects: true }, logger).jsx,
+    ).toMatchObject({ pure: false })
+    expect(
+      convertEsbuildConfigToOxcConfig({ jsxSideEffects: false }, logger).jsx,
+    ).toMatchObject({ pure: true })
+  })
+})

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -384,7 +384,6 @@ export function convertEsbuildConfigToOxcConfig(
       jsxOptions.development = esbuildTransformOptions.jsxDev
     }
     if (esbuildTransformOptions.jsxSideEffects !== undefined) {
-      // esbuild's `jsxSideEffects` is the inverse of oxc's `jsx.pure`
       jsxOptions.pure = !esbuildTransformOptions.jsxSideEffects
     }
 

--- a/packages/vite/src/node/plugins/oxc.ts
+++ b/packages/vite/src/node/plugins/oxc.ts
@@ -384,7 +384,8 @@ export function convertEsbuildConfigToOxcConfig(
       jsxOptions.development = esbuildTransformOptions.jsxDev
     }
     if (esbuildTransformOptions.jsxSideEffects !== undefined) {
-      jsxOptions.pure = esbuildTransformOptions.jsxSideEffects
+      // esbuild's `jsxSideEffects` is the inverse of oxc's `jsx.pure`
+      jsxOptions.pure = !esbuildTransformOptions.jsxSideEffects
     }
 
     oxcOptions.jsx = jsxOptions


### PR DESCRIPTION
## Problem

`convertEsbuildConfigToOxcConfig` copies esbuild's `jsxSideEffects` straight into oxc's `jsx.pure`, but the two options mean the **opposite** thing.

```ts
// packages/vite/src/node/plugins/oxc.ts
if (esbuildTransformOptions.jsxSideEffects !== undefined) {
  jsxOptions.pure = esbuildTransformOptions.jsxSideEffects // ← same polarity, but they are inverse
}
```

| Option | `true` means | source |
| --- | --- | --- |
| esbuild `jsxSideEffects` | JSX **has** side effects → **not** pure, keep it | esbuild docs (`#jsx-side-effects`) |
| oxc `jsx.pure` | mark JSX as **pure** → tree-shakeable (`@default true`) | rolldown `JsxOptions.pure` |

So `jsxSideEffects: false` ⟺ `pure: true` and `jsxSideEffects: true` ⟺ `pure: false`. The direct copy inverts the user's intent: a user setting `jsxSideEffects: true` to keep side-effectful JSX would get `pure: true` (mark it removable).

Reachable via the legacy `esbuild` config option (`config.ts:1931` → `convertEsbuildConfigToOxcConfig`).

## Fix

```diff
  if (esbuildTransformOptions.jsxSideEffects !== undefined) {
+   // esbuild's `jsxSideEffects` is the inverse of oxc's `jsx.pure`
-   jsxOptions.pure = esbuildTransformOptions.jsxSideEffects
+   jsxOptions.pure = !esbuildTransformOptions.jsxSideEffects
  }
```

## When it matters

oxc honors `jsx.pure` only when a **custom JSX factory** is configured. From `oxc_transformer`:

```rust
// jsx/jsx_impl.rs
let pure = options.pure || (options.import_source.is_none() && options.pragma.is_none());
```

So with the **default React** runtime, JSX is always marked `/* @__PURE__ */` regardless of `pure`. But when the user sets a custom `jsxFactory`/`jsxImportSource` (e.g. a non-React JSX library), `jsx.pure` is respected — which is exactly when `jsxSideEffects` is meaningful. Verified with `transformSync`:

```
pragma 'h', pure: true  -> const el = /* @__PURE__ */ h("div", null);
pragma 'h', pure: false -> const el = h("div", null);
```

With the bug, a user setting a custom factory + `jsxSideEffects: true` (JSX has side effects, keep it) got `pure: true` → `@__PURE__` → their side-effectful JSX could be tree-shaken away. The fix maps it correctly to `pure: false` (kept).

## Test

`packages/vite/src/node/__tests__/oxc.spec.ts` unit-tests the conversion (independent of whether oxc consumes the value):

- `{ jsxSideEffects: true }` → `jsx.pure === false`
- `{ jsxSideEffects: false }` → `jsx.pure === true`