### PR TITLE
fix(build): add workaround for building on stackblitz

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -243,7 +243,7 @@ function getPreloadCode(
         // is appended inside __vitePreload too.
         `function(dep) { return ${JSON.stringify(environment.config.base)}+dep }`
   // replace `import` as a workaround for stackblitz: https://stackblitz.com/edit/node-vqfvv8dy?file=index.js
-  const preloadMethodCode = preload.toString().replaceAll('(𝐢𝐦𝐩𝐨𝐫𝐭', 'import')
+  const preloadMethodCode = preload.toString().replaceAll('𝐢𝐦𝐩𝐨𝐫𝐭', 'import')
   const preloadCode = `const scriptRel = ${scriptRel};const assetsURL = ${assetsURL};const seen = {};export const ${preloadMethod} = ${preloadMethodCode}`
   return preloadCode
 }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -242,7 +242,9 @@ function getPreloadCode(
       : // If the base isn't relative, then the deps are relative to the projects `outDir` and the base
         // is appended inside __vitePreload too.
         `function(dep) { return ${JSON.stringify(environment.config.base)}+dep }`
-  const preloadCode = `const scriptRel = ${scriptRel};const assetsURL = ${assetsURL};const seen = {};export const ${preloadMethod} = ${preload.toString()}`
+  // replace `import` as a workaround for stackblitz: https://stackblitz.com/edit/node-vqfvv8dy?file=index.js
+  const preloadMethodCode = preload.toString().replaceAll('(𝐢𝐦𝐩𝐨𝐫𝐭', 'import')
+  const preloadCode = `const scriptRel = ${scriptRel};const assetsURL = ${assetsURL};const seen = {};export const ${preloadMethod} = ${preloadMethodCode}`
   return preloadCode
 }
 


### PR DESCRIPTION
When building on stackblitz, the `import.meta.resolve` in the output was replaced with a slightly different value (`𝐢𝐦𝐩𝐨𝐫𝐭.meta.resolve`).
https://stackblitz.com/edit/vitejs-vite-yuazbcvz?file=index.html&terminal=build
This causes `ReferenceError: 𝐢𝐦𝐩𝐨𝐫𝐭 is not defined` error.

This is caused by how stackblitz works and the way we use `function.toString()`: https://stackblitz.com/edit/node-vqfvv8dy?file=index.js

This PR adds a workaround for that.
