### PR TITLE
fix(deps): bump `es-module-lexer` to 2.2.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -98,7 +98,7 @@
     "cors": "^2.8.6",
     "cross-spawn": "^7.0.6",
     "dotenv-expand": "^13.0.0",
-    "es-module-lexer": "^2.1.0",
+    "es-module-lexer": "^2.2.0",
     "esbuild": "^0.28.1",
     "escape-html": "^1.0.3",
     "estree-walker": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,8 +324,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0(patch_hash=49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889)
       es-module-lexer:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -5544,6 +5544,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-module-lexer@2.2.0:
+    resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -11681,6 +11684,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.2.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:


### PR DESCRIPTION
Upstream bug that closes #22750 has been [fixed](https://github.com/guybedford/es-module-lexer/issues/208) and merged into [`es-module-lexer@2.2.0` release](https://github.com/guybedford/es-module-lexer/releases/tag/2.2.0).