### PR TITLE
docs: fix skipLibCheck example to use boolean true

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -118,7 +118,7 @@ Note that this feature has a performance cost and is [discouraged by the TypeScr
 - [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig#experimentalDecorators)
 
 ::: tip `skipLibCheck`
-Vite starter templates have `"skipLibCheck": "true"` by default to avoid typechecking dependencies, as they may choose to only support specific versions and configurations of TypeScript. You can learn more at [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688).
+Vite starter templates have `"skipLibCheck": true` by default to avoid typechecking dependencies, as they may choose to only support specific versions and configurations of TypeScript. You can learn more at [vuejs/vue-cli#5688](https://github.com/vuejs/vue-cli/pull/5688).
 :::
 
 ### Client Types


### PR DESCRIPTION
Vite templates use the boolean true, not the string "true" ("skipLibCheck": "true" is invalid tsconfig). Aligns the doc with create-vite templates.