### PR TITLE
refactor(bundled-dev): avoid injecting server values in the bundle

### DIFF
--- a/packages/vite/src/client/bundledDevClient.ts
+++ b/packages/vite/src/client/bundledDevClient.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid/non-secure'
-import type { DevRuntime as DevRuntimeType } from 'rolldown/experimental/runtime-types'
+import { DevRuntime } from 'rolldown/experimental/runtime'
 import {
   BundledDevHMRClient,
   BundledDevHMRContext,
@@ -21,9 +21,6 @@ export {
   updateStyle,
   ErrorOverlay,
 } from './client'
-
-// injected by rolldown's hmr plugin into the bundle prelude, ahead of this client
-declare const DevRuntime: typeof DevRuntimeType
 
 if (typeof DevRuntime !== 'undefined') {
   class ViteDevRuntime extends DevRuntime {

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -112,8 +112,8 @@ export class BundledDev {
 
   get hasBuildOutput(): boolean {
     return (
-      this.memoryFiles.size > 0 &&
-      (this.memoryFiles.size > 1 ||
+      this.memoryFiles.size > 1 ||
+      (this.memoryFiles.size === 1 &&
         !this.memoryFiles.has(BUNDLED_DEV_CLIENT_FILENAME))
     )
   }

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { setTimeout } from 'node:timers/promises'
 import {
   type BindingClientHmrUpdate,
@@ -19,6 +20,7 @@ import { type NormalizedHotChannelClient, debugHmr, getShortName } from './hmr'
 import { prepareError } from './middlewares/error'
 
 const debug = createDebugger('vite:full-bundle-mode')
+const BUNDLED_DEV_CLIENT_FILENAME = 'bundledDevClient.mjs'
 
 type HmrOutput = BindingClientHmrUpdate['update']
 
@@ -62,6 +64,7 @@ export class MemoryFiles {
 
 export class BundledDev {
   private _devEngine!: DevEngine
+  private viteRuntime?: string
   private initialBuildCompleted = false
   private _closed = false
   private clients = new Clients()
@@ -106,6 +109,14 @@ export class BundledDev {
   }
 
   private pendingPayloadFilenames = new Set<string>()
+
+  get hasBuildOutput(): boolean {
+    return (
+      this.memoryFiles.size > 0 &&
+      (this.memoryFiles.size > 1 ||
+        !this.memoryFiles.has(BUNDLED_DEV_CLIENT_FILENAME))
+    )
+  }
 
   async listen(): Promise<void> {
     this._closed = false
@@ -251,6 +262,10 @@ export class BundledDev {
         debug?.('INITIAL: run error', e)
       },
     )
+    this.viteRuntime = await getHmrImplementation(
+      this.environment.getTopLevelConfig(),
+    )
+    this.storeOutputFiles([])
     this.waitForInitialBuildFinish().then(() => {
       if (this._closed) return
       debug?.('INITIAL: build done')
@@ -271,7 +286,7 @@ export class BundledDev {
     if (this._closed) return
 
     let state = await this.devEngine.getBundleState()
-    while (this.memoryFiles.size === 0 && !state.lastBuildErrored) {
+    while (!this.hasBuildOutput && !state.lastBuildErrored) {
       await setTimeout(10)
       if (this._closed) return
       await this.devEngine.ensureCurrentBuildFinish()
@@ -354,12 +369,25 @@ export class BundledDev {
     this.initialBuildCompleted = false
   }
 
-  private storeOutputFiles(output: RolldownOutput['output']): void {
+  private storeOutputFiles(output: RolldownOutput['output'][number][]): void {
     // NOTE: don't clear memoryFiles here as incremental build reuses the files
+    if (this.viteRuntime) {
+      this.memoryFiles.set(BUNDLED_DEV_CLIENT_FILENAME, {
+        source: this.viteRuntime,
+        etag: getEtag(Buffer.from(this.viteRuntime), { weak: true }),
+      })
+    }
     for (const outputFile of output) {
       this.memoryFiles.set(outputFile.fileName, () => {
-        const source =
+        let source =
           outputFile.type === 'chunk' ? outputFile.code : outputFile.source
+        if (outputFile.type === 'chunk' && outputFile.isEntry) {
+          const runtimePath = path.posix.join(
+            this.environment.config.base,
+            BUNDLED_DEV_CLIENT_FILENAME,
+          )
+          source = `import ${JSON.stringify(runtimePath)}\n${source}`
+        }
         return {
           source,
           etag: getEtag(Buffer.from(source), { weak: true }),
@@ -380,9 +408,7 @@ export class BundledDev {
       ...(typeof rolldownOptions.experimental.devMode === 'object'
         ? rolldownOptions.experimental.devMode
         : {}),
-      implement: await getHmrImplementation(
-        this.environment.getTopLevelConfig(),
-      ),
+      implement: '',
     }
 
     // disable inlineConst optimization due to a bug in Rolldown

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -409,6 +409,7 @@ export class BundledDev {
         ? rolldownOptions.experimental.devMode
         : {}),
       implement: '',
+      skipCommonRuntimeInjection: true,
     }
 
     // disable inlineConst optimization due to a bug in Rolldown

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -475,7 +475,7 @@ export function indexHtmlMiddleware(
         const filePath = pathname.slice(1) // remove first /
 
         let file = fullBundle.memoryFiles.get(filePath)
-        if (!file && fullBundle.memoryFiles.size !== 0) {
+        if (!file && fullBundle.hasBuildOutput) {
           return next()
         }
         const secFetchDest = req.headers['sec-fetch-dest']


### PR DESCRIPTION
Avoid injecting server values (e.g. port number) to the bundle output so that we can create bundles before the server is listening.
The default client environment requires the server to listen to execute a module, but some of the server environments doesn't require it and meta-frameworks seem to rely on it.
This PR will allow that to be possible when implementing the bundled dev support for SSR.