### PR TITLE
docs: add advisors to team page

### DIFF
--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -132,10 +132,10 @@ export const advisors = [
   {
     avatar: 'https://github.com/jamesopstad.png',
     name: 'James Opstad',
-    title: '',
-    org: '',
-    orgLink: '',
-    desc: '',
+    title: 'Senior Engineer',
+    org: 'Cloudflare',
+    orgLink: 'https://www.cloudflare.com/',
+    desc: 'Building developer tools at Cloudflare',
     links: [{ icon: 'github', link: 'https://github.com/jamesopstad' }],
   },
   {

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -141,10 +141,10 @@ export const advisors = [
   {
     avatar: 'https://github.com/danielroe.png',
     name: 'Daniel Roe',
-    title: '',
-    org: '',
-    orgLink: '',
-    desc: '',
+    title: 'Open Source Maintainer',
+    org: 'Vercel',
+    orgLink: 'https://vercel.com/',
+    desc: 'Leading the Nuxt team',
     links: [
       { icon: 'github', link: 'https://github.com/danielroe' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/danielroe.dev' },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -116,6 +116,43 @@ export const core = [
   },
 ]
 
+export const advisors = [
+  {
+    avatar: 'https://github.com/serhalp.png',
+    name: 'Philippe Serhal',
+    title: '',
+    org: '',
+    orgLink: '',
+    desc: '',
+    links: [
+      { icon: 'github', link: 'https://github.com/serhalp' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/philippeserhal.com' },
+    ],
+  },
+  {
+    avatar: 'https://github.com/jamesopstad.png',
+    name: 'James Opstad',
+    title: '',
+    org: '',
+    orgLink: '',
+    desc: '',
+    links: [{ icon: 'github', link: 'https://github.com/jamesopstad' }],
+  },
+  {
+    avatar: 'https://github.com/danielroe.png',
+    name: 'Daniel Roe',
+    title: '',
+    org: '',
+    orgLink: '',
+    desc: '',
+    links: [
+      { icon: 'github', link: 'https://github.com/danielroe' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/danielroe.dev' },
+    ],
+    sponsor: 'https://github.com/sponsors/danielroe',
+  },
+]
+
 export const emeriti = [
   {
     avatar: 'https://i.imgur.com/KMed6rQ.jpeg',

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -120,10 +120,10 @@ export const advisors = [
   {
     avatar: 'https://github.com/serhalp.png',
     name: 'Philippe Serhal',
-    title: '',
-    org: '',
-    orgLink: '',
-    desc: '',
+    title: 'Staff Software Engineer',
+    org: 'Netlify',
+    orgLink: 'https://www.netlify.com/',
+    desc: 'Juggling all the frameworks at Netlify',
     links: [
       { icon: 'github', link: 'https://github.com/serhalp' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/philippeserhal.com' },

--- a/docs/team.md
+++ b/docs/team.md
@@ -11,7 +11,7 @@ import {
   VPTeamPageSection,
   VPTeamMembers
 } from '@voidzero-dev/vitepress-theme'
-import { core, emeriti } from './_data/team'
+import { core, advisors, emeriti } from './_data/team'
 </script>
 
 <VPTeamPage>
@@ -23,6 +23,16 @@ import { core, emeriti } from './_data/team'
     </template>
   </VPTeamPageTitle>
   <VPTeamMembers :members="core" />
+  <VPTeamPageSection>
+    <template #title>Advisors</template>
+    <template #lead>
+      Advisors help guide Vite from the ecosystem side, sharing their
+      experience to shape the Environment API and the design of future APIs.
+    </template>
+    <template #members>
+      <VPTeamMembers size="small" :members="advisors" />
+    </template>
+  </VPTeamPageSection>
   <VPTeamPageSection>
     <template #title>Team Emeriti</template>
     <template #lead>


### PR DESCRIPTION
Adding the scaffold for the advisors section of the team page.
