### PR TITLE
fix(optimizer): respect importer module format for dynamic import interop with CJS deps

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -42,6 +42,7 @@ import {
   isDefined,
   isExternalUrl,
   isFilePathESM,
+  isFilePathFormatExplicit,
   isInNodeModules,
   isJSRequest,
   joinUrlSegments,
@@ -459,6 +460,17 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         _isNodeModeResult ??= isFilePathESM(importer, config.packageCache)
         return _isNodeModeResult
       }
+      let _isNodeModeForDynamicImportResult = config.legacy
+        ?.inconsistentCjsInterop
+        ? false
+        : undefined
+      const isNodeModeForDynamicImport = () => {
+        _isNodeModeForDynamicImportResult ??= isFilePathFormatExplicit(
+          importer,
+          config.packageCache,
+        )
+        return _isNodeModeForDynamicImportResult
+      }
 
       await Promise.all(
         imports.map(async (importSpecifier, index) => {
@@ -626,7 +638,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                     url,
                     index,
                     importer,
-                    isNodeMode(),
+                    isDynamicImport
+                      ? isNodeModeForDynamicImport()
+                      : isNodeMode(),
                     config,
                   )
                   rewriteDone = true
@@ -948,12 +962,11 @@ export function interopNamedImports(
   } = importSpecifier
   const exp = source.slice(expStart, expEnd)
   if (dynamicIndex > -1) {
-    const inconsistentCjsInterop = !!config.legacy?.inconsistentCjsInterop
     // rewrite `import('package')` to expose the default directly
     str.overwrite(
       expStart,
       expEnd,
-      `import('${rewrittenUrl}').then(m => (${interopHelperStr})(m.default, ${inconsistentCjsInterop ? 0 : 1}))` +
+      `import('${rewrittenUrl}').then(m => (${interopHelperStr})(m.default, ${+isNodeMode}))` +
         getLineBreaks(exp),
       { contentOnly: true },
     )

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -441,6 +441,26 @@ export function isFilePathESM(
   }
 }
 
+/**
+ * Whether the file's module format is explicitly determined as ESM or CJS by
+ * its extension or the nearest `package.json` `"type"` field, as opposed to
+ * being ambiguous.
+ */
+export function isFilePathFormatExplicit(
+  filePath: string,
+  packageCache?: PackageCache,
+): boolean {
+  if (/\.[mc][jt]s$/.test(filePath)) {
+    return true
+  }
+  try {
+    const pkg = findNearestPackageData(path.dirname(filePath), packageCache)
+    return pkg?.data.type === 'module' || pkg?.data.type === 'commonjs'
+  } catch {
+    return false
+  }
+}
+
 export const splitRE: RegExp = /\r?\n/g
 
 const range: number = 2

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -79,6 +79,18 @@ test('dynamic default import from cjs with es-module-flag (cjs-dynamic-dep-cjs-w
     .toBe('ok')
 })
 
+test('dynamic import from format-ambiguous importer respects __esModule flag (cjs-dynamic-importer-ambiguous)', async () => {
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic-importer-ambiguous'))
+    .toBe('ok')
+})
+
+test('dynamic import from explicit cjs importer uses node interop (cjs-dynamic-importer-cjs)', async () => {
+  await expect
+    .poll(() => page.textContent('.cjs-dynamic-importer-cjs'))
+    .toBe('ok')
+})
+
 test('dedupe', async () => {
   await expect.poll(() => page.textContent('.dedupe button')).toBe('count is 0')
   await page.click('.dedupe button')

--- a/playground/optimize-deps/cjs-dynamic-importer-ambiguous/index.js
+++ b/playground/optimize-deps/cjs-dynamic-importer-ambiguous/index.js
@@ -1,0 +1,9 @@
+// test dynamic import to a cjs dep with __esModule flag from an importer
+// whose module format is ambiguous (nearest package.json has no "type" field).
+// the __esModule flag should be respected: `default` is `module.exports.default`
+import('@vitejs/test-dep-cjs-compiled-from-esm').then((ns) => {
+  const ok = typeof ns.default === 'function' && ns.default() === 'foo'
+  document.querySelector('.cjs-dynamic-importer-ambiguous').textContent = ok
+    ? 'ok'
+    : 'fail'
+})

--- a/playground/optimize-deps/cjs-dynamic-importer-ambiguous/package.json
+++ b/playground/optimize-deps/cjs-dynamic-importer-ambiguous/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-optimize-deps-cjs-dynamic-importer-ambiguous",
+  "private": true,
+  "version": "0.0.0",
+  "//": "intentionally no \"type\" field: the importer's module format is ambiguous"
+}

--- a/playground/optimize-deps/cjs-dynamic-importer-cjs/index.js
+++ b/playground/optimize-deps/cjs-dynamic-importer-cjs/index.js
@@ -1,0 +1,10 @@
+// test dynamic import to a cjs dep with __esModule flag from an importer
+// explicitly marked as CJS (nearest package.json has "type": "commonjs").
+// Node interop semantics apply: `default` is the whole `module.exports`
+import('@vitejs/test-dep-cjs-compiled-from-esm').then((ns) => {
+  const ok =
+    typeof ns.default.default === 'function' && ns.default.default() === 'foo'
+  document.querySelector('.cjs-dynamic-importer-cjs').textContent = ok
+    ? 'ok'
+    : 'fail'
+})

--- a/playground/optimize-deps/cjs-dynamic-importer-cjs/package.json
+++ b/playground/optimize-deps/cjs-dynamic-importer-cjs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-optimize-deps-cjs-dynamic-importer-cjs",
+  "private": true,
+  "version": "0.0.0",
+  "type": "commonjs"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -30,6 +30,14 @@
 
 <script type="module" src="./cjs-dynamic.js"></script>
 
+<h2>CommonJS dynamic import from format-ambiguous importer</h2>
+<div class="cjs-dynamic-importer-ambiguous"></div>
+<h2>CommonJS dynamic import from explicit CJS importer (package.json type)</h2>
+<div class="cjs-dynamic-importer-cjs"></div>
+
+<script type="module" src="./cjs-dynamic-importer-ambiguous/index.js"></script>
+<script type="module" src="./cjs-dynamic-importer-cjs/index.js"></script>
+
 <h2>Dedupe (dep in linked & optimized package)</h2>
 <div class="dedupe"></div>
 <script type="module" src="./dedupe.js"></script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1212,6 +1212,10 @@ importers:
 
   playground/optimize-deps/added-in-entries: {}
 
+  playground/optimize-deps/cjs-dynamic-importer-ambiguous: {}
+
+  playground/optimize-deps/cjs-dynamic-importer-cjs: {}
+
   playground/optimize-deps/dep-alias-using-absolute-path:
     dependencies:
       '@vitejs/test-dep-lodash':


### PR DESCRIPTION
Dynamic imports from modules that the format is implicit against CJS modules used the Node semantics in dev, while the build used the bundler semantics.

This PR fixes that inconsistency by aligning the dev behavior to build so that it aligns with https://rolldown.rs/in-depth/bundling-cjs#ambiguous-default-import-from-cjs-modules.

fixes #22942
