### PR TITLE
ci: use node 24.15 for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,8 @@ jobs:
           - os: macos-latest
             node_version: 24
           - os: windows-latest
-            node_version: 24
+            # use older minor to workaround https://github.com/nodejs/node/issues/63638
+            node_version: 24.15.0
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"


### PR DESCRIPTION
Due to https://github.com/nodejs/node/issues/63638, the Windows CI is failing multiple times.

> Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72

This PR fixes that by downgrading the Node CI to 24.15 for now.


