### PR TITLE
fix(client): overlay error message format align rolldown

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -108,7 +108,7 @@ pre.frame {
 
 .message {
   line-height: 1.3;
-  font-weight: 600;
+  font-weight: 400;
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
When `bundledDev` is enabled, if the project displays the following error message, it appears formatted correctly in the terminal, but misaligns when sent to the client's overlay display. 

This is because the error message output in the terminal is not explicitly bolded, while the client-side stylesheet sets `font-weight: 600` for the message. To prevent misalignment, the message's font-weight is set to 400.

|terminal|overlay|overlay(400)|
|---|---|---|
|<img width="1332" height="430" alt="image" src="https://github.com/user-attachments/assets/548d28e9-949a-4441-9309-5d70318f39ad" />|<img width="1946" height="658" alt="image" src="https://github.com/user-attachments/assets/757a049c-31e2-4f2b-9c14-5c20c6867ffe" />|<img width="1842" height="648" alt="image" src="https://github.com/user-attachments/assets/1ee63ee7-cedb-4ac7-9dbe-2de1e0f503dc" />|