### PR TITLE
docs: fix browser target grammar

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -4,7 +4,7 @@ If you are migrating from `rolldown-vite`, the technical preview release for Rol
 
 ## Default Browser Target Change [<Badge text="NRV" type="warning" />](#migration-from-v7)
 
-The default browser value of `build.target` and `'baseline-widely-available'`, is updated to newer browser version:
+The default browser values of `build.target` and `'baseline-widely-available'` are updated to newer browser versions:
 
 - Chrome 107 → 111
 - Edge 107 → 111


### PR DESCRIPTION
## Summary

Corrects singular grammar in the V7 migration guide's browser-target change description.

## Why

The sentence refers to the two defaults and lists several browser targets, so plural agreement makes the migration note clearer for readers.

## Validation

- Confirmed the diff is limited to the documentation sentence.
- Ran `git diff --check`.
