### PR TITLE
fix(asset): wrap enclosing string literal when injecting runtime asset URL

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/asset.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/asset.spec.ts
@@ -1,0 +1,114 @@
+import MagicString from 'magic-string'
+import { describe, expect, test } from 'vitest'
+import { assetUrlRE, injectRuntimeIntoStringLiteral } from '../../plugins/asset'
+
+const runtime = `new URL("hero.png", "http://localhost/assets/").href`
+const url = 'http://localhost/assets/hero.png'
+
+function rewrite(code: string, expr: string = runtime): string {
+  const s = new MagicString(code)
+  const wrappedLiterals = new Set<number>()
+  let match: RegExpExecArray | null
+  assetUrlRE.lastIndex = 0
+  while ((match = assetUrlRE.exec(code))) {
+    injectRuntimeIntoStringLiteral(
+      s,
+      code,
+      match.index,
+      match.index + match[0].length,
+      expr,
+      wrappedLiterals,
+    )
+  }
+  return s.toString()
+}
+
+/** Evaluate a rewritten expression, proving it both parses and keeps its meaning. */
+function evaluate(code: string): unknown {
+  return new Function(`return (${code})`)()
+}
+
+describe('injectRuntimeIntoStringLiteral', () => {
+  test('wraps the literal so a unary operator binds across the concatenation', () => {
+    const code = 'typeof "__VITE_ASSET__abc__"'
+    expect(rewrite(code)).toBe(`typeof (""+(${runtime})+"")`)
+    expect(evaluate(rewrite(code))).toBe('string')
+  })
+
+  test('wraps the enclosing literal when the placeholder is embedded in it', () => {
+    // CSS-in-JS shape, produced by `import css from './a.css?inline'`
+    const code = 'typeof ".a{background:url(__VITE_ASSET__abc__)}"'
+    expect(rewrite(code)).toBe(
+      `typeof (".a{background:url("+(${runtime})+")}")`,
+    )
+    expect(evaluate(rewrite(code))).toBe('string')
+  })
+
+  test('property access resolves against the concatenation', () => {
+    expect(evaluate(rewrite('"__VITE_ASSET__abc__".length'))).toBe(url.length)
+  })
+
+  test('parenthesizes the runtime expression', () => {
+    // `experimental.renderBuiltUrl` may return an arbitrary expression
+    expect(rewrite('var x = "__VITE_ASSET__abc__"', 'cond ? a : b')).toBe(
+      'var x = (""+(cond ? a : b)+"")',
+    )
+  })
+
+  test('wraps a literal holding several placeholders exactly once', () => {
+    const out = rewrite(
+      'typeof ".a{background:url(__VITE_ASSET__abc__)}.b{background:url(__VITE_ASSET__def__)}"',
+    )
+    expect(out).toBe(
+      `typeof (".a{background:url("+(${runtime})+")}.b{background:url("+(${runtime})+")}")`,
+    )
+    expect(evaluate(out)).toBe('string')
+  })
+
+  test('keeps single quotes', () => {
+    expect(rewrite(`var x = 'url(__VITE_ASSET__abc__)'`)).toBe(
+      `var x = ('url('+(${runtime})+')')`,
+    )
+  })
+
+  test('keeps backticks', () => {
+    expect(rewrite('var x = `url(__VITE_ASSET__abc__)`')).toBe(
+      `var x = (\`url(\`+(${runtime})+\`)\`)`,
+    )
+  })
+
+  test('ignores escaped quotes when finding the literal bounds', () => {
+    // `background: url("./hero.png")` keeps its inner quotes, which get escaped
+    // once the stylesheet is embedded in a JS string literal.
+    const out = rewrite(
+      String.raw`typeof ".a{background:url(\"__VITE_ASSET__abc__\")}"`,
+    )
+    expect(out).toBe(
+      String.raw`typeof (".a{background:url(\""+(${runtime})+"\")}")`,
+    )
+    expect(evaluate(out)).toBe('string')
+    expect(evaluate(out.slice('typeof '.length))).toBe(
+      `.a{background:url("${url}")}`,
+    )
+  })
+
+  test('treats an escaped backslash before the closing quote as a real bound', () => {
+    const out = rewrite(String.raw`typeof "url(__VITE_ASSET__abc__)\\"`)
+    expect(out).toBe(String.raw`typeof ("url("+(${runtime})+")\\")`)
+    expect(evaluate(out)).toBe('string')
+    expect(evaluate(out.slice('typeof '.length))).toBe(`url(${url})\\`)
+  })
+
+  test('falls back to a bare splice when no enclosing literal is found', () => {
+    // A line break cannot occur inside a '/" literal, so the bounds are unsafe.
+    expect(rewrite('var x = "a"\n__VITE_ASSET__abc__\nvar y = "b"')).toBe(
+      `var x = "a"\n"+(${runtime})+"\nvar y = "b"`,
+    )
+  })
+
+  test('falls back when the enclosing template literal has an interpolation', () => {
+    expect(rewrite('var x = `${a}url(__VITE_ASSET__abc__)`')).toBe(
+      'var x = `${a}url("+(' + runtime + ')+")`',
+    )
+  })
+})

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -73,6 +73,91 @@ export function registerCustomMime(): void {
   mrmime.mimes.eot = 'application/vnd.ms-fontobject'
 }
 
+/**
+ * Minimal surface of `MagicString` / rolldown's native magic string that
+ * {@link injectRuntimeIntoStringLiteral} needs.
+ */
+export interface UpdatableMagicString {
+  update(start: number, end: number, content: string): unknown
+  appendLeft(index: number, content: string): unknown
+  appendRight(index: number, content: string): unknown
+}
+
+const quoteChars = new Set(['"', "'", '`'])
+
+function isEscaped(code: string, index: number): boolean {
+  let backslashes = 0
+  for (let i = index - 1; i >= 0 && code[i] === '\\'; i--) {
+    backslashes++
+  }
+  return backslashes % 2 === 1
+}
+
+/**
+ * Scan away from a placeholder for the quote that delimits the string literal
+ * containing it. A placeholder never contains a quote, so within its literal
+ * the only unescaped quote characters are the delimiters themselves.
+ * Returns -1 when no delimiter is found before a line break, which cannot occur
+ * inside a `'`/`"` literal.
+ */
+function findLiteralDelimiter(
+  code: string,
+  from: number,
+  step: 1 | -1,
+): number {
+  for (let i = from; i >= 0 && i < code.length; i += step) {
+    const char = code[i]
+    if (char === '\n' || char === '\r') return -1
+    if (quoteChars.has(char) && !isEscaped(code, i)) return i
+  }
+  return -1
+}
+
+/**
+ * Replace an asset placeholder that sits inside a string literal with a runtime
+ * expression, splicing it out of the literal (`"a" + runtime + "b"`).
+ *
+ * The concatenation binds looser than unary operators and property access, so
+ * the whole literal is wrapped in parentheses. Without them, `typeof "<ph>"`
+ * would become `typeof "" + runtime + ""`, which parses as
+ * `(typeof "") + runtime + ""`. See #22304.
+ *
+ * `wrappedLiterals` tracks which literals already got their parentheses, so a
+ * literal holding several placeholders (a CSS chunk with two `url()`s) is only
+ * wrapped once.
+ */
+export function injectRuntimeIntoStringLiteral(
+  s: UpdatableMagicString,
+  code: string,
+  start: number,
+  end: number,
+  runtime: string,
+  wrappedLiterals: Set<number>,
+): void {
+  const open = findLiteralDelimiter(code, start - 1, -1)
+  const close = open === -1 ? -1 : findLiteralDelimiter(code, end, 1)
+  const quote = code[open]
+  if (
+    close === -1 ||
+    code[close] !== quote ||
+    // a `${` means the bounds we found may belong to a nested expression
+    (quote === '`' && code.slice(open, close).includes('${'))
+  ) {
+    // Not confidently inside a string literal. All placeholders are emitted
+    // inside one, so this should not happen; splice without parens rather than
+    // risk emitting unbalanced ones.
+    s.update(start, end, `"+(${runtime})+"`)
+    return
+  }
+
+  if (!wrappedLiterals.has(open)) {
+    wrappedLiterals.add(open)
+    s.appendLeft(open, '(')
+    s.appendRight(close + 1, ')')
+  }
+  s.update(start, end, `${quote}+(${runtime})+${quote}`)
+}
+
 export function renderAssetUrlInJS(
   pluginContext: PluginContext,
   chunk: RenderedChunk,
@@ -94,7 +179,9 @@ export function renderAssetUrlInJS(
   // Urls added in CSS that is imported in JS end up like
   // var inlined = ".inlined{color:green;background:url(__VITE_ASSET__5aA0Ddc0__)}\n";
 
-  // In both cases, the wrapping should already be fine
+  // In both cases the placeholder sits inside a string literal, so a runtime
+  // replacement has to splice itself out of that literal.
+  const wrappedLiterals = new Set<number>()
 
   assetUrlRE.lastIndex = 0
   while ((match = assetUrlRE.exec(code))) {
@@ -111,11 +198,24 @@ export function renderAssetUrlInJS(
       'js',
       toRelativeRuntime,
     )
-    const replacementString =
-      typeof replacement === 'string'
-        ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-        : `"+${replacement.runtime}+"`
-    s.update(match.index, match.index + full.length, replacementString)
+    const start = match.index
+    const end = match.index + full.length
+    if (typeof replacement === 'string') {
+      s.update(
+        start,
+        end,
+        JSON.stringify(encodeURIPath(replacement)).slice(1, -1),
+      )
+    } else {
+      injectRuntimeIntoStringLiteral(
+        s,
+        code,
+        start,
+        end,
+        replacement.runtime,
+        wrappedLiterals,
+      )
+    }
   }
 
   // Replace __VITE_PUBLIC_ASSET__5aA0Ddc0__ with absolute paths
@@ -136,11 +236,24 @@ export function renderAssetUrlInJS(
       'js',
       toRelativeRuntime,
     )
-    const replacementString =
-      typeof replacement === 'string'
-        ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-        : `"+${replacement.runtime}+"`
-    s.update(match.index, match.index + full.length, replacementString)
+    const start = match.index
+    const end = match.index + full.length
+    if (typeof replacement === 'string') {
+      s.update(
+        start,
+        end,
+        JSON.stringify(encodeURIPath(replacement)).slice(1, -1),
+      )
+    } else {
+      injectRuntimeIntoStringLiteral(
+        s,
+        code,
+        start,
+        end,
+        replacement.runtime,
+        wrappedLiterals,
+      )
+    }
   }
 
   return s

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -99,6 +99,7 @@ import {
   assetUrlRE,
   cssEntriesMap,
   fileToUrl,
+  injectRuntimeIntoStringLiteral,
   publicAssetUrlCache,
   publicAssetUrlRE,
   publicFileToBuiltUrl,
@@ -832,6 +833,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   config.isWorker,
                 )
               s ||= new MagicString(code)
+              const wrappedLiterals = new Set<number>()
 
               for (const {
                 cssAssetName,
@@ -857,11 +859,22 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   'js',
                   toRelativeRuntime,
                 )
-                const replacementString =
-                  typeof replacement === 'string'
-                    ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-                    : `"+${replacement.runtime}+"`
-                s.update(start, end, replacementString)
+                if (typeof replacement === 'string') {
+                  s.update(
+                    start,
+                    end,
+                    JSON.stringify(encodeURIPath(replacement)).slice(1, -1),
+                  )
+                } else {
+                  injectRuntimeIntoStringLiteral(
+                    s,
+                    code,
+                    start,
+                    end,
+                    replacement.runtime,
+                    wrappedLiterals,
+                  )
+                }
               }
             }
 

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -5,7 +5,7 @@ import type { RolldownMagicString } from 'rolldown'
 import { createToImportMetaURLBasedRelativeRuntime } from '../build'
 import { type Plugin, perEnvironmentPlugin } from '../plugin'
 import { cleanUrl } from '../../shared/utils'
-import { assetUrlRE, fileToUrl } from './asset'
+import { assetUrlRE, fileToUrl, injectRuntimeIntoStringLiteral } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper.js'
 
@@ -141,6 +141,7 @@ ${glueCode}
 
                 let match: RegExpExecArray | null
                 let s: RolldownMagicString | MagicString | undefined
+                const wrappedLiterals = new Set<number>()
 
                 wasmInitUrlRE.lastIndex = 0
                 while ((match = wasmInitUrlRE.exec(code))) {
@@ -151,10 +152,13 @@ ${glueCode}
 
                   s ??= meta.magicString ?? new MagicString(code)
 
-                  s.update(
+                  injectRuntimeIntoStringLiteral(
+                    s,
+                    code,
                     match.index,
                     match.index + full.length,
-                    `"+${runtime}+"`,
+                    runtime,
+                    wrappedLiterals,
                   )
                 }
 

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -25,7 +25,11 @@ import {
 } from '../build'
 import { cleanUrl } from '../../shared/utils'
 import type { Logger } from '../logger'
-import { fileToUrl, toOutputFilePathInJSForBundledDev } from './asset'
+import {
+  fileToUrl,
+  injectRuntimeIntoStringLiteral,
+  toOutputFilePathInJSForBundledDev,
+} from './asset'
 
 type WorkerBundle = {
   entryFilename: string
@@ -596,6 +600,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               const workerOutputCache = workerOutputCaches.get(
                 config.mainConfig || config,
               )!
+              const wrappedLiterals = new Set<number>()
 
               while ((match = workerAssetUrlRE.exec(code))) {
                 const [full, hash] = match
@@ -613,15 +618,24 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
                   'js',
                   toRelativeRuntime,
                 )
-                const replacementString =
-                  typeof replacement === 'string'
-                    ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
-                    : `"+${replacement.runtime}+"`
-                s.update(
-                  match.index,
-                  match.index + full.length,
-                  replacementString,
-                )
+                const start = match.index
+                const end = match.index + full.length
+                if (typeof replacement === 'string') {
+                  s.update(
+                    start,
+                    end,
+                    JSON.stringify(encodeURIPath(replacement)).slice(1, -1),
+                  )
+                } else {
+                  injectRuntimeIntoStringLiteral(
+                    s,
+                    code,
+                    start,
+                    end,
+                    replacement.runtime,
+                    wrappedLiterals,
+                  )
+                }
               }
             }
             return result()

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -770,6 +770,11 @@ test('relative path in html asset', async () => {
   expect(await getColor('.relative-css')).toMatch('red')
 })
 
+test('typeof on an asset url keeps its meaning', async () => {
+  expect(await page.textContent('.typeof-asset-url')).toBe('string')
+  expect(await page.textContent('.typeof-inline-css')).toBe('string')
+})
+
 test('url() contains file in publicDir, in <style> tag', async () => {
   expect(await getBg('.style-public-assets')).toContain(iconMatch)
 })

--- a/playground/assets/__tests__/encoded-base/assets-encoded-base.spec.ts
+++ b/playground/assets/__tests__/encoded-base/assets-encoded-base.spec.ts
@@ -227,3 +227,8 @@ test('relative path in html asset', async () => {
   expect(await page.textContent('.relative-js')).toMatch('hello')
   expect(await getColor('.relative-css')).toMatch('red')
 })
+
+test('typeof on an asset url keeps its meaning', async () => {
+  expect(await page.textContent('.typeof-asset-url')).toBe('string')
+  expect(await page.textContent('.typeof-inline-css')).toBe('string')
+})

--- a/playground/assets/__tests__/relative-base/assets-relative-base.spec.ts
+++ b/playground/assets/__tests__/relative-base/assets-relative-base.spec.ts
@@ -242,3 +242,8 @@ test('relative path in html asset', async () => {
   expect(await page.textContent('.relative-js')).toMatch('hello')
   expect(await getColor('.relative-css')).toMatch('red')
 })
+
+test('typeof on an asset url keeps its meaning', async () => {
+  expect(await page.textContent('.typeof-asset-url')).toBe('string')
+  expect(await page.textContent('.typeof-inline-css')).toBe('string')
+})

--- a/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
+++ b/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
@@ -233,3 +233,8 @@ test('relative path in html asset', async () => {
   expect(await page.textContent('.relative-js')).toMatch('hello')
   expect(await getColor('.relative-css')).toMatch('red')
 })
+
+test('typeof on an asset url keeps its meaning', async () => {
+  expect(await page.textContent('.typeof-asset-url')).toBe('string')
+  expect(await page.textContent('.typeof-inline-css')).toBe('string')
+})

--- a/playground/assets/__tests__/url-base/assets-url-base.spec.ts
+++ b/playground/assets/__tests__/url-base/assets-url-base.spec.ts
@@ -231,3 +231,8 @@ test('relative path in html asset', async () => {
   expect(await page.textContent('.relative-js')).toMatch('hello')
   expect(await getColor('.relative-css')).toMatch('red')
 })
+
+test('typeof on an asset url keeps its meaning', async () => {
+  expect(await page.textContent('.typeof-asset-url')).toBe('string')
+  expect(await page.textContent('.typeof-inline-css')).toBe('string')
+})

--- a/playground/assets/asset/main.js
+++ b/playground/assets/asset/main.js
@@ -1,4 +1,13 @@
+import assetUrl from '../nested/asset.png'
+import inlineCss from './typeof-inline.css?inline'
+
 function text(el, text) {
   document.querySelector(el).textContent = text
 }
 text('.relative-js', 'hello')
+
+// An asset URL placeholder must keep its meaning when it ends up as the operand
+// of a unary operator. The `=== 'string'` comparison is what makes the bundler
+// inline the placeholder into the `typeof` operand. See #22304.
+text('.typeof-asset-url', typeof assetUrl === 'string' ? 'string' : 'broken')
+text('.typeof-inline-css', typeof inlineCss === 'string' ? 'string' : 'broken')

--- a/playground/assets/asset/typeof-inline.css
+++ b/playground/assets/asset/typeof-inline.css
@@ -1,0 +1,3 @@
+.typeof-inline-css {
+  background: url(../nested/asset.png);
+}

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -482,6 +482,9 @@
 <link rel="stylesheet" href="asset/style.css" />
 <div class="relative-css">link style</div>
 <div class="relative-js"></div>
+<h2>typeof on an asset URL</h2>
+<div class="typeof-asset-url"></div>
+<div class="typeof-inline-css"></div>
 <div class="update-content"></div>
 <script src="asset/main.js" type="module"></script>
 <script src="asset/update.js" type="module"></script>


### PR DESCRIPTION
### Description

Fixes #22304.

`renderAssetUrlInJS` replaces an asset placeholder in place by closing the string literal that holds it, concatenating the runtime expression, and reopening the literal (`"+runtime+"`). That splice is only valid when the enclosing literal sits in a context whose precedence is lower than additive `+`. `typeof` binds tighter, so with a relative base:

```js
if (typeof "__VITE_ASSET__abc__" === "string") { ... }
// became
if (typeof ""+new URL("hero.png", import.meta.url).href+"" === "string") { ... }
```

which parses as `(typeof "") + url + ""`. The branch silently never runs.

The placeholder only reaches a unary operand when the bundler inlines the string constant, which Rolldown does when that unlocks further folding (e.g. an `if` condition). Hence the report against v8, though the splice has always been precedence-unsafe.

### Two shapes, not one

The bug reproduces in two places, and both are fixed here:

1. The placeholder is the whole literal, from `export default "__VITE_ASSET__abc__"` (also `__VITE_PUBLIC_ASSET__`, `__VITE_WORKER_ASSET__`, `__VITE_WASM_INIT__`).
2. The placeholder is embedded in a larger literal, from CSS-in-JS:

```js
// import css from './a.css?inline'; if (typeof css === 'string') { ... }
if (typeof ".a{background:url("+new URL(...).href+")}" === "string") { ... }
```

### Fix

Find the bounds of the string literal containing the placeholder, wrap that whole literal in parentheses, and splice using the literal's actual delimiter:

```js
typeof (".a{background:url(" + (new URL("hero.png", import.meta.url).href) + ")}") === "string"
```

The bounds are found by scanning outward for a quote character that is not escaped (counting preceding backslashes, so `\"` is skipped but `\\"` is a real delimiter). This is sound because a placeholder never contains a quote, so within its literal the only unescaped quote characters are the delimiters. When the bounds cannot be established confidently (no delimiter before a line break, mismatched delimiters, or a template literal with an interpolation) the previous bare splice is used rather than risking unbalanced parentheses.

A literal may hold several placeholders (a CSS chunk with two `url()`s), so the parentheses are added once per literal.

`replacement.runtime` is now parenthesized as well. It comes from `experimental.renderBuiltUrl` and may be an arbitrary expression, so a low-precedence one such as `cond ? a : b` would previously produce `""+cond ? a : b+""`.

The shared helper is applied to all five call sites: `asset.ts` (asset and public asset), `css.ts`, `worker.ts` and `wasm.ts`.

### Relation to #22330

#22330 targets the same issue with the same parenthesizing insight, but expands the range by only one character on each side, so it only recognizes shape 1 and leaves shape 2 (its own "falls back to the legacy substitution" test) broken. This PR generalizes that to the enclosing literal and adds the runtime parenthesization. Happy to close whichever of the two is less useful.

### Tests

- `packages/vite/src/node/__tests__/plugins/asset.spec.ts`: 11 unit tests on the helper, covering both shapes, escaped quotes, escaped backslashes, single/double/backtick delimiters, multiple placeholders per literal, runtime parenthesization, and the two fallback paths. Most of them evaluate the rewritten code, so they check meaning and not just spelling.
- `playground/assets`: `typeof assetUrl === 'string'` and `typeof inlineCss === 'string'` asserted across all base configs. Verified these fail on `relative-base` and `runtime-base` without the source fix and pass with it; the three string-base configs are unaffected either way.

`pnpm test-unit` (855 passed) and `pnpm test-build assets` (223 passed) both pass. `css-codesplit` has a pre-existing flake unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)