### PR TITLE
fix(html): avoid backtracking in import-only check

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1493,12 +1493,24 @@ export async function applyHtmlTransforms(
   return html
 }
 
-const entirelyImportRE =
-  /^(?:import\s*(?:"[^"\n]*[^\\\n]"|'[^'\n]*[^\\\n]');*|\/\*[\s\S]*?\*\/|\/\/.*[$\n])*$/
+const importOrCommentRE =
+  /\s+|\/\*[\s\S]*?\*\/|\/\/[^\n]*(?:\n|$)|import\s*(?:"(?:[^"\\\n]|\\.)*"|'(?:[^'\\\n]|\\.)*')\s*;*/y
+
 function isEntirelyImport(code: string) {
   // only consider "side-effect" imports, which match <script type=module> semantics exactly
-  // the regexes will remove too little in some exotic cases, but false-negatives are alright
-  return entirelyImportRE.test(code.trim())
+  // the regexes will remove too little in some exotic cases, but false-negatives are alright.
+  // Consume one token at a time to avoid backtracking over the whole chunk.
+  let position = 0
+
+  while (position < code.length) {
+    importOrCommentRE.lastIndex = position
+    if (!importOrCommentRE.test(code)) {
+      return false
+    }
+    position = importOrCommentRE.lastIndex
+  }
+
+  return true
 }
 
 function getBaseInHTML(urlRelativePath: string, config: ResolvedConfig) {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1500,16 +1500,12 @@ function isEntirelyImport(code: string) {
   // only consider "side-effect" imports, which match <script type=module> semantics exactly
   // the regexes will remove too little in some exotic cases, but false-negatives are alright.
   // Consume one token at a time to avoid backtracking over the whole chunk.
-  let position = 0
-
-  while (position < code.length) {
-    importOrCommentRE.lastIndex = position
+  importOrCommentRE.lastIndex = 0
+  while (importOrCommentRE.lastIndex < code.length) {
     if (!importOrCommentRE.test(code)) {
       return false
     }
-    position = importOrCommentRE.lastIndex
   }
-
   return true
 }
 


### PR DESCRIPTION
Resolves https://github.com/vitejs/vite/issues/22844 by replacing the anchored `entirelyImportRE` regex with a sticky token one that validates side-effect imports, comments, and whitespace one token at a time.

This should keep the existing behavior while avoiding backtracking on repeated `/* empty css */` comments before real code.