### PR TITLE
chore: remove outdated pnpm configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,6 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - rolldown
   - '@rolldown/binding-*'
-  - es-module-lexer@2.3.0
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
 trustPolicyExclude:


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
After a certain period of time has passed, the default minimumreleaseage configuration no longer restricts the installation of specific versions of es-module-lexer dependency packages, so the relevant exclusion configurations can be removed.

