### PR TITLE
fix(sourcemap): url-encode sources with whitespace (fix #17977)

### DIFF
--- a/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
+++ b/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
@@ -107,15 +107,22 @@ describe.skipIf(isWindows)('rewriteModuleSourceMapSources', () => {
     expect(map.sources).toEqual(['../my%20dir/a.ts'])
   })
 
-  test('escapes `#` and `?`, which encodeURI leaves as-is', () => {
+  test('escapes `#`, which encodeURI leaves as-is', () => {
     const map = {
-      sources: ['../my#dir/a.ts', './what?/b.ts', '/project/c#1/d.ts'],
+      sources: ['../my#dir/a.ts', '/project/c#1/d.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual(['../my%23dir/a.ts', '../c%231/d.ts'])
+  })
+
+  test('preserves query strings', () => {
+    const map = {
+      sources: ['my-worker.ts?worker_file&type=module', './a.ts?v=123'],
     }
     rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
     expect(map.sources).toEqual([
-      '../my%23dir/a.ts',
-      './what%3F/b.ts',
-      '../c%231/d.ts',
+      'my-worker.ts?worker_file&type=module',
+      './a.ts?v=123',
     ])
   })
 

--- a/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
+++ b/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest'
-import { getNodeModulesPackageRoot } from '../sourcemap'
+import {
+  getNodeModulesPackageRoot,
+  rewriteModuleSourceMapSources,
+} from '../sourcemap'
 import { isWindows } from '../../../shared/utils'
 
 describe('getNodeModulesPackageRoot', () => {
@@ -68,4 +71,76 @@ describe('getNodeModulesPackageRoot', () => {
       expect(getNodeModulesPackageRoot(input)).toBe(expected)
     })
   }
+})
+
+describe.skipIf(isWindows)('rewriteModuleSourceMapSources', () => {
+  test('makes absolute paths relative to the module', () => {
+    const map = {
+      sources: ['/project/src/a.ts', '/project/src/nested/b.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual(['a.ts', 'nested/b.ts'])
+  })
+
+  test('URL-encodes whitespace in the resulting relative path (#17977)', () => {
+    // Simulates macOS iCloud paths like `~/Library/Mobile Documents/…`.
+    const map = {
+      sources: ['/Users/foo/My Project/src/a.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/Users/foo/My Project/src/entry.ts')
+    expect(map.sources).toEqual(['a.ts'])
+
+    const map2 = {
+      sources: ['/Users/foo/My Project/src/a.ts'],
+    }
+    rewriteModuleSourceMapSources(map2, '/tmp/entry.ts')
+    expect(map2.sources[0]).not.toContain(' ')
+    expect(map2.sources[0]).toContain('%20')
+    expect(map2.sources[0]).toBe('../Users/foo/My%20Project/src/a.ts')
+  })
+
+  test('URL-encodes whitespace in already-relative sources', () => {
+    const map = {
+      sources: ['../my dir/a.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual(['../my%20dir/a.ts'])
+  })
+
+  test('leaves virtual sources untouched', () => {
+    const map = {
+      sources: [
+        '\0virtual-mod',
+        'virtual:my-mod',
+        'dep:foo',
+        'browser-external:bar',
+      ],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual([
+      '\0virtual-mod',
+      'virtual:my-mod',
+      'dep:foo',
+      'browser-external:bar',
+    ])
+  })
+
+  test('preserves empty entries', () => {
+    const map = {
+      sources: ['', '/project/src/a.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual(['', 'a.ts'])
+  })
+
+  test('is a no-op when the module file is not absolute', () => {
+    const map = {
+      sources: ['/absolute/src/a.ts', '../relative with space/b.ts'],
+    }
+    rewriteModuleSourceMapSources(map, 'not-absolute.ts')
+    expect(map.sources).toEqual([
+      '/absolute/src/a.ts',
+      '../relative with space/b.ts',
+    ])
+  })
 })

--- a/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
+++ b/packages/vite/src/node/server/__tests__/sourcemap.spec.ts
@@ -107,6 +107,18 @@ describe.skipIf(isWindows)('rewriteModuleSourceMapSources', () => {
     expect(map.sources).toEqual(['../my%20dir/a.ts'])
   })
 
+  test('escapes `#` and `?`, which encodeURI leaves as-is', () => {
+    const map = {
+      sources: ['../my#dir/a.ts', './what?/b.ts', '/project/c#1/d.ts'],
+    }
+    rewriteModuleSourceMapSources(map, '/project/src/entry.ts')
+    expect(map.sources).toEqual([
+      '../my%23dir/a.ts',
+      './what%3F/b.ts',
+      '../c%231/d.ts',
+    ])
+  })
+
   test('leaves virtual sources untouched', () => {
     const map = {
       sources: [

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -65,6 +65,8 @@ interface SourceMapLike {
  *   whitespace do not break resolution. The sourcemap spec requires `sources`
  *   entries to be URIs; a raw path containing a space (e.g. `../My Docs/x.ts`)
  *   yields an invalid URI reference. See https://github.com/vitejs/vite/issues/17977.
+ *   `#` and `?` are escaped as well: encodeURI preserves them as URI-reserved
+ *   characters, but in a path they would be parsed as fragment/query delimiters.
  */
 export function rewriteModuleSourceMapSources(
   map: SourceMapLike,
@@ -89,7 +91,11 @@ export function rewriteModuleSourceMapSources(
     // Skip virtual modules (e.g. `\0foo`, `virtual:foo`) — encoding them
     // would corrupt the identifier the debugger uses to fetch content.
     if (!virtualSourceRE.test(rewritten)) {
+      // encodeURI leaves `#` and `?` untouched (reserved chars), but here they
+      // are path characters, not fragment/query delimiters.
       rewritten = encodeURI(rewritten)
+        .replace(/#/g, '%23')
+        .replace(/\?/g, '%3F')
     }
 
     map.sources[index] = rewritten

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -65,8 +65,9 @@ interface SourceMapLike {
  *   whitespace do not break resolution. The sourcemap spec requires `sources`
  *   entries to be URIs; a raw path containing a space (e.g. `../My Docs/x.ts`)
  *   yields an invalid URI reference. See https://github.com/vitejs/vite/issues/17977.
- *   `#` and `?` are escaped as well: encodeURI preserves them as URI-reserved
- *   characters, but in a path they would be parsed as fragment/query delimiters.
+ *   `#` is escaped as well: encodeURI preserves it as a URI-reserved character,
+ *   but in a path it would be parsed as a fragment delimiter. `?` is left
+ *   untouched since sources may carry legitimate query strings.
  */
 export function rewriteModuleSourceMapSources(
   map: SourceMapLike,
@@ -91,11 +92,11 @@ export function rewriteModuleSourceMapSources(
     // Skip virtual modules (e.g. `\0foo`, `virtual:foo`) — encoding them
     // would corrupt the identifier the debugger uses to fetch content.
     if (!virtualSourceRE.test(rewritten)) {
-      // encodeURI leaves `#` and `?` untouched (reserved chars), but here they
-      // are path characters, not fragment/query delimiters.
-      rewritten = encodeURI(rewritten)
-        .replace(/#/g, '%23')
-        .replace(/\?/g, '%3F')
+      // encodeURI leaves `#` untouched (reserved char), but here it is a path
+      // character, not a fragment delimiter — Vite never appends fragments to
+      // module URLs. `?` must stay as-is: sources can carry real query strings
+      // (e.g. `my-worker.ts?worker_file&type=module`).
+      rewritten = encodeURI(rewritten).replace(/#/g, '%23')
     }
 
     map.sources[index] = rewritten

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -55,6 +55,47 @@ interface SourceMapLike {
   sourceRoot?: string
 }
 
+/**
+ * Rewrites the sourcemap's `sources` entries so debuggers (e.g. VS Code) can
+ * resolve them:
+ *
+ * - Absolute file paths are made relative to the module's directory to give
+ *   debuggers a chance to display them meaningfully.
+ * - Non-virtual entries are encoded with {@link encodeURI} so characters like
+ *   whitespace do not break resolution. The sourcemap spec requires `sources`
+ *   entries to be URIs; a raw path containing a space (e.g. `../My Docs/x.ts`)
+ *   yields an invalid URI reference. See https://github.com/vitejs/vite/issues/17977.
+ */
+export function rewriteModuleSourceMapSources(
+  map: SourceMapLike,
+  file: string,
+): void {
+  if (!path.isAbsolute(file)) return
+
+  let modDirname: string | undefined
+  for (let index = 0; index < map.sources.length; index++) {
+    const sourcePath = map.sources[index]
+    if (!sourcePath) continue
+
+    let rewritten = sourcePath
+    // Rewrite sources to relative paths to give debuggers the chance
+    // to resolve and display them in a meaningful way (rather than
+    // with absolute paths).
+    if (path.isAbsolute(rewritten)) {
+      modDirname ??= path.dirname(file)
+      rewritten = path.relative(modDirname, rewritten)
+    }
+
+    // Skip virtual modules (e.g. `\0foo`, `virtual:foo`) — encoding them
+    // would corrupt the identifier the debugger uses to fetch content.
+    if (!virtualSourceRE.test(rewritten)) {
+      rewritten = encodeURI(rewritten)
+    }
+
+    map.sources[index] = rewritten
+  }
+}
+
 async function computeSourceRoute(map: SourceMapLike, file: string) {
   let sourceRoot: string | undefined
   try {

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -31,6 +31,7 @@ import {
   applySourcemapIgnoreList,
   extractSourcemapFromFile,
   injectSourcesContent,
+  rewriteModuleSourceMapSources,
 } from './sourcemap'
 import { isFileLoadingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
@@ -393,28 +394,7 @@ async function loadAndTransform(
       logger,
     )
 
-    if (path.isAbsolute(mod.file)) {
-      let modDirname
-      for (
-        let sourcesIndex = 0;
-        sourcesIndex < normalizedMap.sources.length;
-        ++sourcesIndex
-      ) {
-        const sourcePath = normalizedMap.sources[sourcesIndex]
-        if (sourcePath) {
-          // Rewrite sources to relative paths to give debuggers the chance
-          // to resolve and display them in a meaningful way (rather than
-          // with absolute paths).
-          if (path.isAbsolute(sourcePath)) {
-            modDirname ??= path.dirname(mod.file)
-            normalizedMap.sources[sourcesIndex] = path.relative(
-              modDirname,
-              sourcePath,
-            )
-          }
-        }
-      }
-    }
+    rewriteModuleSourceMapSources(normalizedMap, mod.file)
   }
 
   if (environment._closing && environment.config.dev.recoverable)


### PR DESCRIPTION
### Description

When Vite serves a module from a path that contains whitespace (e.g. macOS iCloud paths like `~/Library/Mobile Documents/…`), the sourcemap's `sources` entries are emitted as raw filesystem-relative paths — not valid URI references. VS Code's `vscode-js-debug` fails to resolve them and breakpoints never bind. See also [`microsoft/vscode-js-debug#2089`](https://github.com/microsoft/vscode-js-debug/issues/2089).

The sourcemap spec requires `sources` entries to be URIs, so the fix is to `encodeURI` real-file entries after they've been rewritten to be relative to the module's directory. Virtual modules (matched by the existing `virtualSourceRE`: `\0`, `virtual:`, `dep:`, `browser-external:`) are passed through unchanged so the identifiers used to fetch their content aren't corrupted.

The rewrite loop already lived in `loadAndTransform`; this PR extracts it into a small `rewriteModuleSourceMapSources` helper in `server/sourcemap.ts` where its sibling `injectSourcesContent`/`applySourcemapIgnoreList` live, and adds the encoding step.

fixes #17977

### Test coverage

Added a `rewriteModuleSourceMapSources` unit-test suite in `packages/vite/src/node/server/__tests__/sourcemap.spec.ts` covering:

- absolute → module-relative rewriting
- `%20`-encoding of whitespace in the resulting relative path (the #17977 reproducer)
- `%20`-encoding of whitespace in sources that were already relative
- virtual sources (`\0`, `virtual:`, `dep:`, `browser-external:`) are untouched
- empty entries are preserved
- no-op when the module file is not an absolute path
