### PR TITLE
fix: avoid duplicate buildStart in bundled dev

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -207,7 +207,11 @@ export class BundledDev {
         debug?.('INITIAL: run error', e)
       },
     )
-    this.waitForInitialBuildFinish().then(() => {
+    const initialBuildPromise = this.waitForInitialBuildFinish()
+    // Rolldown owns the client plugin lifecycle in bundled dev. Normal Vite
+    // transforms must wait for it instead of starting the same plugins again.
+    this.environment.pluginContainer.setBuildStartPromise(initialBuildPromise)
+    initialBuildPromise.then(() => {
       if (this._closed) return
       debug?.('INITIAL: build done')
       this.environment.hot.send({ type: 'full-reload', path: '*' })

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -195,6 +195,20 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   private _buildStartPromise: Promise<void> | undefined
   private _closed = false
 
+  /** @internal Used when another plugin container owns `buildStart`. */
+  setBuildStartPromise(buildStartPromise: Promise<void>): void {
+    this._started = true
+    this._buildStartPromise = buildStartPromise
+    buildStartPromise.then(
+      () => {
+        if (this._buildStartPromise === buildStartPromise) {
+          this._buildStartPromise = undefined
+        }
+      },
+      () => {},
+    )
+  }
+
   /**
    * @internal use `createEnvironmentPluginContainer` instead
    */
@@ -371,6 +385,8 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   ): Promise<PartialResolvedId | null> {
     if (!this._started) {
       this.buildStart()
+    }
+    if (this._buildStartPromise) {
       await this._buildStartPromise
     }
     const skip = options?.skip

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -1,6 +1,14 @@
 import { setTimeout } from 'node:timers/promises'
 import { expect, test, onTestFinished } from 'vitest'
-import { addFile, editFile, isBuild, page, readFile, serverLogs } from '~utils'
+import {
+  addFile,
+  editFile,
+  isBuild,
+  page,
+  readFile,
+  serverLogs,
+  viteServer,
+} from '~utils'
 
 const assetUrl = /asset-[\w-]+\.png/
 
@@ -13,6 +21,8 @@ if (isBuild) {
 } else {
   // INITIAL -> BUNDLING -> BUNDLED
   test('show bundling in progress', async () => {
+    const resolvePromise =
+      viteServer.environments.client.pluginContainer.resolveId('/main.js')
     const reloadPromise = page.waitForEvent('load')
     await expect
       .poll(() => page.textContent('body'))
@@ -25,6 +35,11 @@ if (isBuild) {
       .poll(() => page.textContent('.worker-query'))
       .toBe('worker-query')
     await expect.poll(() => page.textContent('.worker-url')).toBe('worker-url')
+    await resolvePromise
+    const count = await page.evaluate(() =>
+      fetch('/__build-start-count').then((response) => response.text()),
+    )
+    expect(count).toBe('1')
   })
 
   // BUNDLED -> GENERATE_HMR_PATCH -> BUNDLING -> BUNDLE_ERROR -> BUNDLING -> BUNDLED

--- a/playground/hmr-full-bundle-mode/vite.config.ts
+++ b/playground/hmr-full-bundle-mode/vite.config.ts
@@ -8,8 +8,37 @@ export default defineConfig({
     // emit assets as files instead of inlining, for the new-asset HMR test
     assetsInlineLimit: 0,
   },
-  plugins: [waitBundleCompleteUntilAccess(), delayTransformComment()],
+  plugins: [
+    waitBundleCompleteUntilAccess(),
+    delayTransformComment(),
+    countClientBuildStarts(),
+  ],
 })
+
+function countClientBuildStarts(): Plugin {
+  let clientEnvironment: object | undefined
+  let count = 0
+
+  return {
+    name: 'count-client-build-starts',
+    buildStart() {
+      if (this.environment === clientEnvironment) {
+        count++
+      }
+    },
+    configureServer(server) {
+      clientEnvironment = server.environments.client
+      server.middlewares.use((req, res, next) => {
+        if (req.url !== '/__build-start-count') {
+          next()
+          return
+        }
+
+        res.end(String(count))
+      })
+    },
+  }
+}
 
 function waitBundleCompleteUntilAccess(): Plugin {
   let resolvers: PromiseWithResolvers<void>


### PR DESCRIPTION
In bundled dev, Rolldown owns the client plugin lifecycle and already calls `buildStart` while creating the bundle.

Vite’s regular client plugin container was not marked as started. A later resolve, transform, or module graph lookup would therefore call `buildStart` on the same plugins again.

This change marks that container as started and associates it with the initial bundle promise. Normal Vite resolves wait for the bundle to finish instead of starting another plugin lifecycle.

This does not make `buildStart` run only once for the lifetime of the dev server. Rolldown still calls it for actual bundle generations and rebuilds.

The regression test keeps the initial bundled-dev build open, resolves a module through the regular client plugin container, and verifies that the client plugin receives one `buildStart` call.

fixes #22968