### PR TITLE
chore: ignore runtime-created glob-import symlink artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ playground-temp
 temp
 TODOs.md
 .eslintcache
+
+# runtime-created symlink for glob-import playground tests
+playground/glob-import/root/follow-symlinks/linked/my-lib


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
After running tests, the workspace may contain a runtime-created symlink directory from the glob-import playground, which shows up as an untracked file in git status.
This directory is a test artifact rather than a source change, and it introduces noise in local workflows and commit preparation.
To keep the working tree clean, the generated symlink path is now ignored in git.