### PR TITLE
docs: plugin asset emitting

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -596,6 +596,33 @@ function outputMetadataPlugin(): Plugin {
 }
 ```
 
+## Referencing Emitted Assets
+
+To emit an asset from a plugin, call [`this.emitFile({ type: 'asset', ... })`](https://rolldown.rs/reference/Interface.PluginContext#in-depth-type-asset). It returns a `referenceId` that you can use to generate the asset's URL, since its final file name isn't known until the bundle is generated.
+
+### In JavaScript
+
+Use `import.meta.ROLLDOWN_FILE_URL_<referenceId>`:
+
+```js
+const referenceId = this.emitFile({
+  type: 'asset',
+  name: 'icon.png',
+  source: fileContent,
+})
+
+// it's a JavaScript expression, so append any query or hash with string concatenation
+return `export default import.meta.ROLLDOWN_FILE_URL_${referenceId} + '#frag'`
+```
+
+### In CSS or HTML
+
+`import.meta.ROLLDOWN_FILE_URL_<referenceId>` only works in JavaScript expression position. In CSS or HTML, use the `__VITE_ASSET__<referenceId>__` token instead, appending any query or hash right after it:
+
+```css
+background: url(__VITE_ASSET__abc__#frag);
+```
+
 ## Plugin Ordering
 
 A Vite plugin can additionally specify an `enforce` property (similar to webpack loaders) to adjust its application order. The value of `enforce` can be either `"pre"` or `"post"`. The resolved plugins will be in the following order:

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -620,7 +620,7 @@ return `export default import.meta.ROLLDOWN_FILE_URL_${referenceId} + '#frag'`
 `import.meta.ROLLDOWN_FILE_URL_<referenceId>` only works in JavaScript expression position. In CSS or HTML, use the `__VITE_ASSET__<referenceId>__` token instead, appending any query or hash right after it:
 
 ```css
-background: url(__VITE_ASSET__abc__#frag);
+background: url(__VITE_ASSET__<referenceId>__#frag);
 ```
 
 ## Plugin Ordering


### PR DESCRIPTION
Part of the "Document `__VITE_ASSET__referenceId__`" in https://github.com/vitejs/vite/issues/22709#issuecomment-4875776753

Clarified how to use reference assets in JS and CSS / HTML.
