### PR TITLE
feat(bundled-dev): support `hotUpdate` and `handleHotUpdate` hook

### DIFF
--- a/packages/vite/src/node/__tests_dts__/plugin.ts
+++ b/packages/vite/src/node/__tests_dts__/plugin.ts
@@ -27,7 +27,8 @@ type HooksMissingInConstants = Exclude<
 
 export type cases = [
   // Ensure environment plugin hooks are superset of rollup plugin hooks
-  ExpectTrue<ExpectExtends<RolldownPlugin, Plugin>>,
+  // (`hotUpdate` is left out on purpose — see `Plugin` in plugin.ts)
+  ExpectTrue<ExpectExtends<Omit<RolldownPlugin, 'hotUpdate'>, Plugin>>,
 
   // Ensure all Rollup hooks have Vite's plugin context extension
   ExpectTrue<Equal<HooksMissingExtension, never>>,

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -98,7 +98,10 @@ declare module 'rolldown' {
  * Environment Plugins are closer to regular rollup plugins. They can't define
  * app level hooks (like config, configResolved, configureServer, etc).
  */
-export interface Plugin<A = any> extends RolldownPlugin<A> {
+// `hotUpdate` is left out on purpose: rolldown's dev-only version takes plain
+// module ids, Vite's takes `EnvironmentModuleNode` objects. See
+// `bundledDevHmr.ts` for how the two are translated.
+export interface Plugin<A = any> extends Omit<RolldownPlugin<A>, 'hotUpdate'> {
   /**
    * Perform custom handling of HMR updates.
    * The handler receives an options containing changed filename, timestamp, a

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -14,7 +14,9 @@ import {
   createDebugger,
   formatAndTruncateFileList,
 } from '../utils'
+import type { ViteDevServer } from '..'
 import type { DevEnvironment } from './environment'
+import { BundledDevHotUpdateAdapter, BundledModuleGraph } from './bundledDevHmr'
 import { type NormalizedHotChannelClient, debugHmr, getShortName } from './hmr'
 import { prepareError } from './middlewares/error'
 
@@ -90,12 +92,26 @@ export class BundledDev {
 
   memoryFiles: MemoryFiles = new MemoryFiles()
 
+  readonly moduleGraph: BundledModuleGraph
+
+  private hotUpdateAdapter: BundledDevHotUpdateAdapter
+
   constructor(private environment: DevEnvironment) {
     if (environment.name !== 'client') {
       throw new Error(
         'currently full bundle mode is only available for client environment',
       )
     }
+    this.moduleGraph = new BundledModuleGraph(
+      environment.name,
+      environment.config.root,
+      (url: string) => environment.pluginContainer!.resolveId(url, undefined),
+    )
+    this.hotUpdateAdapter = new BundledDevHotUpdateAdapter(
+      environment,
+      this.moduleGraph,
+      this,
+    )
   }
 
   private get devEngine(): DevEngine {
@@ -107,8 +123,9 @@ export class BundledDev {
 
   private pendingPayloadFilenames = new Set<string>()
 
-  async listen(): Promise<void> {
+  async listen(server: ViteDevServer): Promise<void> {
     this._closed = false
+    this.hotUpdateAdapter.setServer(server)
     debug?.('INITIAL: setup bundle options')
     const rolldownOptions = await this.getRolldownOptions()
     // NOTE: only single outputOptions is supported here
@@ -334,6 +351,11 @@ export class BundledDev {
     return result
   }
 
+  requestFullBuildReload(): void {
+    this.fullReloadPending = true
+    this.devEngine.triggerFullBuild()
+  }
+
   /**
    * Called by the serving middlewares when the response for a payload completed.
    * Only delivered payloads are recorded on the server's per-client ship map, so
@@ -411,6 +433,9 @@ export class BundledDev {
         transform.handler = wrappedHandler
       }
     }
+    // One wrapper per plugin, so rolldown's driver keeps the plugin order.
+    this.hotUpdateAdapter.wrapPlugins(plugins)
+
     rolldownOptions.plugins = plugins
 
     // set filenames to make output paths predictable so that `renderChunk` hook does not need to be used

--- a/packages/vite/src/node/server/bundledDevHmr.ts
+++ b/packages/vite/src/node/server/bundledDevHmr.ts
@@ -31,7 +31,6 @@ interface RolldownHotUpdateArgs {
   type: 'create' | 'update' | 'delete'
   file: string
   modules: string[]
-  read: () => Promise<string>
 }
 
 interface RolldownHotUpdateContext {

--- a/packages/vite/src/node/server/bundledDevHmr.ts
+++ b/packages/vite/src/node/server/bundledDevHmr.ts
@@ -1,0 +1,464 @@
+import path from 'node:path'
+import type { ModuleInfo, PartialResolvedId } from 'rolldown'
+import { FS_PREFIX } from '../constants'
+import { monotonicDateNow, removeTimestampQuery } from '../utils'
+import { cleanUrl, withTrailingSlash, wrapId } from '../../shared/utils'
+import { getHookHandler } from '../plugins'
+import type { Plugin } from '../plugin'
+import {
+  ignoreDeprecationWarnings,
+  warnFutureDeprecation,
+} from '../deprecations'
+import type { ViteDevServer } from '..'
+import { EnvironmentModuleGraph, EnvironmentModuleNode } from './moduleGraph'
+import {
+  type HmrContext,
+  type HotUpdateOptions,
+  debugHmr,
+  readModifiedFile,
+} from './hmr'
+import {
+  BasicMinimalPluginContext,
+  basePluginContextMeta,
+} from './pluginContainer'
+import type { ModuleNode } from './mixedModuleGraph'
+import type { DevEnvironment } from './environment'
+import type { BundledDev } from './bundledDev'
+
+// Declared by shape, so this file does not depend on rolldown's experimental
+// exports.
+interface RolldownHotUpdateArgs {
+  type: 'create' | 'update' | 'delete'
+  file: string
+  modules: string[]
+  read: () => Promise<string>
+}
+
+interface RolldownHotUpdateContext {
+  getModuleInfo: (id: string) => ModuleInfo | null
+  getModuleIds: () => IterableIterator<string>
+}
+
+type RolldownHotUpdateHandler = (
+  this: RolldownHotUpdateContext,
+  options: RolldownHotUpdateArgs,
+) => Promise<string[] | undefined>
+
+/**
+ * Stands in for the rolldown dev engine's module graph, which is the real one.
+ * The engine works with plain module ids, while Vite plugins expect
+ * `EnvironmentModuleNode` objects, so this class turns one into the other.
+ *
+ * Each id gets one node, created the first time it is asked for and reused
+ * after that. Identity matters: plugins compare nodes by reference and store
+ * their own state on them. `info`, `importers`, and `importedModules` read live
+ * from the engine registry, so they stay correct after every rebuild.
+ */
+export class BundledModuleGraph extends EnvironmentModuleGraph {
+  /** @internal */
+  _root: string
+  /** @internal */
+  _getModuleInfo: ((id: string) => ModuleInfo | null) | undefined
+  /** @internal */
+  _getModuleIds: (() => IterableIterator<string>) | undefined
+  /** @internal */
+  _onInvalidateModule: ((mod: EnvironmentModuleNode) => void) | undefined
+  /** @internal */
+  _onInvalidateAll: (() => void) | undefined
+
+  constructor(
+    environment: string,
+    root: string,
+    resolveId: (url: string) => Promise<PartialResolvedId | null>,
+  ) {
+    super(environment, resolveId)
+    this._root = root
+  }
+
+  /** @internal */
+  _updateContext(ctx: RolldownHotUpdateContext): void {
+    this._getModuleInfo = (id) => ctx.getModuleInfo(id)
+    this._getModuleIds = () => ctx.getModuleIds()
+  }
+
+  ensureBundledNode(id: string): EnvironmentModuleNode {
+    const existing = this.idToModuleMap.get(id)
+    if (existing) {
+      return existing
+    }
+    const mod = new EnvironmentModuleNode(this._urlForId(id), this.environment)
+    mod.id = id
+    mod.file = cleanUrl(id)
+    // The engine owns the real graph, so writing to a node changes nothing.
+    const lazy = (prop: string, get: () => unknown) =>
+      Object.defineProperty(mod, prop, {
+        configurable: true,
+        enumerable: true,
+        get,
+        set: () => {},
+      })
+    lazy('info', () => this._getModuleInfo?.(id) ?? undefined)
+    lazy('importers', () => {
+      const info = this._getModuleInfo?.(id)
+      return this._nodeSet(info?.importers, info?.dynamicImporters)
+    })
+    lazy('importedModules', () => {
+      const info = this._getModuleInfo?.(id)
+      return this._nodeSet(info?.importedIds, info?.dynamicallyImportedIds)
+    })
+    this.idToModuleMap.set(id, mod)
+    if (!this.urlToModuleMap.has(mod.url)) {
+      this.urlToModuleMap.set(mod.url, mod)
+    }
+    let fileMappedModules = this.fileToModulesMap.get(mod.file)
+    if (!fileMappedModules) {
+      fileMappedModules = new Set()
+      this.fileToModulesMap.set(mod.file, fileMappedModules)
+    }
+    fileMappedModules.add(mod)
+    return mod
+  }
+
+  override getModuleById(id: string): EnvironmentModuleNode | undefined {
+    const mod = super.getModuleById(id)
+    if (mod) {
+      return mod
+    }
+    const cleanId = removeTimestampQuery(id)
+    if (this._getModuleInfo?.(cleanId)) {
+      return this.ensureBundledNode(cleanId)
+    }
+    return undefined
+  }
+
+  override getModulesByFile(
+    file: string,
+  ): Set<EnvironmentModuleNode> | undefined {
+    if (this._getModuleIds) {
+      for (const id of this._getModuleIds()) {
+        if (!this.idToModuleMap.has(id) && cleanUrl(id) === file) {
+          this.ensureBundledNode(id)
+        }
+      }
+    }
+    return super.getModulesByFile(file)
+  }
+
+  /** Adds the module to the current hot-update event's set. Does nothing outside an event. */
+  override invalidateModule(mod: EnvironmentModuleNode): void {
+    this._onInvalidateModule?.(mod)
+  }
+
+  override invalidateAll(): void {
+    this._onInvalidateAll?.()
+  }
+
+  private _nodeSet(
+    ...idLists: (readonly string[] | undefined)[]
+  ): Set<EnvironmentModuleNode> {
+    const nodes = new Set<EnvironmentModuleNode>()
+    for (const ids of idLists) {
+      for (const id of ids ?? []) {
+        nodes.add(this.ensureBundledNode(id))
+      }
+    }
+    return nodes
+  }
+
+  private _urlForId(id: string): string {
+    if (id.startsWith('\0') || id.startsWith('virtual:')) {
+      return wrapId(id)
+    }
+    if (id.startsWith(withTrailingSlash(this._root))) {
+      return id.slice(this._root.length)
+    }
+    if (path.isAbsolute(id)) {
+      return path.posix.join(FS_PREFIX, id)
+    }
+    return id
+  }
+}
+
+interface HotUpdateEventState {
+  timestamp: number
+  invalidatedIds: Set<string>
+  envOptions?: HotUpdateOptions
+  mixedCtx?: HmrContext
+}
+
+/**
+ * Runs Vite's `hotUpdate` and `handleHotUpdate` hooks on top of rolldown's
+ * `hotUpdate` hook. Every Vite plugin gets its own wrapper, so rolldown's
+ * driver keeps the plugin order.
+ *
+ * Around those wrappers, a pre-ordered hook opens the shared state for the
+ * changed file, and a post-ordered hook merges the modules collected through
+ * `moduleGraph.invalidateModule` and closes the state.
+ */
+export class BundledDevHotUpdateAdapter {
+  private server: ViteDevServer | undefined
+  private states = new Map<string, HotUpdateEventState>()
+  private activeFile: string | undefined
+  private legacyContext: BasicMinimalPluginContext
+
+  constructor(
+    private environment: DevEnvironment,
+    private graph: BundledModuleGraph,
+    private bundledDev: BundledDev,
+  ) {
+    this.legacyContext = new BasicMinimalPluginContext(
+      { ...basePluginContextMeta, watchMode: true },
+      environment.getTopLevelConfig().logger,
+    )
+    graph._onInvalidateModule = (mod) => {
+      const state = this.activeFile
+        ? this.states.get(this.activeFile)
+        : undefined
+      if (state && mod.id) {
+        state.invalidatedIds.add(mod.id)
+      } else {
+        debugHmr?.(
+          `invalidateModule(${mod.id}) outside a hot-update event is a no-op under bundled dev`,
+        )
+      }
+    }
+    graph._onInvalidateAll = () => {
+      this.bundledDev.requestFullBuildReload()
+    }
+  }
+
+  setServer(server: ViteDevServer): void {
+    this.server = server
+  }
+
+  wrapPlugins(plugins: unknown[]): void {
+    // Only wrap top-level Vite plugins. A plugin swapped in for one
+    // environment with `applyToEnvironment` is a rolldown plugin, and its
+    // `hotUpdate` already expects plain ids.
+    // `plugins[i]` is a clone of `environment.plugins[i]`, so the original is
+    // looked up by index, and the name is checked to confirm the match.
+    const environmentPlugins = this.environment.plugins
+    const topLevelPlugins = new Set(
+      this.environment.getTopLevelConfig().plugins,
+    )
+    let wrapped = 0
+    for (let i = 0; i < plugins.length; i++) {
+      const plugin = plugins[i] as Plugin
+      if (!plugin || typeof plugin !== 'object') continue
+      const source = environmentPlugins[i]
+      if (
+        !source ||
+        source.name !== plugin.name ||
+        !topLevelPlugins.has(source)
+      ) {
+        continue
+      }
+      if (plugin.hotUpdate) {
+        ;(plugin as any).hotUpdate = this._wrapHotUpdate(plugin)
+        wrapped++
+      } else if (plugin.handleHotUpdate) {
+        ;(plugin as any).hotUpdate = this._wrapHandleHotUpdate(plugin)
+        wrapped++
+      }
+    }
+
+    const captureContext = (ctx: RolldownHotUpdateContext) =>
+      this.graph._updateContext(ctx)
+    const openEvent = (
+      ctx: RolldownHotUpdateContext,
+      options: RolldownHotUpdateArgs,
+    ) => {
+      this.graph._updateContext(ctx)
+      this.activeFile = options.file
+      this.states.set(options.file, {
+        timestamp: monotonicDateNow(),
+        invalidatedIds: new Set(),
+      })
+      return this._expandModulesByFile(options)
+    }
+    const pre: any = {
+      name: 'vite:bundled-dev-hot-update-pre',
+      // lets the module graph stand-in answer reads outside hot-update events
+      buildStart(this: RolldownHotUpdateContext) {
+        captureContext(this)
+      },
+    }
+    if (wrapped > 0) {
+      pre.hotUpdate = {
+        order: 'pre',
+        handler(
+          this: RolldownHotUpdateContext,
+          options: RolldownHotUpdateArgs,
+        ) {
+          return openEvent(this, options)
+        },
+      }
+    }
+    plugins.unshift(pre)
+    if (wrapped > 0) {
+      plugins.push({
+        name: 'vite:bundled-dev-hot-update-post',
+        hotUpdate: {
+          order: 'post',
+          handler: (options: RolldownHotUpdateArgs) => {
+            const state = this.states.get(options.file)
+            this.states.delete(options.file)
+            if (this.activeFile === options.file) {
+              this.activeFile = undefined
+            }
+            if (state && state.invalidatedIds.size > 0) {
+              const merged = new Set(options.modules)
+              for (const id of state.invalidatedIds) {
+                merged.add(id)
+              }
+              return [...merged]
+            }
+          },
+        },
+      })
+    }
+  }
+
+  private _wrapHotUpdate(plugin: Plugin): unknown {
+    const hook = plugin.hotUpdate!
+    const handler = getHookHandler(hook)
+    const run = async (
+      ctx: RolldownHotUpdateContext,
+      options: RolldownHotUpdateArgs,
+    ): Promise<string[] | undefined> => {
+      this.graph._updateContext(ctx)
+      const state = this._ensureState(options.file)
+      const toNodes = () =>
+        options.modules.map((id) => this.graph.ensureBundledNode(id))
+      let viteOptions = state.envOptions
+      if (!viteOptions) {
+        viteOptions = state.envOptions = {
+          type: options.type,
+          file: options.file,
+          timestamp: state.timestamp,
+          modules: toNodes(),
+          read: () => readModifiedFile(options.file),
+          server: this._requireServer(),
+        }
+      } else {
+        // Vite passes one shared options object to every plugin in turn, so a
+        // change made by one plugin is visible to the next. Only the module
+        // set is rebuilt here.
+        viteOptions.modules = toNodes()
+      }
+      const result = await handler.call(
+        this.environment.pluginContainer.minimalContext as any,
+        viteOptions,
+      )
+      if (result) {
+        return result
+          .map((mod: EnvironmentModuleNode) => mod.id)
+          .filter((id: string | null): id is string => id != null)
+      }
+    }
+    const wrappedHandler: RolldownHotUpdateHandler = function (options) {
+      return run(this, options)
+    }
+    return typeof hook === 'object' && hook.order
+      ? { order: hook.order, handler: wrappedHandler }
+      : wrappedHandler
+  }
+
+  private _wrapHandleHotUpdate(plugin: Plugin): unknown {
+    const hook = plugin.handleHotUpdate!
+    const handler = getHookHandler(hook)
+    const config = this.environment.getTopLevelConfig()
+    const run = async (
+      ctx: RolldownHotUpdateContext,
+      options: RolldownHotUpdateArgs,
+    ): Promise<string[] | undefined> => {
+      // Same as Vite: the legacy hook runs only for updates.
+      if (options.type !== 'update') {
+        return
+      }
+      this.graph._updateContext(ctx)
+      const state = this._ensureState(options.file)
+      const server = this._requireServer()
+      const mixedGraph = ignoreDeprecationWarnings(() => server.moduleGraph)
+      const toMixed = (id: string) =>
+        mixedGraph.getBackwardCompatibleModuleNode(
+          this.graph.ensureBundledNode(id),
+        )
+      let mixedCtx = state.mixedCtx
+      if (!mixedCtx) {
+        mixedCtx = state.mixedCtx = {
+          file: options.file,
+          timestamp: state.timestamp,
+          modules: options.modules.map(toMixed),
+          read: () => readModifiedFile(options.file),
+          server,
+        }
+      } else {
+        // A `hotUpdate` hook that ran in between may have replaced the module
+        // set. Bring the list up to date, but keep the same context object,
+        // because the event shares it across plugins.
+        const currentIds = new Set(options.modules)
+        mixedCtx.modules = mixedCtx.modules.filter(
+          (mod) => mod.id != null && currentIds.has(mod.id),
+        )
+        for (const id of options.modules) {
+          if (!mixedCtx.modules.some((mod) => mod.id === id)) {
+            mixedCtx.modules.push(toMixed(id))
+          }
+        }
+      }
+      warnFutureDeprecation(
+        config,
+        'removePluginHookHandleHotUpdate',
+        `Used in plugin "${plugin.name}".`,
+        false,
+      )
+      const result = await handler.call(this.legacyContext as any, mixedCtx)
+      if (result) {
+        mixedCtx.modules = result
+        return result
+          .map((mod: ModuleNode) => mod.id)
+          .filter((id: string | null): id is string => id != null)
+      }
+    }
+    const wrappedHandler: RolldownHotUpdateHandler = function (options) {
+      return run(this, options)
+    }
+    return typeof hook === 'object' && hook.order
+      ? { order: hook.order, handler: wrappedHandler }
+      : wrappedHandler
+  }
+
+  private _expandModulesByFile(
+    options: RolldownHotUpdateArgs,
+  ): string[] | undefined {
+    const getModuleIds = this.graph._getModuleIds
+    if (!getModuleIds) return undefined
+    const merged = new Set(options.modules)
+    const before = merged.size
+    for (const id of getModuleIds()) {
+      if (id.includes('?rolldown-lazy=')) continue
+      if (!merged.has(id) && cleanUrl(id) === options.file) {
+        merged.add(id)
+      }
+    }
+    return merged.size > before ? [...merged] : undefined
+  }
+
+  private _ensureState(file: string): HotUpdateEventState {
+    let state = this.states.get(file)
+    if (!state) {
+      state = { timestamp: monotonicDateNow(), invalidatedIds: new Set() }
+      this.states.set(file, state)
+    }
+    this.activeFile = file
+    return state
+  }
+
+  private _requireServer(): ViteDevServer {
+    if (!this.server) {
+      throw new Error('a hotUpdate hook fired before the dev server was ready')
+    }
+    return this.server
+  }
+}

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -136,9 +136,11 @@ export class DevEnvironment extends BaseEnvironment {
 
     this._pendingRequests = new Map()
 
-    this.moduleGraph = new EnvironmentModuleGraph(name, (url: string) =>
-      this.pluginContainer!.resolveId(url, undefined),
-    )
+    this.moduleGraph = this.bundledDev
+      ? this.bundledDev.moduleGraph
+      : new EnvironmentModuleGraph(name, (url: string) =>
+          this.pluginContainer!.resolveId(url, undefined),
+        )
 
     this._crawlEndFinder = setupOnCrawlEnd()
 
@@ -270,7 +272,10 @@ export class DevEnvironment extends BaseEnvironment {
    */
   async listen(server: ViteDevServer): Promise<void> {
     this.hot.listen()
-    await Promise.all([this.bundledDev?.listen(), this.depsOptimizer?.init()])
+    await Promise.all([
+      this.bundledDev?.listen(server),
+      this.depsOptimizer?.init(),
+    ])
     warmupFiles(server, this)
   }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -465,7 +465,9 @@ export async function handleHMRUpdate(
   }
 
   if (config.experimental.bundledDev) {
-    // TODO: support handleHotUpdate / hotUpdate
+    // The hooks run inside the rolldown dev engine instead (see
+    // `bundledDevHmr.ts`). The config, env, and client-dir handling above
+    // still runs from the chokidar watcher.
     return
   }
 
@@ -1143,7 +1145,7 @@ function error(pos: number) {
 // vitejs/vite#610 when hot-reloading Vue files, we read immediately on file
 // change event and sometimes this can be too early and get an empty buffer.
 // Poll until the file's modified time has changed before reading again.
-async function readModifiedFile(file: string): Promise<string> {
+export async function readModifiedFile(file: string): Promise<string> {
   const content = await fsp.readFile(file, 'utf-8')
   if (!content) {
     const mtime = (await fsp.stat(file)).mtimeMs


### PR DESCRIPTION
Makes Vite's `hotUpdate` and `handleHotUpdate` plugin hooks work in bundled dev. Built on top of rolldown's new dev-only `hotUpdate` hook (rolldown/rolldown#10305).

## Problem

In bundled dev, the rolldown engine owns the module graph and the update flow. When a file changes, hooks run inside the engine, and the engine passes plain module ids. Vite plugins expect Vite's own types: `EnvironmentModuleNode` objects, a `moduleGraph`, and one shared context per change event. With no translation between the two sides, every plugin that uses these hooks does nothing in bundled dev.

Even a plugin as small as this had no effect before this PR:

```js
{
  name: 'my-plugin',
  hotUpdate({ file, modules }) {
    if (!file.endsWith('.css')) return
    return modules.filter((m) => m.id !== skippedId) // never ran in bundled dev
  },
}
```

## Design

```mermaid
flowchart TB
  A[Vite plugin<br/>hotUpdate with module nodes] --> B[adapter in bundledDevHmr.ts<br/>one wrapper per plugin]
  B --> C[rolldown hotUpdate hook<br/>plain module ids]
  C --> D[rolldown dev engine<br/>owns graph and update flow]
```

Two new pieces, both in `bundledDevHmr.ts`:

- **A module graph view** (`BundledModuleGraph`) — an object that looks like Vite's module graph but stores no graph data of its own. It creates a Vite module node for an id the first time that id is asked for, then reuses the same node. Identity matters here: plugins compare nodes by reference and store their own state on them. A node's `info`, `importers`, and `importedModules` are read live from the engine, so they stay correct after every rebuild. Nothing has to be kept in sync by hand. Writing to a node does nothing, because the engine owns the real graph.
- **A hook adapter** (`BundledDevHotUpdateAdapter`) — every Vite plugin that has one of the two hooks gets its own wrapper, registered as that plugin's rolldown `hotUpdate` hook. Plugin order, and the rule that a returned module set replaces the previous one, then come from rolldown's own driver. The adapter does not re-implement them. The wrapper turns ids into nodes before it calls the Vite hook, and turns nodes back into ids after the hook returns.

The main design rules:

- **Each layer keeps its own types.** The engine uses ids. Vite plugins use nodes. Translation happens only at the boundary, inside the adapter.
- **Only top-level Vite plugins are wrapped.** A plugin swapped in for one environment with `applyToEnvironment` is a rolldown plugin. Its `hotUpdate` already expects ids, so it stays unwrapped.
- **One shared state per changed file, as in Vite.** A pre-ordered hook opens the state for the event and expands the module set to every module of that file, so query variants such as `file.vue?type=style` are included. All wrappers for that file share one options object. A change made by one plugin, for example a new `read` function, is therefore visible to the next plugin. A post-ordered hook merges the modules buffered through `moduleGraph.invalidateModule` and closes the state.
- **`invalidateAll` rebuilds everything and reloads the page.** Bundled dev has no partial invalidation to fall back on, so this is what the flag can mean here.
- **The legacy hook keeps its Vite behavior.** `handleHotUpdate` receives the shared `HmrContext` with mixed module nodes, runs only for updates, and warns that it is deprecated.

## Tests

End-to-end coverage lives in the rolldown repo's dev-server test suite (`hmr-hot-update-hook-vite`, 8 browser specs). It covers the common plugin patterns:

- replacing the module set
- buffering `invalidateModule` calls, the way the Tailwind plugin does it
- sending a custom message with `read()` and `hot.send`, the way markdown page plugins do it
- the legacy shared-context `read` chain (unocss together with plugin-vue)
- expanding one file into its sub-modules (Vue SFC)
- suppressing an update
- `invalidateAll`

Unit tests in this repo will follow in a later PR.
