### PR TITLE
ci: use var for github app client id

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -139,7 +139,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          client-id: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_ID }}
+          client-id: ${{ vars.ECOSYSTEM_CI_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ECOSYSTEM_CI_GITHUB_APP_PRIVATE_KEY }}
           repositories: |
             vite


### PR DESCRIPTION
It can be a var instead of secret.
https://github.com/actions/create-github-app-token#create-a-token-for-the-current-repository

