### PR TITLE
fix(legacy): don't use newer syntax when minifying polyfill chunks

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -190,9 +190,12 @@ const outputOptionsForLegacyChunks =
 function resolveLegacyOutputMinify(
   minify: BuildOptions['minify'],
   supportsOxc: boolean | undefined,
+  target?: BuildOptions['target'],
 ): Rollup.OutputOptions['minify'] {
   const usesOxc = supportsOxc && (minify === 'oxc' || minify === true)
-  return usesOxc ? true : false
+  if (!usesOxc) return false
+  if (target === undefined || target === false) return true
+  return { compress: { target } }
 }
 
 function resolveLegacyBuildMinify(
@@ -437,6 +440,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           options.externalSystemJS,
           false,
           supportsLegacyOxcMinification,
+          // Don't use newer syntax for legacy polyfill chunks
+          'es2015',
         )
       }
     },
@@ -944,8 +949,10 @@ async function buildPolyfillChunk(
   excludeSystemJS?: boolean,
   prependModenChunkLegacyGuard?: boolean,
   supportsLegacyOxcMinification?: boolean,
+  overrideMinifyCompressTarget?: BuildOptions['target'],
 ) {
-  const { assetsDir, sourcemap } = buildOptions
+  const { assetsDir, sourcemap, target } = buildOptions
+  const minifyCompressTarget = overrideMinifyCompressTarget ?? target
   const minify = resolveLegacyBuildMinify(
     buildOptions.minify,
     supportsLegacyOxcMinification,
@@ -977,6 +984,7 @@ async function buildPolyfillChunk(
           minify: resolveLegacyOutputMinify(
             buildOptions.minify,
             supportsLegacyOxcMinification,
+            minifyCompressTarget,
           ),
         },
       },

--- a/playground/legacy/__tests__/modern-target/legacy-modern-target.spec.ts
+++ b/playground/legacy/__tests__/modern-target/legacy-modern-target.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { findAssetFile, isBuild, page, viteTestUrl } from '~utils'
+
+test('should load and execute the JS file', async () => {
+  await page.goto(viteTestUrl + '/modern-target.html')
+  await expect.poll(() => page.textContent('#app')).toMatch('at: 3')
+})
+
+describe.runIf(isBuild)('build', () => {
+  test('modern polyfill chunk respects modernTargets', () => {
+    const polyfill = findAssetFile(/polyfills-[-\w]+\.js$/, 'modern-target')
+    expect(polyfill).toBeTruthy()
+    // `modernTargets` includes Chrome 64, which does not support optional catch binding.
+    // `try {} catch (e) {}` must not be collapsed to `try {} catch {}`.
+    expect(polyfill).toMatch(/catch\s*\(/)
+    expect(polyfill).not.toMatch(/catch\s*\{/)
+  })
+})

--- a/playground/legacy/modern-target.html
+++ b/playground/legacy/modern-target.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>legacy modern-target</title>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module" src="/modern-target.js"></script>
+  </body>
+</html>

--- a/playground/legacy/modern-target.js
+++ b/playground/legacy/modern-target.js
@@ -1,0 +1,1 @@
+document.querySelector('#app').textContent = `at: ${[1, 2, 3].at(-1)}`

--- a/playground/legacy/vite.config-modern-target.js
+++ b/playground/legacy/vite.config-modern-target.js
@@ -1,0 +1,24 @@
+import path from 'node:path'
+import legacy from '@vitejs/plugin-legacy'
+import { defineConfig } from 'vite'
+
+export default defineConfig(({ isPreview }) => ({
+  base: !isPreview ? './' : '/modern-target/',
+  plugins: [
+    legacy({
+      modernPolyfills: ['es.array.at'],
+      // a browser without optional catch binding
+      modernTargets: ['chrome >= 64'],
+      renderLegacyChunks: false,
+    }),
+  ],
+
+  build: {
+    outDir: 'dist/modern-target',
+    rolldownOptions: {
+      input: {
+        index: path.resolve(import.meta.dirname, 'modern-target.html'),
+      },
+    },
+  },
+}))


### PR DESCRIPTION
fixes #22930
refs #22468
