### PR TITLE
docs(static-deploy): update xmit guide URL

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -302,7 +302,7 @@ Deploy your static site using [Kinsta](https://kinsta.com/static-site-hosting/) 
 
 ## xmit Static Site Hosting
 
-Deploy your static site using [xmit](https://xmit.co) by following this [guide](https://xmit.co/blog/vite-quickstart).
+Deploy your static site using [xmit](https://xmit.co) by following this [guide](https://xmit.dev/guides/vite-quickstart/).
 
 ## Zephyr Cloud
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -302,7 +302,7 @@ Deploy your static site using [Kinsta](https://kinsta.com/static-site-hosting/) 
 
 ## xmit Static Site Hosting
 
-Deploy your static site using [xmit](https://xmit.co) by following this [guide](https://xmit.dev/posts/vite-quickstart/).
+Deploy your static site using [xmit](https://xmit.co) by following this [guide](https://xmit.co/blog/vite-quickstart).
 
 ## Zephyr Cloud
 


### PR DESCRIPTION
## Summary

xmit relocated their blog from `xmit.dev/posts/` to `xmit.co/blog/`. The canonical Vite deployment guide now lives at `https://xmit.co/blog/vite-quickstart`, which returns 200. The previous link in `docs/guide/static-deploy.md` (https://xmit.dev/posts/vite-quickstart/) returns 404.

## Verification

```sh
$ curl -sL -A 'Mozilla/5.0' -o /dev/null -w '%{http_code}\n' https://xmit.dev/posts/vite-quickstart/
404
$ curl -sL -A 'Mozilla/5.0' -o /dev/null -w '%{http_code}\n' https://xmit.co/blog/vite-quickstart
200
```

The `xmit.co` branding link itself is untouched and still resolves correctly.

## History

The xmit Static Site Hosting section was originally added to the deployment guide in #16441 (`docs(static-deploy): add xmit deployment guide`, merged 2024-05-01).

## Scope

One file, one URL swap. No other docs lines touched.

Signed-off-by: sanjibani <18418553+sanjibani@users.noreply.github.com>