### PR TITLE
docs: fix incorrect `@default` for `server.cors`

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -80,7 +80,7 @@ export interface CommonServerOptions {
    * Set to `true` to allow all methods from any origin, or configure separately
    * using an object.
    *
-   * @default false
+   * @default { origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }
    */
   cors?: CorsOptions | boolean
   /**


### PR DESCRIPTION
The `cors` option's JSDoc says `@default false`, but the resolved default is a restrictive object. `_serverConfigDefaults` sets `cors: { origin: defaultAllowedOrigins }` and it is applied via `mergeWithDefaults` in `resolveServerOptions`, so `server.cors` (and `preview.cors`, which inherits it) default to the loopback-origins regex, not `false`.

The published docs already document this default (`server-options.md`), only the JSDoc lagged. This updates the annotation to match.
