### PR TITLE
feat: support onLog hook in dev

### DIFF
--- a/packages/vite/rolldown.dts.config.ts
+++ b/packages/vite/rolldown.dts.config.ts
@@ -77,6 +77,7 @@ const identifierReplacements: Record<string, Record<string, string>> = {
     FetchResult$1: 'moduleRunner_FetchResult',
   },
   rolldown: {
+    LogLevel$1: 'Rolldown.LogLevel',
     Plugin$1: 'Rolldown.Plugin',
     TransformResult$1: 'Rolldown.TransformResult',
   },

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -194,6 +194,258 @@ describe('plugin container', () => {
     })
   })
 
+  describe('onLog', () => {
+    it('can filter logs in dev', async () => {
+      const logger = createLogger()
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const onLog = vi.fn(() => false)
+      const environment = await getDevEnvironment({
+        customLogger: logger,
+        plugins: [
+          { name: 'log-filter', onLog },
+          {
+            name: 'source',
+            load() {
+              this.warn('test')
+            },
+          },
+        ],
+      })
+
+      await environment.pluginContainer.load('foo')
+
+      expect(onLog).toHaveBeenCalledWith(
+        'warn',
+        expect.objectContaining({ message: 'test', plugin: 'source' }),
+      )
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('normalizes source plugin log metadata', async () => {
+      const onLog = vi.fn(() => false)
+      const environment = await getDevEnvironment({
+        plugins: [
+          { name: 'log-filter', onLog },
+          {
+            name: 'source',
+            resolveId(id) {
+              return id
+            },
+            load() {
+              this.info({ message: 'info', code: 'INFO_CODE' })
+              this.warn({ message: 'warn', code: 'WARN_CODE' })
+              return 'export {}'
+            },
+            transform() {
+              this.warn({ message: 'transform', code: 'TRANSFORM_CODE' })
+            },
+          },
+        ],
+      })
+
+      const id = '/foo.js'
+      await environment.moduleGraph.ensureEntryFromUrl(id, false)
+      await environment.pluginContainer.load(id)
+      await environment.pluginContainer.transform('export {}', id)
+
+      expect(onLog).toHaveBeenNthCalledWith(
+        1,
+        'info',
+        expect.objectContaining({
+          code: 'PLUGIN_LOG',
+          message: 'info',
+          plugin: 'source',
+          pluginCode: 'INFO_CODE',
+        }),
+      )
+      expect(onLog).toHaveBeenNthCalledWith(
+        2,
+        'warn',
+        expect.objectContaining({
+          code: 'PLUGIN_WARNING',
+          message: 'warn',
+          plugin: 'source',
+          pluginCode: 'WARN_CODE',
+        }),
+      )
+      expect(onLog).toHaveBeenNthCalledWith(
+        3,
+        'warn',
+        expect.objectContaining({
+          code: 'PLUGIN_WARNING',
+          message: 'transform',
+          plugin: 'source',
+          pluginCode: 'TRANSFORM_CODE',
+        }),
+      )
+    })
+
+    it('can change log levels in dev', async () => {
+      const logger = createLogger()
+      const info = vi.spyOn(logger, 'info').mockImplementation(() => {})
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const environment = await getDevEnvironment({
+        customLogger: logger,
+        plugins: [
+          {
+            name: 'log-level-changer',
+            onLog(level, log) {
+              if (level === 'warn') {
+                this.info(log)
+                return false
+              }
+            },
+          },
+          {
+            name: 'source',
+            load() {
+              this.warn('test')
+            },
+          },
+        ],
+      })
+
+      await environment.pluginContainer.load('foo')
+
+      expect(info).toHaveBeenCalledOnce()
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('does not attribute fresh logs re-emitted by onLog hooks', async () => {
+      const pluginName = vi.fn()
+      const replacement = vi.fn((_log: unknown) => false)
+      const environment = await getDevEnvironment({
+        plugins: [
+          {
+            name: 'log-level-changer',
+            onLog(level) {
+              if (level === 'warn') {
+                pluginName(this.pluginName)
+                this.info('replacement')
+                return false
+              }
+            },
+          },
+          {
+            name: 'replacement-observer',
+            onLog(level, log) {
+              if (level === 'info') return replacement(log)
+            },
+          },
+          {
+            name: 'source',
+            load() {
+              this.warn('original')
+            },
+          },
+        ],
+      })
+
+      await environment.pluginContainer.load('foo')
+
+      expect(pluginName).toHaveBeenCalledWith('log-level-changer')
+      expect(replacement).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'replacement' }),
+      )
+      expect(replacement.mock.calls[0][0]).not.toHaveProperty('plugin')
+    })
+
+    it('preserves hook order when a hook re-emits a log', async () => {
+      const logger = createLogger()
+      const info = vi.spyOn(logger, 'info').mockImplementation(() => {})
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const calls: string[] = []
+      const environment = await getDevEnvironment({
+        customLogger: logger,
+        plugins: [
+          {
+            name: 'first-observer',
+            onLog(level) {
+              calls.push(`first:${level}`)
+            },
+          },
+          {
+            name: 'log-level-changer',
+            onLog(level, log) {
+              if (level === 'warn') {
+                this.info(log)
+                return false
+              }
+            },
+          },
+          {
+            name: 'last-observer',
+            onLog(level) {
+              calls.push(`last:${level}`)
+            },
+          },
+          {
+            name: 'source',
+            load() {
+              this.warn('test')
+            },
+          },
+        ],
+      })
+
+      await environment.pluginContainer.load('foo')
+
+      expect(calls).toEqual(['first:warn', 'first:info', 'last:info'])
+      expect(info).toHaveBeenCalledOnce()
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('includes the source plugin for logs from options hooks', async () => {
+      const onLog = vi.fn(() => false)
+      const pluginName = vi.fn()
+
+      await getDevEnvironment({
+        plugins: [
+          { name: 'log-filter', onLog },
+          {
+            name: 'options-source',
+            options() {
+              pluginName(this.pluginName)
+              this.warn('test')
+            },
+          },
+        ],
+      })
+
+      expect(pluginName).toHaveBeenCalledWith('options-source')
+      expect(onLog).toHaveBeenCalledWith(
+        'warn',
+        expect.objectContaining({
+          code: 'PLUGIN_WARNING',
+          message: 'test',
+          plugin: 'options-source',
+        }),
+      )
+    })
+
+    it('respects the configured log level', async () => {
+      const onLog = vi.fn()
+      const lazyLog = vi.fn(() => 'test')
+      const environment = await getDevEnvironment({
+        logLevel: 'error',
+        plugins: [
+          { name: 'log-filter', onLog },
+          {
+            name: 'source',
+            load() {
+              this.warn(lazyLog)
+            },
+          },
+        ],
+      })
+
+      await environment.pluginContainer.load('foo')
+
+      expect(onLog).not.toHaveBeenCalled()
+      expect(lazyLog).not.toHaveBeenCalled()
+    })
+  })
+
   describe('load', () => {
     it('can resolve a secondary module', async () => {
       const entryUrl = '/x.js'

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -45,6 +45,7 @@ import type {
   ImportKind,
   InputOptions,
   LoadResult,
+  LogLevel,
   ModuleInfo,
   ModuleOptions,
   ModuleType,
@@ -76,7 +77,7 @@ import {
   warnFutureDeprecation,
 } from '../deprecations'
 import type { Environment } from '../environment'
-import type { Logger } from '../logger'
+import { LogLevels, type Logger } from '../logger'
 import type { Plugin } from '../plugin'
 import {
   createPluginHookUtils,
@@ -177,6 +178,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   private _resolvedRolldownOptions?: InputOptions
   private _processesing = new Set<Promise<any>>()
   private _seenResolves: Record<string, true | undefined> = {}
+  private _defaultLogContext: BasicMinimalPluginContext
 
   // _addedFiles from the `load()` hook gets saved here so it can be reused in the `transform()` hook
   private _moduleNodeToLoadAddedImports = new WeakMap<
@@ -205,9 +207,14 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
     autoStart = true,
   ) {
     this._started = !autoStart
+    this._defaultLogContext = new BasicMinimalPluginContext(
+      { ...basePluginContextMeta, watchMode: true },
+      environment.logger,
+    )
     this.minimalContext = new MinimalPluginContext(
       { ...basePluginContextMeta, watchMode: true },
       environment,
+      (level, log) => this._onLog(level, log),
     )
     const utils = createPluginHookUtils(plugins)
     this.getSortedPlugins = utils.getSortedPlugins
@@ -279,14 +286,21 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   async resolveRolldownOptions(): Promise<InputOptions> {
     if (!this._resolvedRolldownOptions) {
       let options = this.environment.config.build.rolldownOptions
-      for (const optionsHook of this.getSortedPluginHooks('options')) {
+      for (const plugin of this.getSortedPlugins('options')) {
         if (this._closed) {
           throwClosedServerError()
         }
+        const optionsHook = getHookHandler(plugin.options)
+        const context = new MinimalPluginContext(
+          this.minimalContext.meta,
+          this.environment,
+          (level, log) => this._onLog(level, log),
+          plugin.name,
+          true,
+        )
         options =
-          (await this.handleHookPromise(
-            optionsHook.call(this.minimalContext, options),
-          )) || options
+          (await this.handleHookPromise(optionsHook.call(context, options))) ||
+          options
       }
       this._resolvedRolldownOptions = options
     }
@@ -298,6 +312,41 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
       this._pluginContextMap.set(plugin, new PluginContext(plugin, this))
     }
     return this._pluginContextMap.get(plugin)!
+  }
+
+  _onLog(
+    level: LogLevel,
+    rawLog: RawLog,
+    skipped: Set<Plugin> = new Set(),
+  ): void {
+    if (
+      level === 'debug'
+        ? !debugPluginContainerContext
+        : LogLevels[this.environment.config.logLevel || 'info'] <
+          LogLevels[level]
+    ) {
+      return
+    }
+
+    const log = normalizeRawLog(rawLog)
+
+    for (const plugin of this.getSortedPlugins('onLog')) {
+      if (skipped.has(plugin)) continue
+
+      const hook = plugin.onLog
+      if (!hook) continue
+
+      const context = new MinimalPluginContext(
+        this.minimalContext.meta,
+        this.environment,
+        (nextLevel, nextLog) =>
+          this._onLog(nextLevel, nextLog, new Set(skipped).add(plugin)),
+        plugin.name,
+      )
+      if (getHookHandler(hook).call(context, level, log) === false) return
+    }
+
+    this._defaultLogContext[level](log)
   }
 
   // parallel, ignores returns
@@ -681,10 +730,30 @@ export const basePluginContextMeta: {
   rolldownVersion,
 }
 
+type RawLog = string | RollupLog | (() => string | RollupLog)
+
+function normalizeRawLog(rawLog: RawLog): RollupLog {
+  const logValue = typeof rawLog === 'function' ? rawLog() : rawLog
+  return typeof logValue === 'string' ? new Error(logValue) : logValue
+}
+
+function normalizePluginLog(
+  level: LogLevel,
+  rawLog: RawLog,
+  pluginName: string,
+): RollupLog {
+  const log = normalizeRawLog(rawLog)
+  if (log.code && !log.pluginCode) log.pluginCode = log.code
+  log.code = level === 'warn' ? 'PLUGIN_WARNING' : 'PLUGIN_LOG'
+  log.plugin = pluginName
+  return log
+}
+
 export class BasicMinimalPluginContext<Meta = PluginContextMeta> {
   constructor(
     public meta: Meta,
     private _logger: Logger,
+    private _onLog?: (level: LogLevel, log: RawLog) => void,
   ) {}
 
   // FIXME: properly support this later
@@ -693,20 +762,32 @@ export class BasicMinimalPluginContext<Meta = PluginContextMeta> {
     return ''
   }
 
-  debug(rawLog: string | RollupLog | (() => string | RollupLog)): void {
-    const log = this._normalizeRawLog(rawLog)
+  debug(rawLog: RawLog): void {
+    if (this._onLog) {
+      this._onLog('debug', rawLog)
+      return
+    }
+    const log = normalizeRawLog(rawLog)
     const msg = buildErrorMessage(log, [`debug: ${log.message}`], false)
     debugPluginContainerContext?.(msg)
   }
 
-  info(rawLog: string | RollupLog | (() => string | RollupLog)): void {
-    const log = this._normalizeRawLog(rawLog)
+  info(rawLog: RawLog): void {
+    if (this._onLog) {
+      this._onLog('info', rawLog)
+      return
+    }
+    const log = normalizeRawLog(rawLog)
     const msg = buildErrorMessage(log, [`info: ${log.message}`], false)
     this._logger.info(msg, { clear: true, timestamp: true })
   }
 
-  warn(rawLog: string | RollupLog | (() => string | RollupLog)): void {
-    const log = this._normalizeRawLog(rawLog)
+  warn(rawLog: RawLog): void {
+    if (this._onLog) {
+      this._onLog('warn', rawLog)
+      return
+    }
+    const log = normalizeRawLog(rawLog)
     const msg = buildErrorMessage(
       log,
       [colors.yellow(`warning: ${log.message}`)],
@@ -719,13 +800,6 @@ export class BasicMinimalPluginContext<Meta = PluginContextMeta> {
     const err = (typeof e === 'string' ? new Error(e) : e) as RollupError
     throw err
   }
-
-  private _normalizeRawLog(
-    rawLog: string | RollupLog | (() => string | RollupLog),
-  ): RollupLog {
-    const logValue = typeof rawLog === 'function' ? rawLog() : rawLog
-    return typeof logValue === 'string' ? new Error(logValue) : logValue
-  }
 }
 
 class MinimalPluginContext<T extends Environment = Environment>
@@ -733,9 +807,30 @@ class MinimalPluginContext<T extends Environment = Environment>
   implements RollupMinimalPluginContext
 {
   public environment: T
-  constructor(meta: PluginContextMeta, environment: T) {
-    super(meta, environment.logger)
+  constructor(
+    meta: PluginContextMeta,
+    environment: T,
+    onLog?: (level: LogLevel, log: RawLog) => void,
+    private _pluginName = '',
+    normalizeSourceLog = false,
+  ) {
+    super(
+      meta,
+      environment.logger,
+      onLog &&
+        ((level, rawLog) =>
+          onLog(
+            level,
+            normalizeSourceLog
+              ? () => normalizePluginLog(level, rawLog, _pluginName)
+              : rawLog,
+          )),
+    )
     this.environment = environment
+  }
+
+  override get pluginName(): string {
+    return this._pluginName
   }
 }
 
@@ -767,14 +862,18 @@ class PluginContext
   _resolveSkipCalls?: readonly SkipInformation[]
 
   override get pluginName(): string {
-    return this._plugin.name
+    return this._plugin?.name ?? ''
   }
 
   constructor(
     public _plugin: Plugin,
     public _container: EnvironmentPluginContainer,
   ) {
-    super(_container.minimalContext.meta, _container.environment)
+    super(
+      _container.minimalContext.meta,
+      _container.environment,
+      (level, log) => _container._onLog(level, log),
+    )
   }
 
   fs: RollupFsModule = fsModule
@@ -901,24 +1000,18 @@ class PluginContext
   }
 
   override debug(log: string | RollupLog | (() => string | RollupLog)): void {
-    const err = this._formatLog(typeof log === 'function' ? log() : log)
-    super.debug(err)
+    super.debug(() => this._formatPluginLog('debug', log))
   }
 
   override info(log: string | RollupLog | (() => string | RollupLog)): void {
-    const err = this._formatLog(typeof log === 'function' ? log() : log)
-    super.info(err)
+    super.info(() => this._formatPluginLog('info', log))
   }
 
   override warn(
     log: string | RollupLog | (() => string | RollupLog),
     position?: number | { column: number; line: number },
   ): void {
-    const err = this._formatLog(
-      typeof log === 'function' ? log() : log,
-      position,
-    )
-    super.warn(err)
+    super.warn(() => this._formatPluginLog('warn', log, position))
   }
 
   override error(
@@ -928,6 +1021,20 @@ class PluginContext
     // error thrown here is caught by the transform middleware and passed on
     // the error middleware.
     throw this._formatLog(e, position)
+  }
+
+  private _formatPluginLog(
+    level: LogLevel,
+    rawLog: RawLog,
+    position?: number | { column: number; line: number },
+  ): RollupLog {
+    const log = typeof rawLog === 'function' ? rawLog() : rawLog
+    const hasPluginCode = typeof log !== 'string' && log.pluginCode != null
+    const formattedLog = this._formatLog(log, position)
+    if (!hasPluginCode && formattedLog.pluginCode === this._activeCode) {
+      delete formattedLog.pluginCode
+    }
+    return normalizePluginLog(level, formattedLog, this.pluginName)
   }
 
   private _formatLog<E extends RollupLog>(


### PR DESCRIPTION
### Description

Adds Rollup-compatible `onLog` hook support to the dev plugin container.

- routes plugin `debug`, `info`, and `warn` calls through ordered `onLog` hooks
- supports filtering with `false` and re-emitting logs at another level
- preserves source-plugin metadata and Rollup's `PLUGIN_LOG` / `PLUGIN_WARNING` normalization
- applies the configured log level before evaluating lazy log factories
- gives `options` hooks their per-plugin minimal context
- maps Rolldown's generated `LogLevel` type through the existing `Rolldown.*` namespace so bundled type validation passes

Includes regression coverage for filtering, level changes, hook ordering and recursion, source metadata, options-hook logs, and lazy log evaluation.

Fixes #19937.

### Validation

- `corepack pnpm run build`
- `corepack pnpm exec vitest run packages/vite/src/node/server/__tests__/pluginContainer.spec.ts` — 24/24 passed
- `corepack pnpm exec eslint packages/vite/src/node/server/pluginContainer.ts packages/vite/src/node/server/__tests__/pluginContainer.spec.ts packages/vite/rolldown.dts.config.ts`
- `corepack pnpm exec oxfmt --check packages/vite/src/node/server/pluginContainer.ts packages/vite/src/node/server/__tests__/pluginContainer.spec.ts packages/vite/rolldown.dts.config.ts`
- `git diff --check`