### PR TITLE
feat(dev): label network URLs with their interface name

### DIFF
--- a/packages/vite/src/node/__tests__/__snapshots__/logger.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/__snapshots__/logger.spec.ts.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`printServerUrls > aligns interface names into a column 1`] = `
+"
+  ➜  Network: http://172.18.0.1:5173/  eth0
+  ➜  Network: http://10.0.0.2:5173/    wlan0
+"
+`;
+
+exports[`printServerUrls > appends the network interface name to each network URL 1`] = `
+"
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: http://172.18.0.1:5173/  eth0
+  ➜  Network: http://10.0.0.2:5173/    wlan0
+"
+`;
+
+exports[`printServerUrls > omits the annotation when the interface name is unknown 1`] = `
+"
+  ➜  Network: http://10.0.0.2:5173/
+"
+`;
+
+exports[`printServerUrls > truncates an over-long interface name 1`] = `
+"
+  ➜  Network: http://10.0.0.2:5173/  vEthernet (WSL (Hyp…
+"
+`;
+
+exports[`printServerUrls > works when networkInterfaceNames is absent 1`] = `
+"
+  ➜  Network: http://10.0.0.2:5173/
+"
+`;

--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -63,6 +63,7 @@ describe('the dev server', () => {
     expect(urls).toStrictEqual({
       local: ['http://localhost:5013/'],
       network: [],
+      networkInterfaceNames: [],
     })
   })
 })

--- a/packages/vite/src/node/__tests__/logger.spec.ts
+++ b/packages/vite/src/node/__tests__/logger.spec.ts
@@ -1,0 +1,64 @@
+import { stripVTControlCharacters } from 'node:util'
+import { describe, expect, test } from 'vitest'
+import { printServerUrls } from '../logger'
+import type { ResolvedServerUrls } from '../server'
+
+function collectServerUrls(urls: ResolvedServerUrls): string[] {
+  const messages: string[] = []
+  printServerUrls(urls, undefined, (msg) =>
+    messages.push(stripVTControlCharacters(String(msg))),
+  )
+  return messages
+}
+
+describe('printServerUrls', () => {
+  test('appends the network interface name to each network URL', () => {
+    const messages = collectServerUrls({
+      local: ['http://localhost:5173/'],
+      network: ['http://172.18.0.1:5173/', 'http://10.0.0.2:5173/'],
+      networkInterfaceNames: ['eth0', 'wlan0'],
+    })
+    expect(messages[0]).toContain('Local:')
+    expect(messages[1]).toContain('http://172.18.0.1:5173/')
+    expect(messages[1]).toMatch(/eth0$/)
+    expect(messages[2]).toMatch(/wlan0$/)
+  })
+
+  test('aligns interface names into a column', () => {
+    const messages = collectServerUrls({
+      local: [],
+      network: ['http://172.18.0.1:5173/', 'http://10.0.0.2:5173/'],
+      networkInterfaceNames: ['eth0', 'wlan0'],
+    })
+    expect(messages[0].indexOf('eth0')).toBe(messages[1].indexOf('wlan0'))
+  })
+
+  test('truncates an over-long interface name', () => {
+    const messages = collectServerUrls({
+      local: [],
+      network: ['http://10.0.0.2:5173/'],
+      networkInterfaceNames: ['vEthernet (WSL (Hyper-V firewall))'],
+    })
+    expect(messages[0]).toContain('vEthernet (WSL (Hyp…')
+    expect(messages[0]).not.toContain('firewall')
+  })
+
+  test('omits the annotation when the interface name is unknown', () => {
+    const messages = collectServerUrls({
+      local: [],
+      network: ['http://10.0.0.2:5173/'],
+      networkInterfaceNames: [undefined],
+    })
+    expect(messages[0].trimEnd()).toMatch(
+      /Network: http:\/\/10\.0\.0\.2:5173\/$/,
+    )
+  })
+
+  test('works when networkInterfaceNames is absent', () => {
+    const messages = collectServerUrls({
+      local: [],
+      network: ['http://10.0.0.2:5173/'],
+    })
+    expect(messages[0]).toContain('http://10.0.0.2:5173/')
+  })
+})

--- a/packages/vite/src/node/__tests__/logger.spec.ts
+++ b/packages/vite/src/node/__tests__/logger.spec.ts
@@ -3,12 +3,12 @@ import { describe, expect, test } from 'vitest'
 import { printServerUrls } from '../logger'
 import type { ResolvedServerUrls } from '../server'
 
-function collectServerUrls(urls: ResolvedServerUrls): string[] {
+function collectServerUrls(urls: ResolvedServerUrls): string {
   const messages: string[] = []
   printServerUrls(urls, undefined, (msg) =>
-    messages.push(stripVTControlCharacters(String(msg))),
+    messages.push(stripVTControlCharacters(msg)),
   )
-  return messages
+  return '\n' + messages.join('\n') + '\n'
 }
 
 describe('printServerUrls', () => {
@@ -18,10 +18,7 @@ describe('printServerUrls', () => {
       network: ['http://172.18.0.1:5173/', 'http://10.0.0.2:5173/'],
       networkInterfaceNames: ['eth0', 'wlan0'],
     })
-    expect(messages[0]).toContain('Local:')
-    expect(messages[1]).toContain('http://172.18.0.1:5173/')
-    expect(messages[1]).toMatch(/eth0$/)
-    expect(messages[2]).toMatch(/wlan0$/)
+    expect(messages).toMatchSnapshot()
   })
 
   test('aligns interface names into a column', () => {
@@ -30,7 +27,7 @@ describe('printServerUrls', () => {
       network: ['http://172.18.0.1:5173/', 'http://10.0.0.2:5173/'],
       networkInterfaceNames: ['eth0', 'wlan0'],
     })
-    expect(messages[0].indexOf('eth0')).toBe(messages[1].indexOf('wlan0'))
+    expect(messages).toMatchSnapshot()
   })
 
   test('truncates an over-long interface name', () => {
@@ -39,8 +36,7 @@ describe('printServerUrls', () => {
       network: ['http://10.0.0.2:5173/'],
       networkInterfaceNames: ['vEthernet (WSL (Hyper-V firewall))'],
     })
-    expect(messages[0]).toContain('vEthernet (WSL (Hyp…')
-    expect(messages[0]).not.toContain('firewall')
+    expect(messages).toMatchSnapshot()
   })
 
   test('omits the annotation when the interface name is unknown', () => {
@@ -49,9 +45,7 @@ describe('printServerUrls', () => {
       network: ['http://10.0.0.2:5173/'],
       networkInterfaceNames: [undefined],
     })
-    expect(messages[0].trimEnd()).toMatch(
-      /Network: http:\/\/10\.0\.0\.2:5173\/$/,
-    )
+    expect(messages).toMatchSnapshot()
   })
 
   test('works when networkInterfaceNames is absent', () => {
@@ -59,6 +53,6 @@ describe('printServerUrls', () => {
       local: [],
       network: ['http://10.0.0.2:5173/'],
     })
-    expect(messages[0]).toContain('http://10.0.0.2:5173/')
+    expect(messages).toMatchSnapshot()
   })
 })

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import { describe, expect, test } from 'vitest'
+import os from 'node:os'
+import { describe, expect, test, vi } from 'vitest'
 import { fileURLToPath } from 'mlly'
 import {
   asyncFlatten,
@@ -1095,5 +1096,50 @@ describe('resolveServerUrls', () => {
     )
 
     expect(result.local).toContain('https://localhost:3000/')
+  })
+
+  test('captures interface names aligned with the network URLs', () => {
+    const mockServer = createMockServer('IPv4', '0.0.0.0')
+    const networkInterfacesSpy = vi
+      .spyOn(os, 'networkInterfaces')
+      .mockReturnValue({
+        lo: [{ address: '127.0.0.1', family: 'IPv4' } as any],
+        eth0: [{ address: '192.168.1.10', family: 'IPv4' } as any],
+        wlan0: [{ address: '10.0.0.5', family: 'IPv4' } as any],
+      })
+
+    const result = resolveServerUrls(
+      mockServer,
+      { https: false } as any,
+      { host: undefined, name: 'localhost' } as any,
+      {},
+      { rawBase: '/' } as any,
+    )
+
+    expect(result.network).toEqual([
+      'http://192.168.1.10:3000/',
+      'http://10.0.0.5:3000/',
+    ])
+    expect(result.networkInterfaceNames).toEqual(['eth0', 'wlan0'])
+    expect(result.networkInterfaceNames).toHaveLength(result.network.length)
+    // The loopback interface is reported as a local URL, not a network one.
+    expect(result.local).toContain('http://localhost:3000/')
+
+    networkInterfacesSpy.mockRestore()
+  })
+
+  test('uses an undefined interface name for an explicit network host', () => {
+    const mockServer = createMockServer('IPv4', '0.0.0.0')
+
+    const result = resolveServerUrls(
+      mockServer,
+      { https: false } as any,
+      { host: 'example.com', name: 'example.com' } as any,
+      {},
+      { rawBase: '/' } as any,
+    )
+
+    expect(result.network).toEqual(['http://example.com:3000/'])
+    expect(result.networkInterfaceNames).toEqual([undefined])
   })
 })

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import os from 'node:os'
-import { describe, expect, test, vi } from 'vitest'
+import os, { type NetworkInterfaceInfoIPv4 } from 'node:os'
+import { describe, expect, test, vi, onTestFinished } from 'vitest'
 import { fileURLToPath } from 'mlly'
 import {
   asyncFlatten,
@@ -1103,10 +1103,22 @@ describe('resolveServerUrls', () => {
     const networkInterfacesSpy = vi
       .spyOn(os, 'networkInterfaces')
       .mockReturnValue({
-        lo: [{ address: '127.0.0.1', family: 'IPv4' } as any],
-        eth0: [{ address: '192.168.1.10', family: 'IPv4' } as any],
-        wlan0: [{ address: '10.0.0.5', family: 'IPv4' } as any],
+        lo: [
+          { address: '127.0.0.1', family: 'IPv4' } as NetworkInterfaceInfoIPv4,
+        ],
+        eth0: [
+          {
+            address: '192.168.1.10',
+            family: 'IPv4',
+          } as NetworkInterfaceInfoIPv4,
+        ],
+        wlan0: [
+          { address: '10.0.0.5', family: 'IPv4' } as NetworkInterfaceInfoIPv4,
+        ],
       })
+    onTestFinished(() => {
+      networkInterfacesSpy.mockRestore()
+    })
 
     const result = resolveServerUrls(
       mockServer,
@@ -1120,12 +1132,10 @@ describe('resolveServerUrls', () => {
       'http://192.168.1.10:3000/',
       'http://10.0.0.5:3000/',
     ])
-    expect(result.networkInterfaceNames).toEqual(['eth0', 'wlan0'])
+    expect(result.networkInterfaceNames).toStrictEqual(['eth0', 'wlan0'])
     expect(result.networkInterfaceNames).toHaveLength(result.network.length)
     // The loopback interface is reported as a local URL, not a network one.
     expect(result.local).toContain('http://localhost:3000/')
-
-    networkInterfacesSpy.mockRestore()
   })
 
   test('uses an undefined interface name for an explicit network host', () => {
@@ -1139,7 +1149,7 @@ describe('resolveServerUrls', () => {
       { rawBase: '/' } as any,
     )
 
-    expect(result.network).toEqual(['http://example.com:3000/'])
-    expect(result.networkInterfaceNames).toEqual([undefined])
+    expect(result.network).toStrictEqual(['http://example.com:3000/'])
+    expect(result.networkInterfaceNames).toStrictEqual([undefined])
   })
 })

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -165,6 +165,8 @@ export function createLogger(
   return logger
 }
 
+const maxNetworkInterfaceNameLength = 20
+
 export function printServerUrls(
   urls: ResolvedServerUrls,
   optionsHost: string | boolean | undefined,
@@ -175,9 +177,25 @@ export function printServerUrls(
   for (const url of urls.local) {
     info(`  ${colors.green('➜')}  ${colors.bold('Local')}:   ${colorUrl(url)}`)
   }
-  for (const url of urls.network) {
-    info(`  ${colors.green('➜')}  ${colors.bold('Network')}: ${colorUrl(url)}`)
-  }
+  const networkUrlMaxLength = Math.max(
+    ...urls.network.map((url) => url.length),
+    0,
+  )
+  urls.network.forEach((url, index) => {
+    const interfaceName = urls.networkInterfaceNames?.[index]
+    let suffix = ''
+    if (interfaceName) {
+      const label =
+        interfaceName.length > maxNetworkInterfaceNameLength
+          ? `${interfaceName.slice(0, maxNetworkInterfaceNameLength - 1)}…`
+          : interfaceName
+      suffix =
+        ' '.repeat(networkUrlMaxLength - url.length + 2) + colors.dim(label)
+    }
+    info(
+      `  ${colors.green('➜')}  ${colors.bold('Network')}: ${colorUrl(url)}${suffix}`,
+    )
+  })
   if (urls.network.length === 0 && optionsHost === undefined) {
     info(
       colors.dim(`  ${colors.green('➜')}  ${colors.bold('Network')}: use `) +

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -468,6 +468,15 @@ export interface ViteDevServer {
 export interface ResolvedServerUrls {
   local: string[]
   network: string[]
+  /**
+   * Names of the network interface that each {@link ResolvedServerUrls.network}
+   * URL is bound to, in the same order as `network`. An entry is `undefined`
+   * when the interface name is not known, for example when an explicit `host`
+   * is set.
+   *
+   * @experimental
+   */
+  networkInterfaceNames?: (string | undefined)[]
 }
 
 export function createServer(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -473,8 +473,6 @@ export interface ResolvedServerUrls {
    * URL is bound to, in the same order as `network`. An entry is `undefined`
    * when the interface name is not known, for example when an explicit `host`
    * is set.
-   *
-   * @experimental
    */
   networkInterfaceNames?: (string | undefined)[]
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1023,11 +1023,13 @@ export function resolveServerUrls(
 
   const isAddressInfo = (x: any): x is AddressInfo => x?.address
   if (!isAddressInfo(address)) {
-    return { local: [], network: [] }
+    return { local: [], network: [], networkInterfaceNames: [] }
   }
 
   const local: string[] = []
   const network: string[] = []
+  // Interface name for each `network` URL, kept in the same order as `network`.
+  const networkInterfaceNames: (string | undefined)[] = []
   const protocol = options.https ? 'https' : 'http'
   const port = address.port
   const base =
@@ -1044,24 +1046,27 @@ export function resolveServerUrls(
       local.push(address)
     } else {
       network.push(address)
+      networkInterfaceNames.push(undefined)
     }
   } else {
-    Object.values(os.networkInterfaces())
-      .flatMap((nInterface) => nInterface ?? [])
-      .filter((detail) => detail.address && detail.family === 'IPv4')
-      .forEach((detail) => {
-        let host = detail.address.replace('127.0.0.1', hostname.name)
-        // ipv6 host
-        if (host.includes(':')) {
-          host = `[${host}]`
-        }
-        const url = `${protocol}://${host}:${port}${base}`
-        if (detail.address.includes('127.0.0.1')) {
-          local.push(url)
-        } else {
-          network.push(url)
-        }
-      })
+    Object.entries(os.networkInterfaces()).forEach(([name, nInterface]) => {
+      ;(nInterface ?? [])
+        .filter((detail) => detail.address && detail.family === 'IPv4')
+        .forEach((detail) => {
+          let host = detail.address.replace('127.0.0.1', hostname.name)
+          // ipv6 host
+          if (host.includes(':')) {
+            host = `[${host}]`
+          }
+          const url = `${protocol}://${host}:${port}${base}`
+          if (detail.address.includes('127.0.0.1')) {
+            local.push(url)
+          } else {
+            network.push(url)
+            networkInterfaceNames.push(name)
+          }
+        })
+    })
   }
 
   const hostnamesFromCert = extractHostnamesFromCerts(httpsOptions?.cert)
@@ -1074,7 +1079,7 @@ export function resolveServerUrls(
     )
   }
 
-  return { local, network }
+  return { local, network, networkInterfaceNames }
 }
 
 export function extractHostnamesFromSubjectAltName(


### PR DESCRIPTION
Closes #22796.

When you run with `--host` and have a few interfaces (VPN, Docker, WSL, Wi-Fi), the Network list is just a stack of IPs with no hint which one to open on your phone. This labels each Network URL with the interface it is bound to:

```
  ➜  Local:   http://localhost:5173/
  ➜  Network: http://172.18.0.1:5173/     xray_tun
  ➜  Network: http://10.233.157.11:5173/  Wi-Fi
  ➜  Network: http://192.168.1.5:5173/    vEthernet (WSL (Hyp…
```

The name is just the key from `os.networkInterfaces()`, so `resolveServerUrls` reads it with `Object.entries` and keeps it next to each network URL. Per @sapphi-red's note on the issue, long names are capped at 20 characters with an ellipsis so the column stays tidy.

How it is wired:

- `ResolvedServerUrls` gets an optional `networkInterfaceNames?: (string | undefined)[]`, in the same order as `network`. I went with an additive field (marked `@experimental`) instead of reshaping `network` into objects, so the existing `local` / `network` arrays keep working unchanged. An entry is `undefined` when the name is not known (for example an explicit `host`), and the label is omitted in that case. `printServerUrls` is the only consumer, so if you would rather not widen the public type at all, I am happy to keep this display-only instead.
- `printServerUrls` appends the dimmed, column-aligned name after each URL.

Tests: `printServerUrls` had no spec, so I added `logger.spec.ts` covering the annotation, column alignment, truncation, the unknown-name case, and the absent-field case. I also added two `resolveServerUrls` cases that mock `os.networkInterfaces()` to lock the `network` / `networkInterfaceNames` ordering and the explicit-host `undefined` path. `pnpm --filter vite build` (including `tsc`), eslint, and the logger + utils unit specs all pass locally.
