### PR TITLE
fix(optimizer): avoid optimizer run for transform request before init

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/optimizer-discover-before-listen/entry.js
+++ b/packages/vite/src/node/__tests__/fixtures/optimizer-discover-before-listen/entry.js
@@ -1,0 +1,3 @@
+import * as vue from 'vue'
+
+export default vue

--- a/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
@@ -1,0 +1,87 @@
+import path from 'node:path'
+import { setTimeout } from 'node:timers/promises'
+import { afterEach, expect, test } from 'vitest'
+import type { ViteDevServer } from '../..'
+import { createLogger, createServer } from '../..'
+import { promiseWithResolvers } from '../../../shared/utils'
+
+let server: ViteDevServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+// regression test for https://github.com/vitejs/vite/issues/22847
+// When a module importing a bare specifier is transformed between `createServer()`
+// and `server.listen()`, the dep is discovered and a debounced optimizer run starts
+// before `depsOptimizer.init()` runs. `init()` then resets the optimizer metadata
+// while that run is in flight, so `commitProcessing()` reads a dep from the run
+// result that no longer exists in the (freshly reset) metadata and crashes with
+// `Cannot read properties of undefined (reading 'browserHash')`.
+test('does not crash when a dep is discovered before the server starts listening', async () => {
+  const errors: string[] = []
+  const logger = createLogger('error')
+  logger.error = (msg) => {
+    errors.push(typeof msg === 'string' ? msg : String(msg))
+  }
+
+  const bundleStarted = promiseWithResolvers<void>()
+
+  server = await createServer({
+    configFile: false,
+    customLogger: logger,
+    root: path.join(
+      import.meta.dirname,
+      '../fixtures/optimizer-discover-before-listen',
+    ),
+    environments: {
+      ssr: {
+        resolve: {
+          noExternal: true,
+        },
+        optimizeDeps: {
+          // ensure a cold cache so the optimizer takes the crawl-end path in init()
+          force: true,
+          noDiscovery: false,
+          rolldownOptions: {
+            plugins: [
+              {
+                name: 'test:signal-pre-bundle',
+                buildStart() {
+                  bundleStarted.resolve()
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
+
+  const ssr = server.environments.ssr
+
+  // Transform a module importing a bare specifier before the server is listening.
+  // This discovers the dep and, on the buggy code, schedules a debounced optimizer
+  // run, all before `depsOptimizer.init()` has run (init is deferred to `listen()`).
+  await ssr.transformRequest('/entry.js')
+
+  // The bug is that discovering a dep here schedules a debounced optimizer run
+  // that races with `depsOptimizer.init()` (deferred to `listen()`) resetting the
+  // metadata, crashing in `commitProcessing`. The fix's guarantee is that no run
+  // starts before `init()`, so assert exactly that: fail if one starts.
+  const preInitRunStarted = await Promise.race([
+    bundleStarted.promise.then(() => true),
+    setTimeout(300, false),
+  ])
+  expect(preInitRunStarted).toBe(false)
+
+  // Starting the server runs `init()`, which scans and optimizes in the
+  // background. Wait for that startup work to settle so any optimizer error has
+  // surfaced (this also backstops the probe above: a run that somehow starts just
+  // after it would still crash here), then assert none was logged.
+  await server.listen()
+  await ssr.waitForRequestsIdle()
+  await ssr.depsOptimizer?.scanProcessing
+  expect(errors).toStrictEqual([])
+})

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -154,10 +154,10 @@ export function createDepsOptimizer(
     ])
   }
 
-  let inited = false
+  let initState: 'idle' | 'initializing' | 'initialized' = 'idle'
   async function init() {
-    if (inited) return
-    inited = true
+    if (initState !== 'idle') return
+    initState = 'initializing'
 
     const cachedMetadata = await loadCachedDepOptimizationMetadata(environment)
 
@@ -283,6 +283,7 @@ export function createDepsOptimizer(
         })
       }
     }
+    initState = 'initialized'
   }
 
   function startNextDiscoveredBatch() {
@@ -579,7 +580,10 @@ export function createDepsOptimizer(
     // we can get a list of every missing dependency before giving to the
     // browser a dependency that may be outdated, thus avoiding full page reloads
 
-    if (!waitingForCrawlEnd) {
+    // A module can be transformed between `createServer()` and `server.listen()`,
+    // which discovers a dep before `init()` runs. Starting a run here would race
+    // with `init()` resetting the metadata and crash in `commitProcessing`.
+    if (initState === 'initialized' && !waitingForCrawlEnd) {
       // Debounced rerun, let other missing dependencies be discovered before
       // the running next optimizeDeps
       debouncedProcessing()


### PR DESCRIPTION
The dependency optimizer crashed with `TypeError: Cannot read properties of undefined (reading 'browserHash')` when `transformRequest` is called before `server.listen()`.

`transformRequest` was triggering `debouncedProcessing()`, which was not expected to be called before `depsOptimizer.init()`. 

This PR fixes the error by avoiding `debouncedProcessing()` to be called before `depsOptimizer.init()` is completed.

fixes #22847