### PR TITLE
fix(module-runner): don't crash stack-trace source mapping when globalThis.Buffer is absent

### DIFF
--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -1,6 +1,6 @@
 import type { OriginalMapping } from '@jridgewell/trace-mapping'
 import type { ModuleRunner } from '../runner'
-import { posixDirname, posixResolve } from '../utils'
+import { decodeBase64, posixDirname, posixResolve } from '../utils'
 import type { EvaluatedModules } from '../evaluatedModules'
 import { slash } from '../../shared/utils'
 import { DecodedMap, getOriginalPosition } from './decoder'
@@ -154,7 +154,7 @@ function retrieveSourceMap(source: string) {
   if (reSourceMap.test(sourceMappingURL)) {
     // Support source map URL as a data url
     const rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1)
-    sourceMapData = Buffer.from(rawData, 'base64').toString()
+    sourceMapData = decodeBase64(rawData)
     sourceMappingURL = source
   } else {
     // Support source map URLs relative to the source URL

--- a/packages/vite/src/module-runner/utils.ts
+++ b/packages/vite/src/module-runner/utils.ts
@@ -4,8 +4,13 @@ import { isWindows } from '../shared/utils'
 const textDecoder = new TextDecoder()
 
 export const decodeBase64: (base64: string) => string = (() => {
-  if (typeof Buffer === 'function' && typeof Buffer.from === 'function') {
-    return (base64: string) => Buffer.from(base64, 'base64').toString('utf-8')
+  // Capture the binding at module load: realms may legitimately delete
+  // `globalThis.Buffer` afterwards (e.g. browser-parity tests), and this
+  // decoder runs lazily while preparing stack traces
+  const capturedBuffer = typeof Buffer === 'function' ? Buffer : undefined
+  if (capturedBuffer && typeof capturedBuffer.from === 'function') {
+    return (base64: string) =>
+      capturedBuffer.from(base64, 'base64').toString('utf-8')
   }
 
   return (base64: string) =>

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect } from 'vitest'
 import type { ViteDevServer } from '../../..'
 import type { ModuleRunnerContext } from '../../../../module-runner'
 import { ESModulesEvaluator } from '../../../../module-runner'
+import { SOURCEMAPPING_URL } from '../../../../shared/constants'
 import {
   createFixtureEditor,
   createModuleRunnerTester,
@@ -156,6 +157,29 @@ describe('module runner initialization', async () => {
       ]
     `)
   })
+
+  it('should not crash when preparing a stack trace while globalThis.Buffer is absent', async ({
+    runner,
+    server,
+  }) => {
+    const mod = await runner.import('/fixtures/throws-error-method.ts')
+    const methodError = await getError(() => mod.throwError())
+
+    // Realms may legitimately remove `Buffer` after modules were loaded
+    // (e.g. browser-parity tests). Preparing a stack in that window must not
+    // depend on the global still existing.
+    const bufferBackup = globalThis.Buffer
+    Reflect.deleteProperty(globalThis, 'Buffer')
+    try {
+      // `.stack` access lazily invokes `prepareStackTrace`, which decodes the
+      // inline source map of the runner module
+      expect(serializeStack(server, methodError)).toBe(
+        '    at Module.throwError (<root>/fixtures/throws-error-method.ts:6:9)',
+      )
+    } finally {
+      globalThis.Buffer = bufferBackup
+    }
+  })
 })
 
 describe('module runner with node:vm executor', async () => {
@@ -191,5 +215,70 @@ describe('module runner with node:vm executor', async () => {
     expect(() =>
       error.stack.includes('.stack access triggers the bug'),
     ).not.toThrow()
+  })
+})
+
+describe('module runner interceptor with inline data: source map', async () => {
+  const syntheticFile = '/virtual-bufferless/inline-map.js'
+  // Minimal map pointing every generated position at line 1, column 0 of
+  // "inline-map-original.ts"
+  const syntheticSourceMap = {
+    version: 3,
+    sources: ['inline-map-original.ts'],
+    names: [],
+    mappings: 'AAAA',
+  }
+  // The comment token is composed from SOURCEMAPPING_URL so that this spec
+  // file itself never contains it (see shared/constants.ts)
+  const syntheticFileContent =
+    `throw new Error('example')\n` +
+    `//# ${SOURCEMAPPING_URL}=data:application/json;base64,${btoa(
+      JSON.stringify(syntheticSourceMap),
+    )}\n`
+
+  class Evaluator extends ESModulesEvaluator {
+    async runInlinedModule(_: ModuleRunnerContext, __: string) {
+      const initModule = runInThisContext(
+        '() => { throw new Error("example") }',
+        { filename: syntheticFile },
+      )
+
+      initModule()
+    }
+  }
+
+  const it = await createModuleRunnerTester(
+    {},
+    {
+      sourcemapInterceptor: {
+        // Serves a file that is not part of the runner module graph and
+        // carries an inline base64 source map, so mapping goes through
+        // `retrieveSourceMap` instead of the runner graph
+        retrieveFile(id) {
+          if (id === syntheticFile) {
+            return syntheticFileContent
+          }
+        },
+      },
+      evaluator: new Evaluator(),
+    },
+  )
+
+  it('should not crash when decoding an inline source map while globalThis.Buffer is absent', async ({
+    runner,
+  }) => {
+    const error: Error = await runner
+      .import('/fixtures/a.ts')
+      .catch((err) => err)
+
+    const bufferBackup = globalThis.Buffer
+    Reflect.deleteProperty(globalThis, 'Buffer')
+    try {
+      expect(error.stack).toContain(
+        '/virtual-bufferless/inline-map-original.ts:1:1',
+      )
+    } finally {
+      globalThis.Buffer = bufferBackup
+    }
   })
 })


### PR DESCRIPTION
### Description

Fixes #22944.

`module-runner` uses the `Buffer` global in two places on the stack-trace source-mapping path:

- `decodeBase64` (`packages/vite/src/module-runner/utils.ts`) guards `typeof Buffer === 'function'` at module load, but the selected arrow function dereferenced the bare `Buffer` global on every call — so deleting `globalThis.Buffer` *after* load makes the "guarded" branch throw `ReferenceError: Buffer is not defined`, and the existing `TextDecoder` fallback is unreachable.
- `retrieveSourceMap` (`packages/vite/src/module-runner/sourcemap/interceptor.ts`) called `Buffer.from(rawData, 'base64').toString()` with no guard at all when decoding inline `data:` source maps.

Because the module runner installs `Error.prepareStackTrace`, preparing **any** error's `.stack` while `Buffer` is absent (e.g. browser-parity tests that temporarily delete Node-only globals — see the issue for a 13-line vitest-level repro) throws from inside `prepareStackTrace`, and the `ReferenceError` masks the original error. This is the same class of realm-assumption bug in the same source-map path as the `TextDecoder` incident (#21985 → vitest#9987).

### The fix

- `utils.ts`: capture the `Buffer` binding once at module load and select the implementation from the captured reference, so late deletion of the global cannot break stack preparation. The `TextDecoder`/`atob` fallback still covers runtimes with no `Buffer` at load.
- `sourcemap/interceptor.ts`: reuse `decodeBase64` instead of the bare `Buffer.from(...)` (identical utf-8 semantics, removes the duplicated decode).

### Tests

Two regression tests added to `server-source-maps.spec.ts`, one per affected path, both restoring `globalThis.Buffer` in `finally` so the suite realm is never left dirty:

1. **runner-module path** — an error from a runner-imported fixture has its stack prepared while `Buffer` is deleted (exercises `getModuleSourceMapById` → `decodeBase64`);
2. **interceptor path** — a frame from a file outside the runner module graph, served via a `sourcemapInterceptor: { retrieveFile }` handler with an inline base64 `data:` source map (exercises `retrieveSourceMap`). The `sourceMappingURL` token in the fixture string is composed from the `SOURCEMAPPING_URL` constant so the spec file itself never contains the literal token.

Both fail on unmodified `main` with (verbatim excerpt):

```
 FAIL  … > should not crash when preparing a stack trace while globalThis.Buffer is absent
ReferenceError: Buffer is not defined
 ❯ packages/vite/src/module-runner/utils.ts:13:52
 ❯ EvaluatedModules.getModuleSourceMapById packages/vite/src/module-runner/evaluatedModules.ts:110:99
 ❯ getRunnerSourceMap packages/vite/src/module-runner/sourcemap/interceptor.ts:61:33
 ❯ mapSourcePosition packages/vite/src/module-runner/sourcemap/interceptor.ts:119:18
 ❯ wrapCallSite packages/vite/src/module-runner/sourcemap/interceptor.ts:277:20
 ❯ Error.prepareStackTrace packages/vite/src/module-runner/sourcemap/interceptor.ts:330:35

 FAIL  … > should not crash when decoding an inline source map while globalThis.Buffer is absent
ReferenceError: Buffer is not defined
 ❯ retrieveSourceMap packages/vite/src/module-runner/sourcemap/interceptor.ts:104:3
 ❯ mapSourcePosition packages/vite/src/module-runner/sourcemap/interceptor.ts:123:21
 ❯ wrapCallSite packages/vite/src/module-runner/sourcemap/interceptor.ts:277:20
 ❯ Error.prepareStackTrace packages/vite/src/module-runner/sourcemap/interceptor.ts:330:35
```

and pass with this change (spec 9/9). Lint, typecheck, and oxfmt pass. The only locally failing unit files (`create-vite/cli.spec.ts`, `scan.spec.ts` under parallel load) fail identically on unmodified `main` in my environment (verified by stashing the change), i.e. unrelated.

### Alternatives considered

- Evaluating the `typeof Buffer` guard at call time instead — works, but pays the check on every call and leaves two code paths per call site.
- Using the `TextDecoder` path unconditionally — simplest, but changes behavior for large maps on Node where `Buffer.from` is the fast path.

Capturing the binding keeps the existing load-time selection semantics and is the smallest change.

Made with [Cursor](https://cursor.com)