### PR TITLE
test(css): cover stale manifest after asset deduplication

### DIFF
--- a/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -63,6 +63,19 @@ describe.runIf(isBuild)('build', () => {
     expect(manifest['other.js'].css.length).toBe(1)
   })
 
+  // Regression test for vitejs/vite#22856: when rolldown deduplicates two same-content css
+  // assets, it must not rename the survivor after Vite has recorded the earlier name, or the
+  // manifest ends up pointing at a css file that was never written.
+  test('manifest should not reference a deduplicated css file that does not exist', () => {
+    const emitted = new Set(listAssets())
+    const referenced = Object.values(readManifest())
+      .flatMap((chunk) => chunk.css ?? [])
+      .map((file) => file.replace(/^assets\//, ''))
+    for (const file of referenced) {
+      expect(emitted).toContain(file)
+    }
+  })
+
   test('should not mark a css chunk with ?url and normal import as pure css chunk', () => {
     expect(findAssetFile(/chunk-.*\.js$/)).toBeTruthy()
   })


### PR DESCRIPTION
Regression test for **vitejs/vite#22856** (stale CSS filenames in `manifest.json` after asset deduplication).

When rolldown deduplicates two same-content CSS files into one, the manifest must point at the file that was actually written. This test asserts the manifest never references a deduplicated CSS file that is not on disk, which is the exact #22856 symptom. It fails before the rolldown fix and passes after it.

## Related

- vitejs/vite#22856