### PR TITLE
docs(build): fix incorrect `@default` for build.lib.formats

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -322,7 +322,9 @@ export interface LibraryOptions {
    */
   name?: string
   /**
-   * Output bundle formats
+   * Output bundle formats. Defaults to `['es', 'umd']` for a single entry, or
+   * `['es', 'cjs']` for multiple entries (`umd` and `iife` do not support
+   * multiple entries).
    * @default ['es', 'umd']
    */
   formats?: LibraryFormats[]


### PR DESCRIPTION
`build.lib.formats` is documented as `@default ['es', 'umd']`, but that default only applies to a single entry. With multiple entries the applied default is `['es', 'cjs']` (`umd` and `iife` do not support multiple entries). This clarifies the JSDoc so it matches the resolved default.
