### PR TITLE
test: avoid warnings

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -271,16 +271,16 @@ describe('mergeConfig', () => {
     expect(newTrue.environments.ssr.resolve.noExternal).toEqual(true)
   })
 
-  test('handles server.hmr.server', () => {
+  test('handles server.ws.server', () => {
     const httpServer = http.createServer()
 
-    const baseConfig = { server: { hmr: { server: httpServer } } }
-    const newConfig = { server: { hmr: { server: httpServer } } }
+    const baseConfig = { server: { ws: { server: httpServer } } }
+    const newConfig = { server: { ws: { server: httpServer } } }
 
     const mergedConfig = mergeConfig(baseConfig, newConfig)
 
     // Server instance should not be recreated
-    expect(mergedConfig.server.hmr.server).toBe(httpServer)
+    expect(mergedConfig.server.ws.server).toBe(httpServer)
   })
 
   test('handles server.allowedHosts', () => {

--- a/packages/vite/src/node/__tests__/fixtures/config/native-import/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/config/native-import/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/playground/client-reload/__tests__/client-reload.spec.ts
+++ b/playground/client-reload/__tests__/client-reload.spec.ts
@@ -54,7 +54,7 @@ describe.runIf(isServe)('client-reload', () => {
   test('custom hmr port', async () => {
     await testClientReload({
       port: ports['client-reload/hmr-port'],
-      hmr: {
+      ws: {
         port: hmrPorts['client-reload/hmr-port'],
       },
     })
@@ -63,7 +63,7 @@ describe.runIf(isServe)('client-reload', () => {
   test('custom hmr port and cross origin isolation', async () => {
     await testClientReload({
       port: ports['client-reload/cross-origin'],
-      hmr: {
+      ws: {
         port: hmrPorts['client-reload/cross-origin'],
       },
       headers: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/config/import-meta: {}
 
+  packages/vite/src/node/__tests__/fixtures/config/native-import: {}
+
   packages/vite/src/node/__tests__/fixtures/config/plugin-module-condition: {}
 
   packages/vite/src/node/__tests__/fixtures/config/siblings:


### PR DESCRIPTION
Tweaked the test code to avoid the following warnings.

```
(node:29300) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///D:/documents/GitHub/vitejs-vite/packages/vite/src/node/__tests__/fixtures/config/native-import/basic.js?fresh-import-jtq4lzyqung=0,file:///D:/documents/GitHub/vitejs-vite/packages/vite/src/node/__tests__/fixtures/config/native-import/basic.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to D:\documents\GitHub\vitejs-vite\packages\vite\src\node\__tests__\package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```
```
`server.hmr.protocol/host/port/path/clientPort/timeout/server` is deprecated. Use `server.ws.*` instead. Note that this option may be set by a plugin. Set VITE_DEPRECATION_TRACE=1 to see where it is called.
```

