### PR TITLE
docs: clarify Express SSR example

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -65,6 +65,8 @@ This is statically replaced during build so it will allow tree-shaking of unused
 
 When building an SSR app, you likely want to have full control over your main server and decouple Vite from the production environment. It is therefore recommended to use Vite in middleware mode. Here is an example with [express](https://expressjs.com/):
 
+Express is used here for its familiar API, but you can use any connect-compatible Node.js framework. For production SSR apps, consider modern alternatives such as [h3](https://github.com/unjs/h3) or [Fastify](https://fastify.dev/).
+
 ```js{15-18} twoslash [server.js]
 import fs from 'node:fs'
 import path from 'node:path'


### PR DESCRIPTION
### Description

Adds a short note to the SSR guide explaining why the example uses Express, while pointing readers toward modern connect-compatible alternatives for production SSR apps.

This follows the maintainer suggestion in #13582 to keep the familiar Express example but clarify that it is not the only recommended option.

### Validation

- `git diff --check -- docs/guide/ssr.md`

`pnpm exec oxfmt --check docs/guide/ssr.md` could not run in this checkout because pnpm attempted to create its store under a restricted home directory before installing workspace dependencies.

Refs #13582
