### PR TITLE
ci: unpin Windows Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,7 @@ jobs:
           - os: macos-latest
             node_version: 24
           - os: windows-latest
-            # use older minor to workaround https://github.com/nodejs/node/issues/63638
-            node_version: 24.15.0
+            node_version: 24
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"


### PR DESCRIPTION
## Summary

- restore the Windows CI matrix entry from `24.15.0` back to normal Node `24`
- remove the temporary Node Windows watcher workaround comment added in #22817

Fixes #22818.

## Testing

- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Notes

AI-assisted: yes. I manually reviewed the diff and validation output before opening this PR.

Not tested locally: the Windows GitHub Actions job itself.
