### PR TITLE
feat(client): show runtime errors in a dismissible toast overlay

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -181,11 +181,13 @@ Specify server response headers.
 
 ## server.hmr
 
-- **Type:** `boolean | { overlay?: boolean }`
+- **Type:** `boolean | { overlay?: boolean, overlayRuntimeErrors?: boolean }`
 
 Disable or configure HMR behavior.
 
 Set `server.hmr.overlay` to `false` to disable the server error overlay.
+
+Set `server.hmr.overlayRuntimeErrors` to `true` to also show uncaught runtime errors and unhandled promise rejections from the browser in a dismissible toast. This is off by default and only applies when `server.hmr.overlay` is not `false`.
 
 ::: warning Deprecated Options
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -26,6 +26,7 @@ declare const __HMR_DIRECT_TARGET__: string
 declare const __HMR_BASE__: string
 declare const __HMR_TIMEOUT__: number
 declare const __HMR_ENABLE_OVERLAY__: boolean
+declare const __HMR_ENABLE_RUNTIME_OVERLAY__: boolean
 declare const __WS_TOKEN__: string
 declare const __SERVER_FORWARD_CONSOLE__: any
 declare const __BUNDLED_DEV__: boolean
@@ -338,6 +339,7 @@ async function handleMessage(payload: HotPayload) {
 }
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__
+const enableRuntimeOverlay = __HMR_ENABLE_RUNTIME_OVERLAY__
 const hasDocument = 'document' in globalThis
 
 function createErrorOverlay(err: ErrorPayload['err']) {
@@ -355,6 +357,45 @@ function clearErrorOverlay() {
 
 function hasErrorOverlay() {
   return document.querySelectorAll(overlayId).length
+}
+
+// Runtime error overlay (opt-in via `server.hmr.overlayRuntimeErrors`).
+// Uncaught errors and unhandled rejections are shown in a small dismissible
+// toast so the page underneath stays usable. Only enabled when the base HMR
+// overlay is also enabled.
+if (hasDocument && enableRuntimeOverlay) {
+  let runtimeErrorToast: ErrorOverlay | undefined
+
+  const normalizeRuntimeError = (
+    value: unknown,
+  ): ErrorPayload['err'] | undefined => {
+    if (value == null) return undefined
+    if (value instanceof Error) {
+      return { message: value.message, stack: value.stack ?? '' }
+    }
+    return { message: String(value), stack: '' }
+  }
+
+  const showRuntimeErrorToast = (value: unknown) => {
+    const err = normalizeRuntimeError(value)
+    if (!err) return
+    try {
+      // only keep the latest runtime error on screen; earlier ones remain in
+      // the console. This avoids stacking toasts on top of each other.
+      runtimeErrorToast?.close()
+      runtimeErrorToast = new ErrorOverlay(err, true, { toast: true })
+      document.body.appendChild(runtimeErrorToast)
+    } catch {
+      // never let the overlay itself break the page
+    }
+  }
+
+  window.addEventListener('error', (event) => {
+    showRuntimeErrorToast(event.error ?? event.message)
+  })
+  window.addEventListener('unhandledrejection', (event) => {
+    showRuntimeErrorToast(event.reason)
+  })
 }
 
 function waitForSuccessfulPing(socketUrl: string) {

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -169,6 +169,100 @@ kbd {
   border-color: rgb(54, 57, 64);
   border-image: initial;
 }
+
+.close {
+  display: none;
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--dim);
+  font-family: var(--monospace);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.close:hover {
+  color: var(--window-color);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.close:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 1px;
+}
+
+/*
+ * Toast variant: a small, dismissible card anchored to the bottom-right that
+ * is used for runtime errors so the page underneath stays usable.
+ */
+:host(.toast) {
+  top: auto;
+  left: auto;
+  right: 16px;
+  bottom: 16px;
+  width: auto;
+  height: auto;
+  pointer-events: none;
+}
+
+:host(.toast) .backdrop {
+  position: static;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  background: transparent;
+}
+
+:host(.toast) .window {
+  pointer-events: auto;
+  margin: 0;
+  max-width: min(420px, calc(100vw - 32px));
+  max-height: 80vh;
+  padding: 16px;
+  padding-right: 36px;
+}
+
+:host(.toast) .close {
+  display: block;
+}
+
+:host(.toast) pre:empty {
+  display: none;
+}
+
+/* the default tip references clicking the backdrop, which a toast has none of */
+:host(.toast) .tip {
+  display: none;
+}
+
+:host(.toast) .stack {
+  max-height: 30vh;
+  overflow: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :host(.toast) .window {
+    animation: vite-error-toast-in 0.2s ease-out;
+  }
+}
+
+@keyframes vite-error-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
 `
 
 // Error Template
@@ -179,6 +273,11 @@ const createTemplate = () =>
     h(
       'div',
       { class: 'window', part: 'window' },
+      h(
+        'button',
+        { class: 'close', part: 'close', 'aria-label': 'Close' },
+        '×',
+      ),
       h(
         'pre',
         { class: 'message', part: 'message' },
@@ -213,14 +312,39 @@ const codeframeRE = /^(?:>?\s*\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
 // `HTMLElement` was not originally defined.
 const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis
+export interface ErrorOverlayOptions {
+  /**
+   * Render a small dismissible toast anchored to the bottom-right instead of a
+   * full-screen overlay. Used for runtime errors so the page stays usable.
+   */
+  toast?: boolean
+}
+
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
   closeOnEsc: (e: KeyboardEvent) => void
 
-  constructor(err: ErrorPayload['err'], links = true) {
+  constructor(
+    err: ErrorPayload['err'],
+    links = true,
+    options: ErrorOverlayOptions = {},
+  ) {
     super()
+    const toast = options.toast === true
     this.root = this.attachShadow({ mode: 'open' })
     this.root.appendChild(createTemplate())
+
+    if (toast) {
+      this.classList.add('toast')
+      // announce to assistive tech and make the card keyboard-focusable so
+      // that Esc works and screen readers pick up the message
+      this.setAttribute('role', 'alert')
+      const windowEl = this.root.querySelector<HTMLElement>('.window')!
+      windowEl.setAttribute('tabindex', '-1')
+      this.root
+        .querySelector('.close')!
+        .addEventListener('click', () => this.close())
+    }
 
     codeframeRE.lastIndex = 0
     const hasFrame = err.frame && codeframeRE.test(err.frame)
@@ -248,9 +372,13 @@ export class ErrorOverlay extends HTMLElement {
       e.stopPropagation()
     })
 
-    this.addEventListener('click', () => {
-      this.close()
-    })
+    if (!toast) {
+      // clicking outside the window (on the backdrop) dismisses the overlay.
+      // a toast has no backdrop, so it is dismissed via the close button or Esc.
+      this.addEventListener('click', () => {
+        this.close()
+      })
+    }
 
     this.closeOnEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape' || e.code === 'Escape') {

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -87,6 +87,8 @@ async function createClientConfigValueReplacer(
 
   const hmrConfig = isObject(config.server.hmr) ? config.server.hmr : undefined
   const overlay = hmrConfig?.overlay !== false
+  // runtime error overlay is opt-in and only active when the base overlay is on
+  const runtimeOverlay = overlay && hmrConfig?.overlayRuntimeErrors === true
 
   // ws.clientPort -> ws.port
   // -> (24678 if middleware mode and WS server is not specified) -> new URL(import.meta.url).port
@@ -114,6 +116,7 @@ async function createClientConfigValueReplacer(
   const hmrBaseReplacement = escapeReplacement(hmrBase)
   const hmrTimeoutReplacement = escapeReplacement(timeout)
   const hmrEnableOverlayReplacement = escapeReplacement(overlay)
+  const hmrEnableRuntimeOverlayReplacement = escapeReplacement(runtimeOverlay)
   const hmrConfigNameReplacement = escapeReplacement(hmrConfigName)
   const wsTokenReplacement = escapeReplacement(config.webSocketToken)
   const serverForwardConsoleReplacement = escapeReplacement(
@@ -135,6 +138,10 @@ async function createClientConfigValueReplacer(
       .replace(`__HMR_BASE__`, hmrBaseReplacement)
       .replace(`__HMR_TIMEOUT__`, hmrTimeoutReplacement)
       .replace(`__HMR_ENABLE_OVERLAY__`, hmrEnableOverlayReplacement)
+      .replace(
+        `__HMR_ENABLE_RUNTIME_OVERLAY__`,
+        hmrEnableRuntimeOverlayReplacement,
+      )
       .replace(`__HMR_CONFIG_NAME__`, hmrConfigNameReplacement)
       .replace(`__WS_TOKEN__`, wsTokenReplacement)
       .replace(`__SERVER_FORWARD_CONSOLE__`, serverForwardConsoleReplacement)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -82,6 +82,12 @@ export interface HmrOptions {
   timeout?: number
   overlay?: boolean
   /**
+   * Show uncaught runtime errors and unhandled promise rejections from the
+   * browser in a dismissible toast. Only applies when `overlay` is not `false`.
+   * @default false
+   */
+  overlayRuntimeErrors?: boolean
+  /**
    * @deprecated Use `server.ws.server` instead.
    */
   server?: HttpServer


### PR DESCRIPTION
Closes the long-standing request in #2076. In the last team meeting bluwy noted you're good with adding this, and that the UI should be either toast style or the Next.js-style pill-with-popup, whichever is easier and less invasive. I went with the toast, since it's the less invasive of the two and reuses the existing error overlay almost entirely. Happy to switch to the pill version if you'd prefer that.

## What this does

When enabled, the client listens for uncaught errors (`window` `error` event) and unhandled promise rejections (`unhandledrejection`) and shows the error message and stack in a small toast anchored to the bottom-right. The page underneath stays fully usable, and only the latest error is shown so toasts don't pile up (earlier ones remain in the console).

## UI

The toast reuses the existing `ErrorOverlay` custom element with a new `toast` option, so there are no new dependencies and the styling stays consistent with the compile-error overlay. It renders in the same shadow DOM, with the backdrop removed and `pointer-events: none` on the host so clicks pass through to the app.

## Accessibility

- `role="alert"` so screen readers announce it
- A real focusable close button, plus Esc to dismiss (same handler the existing overlay uses)
- The slide-in animation is gated behind `prefers-reduced-motion: no-preference`

## Config

Opt-in and off by default. Add `overlayRuntimeErrors` under `server.hmr`:

```js
export default {
  server: { hmr: { overlayRuntimeErrors: true } },
}
```

It only activates when the base `server.hmr.overlay` is not `false`, and is wired through the same client injection as the existing overlay flag. Docs updated in `docs/config/server-options.md`.

## Testing

Verified manually in the browser: throwing in a click handler and rejecting a promise both surface the toast; Esc and the close button dismiss it; the page stays interactive. Typecheck, lint, and the client bundle build all pass. I skipped adding a playground e2e spec to keep the diff focused, but happy to add one if you'd like.

Fixes #2076
