### PR TITLE
fix(dynamic-import-vars): skip glob transform when only the query string has a variable

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -6,17 +6,20 @@ import { isWindows } from '../../../../shared/utils'
 
 const dirname = import.meta.dirname
 
+async function runRaw(input: string) {
+  return await transformDynamicImport(
+    input,
+    normalizePath(resolve(dirname, 'index.js')),
+    (id) =>
+      id
+        .replace('@', resolve(dirname, './mods/'))
+        .replace('#', resolve(dirname, '../../')),
+    dirname,
+  )
+}
+
 async function run(input: string) {
-  const { glob, rawPattern } =
-    (await transformDynamicImport(
-      input,
-      normalizePath(resolve(dirname, 'index.js')),
-      (id) =>
-        id
-          .replace('@', resolve(dirname, './mods/'))
-          .replace('#', resolve(dirname, '../../')),
-      dirname,
-    )) || {}
+  const { glob, rawPattern } = (await runRaw(input)) || {}
   return `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`)`
 }
 
@@ -69,18 +72,6 @@ describe('parse positives', () => {
     ).toMatchSnapshot()
   })
 })
-
-async function runRaw(input: string) {
-  return await transformDynamicImport(
-    input,
-    normalizePath(resolve(dirname, 'index.js')),
-    (id) =>
-      id
-        .replace('@', resolve(dirname, './mods/'))
-        .replace('#', resolve(dirname, '../../')),
-    dirname,
-  )
-}
 
 describe('parse negatives', () => {
   // the module path is static, only the query has a runtime variable, so it

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -69,3 +69,32 @@ describe('parse positives', () => {
     ).toMatchSnapshot()
   })
 })
+
+async function runRaw(input: string) {
+  return await transformDynamicImport(
+    input,
+    normalizePath(resolve(dirname, 'index.js')),
+    (id) =>
+      id
+        .replace('@', resolve(dirname, './mods/'))
+        .replace('#', resolve(dirname, '../../')),
+    dirname,
+  )
+}
+
+describe('parse negatives', () => {
+  // the module path is static, only the query has a runtime variable, so it
+  // must not be routed through `import.meta.glob` (otherwise the glob keys
+  // wouldn't include the query and the runtime lookup would fail)
+  it('variable only in query', async () => {
+    expect(await runRaw('`./mods/mod.js?foo=${bar}`')).toBeNull()
+  })
+
+  it('multiple variables only in query', async () => {
+    expect(await runRaw('`./mods/mod.js?a=${x}&b=${y}`')).toBeNull()
+  })
+
+  it('variable in both path and query is still transformed', async () => {
+    expect(await runRaw('`./mods/${base}.js?foo=${bar}`')).not.toBeNull()
+  })
+})

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -6,17 +6,20 @@ import { normalizePath } from '../../../utils'
 
 const dirname = import.meta.dirname
 
+async function runRaw(input: string) {
+  return await transformDynamicImport(
+    input,
+    normalizePath(resolve(dirname, 'index.js')),
+    (id) =>
+      id
+        .replace('@', resolve(dirname, './mods/'))
+        .replace('#', resolve(dirname, '../../')),
+    dirname,
+  )
+}
+
 async function run(input: string) {
-  const { glob, rawPattern } =
-    (await transformDynamicImport(
-      input,
-      normalizePath(resolve(dirname, 'index.js')),
-      (id) =>
-        id
-          .replace('@', resolve(dirname, './mods/'))
-          .replace('#', resolve(dirname, '../../')),
-      dirname,
-    )) || {}
+  const { glob, rawPattern } = (await runRaw(input)) || {}
   return `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`)`
 }
 
@@ -69,18 +72,6 @@ describe('parse positives', () => {
     ).toMatchSnapshot()
   })
 })
-
-async function runRaw(input: string) {
-  return await transformDynamicImport(
-    input,
-    normalizePath(resolve(dirname, 'index.js')),
-    (id) =>
-      id
-        .replace('@', resolve(dirname, './mods/'))
-        .replace('#', resolve(dirname, '../../')),
-    dirname,
-  )
-}
 
 describe('parse negatives', () => {
   // the module path is static, only the query has a runtime variable, so it

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -4,6 +4,7 @@ import { init, parse as parseImports } from 'es-module-lexer'
 import type { ImportSpecifier } from 'es-module-lexer'
 import { parseAst } from 'rolldown/parseAst'
 import { dynamicImportToGlob } from '@rollup/plugin-dynamic-import-vars'
+import { isDynamicPattern } from 'tinyglobby'
 import { viteDynamicImportVarsPlugin as nativeDynamicImportVarsPlugin } from 'rolldown/experimental'
 import { exactRegex } from 'rolldown/filter'
 import type { Plugin } from '../plugin'
@@ -91,7 +92,7 @@ function parseDynamicImportPattern(
   // through `import.meta.glob` would generate glob keys without the query,
   // so the runtime lookup would always fail with "Unknown variable dynamic
   // import". Leave the dynamic import untouched in that case.
-  if (!userPattern.includes('*')) {
+  if (!isDynamicPattern(userPattern)) {
     return null
   }
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -84,6 +84,17 @@ function parseDynamicImportPattern(
     requestQueryMaybeEscapedSplitRE,
     2,
   )
+
+  // When the module path is static and only the query string contains a
+  // runtime variable (e.g. `./foo.js?bar=${baz}`), `dynamicImportToGlob`
+  // doesn't produce any glob wildcard in the path. Routing such imports
+  // through `import.meta.glob` would generate glob keys without the query,
+  // so the runtime lookup would always fail with "Unknown variable dynamic
+  // import". Leave the dynamic import untouched in that case.
+  if (!userPattern.includes('*')) {
+    return null
+  }
+
   let [rawPattern, search] = filename.split(requestQuerySplitRE, 2)
   let globParams: DynamicImportRequest | null = null
   if (search) {

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -6,6 +6,7 @@ import MagicString from 'magic-string'
 import { viteDynamicImportVarsPlugin as nativeDynamicImportVarsPlugin } from 'rolldown/experimental'
 import { exactRegex } from 'rolldown/filter'
 import { parseAst } from 'rolldown/parseAst'
+import { isDynamicPattern } from 'tinyglobby'
 import type { PartialEnvironment } from '../baseEnvironment'
 import type { ResolvedConfig } from '../config'
 import { CLIENT_ENTRY } from '../constants'
@@ -93,7 +94,7 @@ function parseDynamicImportPattern(
   // through `import.meta.glob` would generate glob keys without the query,
   // so the runtime lookup would always fail with "Unknown variable dynamic
   // import". Leave the dynamic import untouched in that case.
-  if (!userPattern.includes('*')) {
+  if (!isDynamicPattern(userPattern)) {
     return null
   }
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -86,6 +86,17 @@ function parseDynamicImportPattern(
     requestQueryMaybeEscapedSplitRE,
     2,
   )
+
+  // When the module path is static and only the query string contains a
+  // runtime variable (e.g. `./foo.js?bar=${baz}`), `dynamicImportToGlob`
+  // doesn't produce any glob wildcard in the path. Routing such imports
+  // through `import.meta.glob` would generate glob keys without the query,
+  // so the runtime lookup would always fail with "Unknown variable dynamic
+  // import". Leave the dynamic import untouched in that case.
+  if (!userPattern.includes('*')) {
+    return null
+  }
+
   let [rawPattern, search] = filename.split(requestQuerySplitRE, 2)
   let globParams: DynamicImportRequest | null = null
   if (search) {


### PR DESCRIPTION
### Description

A dynamic import whose module **path** is static but whose **query string** contains a runtime variable — e.g.

```js
import(`./foo.js?bar=${baz}`)
```

is still routed through the `vite:dynamic-import-vars` → `import.meta.glob` flow. `dynamicImportToGlob` produces **no `*` wildcard** in the path for these, so the generated glob has key `./foo.js` while the runtime helper looks up `./foo.js?bar=<value>`. The key never matches and the import rejects at runtime with `Unknown variable dynamic import`.

This implements the fix @bluwy described in #16493: skip the `import.meta.glob` flow when the `${}` is only on the query-param side.

### Fix

In `parseDynamicImportPattern` (`packages/vite/src/node/plugins/dynamicImportVars.ts`): after computing the globbed path, if it contains no `*` wildcard the path is fully static (the variable lives only in the query), so return `null` and leave the dynamic import untouched. Path-side variables — including `${a ?? b}` and mixed path+query — still produce a `*` and continue to transform as before.

This fixes Vite's own JS transform (dev / non-bundled path). The `vite build` path now uses rolldown's native implementation, so the build-mode half would be upstream in rolldown; this closes the Vite-side half.

### Tests

`src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts` — added 3 negative cases (query-only variable → untouched) alongside the 11 existing positives. `vitest run … parse.spec.ts` → 14 passed. Verified red→green (fails before the fix, passes after). Lint, format, and `tsc --noEmit` clean.

Closes #16493
