### PR TITLE
feat(optimizer): support aube lockfile

### DIFF
--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -65,7 +65,7 @@ You can further customize Rolldown too with the [`optimizeDeps.rolldownOptions` 
 
 Vite caches the pre-bundled dependencies in `node_modules/.vite`. It determines whether it needs to re-run the pre-bundling step based on a few sources:
 
-- Package manager lockfile content, e.g. `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` or `bun.lock`.
+- Package manager lockfile content, e.g. `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock` or `aube-lock.yaml`.
 - Patches folder modification time.
 - Relevant fields in your `vite.config.js`, if present.
 - `NODE_ENV` value.

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1276,6 +1276,11 @@ const lockfileFormats = [
     checkPatchesDir: 'patches',
     manager: 'bun',
   },
+  {
+    path: 'aube-lock.yaml',
+    checkPatchesDir: false,
+    manager: 'aube',
+  },
 ].sort((_, { manager }) => {
   return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1
 })

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1253,6 +1253,11 @@ const lockfileFormats = [
     checkPatchesDir: false,
     manager: 'pnpm',
   },
+  {
+    path: 'aube-lock.yaml',
+    checkPatchesDir: false,
+    manager: 'aube',
+  },
 
   // discouraged package manager lockfiles
   // or deprecated lockfiles
@@ -1278,11 +1283,6 @@ const lockfileFormats = [
     path: 'bun.lockb',
     checkPatchesDir: 'patches',
     manager: 'bun',
-  },
-  {
-    path: 'aube-lock.yaml',
-    checkPatchesDir: false,
-    manager: 'aube',
   },
 ].sort((_, { manager }) => {
   return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1


### PR DESCRIPTION

- What is this PR solving? Write a clear and concise description.
[Aube](https://aube.jdx.dev/) is a new node package manager which uses the `aube-lock.yaml` lockfile. 

    When using Aube we have the issue that the [File system cache](https://v4.vite.dev/guide/dep-pre-bundling.html#file-system-cache) doesn't get updated when we update our dependencies. This change should solve that.

- Reference the issues it solves (e.g. `fixes #123`).
I didn't create an issue for this, because I think this change will already solve the issue.

- What other alternatives have you explored?
We could also write a plugin for this, but all users of Aube will have this issue.

<!--
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
