### PR TITLE
test: update content length for chokidar polling watcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,9 @@ test('should work', async () => {
 
 Some common test helpers (e.g. `testDir`, `isBuild`, or `editFile`) are also available in the utils. Source code is located at `playground/test-utils.ts`.
 
+> [!NOTE]
+> The dev server's file watcher runs in polling mode during tests. Polling (chokidar) only registers a file as changed when its size differs or its mtime strictly increases. On some platforms a quick in-place rewrite may not report an advanced mtime, so an edit that keeps the exact same byte length can be missed, and the expected HMR update or rebuild never fires (causing flaky timeouts). To enforce this, `editFile` throws if your replacement leaves the file's byte length unchanged; make the edit change the size (for example by adding a trailing space or an extra character that doesn't affect the test's semantics). If you trigger a watched change by some other means, make sure the edit changes the file's byte length.
+
 Note: The test build environment uses a [different default set of Vite config](https://github.com/vitejs/vite/blob/main/playground/vitestSetup.ts#L207-L227) to skip transpilation during tests to make it faster. This may produce a different result compared to the default production build.
 
 ### Extending the Test Suite

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -698,7 +698,7 @@ test.runIf(isBuild)('manifest', async () => {
 
 describe.runIf(isBuild)('css and assets in css in build watch', () => {
   test('css will not be lost and css does not contain undefined', async () => {
-    editFile('index.html', (code) => code.replace('Assets', 'assets'))
+    editFile('index.html', (code) => code.replace('Assets', 'assets2'))
     await notifyRebuildComplete(watcher)
     const cssFile = findAssetFile(/index-[-\w]+\.css$/, 'foo')
     expect(cssFile).not.toBe('')
@@ -714,10 +714,10 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
     expect(oldMainJsFiles.length).toBe(1)
     const oldMainJsFile = oldMainJsFiles[0]
 
-    editFile('asset/update.js', (code) => code.replace('hello', 'world'))
+    editFile('asset/update.js', (code) => code.replace('hello', 'world2'))
     await notifyRebuildComplete(watcher)
     await page.reload()
-    await expect.poll(() => page.textContent('.update-content')).toBe('world')
+    await expect.poll(() => page.textContent('.update-content')).toBe('world2')
 
     const newMainJsFiles = listAssets('foo').filter((f) =>
       /index-[-\w]+\.js$/.test(f),
@@ -736,10 +736,10 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
 
   test('import with raw query', async () => {
     expect(await page.textContent('.raw-query')).toBe('foo')
-    editFile('static/foo.txt', (code) => code.replace('foo', 'zoo'))
+    editFile('static/foo.txt', (code) => code.replace('foo', 'zoo2'))
     await notifyRebuildComplete(watcher)
     await page.reload()
-    expect(await page.textContent('.raw-query')).toBe('zoo')
+    expect(await page.textContent('.raw-query')).toBe('zoo2')
   })
 })
 
@@ -752,7 +752,7 @@ if (!isBuild) {
   test('@import in html style tag hmr', async () => {
     await expect.poll(() => getColor('.import-css')).toBe('rgb(0, 136, 255)')
     const loadPromise = page.waitForEvent('load')
-    editFile('./css/import.css', (code) => code.replace('#0088ff', '#00ff88'))
+    editFile('./css/import.css', (code) => code.replace('#0088ff', '#00ff88 '))
     await loadPromise
     await expect.poll(() => getColor('.import-css')).toBe('rgb(0, 255, 136)')
   })

--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -22,7 +22,7 @@ test('cli should work', async () => {
 
 test.runIf(isServe)('should restart', async () => {
   const logsLengthBeforeEdit = streams.server.out.length
-  editFile('./vite.config.js', (content) => content)
+  editFile('./vite.config.js', (content) => content + '\n')
   await expect
     .poll(() => {
       const logs = streams.server.out.slice(logsLengthBeforeEdit)

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -278,7 +278,7 @@ test('async chunk', async () => {
     expect(findAssetFile(/async-[-\w]{8}\.css$/)).toMatch('.async{color:teal}')
   } else {
     // test hmr
-    editFile('async.css', (code) => code.replace('color: teal', 'color: blue'))
+    editFile('async.css', (code) => code.replace('color: teal', 'color: blue '))
     await expect.poll(() => getColor(el)).toBe('blue')
   }
 })
@@ -301,7 +301,7 @@ test('treeshaken async chunk', async () => {
     // should be present in dev
     const el = await page.$('.async-treeshaken')
     editFile('async-treeshaken.css', (code) =>
-      code.replace('color: plum', 'color: blue'),
+      code.replace('color: plum', 'color: blue '),
     )
     await expect.poll(() => getColor(el)).toBe('blue')
   }
@@ -319,7 +319,7 @@ test('PostCSS dir-dependency', async () => {
   // NOTE: lightningcss does not support registering dependencies in plugins
   if (!isBuild) {
     editFile('glob-dep/foo.css', (code) =>
-      code.replace('color: grey', 'color: blue'),
+      code.replace('color: grey', 'color: blue '),
     )
     await expect.poll(() => getColor(el1)).toBe('blue')
     expect(await getColor(el2)).toBe('grey')
@@ -365,7 +365,8 @@ test('URL separation', async () => {
 
   for (const [c, i] of cases.map((c, i) => [c, i]) as [string, number][]) {
     // Replace the previous case
-    if (i > 0) editFile('imported.css', (code) => code.replace(cases[i - 1], c))
+    if (i > 0)
+      editFile('imported.css', (code) => code.replace(cases[i - 1], c) + '\n')
 
     expect(await getBg(urlSeparated)).toMatch(
       /^url\(.+\)(?:\s*,\s*url\(.+\))*$/,

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -64,13 +64,13 @@ if (isBuild) {
     )
     await setTimeout(100)
     editFile('main.js', (code) =>
-      code.replace("text('.app', 'hello1')", "text('.app', 'hello2')"),
+      code.replace("text('.app', 'hello1')", "text('.app', 'hello2') "),
     )
     await expect.poll(() => page.textContent('.app')).toBe('hello2')
 
     editFile('main.js', (code) =>
       code.replace(
-        "text('.app', 'hello2')\n" + '// @delay-transform',
+        "text('.app', 'hello2') \n" + '// @delay-transform',
         "text('.app', 'hello')",
       ),
     )
@@ -125,13 +125,13 @@ if (isBuild) {
     )
     await setTimeout(100)
     editFile('hmr.js', (code) =>
-      code.replace("const foo = 'hello1'", "const foo = 'hello2'"),
+      code.replace("const foo = 'hello1'", "const foo = 'hello2' "),
     )
     await expect.poll(() => page.textContent('.hmr')).toBe('hello2')
 
     editFile('hmr.js', (code) =>
       code.replace(
-        "const foo = 'hello2'\n" + '// @delay-transform',
+        "const foo = 'hello2' \n" + '// @delay-transform',
         "const foo = 'hello'",
       ),
     )

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -83,7 +83,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmr.ts', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -100,7 +100,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmr.ts', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -120,7 +120,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmrDep.js', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -140,7 +140,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmrDep.js', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -163,7 +163,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmrNestedDep.js', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -183,7 +183,7 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await untilConsoleLogAfter(
       () =>
         editFile('hmrNestedDep.js', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -261,16 +261,15 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
 
   test('plugin hmr handler + custom event', async () => {
     const el = () => hmr('.custom')
-    editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await expect.poll(() => el()).toMatch('edited')
+    editFile('customFile.js', (code) => code.replace('custom', 'edited2'))
+    await expect.poll(() => el()).toMatch('edited2')
   })
 
   test('plugin hmr remove custom events', async () => {
     const el = () => hmr('.toRemove')
-    editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await expect.poll(() => el()).toMatch('edited')
-    editFile('customFile.js', (code) => code.replace('edited', 'custom'))
-    await expect.poll(() => el()).toMatch('edited')
+    await expect.poll(() => el()).toMatch('edited2')
+    editFile('customFile.js', (code) => code.replace('edited2', 'custom33'))
+    await expect.poll(() => el()).toMatch('edited2')
   })
 
   test('plugin client-server communication', async () => {
@@ -307,7 +306,7 @@ describe('self accept with different entry point formats', () => {
       await untilConsoleLogAfter(
         () =>
           editFile('unresolved.ts', (code) =>
-            code.replace('const foo = 1', 'const foo = 2'),
+            code.replace('const foo = 1', 'const foo = 2 '),
           ),
         [
           'foo was: 1',
@@ -322,7 +321,7 @@ describe('self accept with different entry point formats', () => {
       await untilConsoleLogAfter(
         () =>
           editFile('unresolved.ts', (code) =>
-            code.replace('const foo = 2', 'const foo = 3'),
+            code.replace('const foo = 2', 'const foo = 3 '),
           ),
         [
           'foo was: 2',
@@ -387,7 +386,7 @@ describe('acceptExports', () => {
 
       await untilConsoleLogAfter(
         () => {
-          editFile(callbackFile, (code) => code.replace("x = 'Y'", "x = 'Z'"))
+          editFile(callbackFile, (code) => code.replace("x = 'Y'", "x = 'Z' "))
         },
         HOT_UPDATED,
         (logs) => {
@@ -405,7 +404,10 @@ describe('acceptExports', () => {
 
       await untilConsoleLogAfter(
         () => {
-          editFile(depFile, (code) => code.replace('dep0', (dep = 'dep1')))
+          editFile(
+            depFile,
+            (code) => code.replace('dep0', (dep = 'dep1')) + '\n',
+          )
         },
         HOT_UPDATED,
         (logs) => {
@@ -420,7 +422,7 @@ describe('acceptExports', () => {
     test('accepts itself and refreshes on change', async () => {
       await untilConsoleLogAfter(
         () => {
-          editFile(file, (code) => code.replace(/(\b[A-Z])0/g, '$11'))
+          editFile(file, (code) => code.replace(/(\b[A-Z])0/g, '$11') + '\n')
         },
         HOT_UPDATED,
         (logs) => {
@@ -435,13 +437,15 @@ describe('acceptExports', () => {
     test('accepts itself and refreshes on 2nd change', async () => {
       await untilConsoleLogAfter(
         () => {
-          editFile(file, (code) =>
-            code
-              .replace(/(\b[A-Z])1/g, '$12')
-              .replace(
-                "acceptExports(['a', 'default']",
-                "acceptExports(['b', 'default']",
-              ),
+          editFile(
+            file,
+            (code) =>
+              code
+                .replace(/(\b[A-Z])1/g, '$12')
+                .replace(
+                  "acceptExports(['a', 'default']",
+                  "acceptExports(['b', 'default']",
+                ) + '\n',
           )
         },
         HOT_UPDATED,
@@ -457,7 +461,7 @@ describe('acceptExports', () => {
     test('does not accept itself anymore after acceptedExports change', async () => {
       await untilConsoleLogAfter(
         async () => {
-          editFile(file, (code) => code.replace(/(\b[A-Z])2/g, '$13'))
+          editFile(file, (code) => code.replace(/(\b[A-Z])2/g, '$13') + '\n')
         },
         [PROGRAM_RELOAD, />>>>>>/],
         (logs) => {
@@ -496,7 +500,10 @@ describe('acceptExports', () => {
     test('does not stop the HMR bubble on change to dep', async () => {
       await untilConsoleLogAfter(
         async () => {
-          editFile(depFile, (code) => code.replace('dep0', (dep = 'dep1')))
+          editFile(
+            depFile,
+            (code) => code.replace('dep0', (dep = 'dep1')) + '\n',
+          )
         },
         [PROGRAM_RELOAD, />>>>>>/],
         (logs) => {
@@ -509,7 +516,7 @@ describe('acceptExports', () => {
       test('with named exports', async () => {
         await untilConsoleLogAfter(
           async () => {
-            editFile(namedFile, (code) => code.replace(a, 'A1'))
+            editFile(namedFile, (code) => code.replace(a, 'A1') + '\n')
           },
           [PROGRAM_RELOAD, />>>>>>/],
           (logs) => {
@@ -521,7 +528,7 @@ describe('acceptExports', () => {
       test('with default export', async () => {
         await untilConsoleLogAfter(
           async () => {
-            editFile(defaultFile, (code) => code.replace('def0', 'def1'))
+            editFile(defaultFile, (code) => code.replace('def0', 'def1') + '\n')
           },
           [PROGRAM_RELOAD, />>>>>>/],
           (logs) => {
@@ -625,7 +632,10 @@ describe('acceptExports', () => {
 
       await untilConsoleLogAfter(
         () => {
-          editFile(file, (code) => code.replace('-- unused --', '-> unused <-'))
+          editFile(
+            file,
+            (code) => code.replace('-- unused --', '-> unused <-') + '\n',
+          )
         },
         HOT_UPDATED,
         (logs) => {
@@ -649,8 +659,11 @@ describe('acceptExports', () => {
 
       await untilConsoleLogAfter(
         async () => {
-          editFile(file, (code) =>
-            code.replace('foo0', 'foo1').replace('-- used --', '-> used <-'),
+          editFile(
+            file,
+            (code) =>
+              code.replace('foo0', 'foo1').replace('-- used --', '-> used <-') +
+              '\n',
           )
         },
         [PROGRAM_RELOAD, /used:foo/],
@@ -682,7 +695,7 @@ describe('acceptExports', () => {
 
         await untilConsoleLogAfter(
           () => {
-            editFile(file, (code) => code.replace(/([abc])0/g, '$11'))
+            editFile(file, (code) => code.replace(/([abc])0/g, '$11') + '\n')
           },
           HOT_UPDATED,
           (logs) => {
@@ -692,7 +705,7 @@ describe('acceptExports', () => {
 
         await untilConsoleLogAfter(
           () => {
-            editFile(file, (code) => code.replace(/([abc])1/g, '$12'))
+            editFile(file, (code) => code.replace(/([abc])1/g, '$12') + '\n')
           },
           HOT_UPDATED,
           (logs) => {
@@ -716,7 +729,7 @@ describe('acceptExports', () => {
 
         await untilConsoleLogAfter(
           async () => {
-            editFile(file, (code) => code.replace(/([abc])0/g, '$11'))
+            editFile(file, (code) => code.replace(/([abc])0/g, '$11') + '\n')
           },
           [PROGRAM_RELOAD, '>>> ready <<<'],
           (logs) => {
@@ -879,7 +892,7 @@ test('import.meta.hot?.accept', async () => {
   await untilConsoleLogAfter(
     () =>
       editFile('optional-chaining/child.js', (code) =>
-        code.replace('const foo = 1', 'const foo = 2'),
+        code.replace('const foo = 1', 'const foo = 2 '),
       ),
     '(optional-chaining) child update',
   )
@@ -923,7 +936,7 @@ test('not inlined assets HMR', async () => {
   await untilConsoleLogAfter(
     () =>
       editFile('logo-no-inline.svg', (code) =>
-        code.replace('height="30px"', 'height="40px"'),
+        code.replace('height="30px"', 'height="40px" '),
       ),
     /Logo-no-inline updated/,
   )
@@ -938,7 +951,7 @@ test('inlined assets HMR', async () => {
   await untilConsoleLogAfter(
     () =>
       editFile('logo.svg', (code) =>
-        code.replace('height="30px"', 'height="40px"'),
+        code.replace('height="30px"', 'height="40px" '),
       ),
     /Logo updated/,
   )

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -54,7 +54,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmr.ts', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -71,7 +71,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmr.ts', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -91,7 +91,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmrDep.js', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -111,7 +111,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmrDep.js', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -134,7 +134,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmrNestedDep.js', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+          code.replace('const foo = 1', 'const foo = 2 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -154,7 +154,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('hmrNestedDep.js', (code) =>
-          code.replace('const foo = 2', 'const foo = 3'),
+          code.replace('const foo = 2', 'const foo = 3 '),
         ),
       [
         '>>> vite:beforeUpdate -- update',
@@ -287,16 +287,15 @@ if (!isBuild) {
 
   test('plugin hmr handler + custom event', async () => {
     const el = await page.$('.custom')
-    editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await expect.poll(() => el.textContent()).toMatch('edited')
+    editFile('customFile.js', (code) => code.replace('custom', 'edited2'))
+    await expect.poll(() => el.textContent()).toMatch('edited2')
   })
 
   test('plugin hmr remove custom events', async () => {
     const el = await page.$('.toRemove')
-    editFile('customFile.js', (code) => code.replace('custom', 'edited'))
-    await expect.poll(() => el.textContent()).toMatch('edited')
-    editFile('customFile.js', (code) => code.replace('edited', 'custom'))
-    await expect.poll(() => el.textContent()).toMatch('edited')
+    await expect.poll(() => el.textContent()).toMatch('edited2')
+    editFile('customFile.js', (code) => code.replace('edited2', 'custom33'))
+    await expect.poll(() => el.textContent()).toMatch('edited2')
   })
 
   test('plugin client-server communication', async () => {
@@ -338,7 +337,7 @@ if (!isBuild) {
   test('it swaps out link tags', async () => {
     await page.goto(viteTestUrl)
 
-    editFile('global.css', (code) => code.replace('white', 'tomato'))
+    editFile('global.css', (code) => code.replace('tomato', 'white'))
 
     let el = await page.$('.link-tag-added')
     await expect.poll(() => el.textContent()).toMatch('yes')
@@ -359,7 +358,7 @@ if (!isBuild) {
 
     // Modifying `index.ts` triggers a page reload, as expected
     const indexTsLoadPromise = page.waitForEvent('load')
-    editFile('counter/index.ts', (code) => code)
+    editFile('counter/index.ts', (code) => code + '\n')
     await indexTsLoadPromise
     btn = await page.$('button')
     expect(await btn.textContent()).toBe('Counter 0')
@@ -374,7 +373,7 @@ if (!isBuild) {
     // define `accept.module.hot.accept` may wrongfully trigger a full page
     // reload, see discussion at #7561.)
     const depTsLoadPromise = page.waitForEvent('load', { timeout: 1000 })
-    editFile('counter/dep.ts', (code) => code)
+    editFile('counter/dep.ts', (code) => code + ' ')
     await expect(depTsLoadPromise).rejects.toThrow(
       /page\.waitForEvent: Timeout \d+ms exceeded while waiting for event "load"/,
     )
@@ -395,13 +394,13 @@ if (!isBuild) {
       .poll(getOutput)
       .toMatch(['a.js: a0', 'b.js: b0,a0'].join('<br>'))
 
-    editFile('importing-updated/a.js', (code) => code.replace("'a0'", "'a1'"))
+    editFile('importing-updated/a.js', (code) => code.replace("'a0'", "'a1' "))
     await expect
       .poll(getOutput)
       .toMatch(['a.js: a0', 'b.js: b0,a0', 'a.js: a1'].join('<br>'))
 
     editFile('importing-updated/b.js', (code) =>
-      code.replace('`b0,${a}`', '`b1,${a}`'),
+      code.replace('`b0,${a}`', '`b1,${a}` '),
     )
     // note that "a.js: a1" should not happen twice after "b.js: b0,a0'"
     await expect
@@ -460,7 +459,9 @@ if (!isBuild) {
 
         await untilBrowserLogAfter(
           () => {
-            editFile(callbackFile, (code) => code.replace("x = 'Y'", "x = 'Z'"))
+            editFile(callbackFile, (code) =>
+              code.replace("x = 'Y'", "x = 'Z' "),
+            )
           },
           HOT_UPDATED,
           (logs) => {
@@ -478,7 +479,10 @@ if (!isBuild) {
 
         await untilBrowserLogAfter(
           () => {
-            editFile(depFile, (code) => code.replace('dep0', (dep = 'dep1')))
+            editFile(
+              depFile,
+              (code) => code.replace('dep0', (dep = 'dep1')) + '\n',
+            )
           },
           HOT_UPDATED,
           (logs) => {
@@ -493,7 +497,7 @@ if (!isBuild) {
       it('accepts itself and refreshes on change', async () => {
         await untilBrowserLogAfter(
           () => {
-            editFile(file, (code) => code.replace(/(\b[A-Z])0/g, '$11'))
+            editFile(file, (code) => code.replace(/(\b[A-Z])0/g, '$11') + '\n')
           },
           HOT_UPDATED,
           (logs) => {
@@ -508,13 +512,15 @@ if (!isBuild) {
       it('accepts itself and refreshes on 2nd change', async () => {
         await untilBrowserLogAfter(
           () => {
-            editFile(file, (code) =>
-              code
-                .replace(/(\b[A-Z])1/g, '$12')
-                .replace(
-                  "acceptExports(['a', 'default']",
-                  "acceptExports(['b', 'default']",
-                ),
+            editFile(
+              file,
+              (code) =>
+                code
+                  .replace(/(\b[A-Z])1/g, '$12')
+                  .replace(
+                    "acceptExports(['a', 'default']",
+                    "acceptExports(['b', 'default']",
+                  ) + '\n',
             )
           },
           HOT_UPDATED,
@@ -530,7 +536,7 @@ if (!isBuild) {
       it('does not accept itself anymore after acceptedExports change', async () => {
         await untilBrowserLogAfter(
           async () => {
-            editFile(file, (code) => code.replace(/(\b[A-Z])2/g, '$13'))
+            editFile(file, (code) => code.replace(/(\b[A-Z])2/g, '$13') + '\n')
             await page.waitForEvent('load')
           },
           [CONNECTED, />>>>>>/],
@@ -570,7 +576,10 @@ if (!isBuild) {
       it('does not stop the HMR bubble on change to dep', async () => {
         await untilBrowserLogAfter(
           async () => {
-            editFile(depFile, (code) => code.replace('dep0', (dep = 'dep1')))
+            editFile(
+              depFile,
+              (code) => code.replace('dep0', (dep = 'dep1')) + '\n',
+            )
             await page.waitForEvent('load')
           },
           [CONNECTED, />>>>>>/],
@@ -584,7 +593,7 @@ if (!isBuild) {
         it('with named exports', async () => {
           await untilBrowserLogAfter(
             async () => {
-              editFile(namedFile, (code) => code.replace(a, 'A1'))
+              editFile(namedFile, (code) => code.replace(a, 'A1') + '\n')
               await page.waitForEvent('load')
             },
             [CONNECTED, />>>>>>/],
@@ -597,7 +606,10 @@ if (!isBuild) {
         it('with default export', async () => {
           await untilBrowserLogAfter(
             async () => {
-              editFile(defaultFile, (code) => code.replace('def0', 'def1'))
+              editFile(
+                defaultFile,
+                (code) => code.replace('def0', 'def1') + '\n',
+              )
               await page.waitForEvent('load')
             },
             [CONNECTED, />>>>>>/],
@@ -655,8 +667,9 @@ if (!isBuild) {
 
         await untilBrowserLogAfter(
           () => {
-            editFile(file, (code) =>
-              code.replace('-- unused --', '-> unused <-'),
+            editFile(
+              file,
+              (code) => code.replace('-- unused --', '-> unused <-') + '\n',
             )
           },
           HOT_UPDATED,
@@ -681,8 +694,12 @@ if (!isBuild) {
 
         await untilBrowserLogAfter(
           async () => {
-            editFile(file, (code) =>
-              code.replace('foo0', 'foo1').replace('-- used --', '-> used <-'),
+            editFile(
+              file,
+              (code) =>
+                code
+                  .replace('foo0', 'foo1')
+                  .replace('-- used --', '-> used <-') + '\n',
             )
             await page.waitForEvent('load')
           },
@@ -715,7 +732,7 @@ if (!isBuild) {
 
           await untilBrowserLogAfter(
             () => {
-              editFile(file, (code) => code.replace(/([abc])0/g, '$11'))
+              editFile(file, (code) => code.replace(/([abc])0/g, '$11') + '\n')
             },
             HOT_UPDATED,
             (logs) => {
@@ -728,7 +745,7 @@ if (!isBuild) {
 
           await untilBrowserLogAfter(
             () => {
-              editFile(file, (code) => code.replace(/([abc])1/g, '$12'))
+              editFile(file, (code) => code.replace(/([abc])1/g, '$12') + '\n')
             },
             HOT_UPDATED,
             (logs) => {
@@ -756,7 +773,7 @@ if (!isBuild) {
           await untilBrowserLogAfter(
             async () => {
               const loadPromise = page.waitForEvent('load')
-              editFile(file, (code) => code.replace(/([abc])0/g, '$11'))
+              editFile(file, (code) => code.replace(/([abc])0/g, '$11') + '\n')
               await loadPromise
             },
             [CONNECTED, '>>> ready <<<'],
@@ -781,7 +798,7 @@ if (!isBuild) {
     expect(await getBg('.import-image')).toMatch('icon')
 
     const loadPromise = page.waitForEvent('load')
-    editFile('index.html', (code) => code.replace('url("./icon.png")', ''))
+    editFile('index.html', (code) => code.replace("url('./icon.png')", ''))
     await loadPromise
     expect(await getBg('.import-image')).toMatch('')
   })
@@ -831,13 +848,13 @@ if (!isBuild) {
     await page.goto(viteTestUrl)
     const el = await page.$('.virtual-dep')
     expect(await el.textContent()).toBe('0')
-    editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
+    editFile('importedVirtual.js', (code) => code.replace('[wow]', '[wow2]'))
     await expect
       .poll(async () => {
         const el = await page.$('.virtual-dep')
         return await el.textContent()
       })
-      .toBe('[wow]0')
+      .toBe('[wow2]0')
   })
 
   test('invalidate virtual module and accept', async () => {
@@ -851,7 +868,7 @@ if (!isBuild) {
         const el = await page.$('.virtual-dep')
         return await el.textContent()
       })
-      .toBe('[wow]2')
+      .toBe('[wow2]2')
   })
 
   test('keep hmr reload after missing import on server startup', async () => {
@@ -1042,8 +1059,9 @@ if (!isBuild) {
     const el = await page.$('.optional-chaining')
     await untilBrowserLogAfter(
       () =>
-        editFile('optional-chaining/child.js', (code) =>
-          code.replace('const foo = 1', 'const foo = 2'),
+        editFile(
+          'optional-chaining/child.js',
+          (code) => code.replace('const foo = 1', 'const foo = 2') + '\n',
         ),
       '(optional-chaining) child update',
     )
@@ -1087,7 +1105,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('logo-no-inline.svg', (code) =>
-          code.replace('height="30px"', 'height="40px"'),
+          code.replace('height="30px"', 'height="40px" '),
         ),
       /Logo-no-inline updated/,
     )
@@ -1102,7 +1120,7 @@ if (!isBuild) {
     await untilBrowserLogAfter(
       () =>
         editFile('logo.svg', (code) =>
-          code.replace('height="30px"', 'height="40px"'),
+          code.replace('height="30px"', 'height="40px" '),
         ),
       /Logo updated/,
     )

--- a/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
+++ b/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
@@ -20,7 +20,7 @@ test.runIf(isBuild)('rebuilds styles only entry on change', async () => {
   expect(numberOfManifestEntries).toBe(3)
 
   editFile('style-only-entry.css', (originalContents) =>
-    originalContents.replace('#ff69b4', '#ffb6c1'),
+    originalContents.replace('#ff69b4', '#ffb6c1 '),
   )
   await notifyRebuildComplete(watcher)
 

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -68,7 +68,7 @@ test.runIf(isServe)('html proxy is encoded', async () => {
 
 // run this at the end to reduce flakiness
 test.runIf(isServe)('should restart ssr', async () => {
-  editFile('./vite.config.ts', (content) => content)
+  editFile('./vite.config.ts', (content) => content + '\n')
   await expect
     .poll(() => {
       expect(serverLogs).toEqual(

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -191,6 +191,16 @@ export function editFile(
   const modified = (replacer as (content: string | Buffer) => string | Buffer)(
     content,
   )
+  if (Buffer.byteLength(modified) === Buffer.byteLength(content)) {
+    const e = new Error(
+      `editFile("${filename}") did not change the file size. The polling ` +
+        `watcher used in tests may miss same-length edits and cause flaky ` +
+        `failures; change the edit so the file's byte length changes. See ` +
+        `https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#test-env-and-helpers`,
+    )
+    Error.captureStackTrace(e, editFile)
+    throw e
+  }
   fs.writeFileSync(filename, modified)
 }
 

--- a/playground/transform-plugin/__tests__/tests.ts
+++ b/playground/transform-plugin/__tests__/tests.ts
@@ -6,10 +6,10 @@ export const tests = () => {
     expect(await page.textContent('#transform-count')).toBe('1')
 
     if (isBuild) return
-    editFile('plugin-dep.js', (str) => str)
+    editFile('plugin-dep.js', (str) => str + ' ')
     await expect.poll(() => page.textContent('#transform-count')).toBe('2')
 
-    editFile('plugin-dep-load.js', (str) => str)
+    editFile('plugin-dep-load.js', (str) => str + ' ')
     await expect.poll(() => page.textContent('#transform-count')).toBe('3')
   })
 }


### PR DESCRIPTION
Chokidar uses `fs.watchFile` for polling. Because `fs.watchFile` is triggered even for access, chokidar checks the `mtime` difference (and the content length difference) to filter out them [as recommended in Node.js's docs](https://nodejs.org/docs/latest/api/fs.html#fswatchfilefilename-options-listener:~:text=To%20be%20notified%20when%20the%20file%20was%20modified%2C%20not%20just%20accessed%2C%20it%20is%20necessary%20to%20compare%20curr.mtimeMs%20and%20prev.mtimeMs.).
But this also means that the modified event is filtered out if the file is changed in the same mtime. This is normally not a problem but it seems this causes flaky failures.

This PR updates the `editFile` calls to change the content length so that the events are not filtered out incorrectly.