### PR TITLE
docs(build): fix incorrect `@default` for build.cssMinify

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -163,7 +163,7 @@ export interface BuildEnvironmentOptions {
   /**
    * Override CSS minification specifically instead of defaulting to `build.minify`,
    * so you can configure minification for JS and CSS separately.
-   * @default 'lightningcss'
+   * @default 'lightningcss', but false if build.minify is disabled for client build
    */
   cssMinify?: boolean | 'lightningcss' | 'esbuild'
   /**


### PR DESCRIPTION
The `@default 'lightningcss'` for `build.cssMinify` omits the client-build exception: when `build.minify` is disabled, the default is `false` for the client build.

```ts
cssMinify:
  merged.cssMinify ??
  (consumer === 'server' ? 'lightningcss' : !!merged.minify),
```

Updated the `@default` to match the published docs (`build-options.md`): "'lightningcss', but false if build.minify is disabled for client build".
