### PR TITLE
fix(optimizer): resolve excluded deps from importer (fix #21088)

### DIFF
--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -227,6 +227,20 @@ export function rolldownDepPlugin(
           const kind = options.kind
 
           if (moduleListContains(external, id)) {
+            // resolve the excluded dep from its importer and keep the resolved
+            // path in the bundle, so that the import works even when the dep
+            // is not hoisted to the root node_modules (#21088). A bare id kept
+            // in the bundle would be resolved from node_modules/.vite/deps at
+            // serve time and only works for hoisted layouts.
+            if (importer) {
+              const resolved = await resolve(id, importer, kind)
+              if (resolved && path.isAbsolute(resolved)) {
+                return {
+                  id: resolved,
+                  external: 'absolute',
+                }
+              }
+            }
             return {
               id: id,
               external: 'absolute',
@@ -409,10 +423,8 @@ export function rolldownCjsExternalPlugin(
             id: cjsExternalFacadeNamespace + id,
           }
         }
-        return {
-          id,
-          external: 'absolute',
-        }
+        // fall through to vite:dep-pre-bundle which resolves the excluded
+        // dep from its importer (#21088)
       },
     },
     load: {

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -210,6 +210,12 @@ test('import optimize-excluded package that imports optimized-included package',
     .toBe('nested-include')
 })
 
+test('optimized dep importing non-hoisted excluded dep, from a shared chunk', async () => {
+  await expect
+    .poll(() => page.textContent('.excluded-not-hoisted'))
+    .toBe('*A* *B*')
+})
+
 test('import aliased package with colon', async () => {
   await expect.poll(() => page.textContent('.url')).toBe('vite.dev')
 })

--- a/playground/optimize-deps/dep-importing-excluded/index.js
+++ b/playground/optimize-deps/dep-importing-excluded/index.js
@@ -1,0 +1,2 @@
+import { wrap } from './util.js'
+export const msgA = wrap('A')

--- a/playground/optimize-deps/dep-importing-excluded/package.json
+++ b/playground/optimize-deps/dep-importing-excluded/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vitejs/test-dep-importing-excluded",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./second": "./second.js"
+  },
+  "dependencies": {
+    "@vitejs/test-excluded-not-hoisted": "file:../excluded-not-hoisted"
+  }
+}

--- a/playground/optimize-deps/dep-importing-excluded/second.js
+++ b/playground/optimize-deps/dep-importing-excluded/second.js
@@ -1,0 +1,2 @@
+import { wrap } from './util.js'
+export const msgB = wrap('B')

--- a/playground/optimize-deps/dep-importing-excluded/util.js
+++ b/playground/optimize-deps/dep-importing-excluded/util.js
@@ -1,0 +1,2 @@
+import { tag } from '@vitejs/test-excluded-not-hoisted'
+export const wrap = tag

--- a/playground/optimize-deps/excluded-not-hoisted/index.js
+++ b/playground/optimize-deps/excluded-not-hoisted/index.js
@@ -1,0 +1,1 @@
+export const tag = (s) => '*' + s + '*'

--- a/playground/optimize-deps/excluded-not-hoisted/package.json
+++ b/playground/optimize-deps/excluded-not-hoisted/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-excluded-not-hoisted",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -108,6 +108,9 @@
 <h2>Nested include</h2>
 <div>Module path: <span class="nested-include"></span></div>
 
+<h2>Excluded dep resolved from importer</h2>
+<div>Should show *A* *B*: <span class="excluded-not-hoisted"></span></div>
+
 <h2>Alias with colon</h2>
 <div>URL: <span class="url"></span></div>
 
@@ -217,6 +220,10 @@
 
   import { nestedInclude } from '@vitejs/test-nested-exclude'
   text('.nested-include', nestedInclude)
+
+  import { msgA } from '@vitejs/test-dep-importing-excluded'
+  import { msgB } from '@vitejs/test-dep-importing-excluded/second'
+  text('.excluded-not-hoisted', msgA + ' ' + msgB)
 
   import { parse } from 'node:url'
   text('.url', parse('https://vite.dev').hostname)

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -51,6 +51,7 @@
     "@vitejs/test-dep-lodash.clonedeep": "file:./dep-lodash-clonedeep",
     "@vitejs/test-dep-lodash-es": "file:./dep-lodash-es",
     "@vitejs/test-nested-exclude": "file:./nested-exclude",
+    "@vitejs/test-dep-importing-excluded": "file:./dep-importing-excluded",
     "phoenix": "^1.8.9",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
     ],
     exclude: [
       '@vitejs/test-nested-exclude',
+      '@vitejs/test-excluded-not-hoisted',
       '@vitejs/test-dep-non-optimized',
       '@vitejs/test-dep-esm-external',
       'stream',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,9 @@ importers:
       '@vitejs/test-dep-esbuild-plugin-transform':
         specifier: file:./dep-esbuild-plugin-transform
         version: file:playground/optimize-deps/dep-esbuild-plugin-transform
+      '@vitejs/test-dep-importing-excluded':
+        specifier: file:./dep-importing-excluded
+        version: file:playground/optimize-deps/dep-importing-excluded
       '@vitejs/test-dep-incompatible':
         specifier: file:./dep-incompatible
         version: file:playground/optimize-deps/dep-incompatible
@@ -1265,6 +1268,12 @@ importers:
 
   playground/optimize-deps/dep-esm-external: {}
 
+  playground/optimize-deps/dep-importing-excluded:
+    dependencies:
+      '@vitejs/test-excluded-not-hoisted':
+        specifier: file:../excluded-not-hoisted
+        version: file:playground/optimize-deps/excluded-not-hoisted
+
   playground/optimize-deps/dep-incompatible: {}
 
   playground/optimize-deps/dep-linked:
@@ -1324,6 +1333,8 @@ importers:
   playground/optimize-deps/dep-with-optional-peer-dep-submodule: {}
 
   playground/optimize-deps/dep-with-plus-subpath: {}
+
+  playground/optimize-deps/excluded-not-hoisted: {}
 
   playground/optimize-deps/longfilename: {}
 
@@ -4549,6 +4560,9 @@ packages:
   '@vitejs/test-dep-esm-external@file:playground/optimize-deps/dep-esm-external':
     resolution: {directory: playground/optimize-deps/dep-esm-external, type: directory}
 
+  '@vitejs/test-dep-importing-excluded@file:playground/optimize-deps/dep-importing-excluded':
+    resolution: {directory: playground/optimize-deps/dep-importing-excluded, type: directory}
+
   '@vitejs/test-dep-including-a@file:playground/preload/dep-including-a':
     resolution: {directory: playground/preload/dep-including-a, type: directory}
 
@@ -4665,6 +4679,9 @@ packages:
 
   '@vitejs/test-entries@file:playground/ssr-resolve/entries':
     resolution: {directory: playground/ssr-resolve/entries, type: directory}
+
+  '@vitejs/test-excluded-not-hoisted@file:playground/optimize-deps/excluded-not-hoisted':
+    resolution: {directory: playground/optimize-deps/excluded-not-hoisted, type: directory}
 
   '@vitejs/test-external-cjs@file:playground/ssr-noexternal/external-cjs':
     resolution: {directory: playground/ssr-noexternal/external-cjs, type: directory}
@@ -10731,6 +10748,10 @@ snapshots:
 
   '@vitejs/test-dep-esm-external@file:playground/optimize-deps/dep-esm-external': {}
 
+  '@vitejs/test-dep-importing-excluded@file:playground/optimize-deps/dep-importing-excluded':
+    dependencies:
+      '@vitejs/test-excluded-not-hoisted': file:playground/optimize-deps/excluded-not-hoisted
+
   '@vitejs/test-dep-including-a@file:playground/preload/dep-including-a':
     dependencies:
       '@vitejs/test-dep-a': file:playground/preload/dep-a
@@ -10816,6 +10837,8 @@ snapshots:
   '@vitejs/test-dep-with-plus-subpath@file:playground/optimize-deps/dep-with-plus-subpath': {}
 
   '@vitejs/test-entries@file:playground/ssr-resolve/entries': {}
+
+  '@vitejs/test-excluded-not-hoisted@file:playground/optimize-deps/excluded-not-hoisted': {}
 
   '@vitejs/test-external-cjs@file:playground/ssr-noexternal/external-cjs': {}
 


### PR DESCRIPTION
### Description

When a pre-bundled dependency imports a dependency listed in `optimizeDeps.exclude`, the optimizer keeps the excluded dep as a bare specifier in the output chunk. At serve time that bare specifier gets resolved with the chunk (`node_modules/.vite/deps/...`) as the importer, so on non-hoisted layouts like pnpm's, where the excluded dep only exists inside the importing package's own node_modules, the import fails with "Failed to resolve import ... Does the file exist?" (#21088).

There is already a serve-time remap for this in `importAnalysis.ts` (`normalizeUrl`, the loop that swaps the importer for the optimized module's original `src`), but it explicitly skips chunks (`if (!optimizedModule.src) continue`). So the bug only bites when the excluded import lives in a code-split shared chunk. That also explains the "weird thing" @brillout noticed in the issue thread: importing `@brillout/picocolors` from client-only or server-only files worked (entry chunks, remap applies), while the import in `utils/assert.ts` shared by both entries broke (shared chunk, remap skipped).

This PR fixes it at the source instead: in `rolldownDepPlugin`, an excluded dep is now resolved from its actual importer at pre-bundle time, and the resolved absolute path is what gets externalized into the chunk. Absolute paths are importer-independent, so entry chunks and shared chunks behave the same and the serve-time resolution can't pick the wrong base anymore. When resolution does not produce an absolute path (no importer, optional peer dep markers, browser-external markers, builtins like the excluded `stream` in the playground, or an uninstalled dep), it falls back to the current bare-id behavior, so those cases are unchanged. The plain-import branch in `rolldownCjsExternalPlugin` now defers to `vite:dep-pre-bundle` for the same reason; the `require()` facade path is untouched.

Two behavior notes to be transparent about:
- An excluded dep with duplicated nested copies now resolves per importer (Node semantics) instead of always deduping to the root copy. `resolve.dedupe` remains the escape hatch for singleton packages.
- A CJS `require()` of an excluded dep in browser platform still goes through the facade with a bare id, so the non-hoisted case there is not covered by this PR. The reported bug (ESM imports) is.

### Testing

Added a regression test in `playground/optimize-deps`: `@vitejs/test-dep-importing-excluded` has two entries sharing a util that imports `@vitejs/test-excluded-not-hoisted` (declared `file:../excluded-not-hoisted`, so pnpm keeps it non-hoisted). Without the fix, the shared chunk 500s in serve mode and the spec fails (along with a cascade of others, since the page dies). With the fix, serve and build modes pass. Also verified end to end against the built package with a standalone repro mirroring the issue layout. Ran `pnpm run build`, `test-serve optimize-deps`, `test-build optimize-deps`, `lint` and `typecheck` locally, all green.

fixes #21088

---

small disclosure: college freshman here, contributing for the greater good and learning a ton :) Claude Code and I dug through this one together (it traced the shared-chunk gap in the importAnalysis remap and we shaped the fix and the playground test from there, all gates run locally by me). if anything looks off I'd honestly love the feedback.
