### PR TITLE
fix(server): strip base in indexHtml module graph lookup

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/fixtures/base-root/index.html
+++ b/packages/vite/src/node/server/middlewares/__tests__/fixtures/base-root/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/vite/src/node/server/middlewares/__tests__/fixtures/base-root/src/main.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/fixtures/base-root/src/main.ts
@@ -1,0 +1,1 @@
+export const answer = 42

--- a/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
@@ -86,3 +86,45 @@ describe('indexHtml middleware — /@fs/ inline script proxy cache', () => {
     expect(result!.code).toContain('module loaded')
   })
 })
+
+describe('indexHtml middleware — HMR timestamp injection with non-root base', () => {
+  test('entry script URL gets the lastHMRTimestamp query when base is not root', async () => {
+    const root = path.resolve(import.meta.dirname, 'fixtures/base-root')
+    const server = await createServer({
+      configFile: false,
+      root,
+      base: '/ui/',
+      logLevel: 'error',
+      server: {
+        middlewareMode: true,
+        ws: false,
+      },
+      optimizeDeps: {
+        noDiscovery: true,
+        include: [],
+      },
+    })
+    onTestFinished(() => server.close())
+
+    // Register the entry in the module graph under the base-stripped URL
+    // (as the transform middleware records it) and mark it HMR-updated.
+    await server.environments.client.transformRequest('/src/main.ts')
+    const mod =
+      server.environments.client.moduleGraph.urlToModuleMap.get('/src/main.ts')
+    expect(
+      mod,
+      'entry module should be registered under the base-stripped URL',
+    ).toBeTruthy()
+    const timestamp = 1234567890
+    mod!.lastHMRTimestamp = timestamp
+
+    const html = `<!doctype html><html><body><script type="module" src="/src/main.ts"></script></body></html>`
+    const transformed = await server.transformIndexHtml('/index.html', html)
+
+    // Without stripping the base before the module graph lookup, the entry
+    // stays a bare `/ui/src/main.ts` while the module's own references get
+    // the timestamp — two different URLs for the same module, executing the
+    // entry twice.
+    expect(transformed).toContain(`src="/ui/src/main.ts?t=${timestamp}"`)
+  })
+})

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -175,8 +175,15 @@ const processNodeUrl = (
     }
 
     if (server) {
+      // The module graph keys request URLs without the base (the base
+      // middleware strips it before any transform happens), so the lookup
+      // must strip it too — otherwise the entry never gets the HMR
+      // timestamp injected when `base` is not the root, leaving the HTML
+      // entry URL out of sync with the module's own (timestamped)
+      // references and executing the entry twice. Aligns with
+      // `preTransformRequest` below, which already strips the base.
       const mod = server.environments.client.moduleGraph.urlToModuleMap.get(
-        preTransformUrl || url,
+        stripBase(preTransformUrl || url, config.decodedBase),
       )
       if (mod && mod.lastHMRTimestamp > 0) {
         url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -175,13 +175,6 @@ const processNodeUrl = (
     }
 
     if (server) {
-      // The module graph keys request URLs without the base (the base
-      // middleware strips it before any transform happens), so the lookup
-      // must strip it too — otherwise the entry never gets the HMR
-      // timestamp injected when `base` is not the root, leaving the HTML
-      // entry URL out of sync with the module's own (timestamped)
-      // references and executing the entry twice. Aligns with
-      // `preTransformRequest` below, which already strips the base.
       const mod = server.environments.client.moduleGraph.urlToModuleMap.get(
         stripBase(preTransformUrl || url, config.decodedBase),
       )


### PR DESCRIPTION
### Description

When `base` is not the root (e.g. `base: '/ui/'`), the `indexHtml` middleware injects HMR timestamps into entry script URLs by looking up the module in `moduleGraph.urlToModuleMap`. However, the module graph keys request URLs **without** the base prefix because the base middleware strips it before any transform happens. The lookup was using the base-prefixed URL (e.g. `/ui/src/main.ts`), so it failed to find the module and the timestamp was not injected. This left the HTML entry URL out of sync with the module's own timestamped references, causing the entry to be loaded and executed twice.

This PR strips the base from the lookup key, aligning it with `preTransformRequest` which already does the same.

fixes #19690
fixes #23105

### Tests

Added a unit test in `packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts` that reproduces the issue with `base: '/ui/'` and verifies the entry script receives the `?t=<lastHMRTimestamp>` query.

### Related

- Similar previous fix for relative/absolute URL inconsistency: #19601 / #19135
