### PR TITLE
fix(html): resolve modulepreload href for plugin-resolved module ids

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -174,6 +174,25 @@ export const isAsyncScriptMap: WeakMap<
   Map<string, boolean>
 > = new WeakMap()
 
+interface HtmlModulePreload {
+  placeholder: string
+  originalUrl: string
+  resolvedId: string
+}
+
+/**
+ * Module preload links found in each html file during transform. A
+ * `<link rel="modulepreload">` references a module — not a generic asset —
+ * so its href is resolved through the plugin pipeline (like module scripts
+ * are) and rewritten to the output chunk containing that module. The chunk
+ * is only known in `generateBundle`, so the href holds a placeholder until
+ * then.
+ */
+const htmlModulePreloadMap: WeakMap<
+  ResolvedConfig,
+  Map<string, HtmlModulePreload[]>
+> = new WeakMap()
+
 export function nodeIsElement(
   node: DefaultTreeAdapterMap['node'],
 ): node is DefaultTreeAdapterMap['element'] {
@@ -426,6 +445,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
   // Same reason with `htmlInlineProxyPlugin`
   isAsyncScriptMap.set(config, new Map())
+  htmlModulePreloadMap.set(config, new Map())
 
   return {
     name: 'vite:build-html',
@@ -498,6 +518,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         const s = new MagicString(html)
         const scriptUrls: ScriptAssetsUrl[] = []
         const styleUrls: ScriptAssetsUrl[] = []
+        const modulePreloads: HtmlModulePreload[] = []
         let inlineModuleIndex = -1
 
         let everyScriptIsAsync = true
@@ -659,7 +680,36 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   partialEncodeURIPath(toOutputPublicFilePath(url)),
                 )
               } else if (!isExcludedUrl(url)) {
+                const linkRel =
+                  node.nodeName === 'link' ? attr.attributes.rel : undefined
                 if (
+                  linkRel &&
+                  parseRelAttr(linkRel).includes('modulepreload')
+                ) {
+                  // A modulepreload link references a module, not a generic
+                  // asset, so resolve it through the plugin pipeline the same
+                  // way module scripts are — this also covers plugin-resolved
+                  // (e.g. virtual) ids that don't exist on the filesystem
+                  // (#22845). The href is rewritten to the output chunk
+                  // containing the module in generateBundle.
+                  assetUrlsPromises.push(
+                    (async () => {
+                      const resolved = await this.resolve(url, id)
+                      if (resolved && !resolved.external) {
+                        const placeholder = `__VITE_HTML_MODULEPRELOAD__${modulePreloads.length}__`
+                        modulePreloads.push({
+                          placeholder,
+                          originalUrl: attr.value,
+                          resolvedId: normalizePath(resolved.id),
+                        })
+                        overwriteAttrValue(s, attr.location, placeholder)
+                      }
+                      // when unresolvable, leave the href untouched so it can
+                      // be resolved at runtime (e.g. urls handled by a
+                      // server middleware)
+                    })(),
+                  )
+                } else if (
                   node.nodeName === 'link' &&
                   isCSSRequest(url) &&
                   // should not be converted if following attributes are present (#6748)
@@ -752,6 +802,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         })
 
         isAsyncScriptMap.get(config)!.set(id, everyScriptIsAsync)
+        htmlModulePreloadMap.get(config)!.set(id, modulePreloads)
 
         if (someScriptsAreAsync && someScriptsAreDefer) {
           config.logger.warn(
@@ -934,6 +985,47 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         const isAsync = isAsyncScriptMap.get(config)!.get(normalizedId)!
 
         let result = html
+
+        // rewrite modulepreload hrefs to the output chunk containing the
+        // module they resolved to during transform
+        const modulePreloads = htmlModulePreloadMap
+          .get(config)!
+          .get(normalizedId)
+        if (modulePreloads && modulePreloads.length > 0) {
+          const chunks = Object.values(bundle).filter(
+            (c): c is OutputChunk => c.type === 'chunk',
+          )
+          for (const preload of modulePreloads) {
+            // prefer the chunk the module is the facade of, then any chunk
+            // that bundles it
+            const targetChunk =
+              chunks.find(
+                (c) =>
+                  c.facadeModuleId &&
+                  normalizePath(c.facadeModuleId) === preload.resolvedId,
+              ) ??
+              chunks.find((c) =>
+                c.moduleIds.some(
+                  (moduleId) => normalizePath(moduleId) === preload.resolvedId,
+                ),
+              )
+            if (targetChunk) {
+              const builtUrl = partialEncodeURIPath(
+                toOutputAssetFilePath(targetChunk.fileName),
+              )
+              result = result.replace(preload.placeholder, () => builtUrl)
+            } else {
+              config.logger.warn(
+                `\n<link rel="modulepreload" href="${preload.originalUrl}"> in "/${relativeUrlPath}" ` +
+                  `doesn't point to a module included in the bundle, it will remain unchanged`,
+              )
+              result = result.replace(
+                preload.placeholder,
+                () => preload.originalUrl,
+              )
+            }
+          }
+        }
 
         // find corresponding entry chunk
         const chunk = Object.values(bundle).find(

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -6,6 +6,7 @@ import {
   isBuild,
   isServe,
   page,
+  readFile,
   serverLogs,
   untilBrowserLogAfter,
   viteServer,
@@ -152,6 +153,28 @@ describe('nested w/ query', () => {
 })
 
 describe.runIf(isBuild)('build', () => {
+  describe('modulepreload', () => {
+    test('plugin-resolved href points at the output chunk containing the module', () => {
+      const html = readFile('dist/modulepreloadResolved.html')
+
+      // the plugin-resolved href is rewritten to the built chunk (#22845)
+      expect(html).not.toContain('href="/@resolved-virtual-script"')
+      const preloadHref = html.match(
+        /<link rel="modulepreload" href="([^"]+\.js)"/,
+      )?.[1]
+      expect(preloadHref).toBeTruthy()
+
+      // it points at the same chunk the module script was bundled into
+      const scriptSrc = html.match(
+        /<script type="module"[^>]*src="([^"]+\.js)"/,
+      )?.[1]
+      expect(preloadHref).toBe(scriptSrc)
+
+      // an unresolvable href is left untouched to be resolved at runtime
+      expect(html).toContain('href="/@unresolvable-script"')
+    })
+  })
+
   describe('scriptAsync', () => {
     beforeAll(async () => {
       await page.goto(viteTestUrl + '/scriptAsync.html')

--- a/playground/html/modulepreloadResolved.html
+++ b/playground/html/modulepreloadResolved.html
@@ -1,0 +1,4 @@
+<link rel="modulepreload" href="/@resolved-virtual-script" />
+<link rel="modulepreload" href="/@unresolvable-script" />
+<script type="module" src="/@resolved-virtual-script"></script>
+<h1>Modulepreload with plugin-resolved ids</h1>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
           resolve(dirname, 'relative-input.html'),
         ),
         malformedUrl: resolve(dirname, 'malformed-url.html'),
+        modulepreloadResolved: resolve(dirname, 'modulepreloadResolved.html'),
       },
       external: ['/external-path-by-rollup-options.js'],
     },
@@ -130,6 +131,19 @@ ${
               injectTo: 'body',
             },
           ],
+        }
+      },
+    },
+    {
+      name: 'resolved-virtual-script',
+      resolveId(id) {
+        if (id === '/@resolved-virtual-script') {
+          return '\0resolved-virtual-script'
+        }
+      },
+      load(id) {
+        if (id === '\0resolved-virtual-script') {
+          return `document.title = 'virtual script loaded'`
         }
       },
     },


### PR DESCRIPTION
Fixes #22845

<link rel="modulepreload"> references a module, the same as a <script type="module">, but its href was only ever handled through the generic asset pipeline (processAssetUrl -> urlToBuiltUrl), which resolves ids as files and silently leaves the href untouched when the file doesn't exist on disk. Module scripts, by contrast, are resolved through this.resolve()/this.load() (via the import injected into the generated JS) so plugin-resolved (virtual) ids work correctly there.

This meant a modulepreload pointing at a virtual/plugin-resolved module id (e.g. React's prerenderToNodeStream bootstrapModules emitting both a modulepreload and a script tag for the same server-rendered client entry) kept its original, unresolved href in the build output -- a 404 in production -- while the sibling <script> for the exact same module worked fine, since "real" filesystem modules happened to already exist at that same href.

Fix: give modulepreload links their own resolution path. During transform, resolve the href via this.resolve() (same as module scripts) and, when it resolves to a non-external module, replace the href with a placeholder and record which built module it should point at. In generateBundle, once the bundle's chunks are known, look up the chunk containing that resolved module (preferring the chunk it's the facade of, then any chunk that includes it) and substitute the placeholder with that chunk's output path. An href that can't be resolved is left untouched with a warning, so runtime-handled urls (e.g. server middleware responses) keep working as before.

Also fixed a String.replace() footgun found while writing this: the existing modulepreload rewrite (and the new one) use a function replacer instead of a plain string, since a filename or original url containing '$' sequences (e.g. '$&', '$1') would otherwise be interpreted as a special replacement pattern and corrupt the output.

Tests: added playground/html/modulepreloadResolved.html covering both a plugin-resolved (virtual) modulepreload id and an unresolvable one. Verified the new test fails with the exact bug from the issue (the plugin-resolved href reaches the build output unchanged) by reverting only src/node/plugins/html.ts and rebuilding, then passes again with the fix restored. Full html playground suite (build: 55, serve: 54) and the vite package's unit suite (821 tests) all pass.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
