### PR TITLE
fix: Update assets-sanitize.ts to improve asset import functionality

### DIFF
--- a/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
+++ b/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
@@ -1,32 +1,56 @@
 import { expect, test } from 'vitest'
 import { getBg, isBuild, page, readManifest } from '~utils'
 
+async function expectAsset(selector, expected) {
+  const [bg, text] = await Promise.all([
+    getBg(selector),
+    page.textContent(selector),
+  ])
+
+  expect(bg).toContain(expected)
+  expect(text).toMatch(expected)
+}
+
+async function expectBuiltAsset(selector, asset) {
+  const [bg, text] = await Promise.all([
+    getBg(selector),
+    page.textContent(selector),
+  ])
+
+  expect(bg).toMatch(asset)
+  expect(text).toMatch(asset)
+}
+
 if (!isBuild) {
   test('importing asset with special char in filename works in dev', async () => {
-    expect(await getBg('.plus-circle')).toContain('+circle.svg')
-    expect(await page.textContent('.plus-circle')).toMatch('+circle.svg')
-    expect(await getBg('.underscore-circle')).toContain('_circle.svg')
-    expect(await page.textContent('.underscore-circle')).toMatch('_circle.svg')
+    await Promise.all([
+      expectAsset('.plus-circle', '+circle.svg'),
+      expectAsset('.underscore-circle', '_circle.svg'),
+    ])
   })
 } else {
   test('importing asset with special char in filename works in build', async () => {
     const manifest = readManifest()
+
     const plusCircleAsset = manifest['+circle.svg'].file
     const underscoreCircleAsset = manifest['_circle.svg'].file
-    expect(await getBg('.plus-circle')).toMatch(plusCircleAsset)
-    expect(await page.textContent('.plus-circle')).toMatch(plusCircleAsset)
-    expect(await getBg('.underscore-circle')).toMatch(underscoreCircleAsset)
-    expect(await page.textContent('.underscore-circle')).toMatch(
-      underscoreCircleAsset,
-    )
+
+    await Promise.all([
+      expectBuiltAsset('.plus-circle', plusCircleAsset),
+      expectBuiltAsset('.underscore-circle', underscoreCircleAsset),])
     expect(plusCircleAsset).toMatch('/_circle')
     expect(underscoreCircleAsset).toMatch('/_circle')
     expect(plusCircleAsset).not.toEqual(underscoreCircleAsset)
-    expect(Object.keys(manifest).length).toBe(3) // 2 svg, 1 index.js
+    expect(Object.keys(manifest)).toHaveLength(3)
   })
 }
 
 test.runIf(!isBuild)('denied .env', async () => {
-  expect(await page.textContent('.unsafe-dotenv')).toBe('403')
-  expect(await page.textContent('.unsafe-dotenv-double-slash')).toBe('200') // SPA fallback
+  const [dotenv, dotenvDoubleSlash] = await Promise.all([
+    page.textContent('.unsafe-dotenv'),
+    page.textContent('.unsafe-dotenv-double-slash'),
+  ])
+
+  expect(dotenv).toBe('403')
+  expect(dotenvDoubleSlash).toBe('200') // SPA fallback
 })


### PR DESCRIPTION
 Description

This PR optimizes the asset import tests by reducing unnecessary sequential asynchronous operations.

Changes

* Parallelized independent browser operations using `Promise.all`.
* Reduced redundant asynchronous waits during test execution.
* Kept the existing test behavior and assertions unchanged.

Motivation

The previous implementation executed several independent browser queries sequentially, resulting in unnecessary waiting time. Since these operations are independent, they can safely be executed in parallel, improving test execution efficiency without affecting correctness.

Alternatives Considered

* Keeping the existing sequential execution (simpler but slower).
* Combining assertions into helper functions only, which improves readability but provides less performance benefit than parallelizing the asynchronous operations.

Reviewer Notes

This is a performance-focused refactor of the test suite only. There are no changes to production code or test behavior.

No documentation changes are required.

Tests

The existing tests have been updated to execute independent asynchronous operations concurrently. No new test cases are required because the functionality and expected behavior remain unchanged.

