### PR TITLE
test: enable "manual chunk path" test and remove "worker.format error" test

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -958,27 +958,6 @@ test('sharedConfigBuild and emitAssets', async () => {
   ])
 })
 
-test.skip('adjust worker build error for worker.format', async () => {
-  try {
-    await build({
-      root: resolve(dirname, 'fixtures/worker-dynamic'),
-      build: {
-        rolldownOptions: {
-          input: {
-            index: '/main.js',
-          },
-        },
-      },
-      logLevel: 'silent',
-    })
-  } catch (e) {
-    expect(e.message).toContain('worker.format')
-    expect(e.message).not.toContain('output.format')
-    return
-  }
-  expect.unreachable()
-})
-
 describe('onRollupLog', () => {
   const pluginName = 'rollup-plugin-test'
   const msgInfo = 'This is the INFO message.'

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -497,8 +497,7 @@ test('@import scss', async () => {
   expect(await getColor('.at-import-scss')).toBe('red')
 })
 
-// TODO: skipped because of https://github.com/rolldown/rolldown/issues/7315
-test.runIf(isBuild).skip('manual chunk path', async () => {
+test.runIf(isBuild)('manual chunk path', async () => {
   // assert that the manual-chunk css is output in the directory specified in manualChunk (#12072)
   expect(
     findAssetFile(/manual-chunk-[-\w]{8}\.css$/, undefined, 'assets/dir/dir2'),


### PR DESCRIPTION
"manual chunk path" test now passes, and "worker.format error" test is no longer relevant

