### PR TITLE
docs(static-deploy): fix dead Azure Static Web Apps links

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -260,9 +260,9 @@ You can also deploy to a [custom domain](https://surge.sh/help/adding-a-custom-d
 
 ## Azure Static Web Apps
 
-You can quickly deploy your Vite app with Microsoft Azure [Static Web Apps](https://aka.ms/staticwebapps) service. You need:
+You can quickly deploy your Vite app with Microsoft Azure [Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static) service. You need:
 
-- An Azure account and a subscription key. You can create a [free Azure account here](https://azure.microsoft.com/free).
+- An Azure account and a subscription key. You can create a [free Azure account here](https://azure.microsoft.com/en-us/free).
 - Your app code pushed to [GitHub](https://github.com).
 - The [SWA Extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurestaticwebapps) in [Visual Studio Code](https://code.visualstudio.com).
 


### PR DESCRIPTION
The Azure Static Web Apps section in `docs/guide/static-deploy.md` referenced two URLs that now return 404:

- `https://aka.ms/staticwebapps` redirects to `https://azure.microsoft.com/services/app-service/static` which returns 404; the canonical product page is now `https://azure.microsoft.com/en-us/products/app-service/static` (returns 200, title "Azure Static Web Apps | Microsoft Azure").
- `https://azure.microsoft.com/free` returns 404; the localized `https://azure.microsoft.com/en-us/free` serves the same "Create Your Azure Free Account" page.

Both replacement URLs were verified via `curl -sIL -A 'Mozilla/5.0'` (HTTP 200 with the expected page titles). Switching to the localized `/en-us/` form also matches the canonical URL style used elsewhere on the Microsoft Azure site.

1 file changed, 2 links updated.