### PR TITLE
fix(css): stabilize CSS module scoped name hash across queries (fix #22957)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -104,6 +104,7 @@
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",
     "fresh-import": "^0.2.1",
+    "generic-names": "^4.0.0",
     "host-validation-middleware": "^0.1.4",
     "http-proxy-3": "^1.23.3",
     "launch-editor-middleware": "^2.14.1",

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1659,9 +1659,24 @@ async function compilePostCSS(
   let modules: Record<string, string> | undefined
 
   if (isModule) {
+    let processedModulesOptions = { ...modulesOptions }
+    if (
+      modulesOptions &&
+      typeof modulesOptions.generateScopedName === 'string'
+    ) {
+      const genericNames = (await importGenericNames()).default
+      const generate = genericNames(modulesOptions.generateScopedName, {
+        context: config.root,
+      })
+      processedModulesOptions = {
+        ...modulesOptions,
+        generateScopedName: (name: string, filename: string) =>
+          generate(name, cleanUrl(filename)),
+      }
+    }
     postcssPlugins.unshift(
       (await importPostcssModules()).default({
-        ...modulesOptions,
+        ...processedModulesOptions,
         localsConvention: modulesOptions?.localsConvention,
         getJSON(
           cssFileName: string,
@@ -1848,6 +1863,7 @@ function createCachedImport<T>(imp: () => Promise<T>): () => T | Promise<T> {
 const importPostcssImport = createCachedImport(() => import('postcss-import'))
 const importPostcssModules = createCachedImport(() => import('postcss-modules'))
 const importPostcss = createCachedImport(() => import('postcss'))
+const importGenericNames = createCachedImport(() => import('generic-names'))
 
 const preprocessorWorkerControllerCache = new WeakMap<
   ResolvedConfig,

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -1,1 +1,12 @@
+import { test, expect } from 'vitest'
+import { page, viteTestUrl } from '~utils'
 import './tests'
+
+test('css module hash consistency across queries', async () => {
+  await page.goto(viteTestUrl)
+  const result = JSON.parse(
+    await page.textContent('.css-module-hash-consistency'),
+  )
+  expect(result.normal).toBeTruthy()
+  expect(result.normal).toBe(result.inline)
+})

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -149,6 +149,9 @@
   <p>Inline CSS module:</p>
   <pre class="modules-inline"></pre>
 
+  <p>CSS module hash consistency (normal vs ?inline):</p>
+  <pre class="css-module-hash-consistency"></pre>
+
   <p>CSS with @charset:</p>
   <pre class="charset-css"></pre>
 

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -48,6 +48,18 @@ text(
 import inlineMod from './inline.module.css?inline'
 text('.modules-inline', inlineMod)
 
+import modInline from './mod.module.css?inline'
+const modInlineClass = modInline.match(
+  /\.(mod-module__apply-color___[\w-]{5})/,
+)?.[1]
+text(
+  '.css-module-hash-consistency',
+  JSON.stringify({
+    normal: mod['apply-color'],
+    inline: modInlineClass,
+  }),
+)
+
 import charset from './charset.css?inline'
 text('.charset-css', charset)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       fresh-import:
         specifier: ^0.2.1
         version: 0.2.1
+      generic-names:
+        specifier: ^4.0.0
+        version: 4.0.0
       host-validation-middleware:
         specifier: ^0.1.4
         version: 0.1.4


### PR DESCRIPTION
## Description

### What is this PR solving?

When `css.modules.generateScopedName` is a string pattern containing `[hash]` (e.g. `[name]__[local]___[hash:base64:5]`), the same CSS module file produces different scoped class names when imported with different queries (`?inline`, `?used`). For example:

```
import styles from './foo.module.css'          // .title → _SGzINF8r
import inline from './foo.module.css?inline'   // .title → _ZhC-jWQM
```

This happens because `postcss-modules` delegates string patterns to `generic-names`, which hashes the filepath — and Vite passes `from: removeDirectQuery(id)` to postcss, which only strips `?direct`, leaving other queries intact in the filename used for hashing.

**Real-world impact:** Nuxt's `inlineStyles` feature imports every style with `?inline&used`. With a string `generateScopedName` pattern, the CSS inlined into the SSR response gets different class names than the server-rendered markup and the client bundle, leaving the page unstyled until the external CSS loads.

Fixes #22957.

### What other alternatives have been explored?

| Approach | Why rejected |
|---|---|
| Change `removeDirectQuery` → `cleanUrl` in `runPostCSS` | Would break the existing `PostCSS source.input.from includes query` test. Also too broad — affects all postcss processing, not just CSS modules. |
| Fix upstream in `postcss-modules` | The maintainer (`sapphi-red`) agreed this is a bug in postcss-modules and labelled it `bug: upstream`. However, a fix in Vite is needed now for users hitting this in production. |

**Chosen approach:** Wrap string `generateScopedName` in `compilePostCSS` with a function that passes `cleanUrl(filename)` to `generic-names` and uses `config.root` as the hashing context. This also makes the hash independent of `process.cwd()`, so the same project produces consistent class names regardless of the working directory.

### Test coverage

Added a test in `playground/css` that imports the same CSS module both normally and with `?inline`, then asserts the scoped class names match. Both serve and build test suites pass with this test.

### Additional notes

- `generic-names` is already a transitive dependency of `postcss-modules` (listed in `packages/vite/LICENSE.md`). It was added as a direct `devDependency` so it can be imported and pre-bundled by Rolldown.
- The `?inline` path through `cssPostPlugin.transform()` returns the CSS string with scoped names embedded, allowing the test to extract and compare the generated class name.
- No documentation changes needed — this is a bug fix, not a feature or API change.