### PR TITLE
test: avoid scanner scanning all files under `__tests__`

### DIFF
--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -40,6 +40,12 @@ describe('the dev server', () => {
     server = await createServer({
       root: import.meta.dirname,
       logLevel: 'error',
+      // `server.listen()` would otherwise start a dep scan that crawls every
+      // HTML fixture under `__tests__`
+      optimizeDeps: {
+        noDiscovery: true,
+        include: [],
+      },
       server: {
         strictPort: true,
         ws: false,

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -3,9 +3,15 @@ import net from 'node:net'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { wildcardHosts } from '../constants'
 import { createServer } from '..'
-import type { ViteDevServer } from '..'
+import type { InlineConfig, ViteDevServer } from '..'
 
 const BASE_PORT = 15181
+
+// `server.listen()` would otherwise start a dep scan that crawls every HTML fixture under `__tests__`
+const optimizeDeps: InlineConfig['optimizeDeps'] = {
+  noDiscovery: true,
+  include: [],
+}
 
 describe('port detection', () => {
   let blockingServer: http.Server | null = null
@@ -50,6 +56,7 @@ describe('port detection', () => {
 
       viteServer = await createServer({
         root: import.meta.dirname,
+        optimizeDeps,
         logLevel: 'silent',
         server: { port: BASE_PORT, strictPort: false, ws: false },
       })
@@ -73,6 +80,7 @@ describe('port detection', () => {
 
       viteServer = await createServer({
         root: import.meta.dirname,
+        optimizeDeps,
         logLevel: 'silent',
         server: { port: BASE_PORT, strictPort: false, ws: false },
       })
@@ -92,6 +100,7 @@ describe('port detection', () => {
 
       viteServer = await createServer({
         root: import.meta.dirname,
+        optimizeDeps,
         logLevel: 'silent',
         server: { port: BASE_PORT, strictPort: false, ws: false },
       })
@@ -116,6 +125,7 @@ describe('port detection', () => {
 
       viteServer = await createServer({
         root: import.meta.dirname,
+        optimizeDeps,
         logLevel: 'silent',
         server: { port: BASE_PORT, strictPort: false, ws: false },
       })
@@ -143,6 +153,7 @@ describe('port detection', () => {
 
       viteServer = await createServer({
         root: import.meta.dirname,
+        optimizeDeps,
         logLevel: 'silent',
         server: {
           port: BASE_PORT,
@@ -188,6 +199,7 @@ describe('port detection', () => {
 
     viteServer = await createServer({
       root: import.meta.dirname,
+      optimizeDeps,
       logLevel: 'silent',
       server: { port: BASE_PORT, strictPort: false, ws: false },
     })
@@ -205,6 +217,7 @@ describe('port detection', () => {
 
     viteServer = await createServer({
       root: import.meta.dirname,
+      optimizeDeps,
       logLevel: 'silent',
       server: { port: BASE_PORT, strictPort: true, ws: false },
     })
@@ -220,6 +233,7 @@ describe('port detection', () => {
     const warnMessages: string[] = []
     viteServer = await createServer({
       root: import.meta.dirname,
+      optimizeDeps,
       customLogger: {
         info: () => {},
         warn: (msg) => warnMessages.push(msg),

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -11,6 +11,11 @@ describe('import and resolveId', () => {
       configFile: false,
       root: import.meta.dirname,
       logLevel: 'error',
+      // the scanner would otherwise crawl every HTML fixture under `__tests__`
+      optimizeDeps: {
+        noDiscovery: true,
+        include: [],
+      },
       server: {
         middlewareMode: true,
         ws: false,


### PR DESCRIPTION
This PR aims to fix the following error shown in `pnpm test-unit`:
```
stderr | packages/vite/src/node/__tests__/resolve.spec.ts > import and resolveId > import first
(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error: The following dependencies are imported but could not be resolved:

  entry.js (imported by /home/runner/work/vite/vite/packages/vite/src/node/__tests__/packages/build-project/index.html)

Are they installed?
    at /home/runner/work/vite/vite/packages/vite/src/node/optimizer/index.ts:471:15
    at /home/runner/work/vite/vite/packages/vite/src/node/optimizer/optimizer.ts:219:24
```

This was happening because the tests were running the scanner on the entire `__tests__` directory.

This PR fixes it by avoiding the scanner.

close #21111
