### PR TITLE
refactor: exclude postfix from `__VITE_ASSET__`

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -44,7 +44,7 @@ import type { Environment } from '../environment'
 import type { PartialEnvironment } from '../baseEnvironment'
 
 // referenceId is base64url but replaces - with $
-export const assetUrlRE: RegExp = /__VITE_ASSET__([\w$]+)__(?:\$_(.*?)__)?/g
+export const assetUrlRE: RegExp = /__VITE_ASSET__([\w$]+)__/g
 
 const jsSourceMapRE = /\.[cm]?js\.map$/
 
@@ -99,13 +99,12 @@ export function renderAssetUrlInJS(
   assetUrlRE.lastIndex = 0
   while ((match = assetUrlRE.exec(code))) {
     s ||= new MagicString(code)
-    const [full, referenceId, postfix = ''] = match
+    const [full, referenceId] = match
     const file = pluginContext.getFileName(referenceId)
     chunk.viteMetadata!.importedAssets.add(cleanUrl(file))
-    const filename = file + postfix
     const replacement = toOutputFilePathInJS(
       environment,
-      filename,
+      file,
       'asset',
       chunk.fileName,
       'js',
@@ -480,7 +479,7 @@ async function fileToBuiltUrl(
       const outputFilename = pluginContext.getFileName(referenceId)
       url = toOutputFilePathInJSForBundledDev(environment, outputFilename)
     } else {
-      url = `__VITE_ASSET__${referenceId}__${postfix ? `$_${postfix}__` : ``}`
+      url = `__VITE_ASSET__${referenceId}__${postfix}`
     }
   }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -745,23 +745,20 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               }
 
               // replace asset url references with resolved url.
-              chunkCSS = chunkCSS.replace(
-                assetUrlRE,
-                (_, fileHash, postfix = '') => {
-                  const filename = this.getFileName(fileHash) + postfix
-                  chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
-                  return encodeURIPath(
-                    toOutputFilePathInCss(
-                      filename,
-                      'asset',
-                      cssAssetName,
-                      'css',
-                      config,
-                      toRelative,
-                    ),
-                  )
-                },
-              )
+              chunkCSS = chunkCSS.replace(assetUrlRE, (_, fileHash) => {
+                const filename = this.getFileName(fileHash)
+                chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
+                return encodeURIPath(
+                  toOutputFilePathInCss(
+                    filename,
+                    'asset',
+                    cssAssetName,
+                    'css',
+                    config,
+                    toRelative,
+                  ),
+                )
+              })
               // resolve public URL from CSS paths
               if (encodedPublicUrls) {
                 const relativePathToPublicFromCSS = normalizePath(

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1039,12 +1039,12 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           },
         )
         // resolve asset url references
-        result = result.replace(assetUrlRE, (_, fileHash, postfix = '') => {
+        result = result.replace(assetUrlRE, (_, fileHash) => {
           const file = this.getFileName(fileHash)
           if (chunk) {
             chunk.viteMetadata!.importedAssets.add(cleanUrl(file))
           }
-          return encodeURIPath(toOutputAssetFilePath(file)) + postfix
+          return encodeURIPath(toOutputAssetFilePath(file))
         })
 
         result = result.replace(publicAssetUrlRE, (_, fileHash) => {


### PR DESCRIPTION
Part of the "Use of `import.meta.ROLLUP_FILE_URL_referenceId`" in https://github.com/vitejs/vite/issues/22709#issuecomment-4875776753

This refactor is need to migrate some parts to `import.meta.ROLLUP_FILE_URL_referenceId`.
The postfix was added in https://github.com/vitejs/vite/commit/4188ac628e759d102d71d169534cc174935f7ac6 but I think it's not needed.
