### PR TITLE
fix(ssr): reject duplicate module-scope bindings

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -49,6 +49,27 @@ test('named import: arbitrary module namespace specifier', async () => {
   )
 })
 
+test('duplicate module-scope bindings', async () => {
+  for (const code of [
+    `import { join } from 'node:path';import { join } from 'node:path';`,
+    `import { join } from 'node:path';const join = () => {};`,
+    `import { join } from 'node:path';function join() {}`,
+    `import { join } from 'node:path';export class join {}`,
+    `import { join } from 'node:path';export default function join() {}`,
+    `var join;import { join } from 'node:path';`,
+    `import { join } from 'node:path';if (true) { var join; }`,
+    `import { join } from 'node:path';for (var join = 0; false;) {}`,
+  ]) {
+    await expect(ssrTransformSimpleCode(code)).rejects.toThrow(
+      "Identifier 'join' has already been declared",
+    )
+  }
+
+  await expect(ssrTransformSimpleCode(`var join;var join;`)).resolves.toBe(
+    `var join;var join;`,
+  )
+})
+
 test('named import colliding with label', async () => {
   expect(
     await ssrTransformSimpleCode(

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -85,6 +85,8 @@ async function ssrTransformScript(
     throw err
   }
 
+  validateModuleScopeBindings(ast, code, url)
+
   let uid = 0
   const deps = new Set<string>()
   const dynamicDeps = new Set<string>()
@@ -425,6 +427,125 @@ async function ssrTransformScript(
 
 function getIdentifierNameOrLiteralValue(node: ESTree.ModuleExportName) {
   return node.type === 'Identifier' ? node.name : node.value
+}
+
+function validateModuleScopeBindings(
+  ast: ESTree.Program,
+  code: string,
+  url: string,
+) {
+  const lexicalBindings = new Set<string>()
+  const varBindings = new Set<string>()
+
+  const declareLexical = (
+    name: string,
+    node: ESTree.Node & { start: number },
+  ) => {
+    if (lexicalBindings.has(name) || varBindings.has(name)) {
+      throw createDuplicateBindingError(name, node, code, url)
+    }
+    lexicalBindings.add(name)
+  }
+
+  const declareVar = (name: string, node: ESTree.Node & { start: number }) => {
+    if (lexicalBindings.has(name)) {
+      throw createDuplicateBindingError(name, node, code, url)
+    }
+    varBindings.add(name)
+  }
+
+  const declareVariable = (declaration: ESTree.VariableDeclaration) => {
+    const declare = declaration.kind === 'var' ? declareVar : declareLexical
+
+    for (const decl of declaration.declarations) {
+      for (const name of extractNames(decl.id as any)) {
+        declare(name, decl.id as ESTree.Node & { start: number })
+      }
+    }
+  }
+
+  for (const node of ast.body) {
+    if (node.type === 'ImportDeclaration') {
+      for (const spec of node.specifiers) {
+        declareLexical(spec.local.name, spec.local)
+      }
+    } else if (node.type === 'VariableDeclaration') {
+      declareVariable(node)
+    } else if (node.type === 'FunctionDeclaration' && node.id) {
+      declareLexical(node.id.name, node.id)
+    } else if (node.type === 'ClassDeclaration' && node.id) {
+      declareLexical(node.id.name, node.id)
+    } else if (node.type === 'ExportNamedDeclaration' && node.declaration) {
+      const declaration = node.declaration
+      if (declaration.type === 'VariableDeclaration') {
+        declareVariable(declaration)
+      } else if (
+        (declaration.type === 'FunctionDeclaration' ||
+          declaration.type === 'ClassDeclaration') &&
+        declaration.id
+      ) {
+        declareLexical(declaration.id.name, declaration.id)
+      }
+    } else if (node.type === 'ExportDefaultDeclaration') {
+      const declaration = node.declaration
+      if (
+        (declaration.type === 'FunctionDeclaration' ||
+          declaration.type === 'ClassDeclaration') &&
+        declaration.id
+      ) {
+        declareLexical(declaration.id.name, declaration.id)
+      }
+    }
+
+    collectModuleScopedVarDeclarations(node, declareVar)
+  }
+}
+
+function createDuplicateBindingError(
+  name: string,
+  node: ESTree.Node & { start: number },
+  code: string,
+  url: string,
+) {
+  const err = new SyntaxError(
+    `Identifier '${name}' has already been declared`,
+  ) as SyntaxError & {
+    id?: string
+    loc?: ReturnType<typeof numberToPos> & { file?: string }
+    frame?: string
+  }
+
+  err.id = url
+  err.loc = numberToPos(code, node.start)
+  err.loc.file = url
+  err.frame = generateCodeFrame(code, node.start)
+
+  return err
+}
+
+function collectModuleScopedVarDeclarations(
+  root: ESTree.Node,
+  declareVar: (name: string, node: ESTree.Node & { start: number }) => void,
+) {
+  ;(eswalk as any)(root, {
+    enter(node: ESTree.Node, _parent: ESTree.Node | null) {
+      if (
+        isFunction(node) ||
+        node.type === 'ClassDeclaration' ||
+        node.type === 'ClassExpression'
+      ) {
+        return this.skip()
+      }
+
+      if (node.type === 'VariableDeclaration' && node.kind === 'var') {
+        for (const decl of node.declarations) {
+          for (const name of extractNames(decl.id as any)) {
+            declareVar(name, decl.id as ESTree.Node & { start: number })
+          }
+        }
+      }
+    },
+  })
 }
 
 interface Visitors {


### PR DESCRIPTION
refs #19617

Currently, duplicate imported bindings are rejected by native ESM with `Identifier 'join' has already been declared`, but Vite SSR rewrites the imports into internal async imports and the module ends up running successfully. This means an invalid ESM module can behave differently under SSR.

This PR adds a small module-scope binding validation step before the SSR import rewrite. It catches duplicate bindings from imports, lexical declarations, function/class declarations, and module-scoped `var` declarations. Also, Tests were added for the duplicate binding cases.