### PR TITLE
fix(bundled-dev): avoid duplicated `buildEnd`

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -64,6 +64,7 @@ export class MemoryFiles {
 export class BundledDev {
   private _devEngine!: DevEngine
   private initialBuildCompleted = false
+  private _closed = false
   private clients = new Clients()
   private invalidateCalledModules = new Map<
     NormalizedHotChannelClient,
@@ -98,6 +99,7 @@ export class BundledDev {
   }
 
   async listen(): Promise<void> {
+    this._closed = false
     debug?.('INITIAL: setup bundle options')
     const rolldownOptions = await this.getRolldownOptions()
     // NOTE: only single outputOptions is supported here
@@ -206,6 +208,7 @@ export class BundledDev {
       },
     )
     this.waitForInitialBuildFinish().then(() => {
+      if (this._closed) return
       debug?.('INITIAL: build done')
       this.environment.hot.send({ type: 'full-reload', path: '*' })
       this.initialBuildCompleted = true
@@ -213,11 +216,16 @@ export class BundledDev {
   }
 
   private async waitForInitialBuildFinish(): Promise<void> {
+    if (this._closed) return
     await this.devEngine.ensureCurrentBuildFinish()
+    if (this._closed) return
+
     let state = await this.devEngine.getBundleState()
     while (this.memoryFiles.size === 0 && !state.lastBuildErrored) {
       await setTimeout(10)
+      if (this._closed) return
       await this.devEngine.ensureCurrentBuildFinish()
+      if (this._closed) return
       state = await this.devEngine.getBundleState()
     }
   }
@@ -322,6 +330,7 @@ export class BundledDev {
   }
 
   async close(): Promise<void> {
+    this._closed = true
     this.memoryFiles.clear()
     await this._devEngine?.close()
     this.initialBuildCompleted = false

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -329,8 +329,7 @@ export class DevEnvironment extends BaseEnvironment {
 
     this._crawlEndFinder.cancel()
     await Promise.allSettled([
-      this.pluginContainer.close(),
-      this.bundledDev?.close(),
+      this.bundledDev ? this.bundledDev.close() : this.pluginContainer.close(),
       this.depsOptimizer?.close(),
       // WebSocketServer is independent of HotChannel and should not be closed on environment close
       isWebSocketServer in this.hot ? Promise.resolve() : this.hot.close(),

--- a/playground/hmr-full-bundle-mode/__tests__/build-hooks.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/build-hooks.spec.ts
@@ -1,0 +1,51 @@
+import path from 'node:path'
+import { type Plugin, type ViteDevServer, createServer } from 'vite'
+import { afterEach, describe, expect, test } from 'vitest'
+import { isServe } from '~utils'
+
+let server: ViteDevServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+// In full bundle mode the build is driven by Rolldown's dev engine, which is the
+// one that invokes plugins' `buildStart`/`buildEnd` hooks. Regression test for
+// `buildEnd` being called twice because both `bundledDev.close()` and
+// `pluginContainer.close()` fired it on server close.
+describe.runIf(isServe)('full bundle mode build hooks', () => {
+  test('buildStart and buildEnd are each called only once', async () => {
+    let buildStartCount = 0
+    let buildEndCount = 0
+    const countPlugin: Plugin = {
+      name: 'count-build-hooks',
+      buildStart() {
+        buildStartCount++
+      },
+      buildEnd() {
+        buildEndCount++
+      },
+    }
+
+    server = await createServer({
+      root: path.resolve(import.meta.dirname, '..'),
+      configFile: false,
+      logLevel: 'silent',
+      experimental: { bundledDev: true },
+      plugins: [countPlugin],
+    })
+    await server.listen()
+
+    // the initial full-bundle build runs on listen and fires buildStart + buildEnd once
+    await expect.poll(() => buildEndCount, { timeout: 10000 }).toBe(1)
+    expect(buildStartCount).toBe(1)
+
+    await server.close()
+    server = undefined
+
+    // closing must not fire buildStart/buildEnd again
+    expect(buildStartCount).toBe(1)
+    expect(buildEndCount).toBe(1)
+  })
+})


### PR DESCRIPTION
`buildEnd` was called twice because both `bundledDev.close()` and `pluginContainer.close()` fired it on server close.