### PR TITLE
fix: skip watching missing publicDir (fix #19864)

### DIFF
--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,4 +1,6 @@
-import { resolve } from 'node:path'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { type ViteDevServer, createServer } from '../index'
@@ -7,11 +9,16 @@ const stubGetWatchedCode = /\(\)\s*\{\s*return this;\s*\}/
 
 describe('watcher configuration', () => {
   let server: ViteDevServer | undefined
+  let tempRoot: string | undefined
 
   afterEach(async () => {
     if (server) {
       await server.close()
       server = undefined
+    }
+    if (tempRoot) {
+      await fsp.rm(tempRoot, { recursive: true, force: true })
+      tempRoot = undefined
     }
   })
 
@@ -52,5 +59,43 @@ describe('watcher configuration', () => {
         ]),
       )
     })
+  })
+
+  it('should keep watching the root when the configured publicDir does not exist', async () => {
+    // watching a non-existent nested path breaks watching of the subtree
+    // containing it (https://github.com/paulmillr/chokidar/issues/1470),
+    // so a missing publicDir must not be passed to chokidar
+    tempRoot = await fsp.realpath(
+      await fsp.mkdtemp(join(os.tmpdir(), 'vite-watcher-test-')),
+    )
+    const entry = join(tempRoot, 'src', 'frontend', 'src', 'main.js')
+    await fsp.mkdir(dirname(entry), { recursive: true })
+    await fsp.writeFile(entry, 'export const foo = 1\n')
+
+    server = await createServer({
+      root: tempRoot,
+      configFile: false,
+      logLevel: 'silent',
+      publicDir: join(tempRoot, 'src', 'frontend', 'public'),
+      server: {
+        // poll so the behavior is the same on every OS (the native macOS
+        // backend is not affected by the chokidar bug, the others are)
+        watch: { usePolling: true, interval: 100 },
+      },
+    })
+    await new Promise((resolve) => server!.watcher.once('ready', resolve))
+
+    let changed = false
+    server!.watcher.on('change', (file) => {
+      if (file === entry) changed = true
+    })
+    await vi.waitFor(
+      async () => {
+        // keep appending in case the first edit lands before polling starts
+        await fsp.appendFile(entry, '// edited\n')
+        expect(changed).toBe(true)
+      },
+      { timeout: 8000, interval: 200 },
+    )
   })
 })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -556,8 +556,12 @@ export async function _createServer(
           ...config.configFileDependencies,
           ...getEnvFilesForMode(config.mode, config.envDir),
           // Watch the public directory explicitly because it might be outside
-          // of the root directory.
-          ...(publicDir && publicFiles ? [publicDir] : []),
+          // of the root directory. Skip it if it doesn't exist: chokidar
+          // stops watching the subtree containing a watched path that does
+          // not exist (https://github.com/paulmillr/chokidar/issues/1470)
+          ...(publicDir && publicFiles && fs.existsSync(publicDir)
+            ? [publicDir]
+            : []),
         ],
 
         resolvedWatchOptions,


### PR DESCRIPTION
### Description

When `publicDir` points to a directory that does not exist, the dev server starts fine but file watching silently dies on Linux and Windows, so HMR just stops working with no error (#19864).

Root cause: `initPublicFiles` returns an empty (but truthy) `Set` for a missing directory, so the watch list built in `_createServer` (`packages/vite/src/node/server/index.ts`) still passed the non-existent `publicDir` path to chokidar. chokidar has a bug where watching a non-existent path nested inside another watched directory silently stops watching the subtree containing it (paulmillr/chokidar#1470, present in v3 and v5). In the issue's repro, the missing `src/main/frontend/public` killed watching of everything under `src/main/frontend`, which is why edits to `main.js` never produced an HMR update. The macOS fsevents backend is not affected, which is why this mostly bites Linux/Windows users (and anyone on polling).

The fix skips the explicit `publicDir` watch entry when the directory does not exist. I went with `fs.existsSync` rather than checking `publicFiles.size` (what the earlier attempt in #21864 did) because an existing-but-empty public dir still needs to be watched, otherwise files added to it later would never reach the `publicFiles` cache handler.

About #21864: it was closed for lack of response after a review question about why a non-existent path in the watch list breaks HMR. The chokidar issue linked above is the answer to that question. This PR also differs by keeping empty-but-existing dirs watched and by adding a regression test.

One behavior note: a `publicDir` outside the root that is created after server start will not be watched until restart. That is not a regression, the watcher was fully broken in that scenario before this change.

### Testing

The new test in `watcher.spec.ts` fails on main and passes with the fix. It forces polling so the chokidar bug reproduces on every OS. I also reproduced the end-to-end behavior against the built package (fsevents disabled and polling, before and after the fix) and ran `pnpm run build`, `pnpm run test-unit watcher`, `pnpm run test-serve assets`, `pnpm run lint` and `pnpm run typecheck` locally, all green.

fixes #19864

---

quick note: I'm a college freshman trying my best to contribute for the greater good :) I worked through this one together with Claude Code (it helped me chase the root cause down to the chokidar issue and shape the fix and the test, and I ran all the gates locally). apologies in advance if anything looks off, if there are mistakes I'd genuinely love to learn from them.
