### PR TITLE
fix: allow build output to start with asset (fix #22647)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -171,6 +171,44 @@ describe('build', () => {
     })
   })
 
+  test('css-only entry can return an asset as the first build output', async () => {
+    const result = await build({
+      logLevel: 'silent',
+      configFile: false,
+      publicDir: false,
+      build: {
+        write: false,
+        rolldownOptions: {
+          input: 'style.css',
+        },
+      },
+      plugins: [
+        {
+          name: 'fixture-css-entry',
+          resolveId(id) {
+            if (id === 'style.css') {
+              return '\0style.css'
+            }
+          },
+          load(id) {
+            if (id === '\0style.css') {
+              return '.foo { color: red }'
+            }
+          },
+        },
+      ],
+    })
+
+    expect(Array.isArray(result)).toBe(false)
+    expect('output' in result).toBe(true)
+
+    if (Array.isArray(result) || !('output' in result)) {
+      return
+    }
+
+    expect(result.output[0].type).toBe('asset')
+  })
+
   test.for([
     [true, true],
     [true, false],

--- a/packages/vite/src/node/__tests_dts__/build.ts
+++ b/packages/vite/src/node/__tests_dts__/build.ts
@@ -1,0 +1,14 @@
+import type { Equal, ExpectTrue } from '@type-challenges/utils'
+import type { OutputAsset, OutputChunk } from 'rolldown'
+import type { build, ViteBuildOutput } from '..'
+
+type BuildResult = Awaited<ReturnType<typeof build>>
+type SingleBuildOutput = Extract<BuildResult, { output: unknown }>
+type FirstOutput = SingleBuildOutput['output'][0]
+
+export type cases = [
+  ExpectTrue<Equal<FirstOutput, OutputAsset | OutputChunk>>,
+  ExpectTrue<Equal<ViteBuildOutput['output'][0], OutputAsset | OutputChunk>>,
+]
+
+export {}

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -558,9 +558,18 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
  * Bundles a single environment for production.
  * Returns a Promise containing the build result.
  */
+export type ViteBuildOutput = Omit<RolldownOutput, 'output'> & {
+  output: [OutputAsset | OutputChunk, ...(OutputAsset | OutputChunk)[]]
+}
+
+export type ViteBuildResult =
+  | ViteBuildOutput
+  | ViteBuildOutput[]
+  | RolldownWatcher
+
 export async function build(
   inlineConfig: InlineConfig = {},
-): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher> {
+): Promise<ViteBuildResult> {
   const builder = await createBuilder(inlineConfig, true)
   const environment = Object.values(builder.environments)[0]
   if (!environment) throw new Error('No environment found')
@@ -812,7 +821,7 @@ export function resolveRolldownOptions(
  **/
 async function buildEnvironment(
   environment: BuildEnvironment,
-): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher> {
+): Promise<ViteBuildResult> {
   const { logger, config } = environment
   const { root, build: options } = config
 
@@ -1755,9 +1764,7 @@ export interface ViteBuilder {
   environments: Record<string, BuildEnvironment>
   config: ResolvedConfig
   buildApp(): Promise<void>
-  build(
-    environment: BuildEnvironment,
-  ): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher>
+  build(environment: BuildEnvironment): Promise<ViteBuildResult>
   runDevTools(): Promise<void>
 }
 
@@ -1863,9 +1870,7 @@ export async function createBuilder(
         }
       }
     },
-    async build(
-      environment: BuildEnvironment,
-    ): Promise<RolldownOutput | RolldownOutput[] | RolldownWatcher> {
+    async build(environment: BuildEnvironment): Promise<ViteBuildResult> {
       const output = await buildEnvironment(environment)
       environment.isBuilt = true
       return output

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -36,7 +36,12 @@ export { perEnvironmentPlugin } from './plugin'
 export { perEnvironmentState } from './environment'
 export { createServer } from './server'
 export { preview } from './preview'
-export { build, createBuilder } from './build'
+export {
+  build,
+  createBuilder,
+  type ViteBuildOutput,
+  type ViteBuildResult,
+} from './build'
 
 export { optimizeDeps } from './optimizer'
 export { createIdResolver } from './idResolver'


### PR DESCRIPTION
## Summary

- widen Vite's public build result type so `output[0]` can be an `OutputAsset` or an `OutputChunk`
- export named build result helper types from `vite`
- add runtime and dts regressions for CSS-only entries returning an asset first

## Why

CSS-only builds can return a CSS asset as the first output item when `write: false`, but the inherited Rolldown return type described `output[0]` as an `OutputChunk`. This made valid usage fail type checking even though the runtime result is an asset.

Fixes #22647

## Validation

- `pnpm exec lint-staged --concurrent false`
- `pnpm exec eslint packages/vite/src/node/index.ts packages/vite/src/node/build.ts packages/vite/src/node/__tests__/build.spec.ts packages/vite/src/node/__tests_dts__/build.ts`
- `pnpm exec tsc -p packages/vite/src/node/__tests_dts__/tsconfig.json --noEmit`
- `pnpm run test-unit packages/vite/src/node/__tests__/build.spec.ts`
- `pnpm --filter vite run typecheck`
- `pnpm run build`
- `git diff --check`

Note: the local git hook shell could not find `pnpm`, so I ran the hook command directly before committing.