### PR TITLE
fix(css): defer `getFileName` to `generateBundle` (fix #22856)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -12,6 +12,7 @@ import type {
   RenderedChunk,
   RenderedModule,
   RollupError,
+  SourceMap,
   SourceMapInput,
 } from 'rolldown'
 import { dataToEsm } from '@rollup/pluginutils'
@@ -28,6 +29,7 @@ import type {
   TransformAttributeResult as LightningCssTransformAttributeResult,
   TransformResult as LightningCssTransformResult,
 } from 'lightningcss'
+import convertSourceMap from 'convert-source-map'
 import type { LightningCSSOptions } from '#types/internal/lightningcssOptions'
 import type {
   LessPreprocessorBaseOptions,
@@ -36,7 +38,11 @@ import type {
 } from '#types/internal/cssPreprocessorOptions'
 import type { EsbuildTransformOptions } from '#types/internal/esbuildOptions'
 import type { CustomPluginOptionsVite } from '#types/metadata'
-import { getCodeWithSourcemap, injectSourcesContent } from '../server/sourcemap'
+import {
+  getCodeWithSourcemap,
+  genSourceMapUrl,
+  injectSourcesContent,
+} from '../server/sourcemap'
 import type { EnvironmentModuleNode } from '../server/moduleGraph'
 import {
   createToImportMetaURLBasedRelativeRuntime,
@@ -731,6 +737,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               }
 
               // replace asset url references with resolved url.
+              // these assets are emitted by `vite:asset` during `load`
+              // During `renderChunk`, shortest file names are settled,
+              // so we can use `this.getFileName` to get the final file name.
               chunkCSS = chunkCSS.replace(
                 assetUrlRE,
                 (_, fileHash, postfix = '') => {
@@ -1022,24 +1031,68 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         if (cssUrlPendingRefIds.has(chunk.preliminaryFileName)) {
-          chunk.code = chunk.code.replace(
-            cssUrlDeferredRE,
-            (_match, referenceId) => {
-              const filename = this.getFileName(referenceId)
-              chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
-              const replacement = toOutputFilePathInJS(
-                this.environment,
-                filename,
-                'asset',
-                chunk.fileName,
-                'js',
-                toRelativeRuntime,
-              )
-              return typeof replacement === 'string'
+          const s = new MagicString(chunk.code)
+
+          cssUrlDeferredRE.lastIndex = 0
+          let match: RegExpExecArray | null
+          while ((match = cssUrlDeferredRE.exec(chunk.code))) {
+            const [full, referenceId] = match
+            const filename = this.getFileName(referenceId)
+            chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
+            const replacement = toOutputFilePathInJS(
+              this.environment,
+              filename,
+              'asset',
+              chunk.fileName,
+              'js',
+              toRelativeRuntime,
+            )
+            const replacementString =
+              typeof replacement === 'string'
                 ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
                 : `"+${replacement.runtime}+"`
-            },
-          )
+            s.update(match.index, match.index + full.length, replacementString)
+          }
+
+          // fix source map, ported fro ./importAnalysisBuild.ts:594
+          if (s.hasChanged()) {
+            chunk.code = s.toString()
+            if (config.build.sourcemap && chunk.map) {
+              const nextMap = s.generateMap({
+                source: chunk.fileName,
+                hires: 'boundary',
+              })
+              const originalFile = chunk.map.file
+              const map = combineSourcemaps(chunk.fileName, [
+                nextMap as RawSourceMap,
+                chunk.map as RawSourceMap,
+              ]) as SourceMap
+              map.toUrl = () => genSourceMapUrl(map)
+              if (originalFile) {
+                map.file = originalFile
+              }
+
+              const originalDebugId = chunk.map.debugId
+              chunk.map = map
+
+              if (config.build.sourcemap === 'inline') {
+                chunk.code = chunk.code.replace(
+                  convertSourceMap.mapFileCommentRegex,
+                  '',
+                )
+                chunk.code += '\n//# sourceMappingURL=' + genSourceMapUrl(map)
+              } else {
+                if (originalDebugId) {
+                  map.debugId = originalDebugId
+                }
+                const mapAsset = bundle[chunk.fileName + '.map']
+                if (mapAsset && mapAsset.type === 'asset') {
+                  mapAsset.source = map.toString()
+                }
+              }
+            }
+          }
+
           cssUrlPendingRefIds.delete(chunk.preliminaryFileName)
         }
       }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -471,6 +471,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
   // since output formats have no effect on the generated CSS.
   let hasEmitted = false
   let chunkCSSMap: Map<string, string>
+  let cssCodeSplitPendingRefIds: Map<string, string[]>
+  let cssUrlPendingRefIds: Map<string, string[]>
 
   const rolldownOptionsOutput = config.build.rolldownOptions.output
   const assetFileNames = (
@@ -525,6 +527,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       hasEmitted = false
       chunkCSSMap = new Map()
       codeSplitEmitQueue = createSerialPromiseQueue()
+      cssCodeSplitPendingRefIds = new Map()
+      cssUrlPendingRefIds = new Map()
     },
 
     transform: {
@@ -826,11 +830,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               ),
             )
             if (urlEmitTasks.length > 0) {
-              const toRelativeRuntime =
-                createToImportMetaURLBasedRelativeRuntime(
-                  opts.format,
-                  config.isWorker,
-                )
               s ||= new MagicString(code)
 
               for (const {
@@ -847,21 +846,16 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   source: content,
                 })
 
-                const filename = this.getFileName(referenceId)
-                chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
-                const replacement = toOutputFilePathInJS(
-                  this.environment,
-                  filename,
-                  'asset',
-                  chunk.fileName,
-                  'js',
-                  toRelativeRuntime,
-                )
-                const replacementString =
-                  typeof replacement === 'string'
-                    ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-                    : `"+${replacement.runtime}+"`
-                s.update(start, end, replacementString)
+                let pending = cssUrlPendingRefIds.get(chunk.fileName)
+                if (!pending) {
+                  pending = []
+                  cssUrlPendingRefIds.set(chunk.fileName, pending)
+                }
+                pending.push(referenceId)
+
+                // avoid writing `getFileName` here because it may return a wrong file name
+                // if the chunk is later deduplicated.
+                s.update(start, end, `__VITE_CSS_DEFERRED__${referenceId}__`)
               }
             }
 
@@ -921,9 +915,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                       .get(this.environment)!
                       .set(chunk.fileName, { referenceId, name: chunk.name })
                   }
-                  chunk.viteMetadata!.importedCss.add(
-                    this.getFileName(referenceId),
-                  )
+
+                  let pending = cssCodeSplitPendingRefIds.get(chunk.fileName)
+                  if (!pending) {
+                    pending = []
+                    cssCodeSplitPendingRefIds.set(chunk.fileName, pending)
+                  }
+                  pending.push(referenceId)
                 } else if (this.environment.config.consumer === 'client') {
                   // legacy build and inline css
 
@@ -978,13 +976,22 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           },
 
           augmentChunkHash(chunk) {
+            let hash = ''
             if (chunk.viteMetadata?.importedCss.size) {
-              let hash = ''
               for (const id of chunk.viteMetadata.importedCss) {
                 hash += id
               }
-              return hash
             }
+            const codeSplitPending = cssCodeSplitPendingRefIds.get(
+              chunk.fileName,
+            )
+            if (codeSplitPending) {
+              for (const refId of codeSplitPending) {
+                // used to compute hash only, so stale file name is fine
+                hash += this.getFileName(refId)
+              }
+            }
+            return hash || undefined
           },
         }
       : {}),
@@ -993,6 +1000,48 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       // to avoid emitting duplicate assets for modern build and legacy build
       if (this.environment.config.isOutputOptionsForLegacyChunks?.(opts)) {
         return
+      }
+
+      const cssUrlDeferredRE = /__VITE_CSS_DEFERRED__([\w$]+)__/g
+      const toRelativeRuntime = createToImportMetaURLBasedRelativeRuntime(
+        opts.format,
+        config.isWorker,
+      )
+
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk') continue
+
+        const codeSplitRefIds = cssCodeSplitPendingRefIds.get(
+          chunk.preliminaryFileName,
+        )
+        if (codeSplitRefIds) {
+          for (const refId of codeSplitRefIds) {
+            chunk.viteMetadata!.importedCss.add(this.getFileName(refId))
+          }
+          cssCodeSplitPendingRefIds.delete(chunk.preliminaryFileName)
+        }
+
+        if (cssUrlPendingRefIds.has(chunk.preliminaryFileName)) {
+          chunk.code = chunk.code.replace(
+            cssUrlDeferredRE,
+            (_match, referenceId) => {
+              const filename = this.getFileName(referenceId)
+              chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
+              const replacement = toOutputFilePathInJS(
+                this.environment,
+                filename,
+                'asset',
+                chunk.fileName,
+                'js',
+                toRelativeRuntime,
+              )
+              return typeof replacement === 'string'
+                ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
+                : `"+${replacement.runtime}+"`
+            },
+          )
+          cssUrlPendingRefIds.delete(chunk.preliminaryFileName)
+        }
       }
 
       // vite:asset cleans up earlier assets of 'renderChunk',


### PR DESCRIPTION
## Description

This is a fix for #22856 

For CSS URL assets, `getFileName` is deferred, a placeholder `__VITE_CSS_DEFERRED__<refId>__` was used instead of directly writing code. At `generateBundle`, the placeholders were replaced with actual `getFileName` results, which would be stable at that point, as all asset files have been emitted. `importedAssets` also got updated here.

For code-split CSSs, `importedCss` is also deferred. `referenceId`s are stored at `renderChunk`, and later resolved at `generateBundle`. `augmentChunkHash` calls `getFileName` to augment the chunk hash, getting file names which may later become stale, but that does not really matter in hash computing.

Since we deferred the code modification to `generateBundle`, source map will not be accurate. So we need to update source map during `generateBundle` as well. A fix was ported from https://github.com/vitejs/vite/blob/a1d73a3879196cfd76b05a364e30b1e6b4bdf757/packages/vite/src/node/plugins/importAnalysisBuild.ts#L594-L630

## Testing

There exists a relevant testing case `playground/css-codesplit/__tests__/css-codesplit-consistent.spec.ts`. This fix DO pass this test, but still, as mentioned in the issue, I wonder why it is `style2-` got emitted instead of `style-`, the latter having shorter name.

Updating rolldown to 1.1.4 causes vite to fail this test, even without this fix. The emitted file becomes `style-` instead of `style2-`.