### PR TITLE
docs: fix stale 'http-proxy' reference in proxy configure example

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -142,7 +142,7 @@ export default defineConfig({
         target: 'http://jsonplaceholder.typicode.com',
         changeOrigin: true,
         configure: (proxy, options) => {
-          // proxy will be an instance of 'http-proxy'
+          // proxy will be an instance of 'http-proxy-3'
         },
       },
       // Proxying websockets or socket.io:


### PR DESCRIPTION
## Summary

Fix a stale package name in the `server.proxy` code example comment:

```diff
  configure: (proxy, options) => {
-   // proxy will be an instance of 'http-proxy'
+   // proxy will be an instance of 'http-proxy-3'
  },
```

The dependency was updated to `http-proxy-3` and the surrounding prose on line 110 already correctly states "Extends [`http-proxy-3`](...)" — but this inline comment in the code example was not updated at the same time.

`packages/vite/package.json` confirms `"http-proxy-3": "^1.23.3"` is the current dependency.

## How did you test this change?

Documentation-only change — no runtime behavior affected, no tests needed. Verified by:

1. Confirming `packages/vite/package.json` lists `"http-proxy-3": "^1.23.3"` as the dependency.
2. Confirming the prose directly above the code example (line 110) already says "Extends `http-proxy-3`", making the old comment inconsistent with the surrounding doc.