### PR TITLE
fix: correct build output asset typing

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -11,7 +11,7 @@ import type {
   RolldownOutput,
   RollupLog,
 } from 'rolldown'
-import type { LibraryFormats, LibraryOptions } from '../build'
+import type { BuildOutput, LibraryFormats, LibraryOptions } from '../build'
 import {
   build,
   createBuilder,
@@ -28,6 +28,24 @@ const dirname = import.meta.dirname
 type FormatsToFileNames = [LibraryFormats, string][]
 
 describe('build', () => {
+  test('returns an asset first when building a css entry', async () => {
+    const result = (await build({
+      configFile: false,
+      publicDir: false,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        rolldownOptions: {
+          input: resolve(dirname, 'fixtures/emit-assets/css-normal.css'),
+        },
+      },
+    })) as BuildOutput
+
+    expect(result.output[0]).toMatchObject({
+      type: 'asset',
+    })
+  })
+
   test('file hash should change when css changes for dynamic entries', async () => {
     const buildProject = async (cssColor: string) => {
       return (await build({

--- a/packages/vite/src/node/__tests_dts__/build.ts
+++ b/packages/vite/src/node/__tests_dts__/build.ts
@@ -1,0 +1,24 @@
+import type { Equal, ExpectTrue } from '@type-challenges/utils'
+import type { OutputAsset, OutputChunk, RolldownWatcher } from 'rolldown'
+import type { build, BuildOutput, BuildResult, createBuilder } from '../build'
+
+type BuildReturn = Awaited<ReturnType<typeof build>>
+type Builder = Awaited<ReturnType<typeof createBuilder>>
+type BuilderBuildReturn = Awaited<ReturnType<Builder['build']>>
+
+type SingleBuildOutput = Exclude<BuildReturn, BuildOutput[] | RolldownWatcher>
+type BuilderSingleBuildOutput = Exclude<
+  BuilderBuildReturn,
+  BuildOutput[] | RolldownWatcher
+>
+
+export type cases = [
+  ExpectTrue<Equal<BuildReturn, BuildResult>>,
+  ExpectTrue<Equal<BuilderBuildReturn, BuildResult>>,
+  ExpectTrue<Equal<SingleBuildOutput['output'][0], OutputChunk | OutputAsset>>,
+  ExpectTrue<
+    Equal<BuilderSingleBuildOutput['output'][0], OutputChunk | OutputAsset>
+  >,
+]
+
+export {}

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -311,6 +311,12 @@ export interface BuildEnvironmentOptions {
 
 export type BuildOptions = BuildEnvironmentOptions
 
+export type BuildOutput = Omit<RolldownOutput, 'output'> & {
+  output: [OutputChunk | OutputAsset, ...(OutputChunk | OutputAsset)[]]
+}
+
+export type BuildResult = BuildOutput | BuildOutput[] | RolldownWatcher
+
 export interface LibraryOptions {
   /**
    * Path of library entry
@@ -560,7 +566,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
  */
 export async function build(
   inlineConfig: InlineConfig = {},
-): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher> {
+): Promise<BuildResult> {
   const builder = await createBuilder(inlineConfig, true)
   const environment = Object.values(builder.environments)[0]
   if (!environment) throw new Error('No environment found')
@@ -1755,9 +1761,7 @@ export interface ViteBuilder {
   environments: Record<string, BuildEnvironment>
   config: ResolvedConfig
   buildApp(): Promise<void>
-  build(
-    environment: BuildEnvironment,
-  ): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher>
+  build(environment: BuildEnvironment): Promise<BuildResult>
   runDevTools(): Promise<void>
 }
 
@@ -1863,9 +1867,7 @@ export async function createBuilder(
         }
       }
     },
-    async build(
-      environment: BuildEnvironment,
-    ): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher> {
+    async build(environment: BuildEnvironment): Promise<BuildResult> {
       const output = await buildEnvironment(environment)
       environment.isBuilt = true
       return output

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -149,6 +149,8 @@ export type {
 export type {
   ViteBuilder,
   BuildAppHook,
+  BuildOutput,
+  BuildResult,
   BuilderOptions,
   BuildOptions,
   BuildEnvironmentOptions,


### PR DESCRIPTION
### Description

Fixes #22647.

Vite can return an asset as the first item in `build()` output when the build input is a CSS entry. The public build result type now reflects that by allowing the first output item to be either an `OutputChunk` or an `OutputAsset`.

This also applies the same result type to `ViteBuilder.build()` and adds type/runtime coverage for the CSS-entry case.

### Tests

- `pnpm --filter vite build`
- `pnpm --filter vite typecheck`
- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec eslint packages/vite/src/node/build.ts packages/vite/src/node/index.ts packages/vite/src/node/__tests_dts__/build.ts packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/build.ts packages/vite/src/node/index.ts packages/vite/src/node/__tests_dts__/build.ts packages/vite/src/node/__tests__/build.spec.ts`
- `git diff --check`