### PR TITLE
feat: use `import.meta.ROLLDOWN_FILE_URL_*` for other plugins

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -410,13 +410,15 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
 export async function fileToUrl(
   pluginContext: PluginContext,
   id: string,
+  format: AssetUrlFormat,
   asFileUrl = false,
 ): Promise<string> {
   const { environment } = pluginContext
   if (!environment.config.isBundled) {
-    return fileToDevUrl(environment, id, asFileUrl)
+    const value = await fileToDevUrl(environment, id, asFileUrl)
+    return formatBuiltAsset({ type: 'string', value }, format)
   } else {
-    return fileToBuiltUrl(pluginContext, id, 'string')
+    return fileToBuiltUrl(pluginContext, id, format)
   }
 }
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -139,14 +139,14 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           // Get final asset URL. If the file does not exist,
           // we fall back to the initial URL and let it resolve in runtime
-          let builtUrl: string | undefined
+          let builtUrlExpr: string | undefined
           if (file) {
             try {
               if (publicDir && isParentDirectory(publicDir, file)) {
                 const publicPath = '/' + path.posix.relative(publicDir, file)
-                builtUrl = await fileToUrl(this, publicPath)
+                builtUrlExpr = await fileToUrl(this, publicPath, 'js')
               } else {
-                builtUrl = await fileToUrl(this, file)
+                builtUrlExpr = await fileToUrl(this, file, 'js')
                 // during dev, builtUrl may point to a directory or a non-existing file
                 if (tryStatSync(file)?.isFile()) {
                   this.addWatchFile(file)
@@ -156,19 +156,19 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               // do nothing, we'll log a warning after this
             }
           }
-          if (!builtUrl) {
+          if (!builtUrlExpr) {
             const rawExp = code.slice(startIndex, endIndex)
             config.logger.warnOnce(
               `\n${rawExp} doesn't exist at build time, it will remain unchanged to be resolved at runtime. ` +
                 `If this is intended, you can use the /* @vite-ignore */ comment to suppress this warning.`,
             )
-            builtUrl = url
+            builtUrlExpr = JSON.stringify(url)
           }
           s.update(
             startIndex,
             endIndex,
             // NOTE: add `'' +` to opt-out rolldown's transform: https://github.com/rolldown/rolldown/issues/2745
-            `new URL(${JSON.stringify(builtUrl)}, '' + import.meta.url)`,
+            `new URL(${builtUrlExpr}, '' + import.meta.url)`,
           )
         }
         if (s) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -409,7 +409,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
           let resolved = await resolveUrl(id, importer)
           if (resolved) {
             if (fragment) resolved += '#' + fragment
-            let url = await fileToUrl(this, resolved)
+            let url = await fileToUrl(this, resolved, 'string')
             // Inherit HMR timestamp if this asset was invalidated
             if (!url.startsWith('data:') && this.environment.mode === 'dev') {
               const mod = [

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -147,16 +147,27 @@ export default ${wasmHelperCode}
             }
           }
 
-          let url = await fileToUrl(this, cleanedId, ssr)
-          assetUrlRE.lastIndex = 0
-          if (ssr && assetUrlRE.test(url)) {
-            url = url.replace('__VITE_ASSET__', '__VITE_WASM_INIT__')
+          let urlExpr: string
+          if (ssr) {
+            // SSR resolves the wasm at runtime relative to `import.meta.url`
+            // as a `file://` URL, so it keeps the string token which is
+            // rewritten to `__VITE_WASM_INIT__` and resolved in `renderChunk`.
+            // TODO: we need a way to pass metadata for each `import.meta.ROLLDOWN_FILE_URL_<id>`
+            //       so that we can differentiate __VITE_ASSET__ and __VITE_WASM_INIT__
+            let url = await fileToUrl(this, cleanedId, 'string', true)
+            assetUrlRE.lastIndex = 0
+            if (assetUrlRE.test(url)) {
+              url = url.replace('__VITE_ASSET__', '__VITE_WASM_INIT__')
+            }
+            urlExpr = JSON.stringify(url)
+          } else {
+            urlExpr = await fileToUrl(this, cleanedId, 'js')
           }
 
           if (isInit) {
             return `
   import initWasm from "${wasmHelperId}"
-  export default opts => initWasm(opts, ${JSON.stringify(url)})
+  export default opts => initWasm(opts, ${urlExpr})
   `
           }
 
@@ -167,7 +178,7 @@ export default ${wasmHelperCode}
 
           return `
 import __vite__initWasm from "${wasmHelperId}"
-const __vite__wasmUrl = ${JSON.stringify(url)}
+const __vite__wasmUrl = ${urlExpr}
 ${glueCode}
 `
         },

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -12,10 +12,9 @@ import { type ImportSpecifier, init, parse } from 'es-module-lexer'
 import { viteWebWorkerPostPlugin as nativeWebWorkerPostPlugin } from 'rolldown/experimental'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
+import type { Environment } from '../environment'
 import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
 import {
-  encodeURIPath,
-  getHash,
   injectQuery,
   normalizePath,
   prettifyUrl,
@@ -25,10 +24,8 @@ import {
 import {
   BuildEnvironment,
   ChunkMetadataMap,
-  createToImportMetaURLBasedRelativeRuntime,
   injectEnvironmentToHooks,
   onRollupLog,
-  toOutputFilePathInJS,
 } from '../build'
 import { cleanUrl, splitFileAndPostfix } from '../../shared/utils'
 import type { Logger } from '../logger'
@@ -37,10 +34,16 @@ import { fileToUrl, toOutputFilePathInJSForBundledDev } from './asset'
 type WorkerBundle = {
   entryFilename: string
   entryCode: string
-  entryUrlPlaceholder: string
   referencedAssets: Set<string>
   moduleIds: Set<string>
   watchedFiles: string[]
+  /**
+   * referenceId of the entry emitted for each build via
+   * `import.meta.ROLLDOWN_FILE_URL_<id>`. Keyed by `Environment` because
+   * referenceIds are per-build and this bundle is shared across the main build
+   * and nested worker sub-builds.
+   */
+  entryReferenceIds: WeakMap<Environment, /* referenceId */ string>
 }
 
 type WorkerBundleAsset = {
@@ -65,10 +68,6 @@ class WorkerOutputCache {
   private bundles = new Map</* inputId */ string, WorkerBundle>()
   /** list of assets emitted for the worker bundles */
   private assets = new Map<string, WorkerBundleAsset>()
-  private fileNameHash = new Map<
-    /* hash */ string,
-    /* entryFilename */ string
-  >()
   private invalidatedBundles = new Set</* inputId */ string>()
   /**
    * Worker references grouped by their containing bundle and module.
@@ -101,11 +100,10 @@ class WorkerOutputCache {
     const bundle: WorkerBundle = {
       entryFilename: outputEntryFilename,
       entryCode: outputEntryCode,
-      entryUrlPlaceholder:
-        this.generateEntryUrlPlaceholder(outputEntryFilename),
       referencedAssets: new Set(outputAssets.map((asset) => asset.fileName)),
       moduleIds,
       watchedFiles,
+      entryReferenceIds: new WeakMap(),
     }
     this.bundles.set(file, bundle)
     return bundle
@@ -146,7 +144,6 @@ class WorkerOutputCache {
     if (!bundle) return
 
     this.bundles.delete(file)
-    this.fileNameHash.delete(getHash(bundle.entryFilename))
 
     this.assets.delete(bundle.entryFilename)
 
@@ -220,16 +217,34 @@ class WorkerOutputCache {
     return this.assets.values()
   }
 
-  getEntryFilenameFromHash(hash: string) {
-    return this.fileNameHash.get(hash)
+  /**
+   * Emit the worker entry as an asset (once per build) and return the JS
+   * expression referencing it: `import.meta.ROLLDOWN_FILE_URL_<referenceId>`. The
+   * `vite:asset` `resolveFileUrl` hook turns that into the final URL (respecting
+   * base / `renderBuiltUrl`). The emitted file is deduplicated against this
+   * cache's `generateBundle` emit via its content check.
+   */
+  generateEntryUrlExpr(
+    pluginContext: PluginContext,
+    bundle: WorkerBundle,
+  ): string {
+    const { environment } = pluginContext
+    let referenceId = bundle.entryReferenceIds.get(environment)
+    if (!referenceId) {
+      referenceId = pluginContext.emitFile({
+        type: 'asset',
+        fileName: bundle.entryFilename,
+        source: bundle.entryCode,
+      })
+      bundle.entryReferenceIds.set(environment, referenceId)
+    }
+    return `import.meta.ROLLDOWN_FILE_URL_${referenceId}`
   }
 
-  private generateEntryUrlPlaceholder(entryFilename: string): string {
-    const hash = getHash(entryFilename)
-    if (!this.fileNameHash.has(hash)) {
-      this.fileNameHash.set(hash, entryFilename)
+  clearEntryReferenceIds(environment: Environment): void {
+    for (const bundle of this.bundles.values()) {
+      bundle.entryReferenceIds.delete(environment)
     }
-    return `__VITE_WORKER_ASSET__${hash}__`
   }
 }
 
@@ -270,6 +285,21 @@ export function recordWorkerReference(
   workerOutputCaches
     .get(config.mainConfig || config)!
     .recordReference(parentInputId, childBundleId, referencingModuleId)
+}
+
+/**
+ * Reference a bundled worker entry as `import.meta.ROLLDOWN_FILE_URL_<id>` from the
+ * given build. Thin accessor over `WorkerOutputCache.generateEntryUrlExpr` so
+ * both `vite:worker` and `vite:worker-import-meta-url` can share the cache.
+ */
+export function generateWorkerEntryUrlExpr(
+  pluginContext: PluginContext,
+  config: ResolvedConfig,
+  bundle: WorkerBundle,
+): string {
+  return workerOutputCaches
+    .get(config.mainConfig || config)!
+    .generateEntryUrlExpr(pluginContext, bundle)
 }
 
 async function bundleWorkerEntry(
@@ -421,8 +451,6 @@ async function bundleWorkerEntry(
   return newBundleInfo
 }
 
-export const workerAssetUrlRE: RegExp = /__VITE_WORKER_ASSET__([a-z\d]{8})__/g
-
 export async function workerFileToUrl(
   config: ResolvedConfig,
   id: string,
@@ -529,7 +557,6 @@ export function webWorkerPostPlugin(_config: ResolvedConfig): Plugin {
 }
 
 export function webWorkerPlugin(config: ResolvedConfig): Plugin {
-  const isBuild = config.command === 'build'
   const isWorker = config.isWorker
 
   workerOutputCaches.set(config, new WorkerOutputCache())
@@ -541,6 +568,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     buildStart() {
       if (isWorker) return
       emittedAssets.clear()
+      workerOutputCaches.get(config)!.clearEntryReferenceIds(this.environment)
     },
 
     load: {
@@ -631,27 +659,27 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               id,
             )
             const result = await workerFileToUrl(config, id)
-            let url: string
             if (
               this.environment.config.command === 'serve' &&
               this.environment.config.isBundled
             ) {
               emitWorkerAssetsForBundledDev(this, config)
-              url = toOutputFilePathInJSForBundledDev(
-                this.environment,
-                result.entryFilename,
+              urlCode = JSON.stringify(
+                toOutputFilePathInJSForBundledDev(
+                  this.environment,
+                  result.entryFilename,
+                ),
               )
             } else {
-              url = result.entryUrlPlaceholder
+              urlCode = generateWorkerEntryUrlExpr(this, config, result)
             }
-            urlCode = JSON.stringify(url)
             for (const file of result.watchedFiles) {
               this.addWatchFile(file)
             }
           }
         } else {
           const { file, postfix } = splitWorkerRequest(id)
-          let url = await fileToUrl(this, file)
+          let url = await fileToUrl(this, file, 'string')
           url = injectQuery(
             `${url}${postfix}`,
             `${WORKER_FILE_ID}&type=${workerType}`,
@@ -722,69 +750,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       },
     },
 
-    ...(isBuild
-      ? {
-          renderChunk(code, chunk, outputOptions) {
-            let s: MagicString
-            const result = () => {
-              return (
-                s && {
-                  code: s.toString(),
-                  map: this.environment.config.build.sourcemap
-                    ? s.generateMap({ hires: 'boundary' })
-                    : null,
-                }
-              )
-            }
-            workerAssetUrlRE.lastIndex = 0
-            if (workerAssetUrlRE.test(code)) {
-              const toRelativeRuntime =
-                createToImportMetaURLBasedRelativeRuntime(
-                  outputOptions.format,
-                  this.environment.config.isWorker,
-                )
-
-              let match: RegExpExecArray | null
-              s = new MagicString(code)
-              workerAssetUrlRE.lastIndex = 0
-
-              // Replace "__VITE_WORKER_ASSET__5aa0ddc0__" using relative paths
-              const workerOutputCache = workerOutputCaches.get(
-                config.mainConfig || config,
-              )!
-
-              while ((match = workerAssetUrlRE.exec(code))) {
-                const [full, hash] = match
-                const filename =
-                  workerOutputCache.getEntryFilenameFromHash(hash)
-                if (!filename) {
-                  this.warn(`Could not find worker asset for hash: ${hash}`)
-                  continue
-                }
-                const replacement = toOutputFilePathInJS(
-                  this.environment,
-                  filename,
-                  'asset',
-                  chunk.fileName,
-                  'js',
-                  toRelativeRuntime,
-                )
-                const replacementString =
-                  typeof replacement === 'string'
-                    ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-                    : `"+${replacement.runtime}+"`
-                s.update(
-                  match.index,
-                  match.index + full.length,
-                  replacementString,
-                )
-              }
-            }
-            return result()
-          },
-        }
-      : {}),
-
     generateBundle(opts, bundle) {
       // to avoid emitting duplicate assets for modern build and legacy build
       if (
@@ -798,7 +763,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       // Reference tracking relies on hooks running for every module, which is
       // not guaranteed when an incremental build reuses cached modules.
       const liveFileNames =
-        isBuild && !config.build.watch
+        this.environment.config.command === 'build' && !config.build.watch
           ? cache.getLiveAssetFileNames(liveModuleIds)
           : undefined
       for (const asset of cache.getAssets()) {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -209,6 +209,31 @@ class WorkerOutputCache {
     return liveFileNames
   }
 
+  getDeadDirectlyReferencedBundles(
+    bundleId: BundleId,
+    liveModuleIds: Set<string>,
+  ): WorkerBundle[] {
+    const referencesByModule = this.bundleReferences.get(bundleId)
+    if (!referencesByModule) return []
+    const deadBundleIds = new Set<WorkerBundleId>()
+    for (const references of referencesByModule.values()) {
+      for (const childBundleId of references) {
+        deadBundleIds.add(childBundleId)
+      }
+    }
+    for (const moduleId of liveModuleIds) {
+      for (const childBundleId of referencesByModule.get(moduleId) || []) {
+        deadBundleIds.delete(childBundleId)
+      }
+    }
+    const deadBundles: WorkerBundle[] = []
+    for (const childBundleId of deadBundleIds) {
+      const bundle = this.bundles.get(childBundleId)
+      if (bundle) deadBundles.push(bundle)
+    }
+    return deadBundles
+  }
+
   getWorkerBundle(file: string) {
     return this.bundles.get(file)
   }
@@ -752,20 +777,39 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
 
     generateBundle(opts, bundle) {
       // to avoid emitting duplicate assets for modern build and legacy build
-      if (
-        this.environment.config.isOutputOptionsForLegacyChunks?.(opts) ||
-        isWorker
-      ) {
+      if (this.environment.config.isOutputOptionsForLegacyChunks?.(opts)) {
         return
       }
-      const cache = workerOutputCaches.get(config)!
+      const cache = workerOutputCaches.get(config.mainConfig || config)!
       const liveModuleIds = collectIncludedModuleIds(Object.values(bundle))
       // Reference tracking relies on hooks running for every module, which is
       // not guaranteed when an incremental build reuses cached modules.
-      const liveFileNames =
+      const shouldFilter =
         this.environment.config.command === 'build' && !config.build.watch
-          ? cache.getLiveAssetFileNames(liveModuleIds)
-          : undefined
+
+      // `import.meta.ROLLDOWN_FILE_URL_*` requires calling `emitFile` while the
+      // referencing module is loaded. Remove those eagerly emitted assets when
+      // Rolldown later tree-shakes the module that referenced them. This also
+      // needs to run for worker sub-builds so dead nested workers don't become
+      // referenced assets of their parent worker bundle.
+      if (shouldFilter) {
+        const rootBundleId = isWorker ? config.bundleChain.at(-1) : undefined
+        for (const workerBundle of cache.getDeadDirectlyReferencedBundles(
+          rootBundleId,
+          liveModuleIds,
+        )) {
+          const emittedAsset = bundle[workerBundle.entryFilename]
+          if (emittedAsset?.type === 'asset') {
+            delete bundle[workerBundle.entryFilename]
+          }
+        }
+      }
+
+      if (isWorker) return
+
+      const liveFileNames = shouldFilter
+        ? cache.getLiveAssetFileNames(liveModuleIds)
+        : undefined
       for (const asset of cache.getAssets()) {
         if (liveFileNames && !liveFileNames.has(asset.fileName)) continue
         if (emittedAssets.has(asset.fileName)) continue

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -15,6 +15,7 @@ import {
   WORKER_FILE_ID,
   emitWorkerAssetsForBundledDev,
   recordWorkerReference,
+  generateWorkerEntryUrlExpr,
   workerFileToUrl,
 } from './worker'
 import { fileToUrl, toOutputFilePathInJSForBundledDev } from './asset'
@@ -260,7 +261,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           ) {
             s.update(expStart, expEnd, 'self.location.href')
           } else {
-            let builtUrl: string
+            let builtUrlExpr: string
             if (isBundled) {
               recordWorkerReference(
                 config,
@@ -271,28 +272,31 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               const result = await workerFileToUrl(config, file)
               if (this.environment.config.command === 'serve') {
                 emitWorkerAssetsForBundledDev(this, config)
-                builtUrl = toOutputFilePathInJSForBundledDev(
-                  this.environment,
-                  result.entryFilename,
+                builtUrlExpr = JSON.stringify(
+                  toOutputFilePathInJSForBundledDev(
+                    this.environment,
+                    result.entryFilename,
+                  ),
                 )
               } else {
-                builtUrl = result.entryUrlPlaceholder
+                builtUrlExpr = generateWorkerEntryUrlExpr(this, config, result)
               }
               for (const file of result.watchedFiles) {
                 this.addWatchFile(file)
               }
             } else {
-              builtUrl = await fileToUrl(this, cleanUrl(file))
-              builtUrl = injectQuery(
-                `${builtUrl}${queryPostfix}`,
+              builtUrlExpr = await fileToUrl(this, cleanUrl(file), 'string')
+              builtUrlExpr = injectQuery(
+                `${builtUrlExpr}${queryPostfix}`,
                 `${WORKER_FILE_ID}&type=${workerType}`,
               )
+              builtUrlExpr = JSON.stringify(builtUrlExpr)
             }
             s.update(
               expStart,
               expEnd,
               // NOTE: add `'' +` to opt-out rolldown's transform: https://github.com/rolldown/rolldown/issues/2745
-              `new URL(/* @vite-ignore */ ${JSON.stringify(builtUrl)}, '' + import.meta.url)`,
+              `new URL(/* @vite-ignore */ ${builtUrlExpr}, '' + import.meta.url)`,
             )
           }
         }

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -79,8 +79,8 @@ describe.runIf(isBuild)('build', () => {
     expect(workerContent).not.toMatch(/import\s*["(]/)
     expect(workerContent).not.toMatch(/\bexport\b/)
     // chunk
-    expect(content).toMatch('new Worker(``+new URL(`../worker-entries/')
-    expect(content).toMatch('new SharedWorker(``+new URL(`../worker-entries/')
+    expect(content).toMatch('new Worker(new URL(`../worker-entries/')
+    expect(content).toMatch('new SharedWorker(new URL(`../worker-entries/')
     // inlined
     expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
     expect(content).toMatch(`self.Blob`)


### PR DESCRIPTION
Part of the "Use of `import.meta.ROLLUP_FILE_URL_referenceId`" in https://github.com/vitejs/vite/issues/22709#issuecomment-4875776753

Similar to #22888 but for the other plugins.

fixes https://github.com/vitejs/vite/issues/13996

