### PR TITLE
docs: document experimentalMinChunkSize migration note

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -292,6 +292,10 @@ The `build.rollupOptions.watch.chokidar` option was removed. Please migrate to t
 
 The object form `output.manualChunks` option is not supported anymore. The function form `output.manualChunks` is deprecated. Rolldown has the more flexible [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) option. See Rolldown's docs for more details about `codeSplitting`: [Manual Code Splitting - Rolldown](https://rolldown.rs/in-depth/manual-code-splitting).
 
+### Removed `build.rollupOptions.output.experimentalMinChunkSize` option
+
+The `output.experimentalMinChunkSize` option is not supported by Rolldown. There is no direct one-to-one replacement because Rollup used it to merge already generated chunks, while Rolldown's [`codeSplitting`](https://rolldown.rs/reference/OutputOptions.codeSplitting) options control how chunks are formed. If you used this option to reduce small chunks, start by reviewing `build.rolldownOptions.output.codeSplitting` and tuning groups for your application's import graph.
+
 ### `build()` Throws `BundleError`
 
 _This change only affects JS API users._


### PR DESCRIPTION
## Summary

- document that `build.rollupOptions.output.experimentalMinChunkSize` has no direct Rolldown equivalent
- point users toward `build.rolldownOptions.output.codeSplitting` for chunk grouping migration work

Closes #21844

## Validation

- `git diff --check`
