### PR TITLE
chore: include changelog notes in GitHub releases

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -39,6 +39,21 @@ jobs:
 
           echo "pkgName=$pkgName" >> $GITHUB_OUTPUT
 
+      - name: Get release notes from changelog
+        id: notes
+        if: steps.tag.outputs.pkgName
+        env:
+          PKG_NAME: ${{ steps.tag.outputs.pkgName }}
+        run: |
+          changelog="packages/$PKG_NAME/CHANGELOG.md"
+          {
+            echo 'body<<CHANGELOG_EOF'
+            # Print the topmost version section, i.e. from the first heading
+            # up to (but excluding) the next one.
+            awk '/^## / { if (seen) exit; seen = 1 } seen' "$changelog"
+            echo CHANGELOG_EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create Release for Tag
         # only run if tag is not alpha
         if: steps.tag.outputs.pkgName
@@ -48,5 +63,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          body: |
-            Please refer to [CHANGELOG.md](https://github.com/vitejs/vite/blob/${{ github.ref_name }}/packages/${{ steps.tag.outputs.pkgName }}/CHANGELOG.md) for details.
+          body: ${{ steps.notes.outputs.body }}


### PR DESCRIPTION
Fixes #22489.

Vite's GitHub Releases only contained a link to CHANGELOG.md, so tools like Dependabot and people reading GitHub notifications couldn't see the actual notes. I updated the release-tag workflow to pull the topmost version section out of the package's CHANGELOG.md and pass it as the release body, so each release now shows its notes inline while the changelog is still maintained as before.

I could not fully run the suite in my environment, so I kept the change small and focused on the issue; a CI run would confirm it.
