### PR TITLE
fix: stabilize CSS module names across queries (fix #22957)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -104,6 +104,7 @@
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",
     "fresh-import": "^0.2.1",
+    "generic-names": "^4.0.0",
     "host-validation-middleware": "^0.1.4",
     "http-proxy-3": "^1.23.3",
     "launch-editor-middleware": "^2.14.1",

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -125,6 +125,32 @@ composes: bar from '@/css/bar.module.css';
     expect(result1.code).toBe(result2.code)
   })
 
+  test('custom generateScopedName uses the project root and ignores queries', async () => {
+    const root = path.join(dirname, 'css-modules-root')
+    const filename = path.join(root, 'foo.module.css')
+    const pattern = 'custom__[hash:base64:5]'
+    const { transform } = await createCssPluginTransform({
+      configFile: false,
+      root,
+      css: {
+        modules: {
+          generateScopedName: pattern,
+        },
+      },
+    })
+    const css = `\
+.foo {
+  color: red;
+}`
+    const result = await transform(css, filename)
+    const generate = (await import('generic-names')).default(pattern, {
+      context: root,
+    })
+
+    expect(result.code).toContain(`.${generate('foo', filename)}`)
+    expect((await transform(css, `${filename}?inline`)).code).toBe(result.code)
+  })
+
   test('custom generateScopedName with lightningcss', async () => {
     const { transform } = await createCssPluginTransform({
       configFile: false,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1659,9 +1659,17 @@ async function compilePostCSS(
   let modules: Record<string, string> | undefined
 
   if (isModule) {
+    let generateScopedName = modulesOptions?.generateScopedName
+    if (typeof generateScopedName === 'string') {
+      const generate = (await importGenericNames()).default(generateScopedName)
+      generateScopedName = (name, filename) =>
+        generate(name, cleanUrl(filename))
+    }
+
     postcssPlugins.unshift(
       (await importPostcssModules()).default({
         ...modulesOptions,
+        generateScopedName,
         localsConvention: modulesOptions?.localsConvention,
         getJSON(
           cssFileName: string,
@@ -1846,6 +1854,7 @@ function createCachedImport<T>(imp: () => Promise<T>): () => T | Promise<T> {
   }
 }
 const importPostcssImport = createCachedImport(() => import('postcss-import'))
+const importGenericNames = createCachedImport(() => import('generic-names'))
 const importPostcssModules = createCachedImport(() => import('postcss-modules'))
 const importPostcss = createCachedImport(() => import('postcss'))
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1661,7 +1661,12 @@ async function compilePostCSS(
   if (isModule) {
     let generateScopedName = modulesOptions?.generateScopedName
     if (typeof generateScopedName === 'string') {
-      const generate = (await importGenericNames()).default(generateScopedName)
+      const generate = (await importGenericNames()).default(
+        generateScopedName,
+        {
+          context: config.root,
+        },
+      )
       generateScopedName = (name, filename) =>
         generate(name, cleanUrl(filename))
     }

--- a/playground/css/__tests__/postcss.spec.ts
+++ b/playground/css/__tests__/postcss.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('CSS modules with string generateScopedName ignore import queries', async () => {
+  const module = await page.$('.modules')
+  const className = await module.evaluate((element) =>
+    [...element.classList].find((name) => name.startsWith('mod-module__')),
+  )
+  const css = await page.textContent('.modules-query-inline')
+
+  expect(css).toContain(`.${className}`)
+})

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -127,6 +127,7 @@
   <p class="modules">CSS modules: this should be turquoise</p>
   <p>Imported CSS module:</p>
   <pre class="modules-code"></pre>
+  <pre class="modules-query-inline"></pre>
 
   <p class="modules-sass">CSS modules w/ SASS: this should be orangered</p>
   <p>Imported SASS module:</p>

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -21,6 +21,9 @@ import mod from './mod.module.css'
 document.querySelector('.modules').classList.add(mod['apply-color'])
 text('.modules-code', JSON.stringify(mod, null, 2))
 
+import inlineModWithQuery from './mod.module.css?inline'
+text('.modules-query-inline', inlineModWithQuery)
+
 import sassMod from './mod.module.scss'
 document.querySelector('.modules-sass').classList.add(sassMod['apply-color'])
 text('.modules-sass-code', JSON.stringify(sassMod, null, 2))
@@ -81,6 +84,8 @@ if (import.meta.hot) {
     list.add(newMod.applyColor)
     text('.modules-code', JSON.stringify(newMod.default, null, 2))
   })
+
+  import.meta.hot.accept('./mod.module.css?inline', () => {})
 
   import.meta.hot.accept('./mod.module.scss', (newMod) => {
     const list = document.querySelector('.modules-sass').classList

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       fresh-import:
         specifier: ^0.2.1
         version: 0.2.1
+      generic-names:
+        specifier: ^4.0.0
+        version: 4.0.0
       host-validation-middleware:
         specifier: ^0.1.4
         version: 0.1.4


### PR DESCRIPTION
## Description

When `css.modules.generateScopedName` is a string pattern, `postcss-modules` receives the full module id as its filename. Import queries such as `?inline` therefore changed the generated hash for the same CSS module.

Wrap string patterns with `generic-names` in Vite and pass it the query-free filename. Function-valued generators and PostCSS source filenames are unchanged.

## User impact

The same CSS Module now receives the same generated class names whether it is imported normally or with `?inline`, preventing mismatches between inlined CSS and rendered markup.

## Tests

- Added a PostCSS playground regression that imports one CSS Module normally and with `?inline`, then compares the generated class name.
- `corepack pnpm@10.34.5 install --lockfile-only`
- `CI=true corepack pnpm@10.34.5 install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test-serve css` (137 passed)
- Targeted regression in serve and build modes (both passed)
- `pnpm run test-unit css` (50 passed)
- Targeted Oxfmt and ESLint checks passed.

The all-repository formatter and ESLint commands are blocked on this Windows checkout by two pre-existing tracked symlink-placeholder fixture files; the changed files pass the scoped checks.
