### PR TITLE
fix(css): don't tree-shake css modules with global styles

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1631,6 +1631,7 @@ async function compilePostCSS(
       code: string
       map?: Exclude<SourceMapInput, string>
       modules?: Record<string, string>
+      pure?: boolean
     }
   | undefined
 > {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -266,9 +266,21 @@ export const isDirectCSSRequest = (request: string): boolean =>
 export const isDirectRequest = (request: string): boolean =>
   directRequestRE.test(request)
 
+interface CSSModuleData {
+  exports: Record<string, string>
+  /**
+   * Whether every rule in the module is scoped to its exports. A pure module
+   * produces no output once its exports are unused, so it can be tree-shaken.
+   * An impure module has a global side effect (`:global`, an element selector,
+   * `@font-face`, ...) that must be preserved even when its exports are unused.
+   * See #19003.
+   */
+  pure: boolean
+}
+
 const cssModulesCache = new WeakMap<
   ResolvedConfig,
-  Map<string, Record<string, string>>
+  Map<string, CSSModuleData>
 >()
 
 export const removedPureCssFilesCache: WeakMap<
@@ -295,7 +307,7 @@ const cssUrlAssetRE = /__VITE_CSS_URL__([\da-f]+)__/g
  */
 export function cssPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
-  let moduleCache: Map<string, Record<string, string>>
+  let moduleCache: Map<string, CSSModuleData>
 
   const idResolver = createBackCompatIdResolver(config, {
     preferRelative: true,
@@ -317,7 +329,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
 
     buildStart() {
       // Ensure a new cache for every build (i.e. rebuilding in watch mode)
-      moduleCache = new Map<string, Record<string, string>>()
+      moduleCache = new Map<string, CSSModuleData>()
       cssModulesCache.set(config, moduleCache)
 
       removedPureCssFilesCache.set(config, new Map<string, RenderedChunk>())
@@ -428,6 +440,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
         const {
           code: css,
           modules,
+          pure,
           deps,
           map,
         } = await compileCSS(
@@ -438,7 +451,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
           urlResolver,
         )
         if (modules) {
-          moduleCache.set(id, modules)
+          moduleCache.set(id, { exports: modules, pure: pure ?? false })
         }
 
         if (deps) {
@@ -561,7 +574,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         const inlined = inlineRE.test(id)
-        const modules = cssModulesCache.get(config)!.get(id)
+        const cssModule = cssModulesCache.get(config)!.get(id)
+        const modules = cssModule?.exports
 
         // #6984, #7552
         // `foo.module.css` => modulesCode
@@ -638,9 +652,15 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         return {
           code,
           map: { mappings: '' },
-          // avoid the css module from being tree-shaken so that we can retrieve
-          // it in renderChunk()
-          moduleSideEffects: modulesCode || inlined ? false : 'no-treeshake',
+          // Allow tree-shaking the css module only when it's "pure" (every rule
+          // is scoped to its exports); an impure css module has global side
+          // effects that must be preserved even when its exports are unused
+          // (#19003). Everything else is kept via 'no-treeshake' so the css can
+          // be retrieved in renderChunk().
+          moduleSideEffects:
+            (modulesCode && cssModule?.pure) || inlined
+              ? false
+              : 'no-treeshake',
           moduleType: 'js',
         }
       },
@@ -1452,6 +1472,7 @@ async function compileCSS(
   code: string
   map?: SourceMapInput
   modules?: Record<string, string>
+  pure?: boolean
   deps?: Set<string>
 }> {
   const { config } = environment
@@ -1517,6 +1538,84 @@ async function compileCSS(
       : { mappings: '' },
     deps,
   }
+}
+
+// At-rules that are themselves a global side effect in a CSS module, regardless
+// of whether the module's exports are used.
+const globalCssModuleAtRuleRE =
+  /^(?:font-face|font-feature-values|font-palette-values|counter-style|property|page|viewport)$/
+// At-rules that only group other rules; their purity depends on their children.
+const groupingCssModuleAtRuleRE =
+  /^(?:media|supports|layer|container|scope|document|starting-style)$/
+const keyframesAtRuleRE = /^(?:-\w+-)?keyframes$/
+
+/**
+ * Whether a selector is scoped to one of the module's locally hashed class/id
+ * names, i.e. the rule can only match when one of the exports is used.
+ */
+function cssModuleSelectorIsScoped(
+  selector: string,
+  localNames: Set<string>,
+): boolean {
+  // drop attribute selectors and string literals so class/id-looking tokens
+  // inside them aren't matched
+  const cleaned = selector
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/(['"])(?:\\.|(?!\1).)*\1/g, ' ')
+  for (const match of cleaned.matchAll(/[.#]((?:\\.|[\w-])+)/g)) {
+    if (localNames.has(match[1])) return true
+  }
+  return false
+}
+
+/**
+ * A CSS module is "pure" when every rule is scoped to its exports, so it
+ * produces no output once its exports are unused and can be safely tree-shaken.
+ * It is "impure" when it has a global side effect (a `:global`/element/`:root`
+ * selector, an `@font-face`, global `@keyframes`, ...) that must be preserved in
+ * the build even when its exports are unused. See #19003.
+ */
+async function isPureCSSModule(
+  css: string,
+  modules: Record<string, string>,
+): Promise<boolean> {
+  const postcss = await importPostcss()
+  const localNames = new Set(
+    Object.values(modules).flatMap((value) => value.split(/\s+/)),
+  )
+  let pure = true
+  const visit = (node: PostCSS.ChildNode): void => {
+    if (!pure) return
+    if (node.type === 'rule') {
+      // keyframe steps (`from`, `to`, `50%`) are covered by their parent
+      if (
+        node.parent?.type === 'atrule' &&
+        keyframesAtRuleRE.test((node.parent as PostCSS.AtRule).name)
+      ) {
+        return
+      }
+      if (!cssModuleSelectorIsScoped(node.selector, localNames)) {
+        pure = false
+      }
+    } else if (node.type === 'atrule') {
+      const name = node.name.toLowerCase()
+      if (keyframesAtRuleRE.test(name)) {
+        // scoped keyframes are exported (their name is in localNames)
+        if (!localNames.has(node.params.trim())) pure = false
+      } else if (globalCssModuleAtRuleRE.test(name)) {
+        pure = false
+      } else if (groupingCssModuleAtRuleRE.test(name)) {
+        node.each(visit)
+      }
+    }
+  }
+  try {
+    postcss.parse(css).each(visit)
+  } catch {
+    // if the transformed CSS can't be analyzed, keep the module to be safe
+    return false
+  }
+  return pure
 }
 
 async function compilePostCSS(
@@ -1694,7 +1793,11 @@ async function compilePostCSS(
     environment.logger,
     devSourcemap,
   )
-  return { ...result, modules }
+  const pure =
+    modules && config.command === 'build'
+      ? await isPureCSSModule(result.code, modules)
+      : undefined
+  return { ...result, modules, pure }
 }
 
 async function transformSugarSS(
@@ -3235,6 +3338,7 @@ async function compileLightningCSS(
   code: string
   map?: string | undefined
   modules?: Record<string, string>
+  pure?: boolean
 }> {
   const { config } = environment
   const filename = removeDirectQuery(id)
@@ -3451,10 +3555,16 @@ async function compileLightningCSS(
     }
   }
 
+  const pure =
+    modules && config.command === 'build'
+      ? await isPureCSSModule(css, modules)
+      : undefined
+
   return {
     code: css,
     map: 'map' in res ? res.map?.toString() : undefined,
     modules,
+    pure,
   }
 }
 

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -509,6 +509,17 @@ test.runIf(isBuild)('CSS modules should be treeshaken if not used', () => {
   expect(css).not.toContain('treeshake-module-b')
 })
 
+test('CSS module imported for side effects keeps its global rule', async () => {
+  // an impure CSS module (with a global rule) imported without using its exports
+  // must apply consistently in dev and build (#19003)
+  expect(await getColor('.treeshake-module-side-effect')).toBe('green')
+})
+
+test.runIf(isBuild)('impure CSS modules should not be treeshaken', () => {
+  const css = findAssetFile(/\.css$/, undefined, undefined, true)
+  expect(css).toContain('treeshake-module-side-effect')
+})
+
 test.runIf(isBuild)('Scoped CSS via cssScopeTo should be treeshaken', () => {
   const css = findAssetFile(/\.css$/, undefined, undefined, true)
   expect(css).not.toMatch(/\btreeshake-scoped-b\b/)

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -134,6 +134,11 @@
 
   <p class="modules-treeshake">CSS modules should treeshake in build</p>
 
+  <p class="treeshake-module-side-effect">
+    CSS module imported for side effects should apply its global rule: this
+    should be green
+  </p>
+
   <p>Imported compose/from CSS/SASS module:</p>
   <p class="path-resolved-modules-css">
     CSS modules composes path resolving: this should be turquoise

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -30,6 +30,9 @@ document
   .querySelector('.modules-treeshake')
   .classList.add(treeshakeMod()['treeshake-module-a'])
 
+// imported only for its side effects: its global rule must survive the build (#19003)
+import './treeshake-module-side-effect.module.css'
+
 import composesPathResolvingMod from './composes-path-resolving.module.css'
 document
   .querySelector('.path-resolved-modules-css')

--- a/playground/css/treeshake-module-side-effect.module.css
+++ b/playground/css/treeshake-module-side-effect.module.css
@@ -1,0 +1,10 @@
+/* Imported only for its side effects (no exports used). It mixes a local class
+   with a global rule, so it must NOT be treeshaken away in build even though its
+   exports are unused (#19003). */
+.treeshake-module-side-effect-local {
+  color: red;
+}
+
+:global(.treeshake-module-side-effect) {
+  color: green;
+}


### PR DESCRIPTION
### Description

CSS modules are marked side-effect-free so Rollup can tree-shake them when their exported class names are unused (#16051). But a CSS module can also contain **global** rules — `:global(...)`, an element/`:root` selector, `@font-face`, global `@keyframes`, etc. Those apply regardless of whether any export is used, so tree-shaking the module drops CSS that was present in dev. That's the dev/build inconsistency in #19003 (and the HTML-linked variant #22242 that was folded into it).

This follows the direction suggested in the issue: decide whether a CSS module is "pure" (every rule is scoped to its exports) and only tree-shake the pure ones.

### Changes

- After a CSS module is transformed, compute whether it is pure by walking the resulting AST and checking that every rule is scoped to one of the module's exported (locally hashed) names. Global side effects — `:global`, element/`:root` selectors, `@font-face`/`@property`/… at-rules, global `@keyframes` — make it impure. This works for both the `postcss-modules` and `lightningcss` pipelines (their exports maps have the same shape) and only runs at build time.
- Pure modules stay tree-shakeable (unchanged from #16051). Impure modules are kept via `'no-treeshake'`, like plain CSS, so their global styles survive the build even when the exports are unused.
- Playground regression in `playground/css`: an impure module imported only for its side effects. It asserts the global rule applies in **both** dev and build, and that the module isn't tree-shaken. The existing "pure + unused ⇒ treeshaken" test still passes.

### Before / after

An impure `.module.css` imported for its side effects (no exports used):

- **before:** no CSS is emitted — the global rule is dropped in build (but applied in dev).
- **after:** the global rule is emitted. Same for a module linked from HTML via `<link rel="stylesheet">` (#22242).

### Notes for reviewers

- Purity is computed only at build time and only for CSS module files.
- For the `lightningcss` path the transformed output is re-parsed with postcss to analyze it; if that analysis ever throws, the module is treated as impure (kept), so a build is never broken by the check. Happy to reuse the already-parsed postcss AST for the postcss path instead if you'd prefer to avoid the second parse.

---

This PR was written with AI assistance (Claude). I've reviewed and verified the change end-to-end and can speak to every line.

fixes #19003
