### PR TITLE
fix: transform CSS url() references in ?url imports for bundledDev (fix #22863)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -103,6 +103,7 @@ import {
   publicAssetUrlRE,
   publicFileToBuiltUrl,
   renderAssetUrlInJS,
+  toOutputFilePathInJSForBundledDev,
 } from './asset'
 import type { ESBuildOptions } from './esbuild'
 import { getChunkOriginalFileName } from './manifest'
@@ -312,6 +313,65 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
     })
   }
 
+  // Shared CSS URL resolver for use in load and transform hooks
+  function createCssUrlResolver(pluginContext: {
+    environment: any
+    [key: string]: any
+  }): CssUrlResolver {
+    const { environment } = pluginContext
+    const resolveUrl = (url: string, importer?: string) =>
+      idResolver(environment, url, importer)
+
+    return async (url, importer) => {
+      const decodedUrl = decodeURI(url)
+      if (checkPublicFile(decodedUrl, config)) {
+        if (encodePublicUrlsInCSS(config)) {
+          return [publicFileToBuiltUrl(decodedUrl, config), undefined]
+        } else {
+          const base = joinUrlSegments(config.server.origin ?? '', config.base)
+          return [joinUrlSegments(base, decodedUrl), undefined]
+        }
+      }
+      const [resolvedId, fragment] = decodedUrl.split('#')
+      let resolved = await resolveUrl(resolvedId, importer)
+      if (resolved) {
+        if (fragment) resolved += '#' + fragment
+        let url = await fileToUrl(pluginContext as any, resolved)
+        if (
+          !url.startsWith('data:') &&
+          pluginContext.environment.mode === 'dev'
+        ) {
+          const mod = [
+            ...(pluginContext.environment.moduleGraph.getModulesByFile(
+              resolved,
+            ) ?? []),
+          ].find((mod) => mod.type === 'asset')
+          if (mod?.lastHMRTimestamp) {
+            url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
+          }
+        }
+        return [url, cleanUrl(resolved)]
+      }
+      if (config.command === 'build') {
+        const isExternal = config.build.rolldownOptions.external
+          ? resolveUserExternal(
+              config.build.rolldownOptions.external,
+              decodedUrl,
+              resolvedId,
+              false,
+            )
+          : false
+
+        if (!isExternal) {
+          config.logger.warnOnce(
+            `\n${decodedUrl} referenced in ${resolvedId} didn't resolve at build time, it will remain unchanged to be resolved at runtime`,
+          )
+        }
+      }
+      return [url, undefined]
+    }
+  }
+
   return {
     name: 'vite:css',
 
@@ -339,7 +399,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: CSS_LANGS_RE,
       },
-      handler(id) {
+      async handler(id) {
         if (urlRE.test(id)) {
           if (isModuleCSSRequest(id)) {
             throw new Error(
@@ -350,7 +410,6 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
           }
 
           // *.css?url
-          // in dev, it's handled by assets plugin.
           if (isBuild) {
             id = injectQuery(removeUrlQuery(id), 'transform-only')
             return (
@@ -359,6 +418,39 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
                 'hex',
               )}__"`
             )
+          }
+
+          // In bundledDev mode, CSS ?url needs its url() references transformed
+          // before being emitted as an asset, since there is no follow-up
+          // transform request from the browser (unlike normal dev mode).
+          if (config.experimental.bundledDev) {
+            const cleanId = cleanUrl(removeUrlQuery(id))
+            const raw = await fsp.readFile(cleanId, 'utf-8')
+            const urlResolver = createCssUrlResolver(this)
+            const { code: transformed } = await compileCSS(
+              this.environment,
+              id,
+              raw,
+              preprocessorWorkerController!,
+              urlResolver,
+            )
+            const referenceId = this.emitFile({
+              type: 'asset',
+              name: path.basename(cleanId),
+              originalFileName: normalizePath(
+                path.relative(config.root, cleanId),
+              ),
+              source: transformed,
+            })
+            const filename = this.getFileName(referenceId)
+            const url = toOutputFilePathInJSForBundledDev(
+              this.environment,
+              filename,
+            )
+            return {
+              code: `export default ${JSON.stringify(encodeURIPath(url))}`,
+              moduleType: 'js',
+            }
           }
         }
       },
@@ -372,58 +464,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       },
       async handler(raw, id) {
         const { environment } = this
-        const resolveUrl = (url: string, importer?: string) =>
-          idResolver(environment, url, importer)
-
-        const urlResolver: CssUrlResolver = async (url, importer) => {
-          const decodedUrl = decodeURI(url)
-          if (checkPublicFile(decodedUrl, config)) {
-            if (encodePublicUrlsInCSS(config)) {
-              return [publicFileToBuiltUrl(decodedUrl, config), undefined]
-            } else {
-              const base = joinUrlSegments(
-                config.server.origin ?? '',
-                config.base,
-              )
-              return [joinUrlSegments(base, decodedUrl), undefined]
-            }
-          }
-          const [id, fragment] = decodedUrl.split('#')
-          let resolved = await resolveUrl(id, importer)
-          if (resolved) {
-            if (fragment) resolved += '#' + fragment
-            let url = await fileToUrl(this, resolved)
-            // Inherit HMR timestamp if this asset was invalidated
-            if (!url.startsWith('data:') && this.environment.mode === 'dev') {
-              const mod = [
-                ...(this.environment.moduleGraph.getModulesByFile(resolved) ??
-                  []),
-              ].find((mod) => mod.type === 'asset')
-              if (mod?.lastHMRTimestamp) {
-                url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
-              }
-            }
-            return [url, cleanUrl(resolved)]
-          }
-          if (config.command === 'build') {
-            const isExternal = config.build.rolldownOptions.external
-              ? resolveUserExternal(
-                  config.build.rolldownOptions.external,
-                  decodedUrl, // use URL as id since id could not be resolved
-                  id,
-                  false,
-                )
-              : false
-
-            if (!isExternal) {
-              // #9800 If we cannot resolve the css url, leave a warning.
-              config.logger.warnOnce(
-                `\n${decodedUrl} referenced in ${id} didn't resolve at build time, it will remain unchanged to be resolved at runtime`,
-              )
-            }
-          }
-          return [url, undefined]
-        }
+        const urlResolver = createCssUrlResolver(this)
 
         const {
           code: css,

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -25,6 +25,8 @@ if (isBuild) {
       .poll(() => page.textContent('.worker-query'))
       .toBe('worker-query')
     await expect.poll(() => page.textContent('.worker-url')).toBe('worker-url')
+    const cssUrlText = await page.textContent('.css-url')
+    expect(cssUrlText).toMatch(/\/assets\/css-with-asset-[\w-]+\.css/)
   })
 
   // BUNDLED -> GENERATE_HMR_PATCH -> BUNDLING -> BUNDLE_ERROR -> BUNDLING -> BUNDLED

--- a/playground/hmr-full-bundle-mode/css-with-asset.css
+++ b/playground/hmr-full-bundle-mode/css-with-asset.css
@@ -1,0 +1,5 @@
+.css-with-asset {
+  background: url(./asset.png);
+  width: 32px;
+  height: 32px;
+}

--- a/playground/hmr-full-bundle-mode/index.html
+++ b/playground/hmr-full-bundle-mode/index.html
@@ -6,6 +6,7 @@
 <div class="hmr-asset"></div>
 <div class="worker-query"></div>
 <div class="worker-url"></div>
+<div class="css-url"></div>
 <div class="invalidation-parent"></div>
 <div>
   <button id="load-dynamic">Load dynamic</button>

--- a/playground/hmr-full-bundle-mode/main.js
+++ b/playground/hmr-full-bundle-mode/main.js
@@ -2,10 +2,12 @@ import './hmr.js'
 import './hmr-asset.js'
 import './invalidation-parent.js'
 import assetUrl from './asset.png'
+import cssUrl from './css-with-asset.css?url'
 import WorkerQuery from './worker-query.js?worker'
 
 text('.app', 'hello')
 text('.asset', assetUrl)
+text('.css-url', cssUrl)
 
 const workerQuery = new WorkerQuery()
 workerQuery.postMessage('ping')


### PR DESCRIPTION
## PR Description

### What is this PR solving?

When `bundledDev: true` is enabled, CSS files imported with `?url` don't have their `url()` references transformed. Assets referenced inside the CSS (e.g., `url("./vite.webp")`) resolve to incorrect paths that the dev server doesn't serve.

**Root cause:** Three code paths converge:

1. **CSS plugin `load` hook** — returned `undefined` for `?url` CSS in dev mode, delegating to the asset plugin which reads the raw file
2. **CSS plugin `transform` filter** — excludes `?url` via `SPECIAL_QUERY_RE`, so `compileCSS()` URL rewriting never runs
3. **Asset plugin `fileToBuiltUrl`** — in bundledDev, emits the raw CSS as-is via `emitFile()`, and `memoryFilesMiddleware` serves it directly without any transform

In normal dev mode this works because `fileToDevUrl` returns the raw file path — the browser then makes a follow-up request that goes through `transformMiddleware`, which invokes the CSS transform. In bundledDev there's no follow-up request; the raw CSS is served directly from in-memory Rolldown output.

Fixes #22863.

### What other alternatives have you explored?

- **Fix in `fileToBuiltUrl` (asset plugin):** Would import CSS transformation logic into the asset plugin — cross-cutting concern, violates single responsibility. Rejected.
- **Remove `?url` from the CSS transform filter exclusion:** The transform handler outputs CSS JS-module code (applying styles), not URL exports. Would require two fundamentally different code paths in one handler. Rejected.
- **Handle in the CSS `load` hook (chosen):** Mirrors the existing build-mode `?url` handling pattern; all CSS logic stays in one plugin; `emitFile` / `getFileName` are natively available in Rolldown `load` hooks; minimal, non-invasive diff.

### Are there any parts you think require more attention from reviewers?

- **HMR:** This fix does not include HMR support for CSS `?url` imports in bundledDev. A file change will require a full page reload (which already happens for the importing module). HMR can be addressed as a follow-up.
- **`preprocessorWorkerController`:** The load hook uses `preprocessorWorkerController!` (non-null assertion), matching the existing pattern in the transform handler. In bundledDev, `buildStart` is called by the Rolldown DevEngine before any `load` hooks, so this is safe.
- **`fileToUrl` type cast:** The shared `createCssUrlResolver` helper uses `pluginContext as any` for the `fileToUrl` call because `this` has different types in bundledDev (Rolldown `PluginContext`) vs normal dev (Vite `TransformPluginContext`). This is an internal helper, not a public API.