### PR TITLE
docs(static-deploy): fix links for Vercel deployment environments

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -162,7 +162,7 @@ After your project has been imported and deployed, all subsequent pushes to bran
 3. Vercel will detect that you are using Vite and will enable the correct settings for your deployment.
 4. Your application is deployed! (e.g. [vite-vue-template.vercel.app](https://vite-vue-template.vercel.app/))
 
-After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/concepts/deployments/environments#preview), and all changes made to the Production Branch (commonly “main”) will result in a [Production Deployment](https://vercel.com/docs/concepts/deployments/environments#production).
+After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://vercel.com/docs/deployments/environments#preview-environment-pre-production), and all changes made to the Production Branch (commonly “main”) will result in a [Production Deployment](https://vercel.com/docs/deployments/environments#production-environment).
 
 Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/git).
 


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
The Vercel documentation has moved from /docs/concepts/deployments/environments to /docs/deployments/environments. Although the old URLs redirect to the new page, the original #preview and #production anchors no longer exist. As a result, both links open the top of the page instead of navigating to the intended Preview and Production environment sections.

Update the Preview Deployment link to https://vercel.com/docs/deployments/environments#preview-environment-pre-production and the Production Build link to https://vercel.com/docs/deployments/environments#production-environment.