### PR TITLE
docs(config): rewrite VS Code debugging section

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -127,19 +127,3 @@ export default defineConfig(({ mode }) => {
   }
 })
 ```
-
-## Debugging the Config File on VS Code
-
-With the default `--configLoader bundle` behavior, Vite writes the generated temporary configuration file to the `node_modules/.vite-temp` folder and a file not found error will occur when setting breakpoint debugging in the Vite config file. To fix the issue, add the following configuration to `.vscode/settings.json`:
-
-```json
-{
-  "debug.javascript.terminalOptions": {
-    "resolveSourceMapLocations": [
-      "${workspaceFolder}/**",
-      "!**/node_modules/**",
-      "**/node_modules/.vite-temp/**"
-    ]
-  }
-}
-```

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -127,3 +127,48 @@ export default defineConfig(({ mode }) => {
   }
 })
 ```
+
+## Debugging the Config File in VS Code
+
+For the most reliable debugging experience, use the native config loader when starting Vite:
+
+```bash
+vite --configLoader native
+```
+
+The native loader executes the original config file directly, so breakpoints in the config file and in plugin hooks such as `transform` map to the original source. It requires a runtime that supports the syntax used by your config file, such as Node.js 22.18+ for TypeScript files.
+
+When using the default `--configLoader bundle`, Vite generates an inline source map and writes the bundled config to `node_modules/.vite-temp` before loading it. If you need to use the bundled loader, add the temporary directory to the source map locations used by the VS Code JavaScript Debug Terminal:
+
+```json
+{
+  "debug.javascript.terminalOptions": {
+    "resolveSourceMapLocations": [
+      "${workspaceFolder}/**",
+      "!**/node_modules/**",
+      "**/node_modules/.vite-temp/**"
+    ]
+  }
+}
+```
+
+This setting only allows the debugger to look for source maps in `.vite-temp`; it does not replace the native loader and may not make breakpoints resolve in every VS Code launch configuration.
+
+If you start Vite from the Run and Debug view instead of a JavaScript Debug Terminal, put `resolveSourceMapLocations` in the launch configuration:
+
+```json
+{
+  "type": "node",
+  "request": "launch",
+  "name": "Vite",
+  "runtimeExecutable": "pnpm",
+  "runtimeArgs": ["exec", "vite", "--configLoader", "bundle"],
+  "console": "integratedTerminal",
+  "sourceMaps": true,
+  "resolveSourceMapLocations": [
+    "${workspaceFolder}/**",
+    "!**/node_modules/**",
+    "**/node_modules/.vite-temp/**"
+  ]
+}
+```

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -138,7 +138,7 @@ vite --configLoader native
 
 The native loader executes the original config file directly, so breakpoints in the config file and in plugin hooks such as `transform` map to the original source. It requires a runtime that supports the syntax used by your config file, such as Node.js 22.18+ for TypeScript files.
 
-When using `--configLoader bundle` (the current default, though `native` is planned to become the default in a future major version), Vite generates an inline source map and writes the bundled config to `node_modules/.vite-temp` before loading it. If you need to use the bundled loader, add the temporary directory to the source map locations used by the VS Code JavaScript Debug Terminal:
+When using `--configLoader bundle` (the current default, though `native` is planned to become the default in a future major version), Vite generates an inline source map and writes the bundled config to `node_modules/.vite-temp` before loading it. If you need to use the bundle loader, add the temporary directory for the JavaScript Debug Terminal in `.vscode/settings.json`:
 
 ```json
 {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -162,7 +162,7 @@ This setting only applies to the JavaScript Debug Terminal, it does not affect l
       "type": "node",
       "request": "launch",
       "name": "Vite",
-      "runtimeExecutable": "pnpm",
+      "runtimeExecutable": "npm",
       "runtimeArgs": ["exec", "vite", "--configLoader", "bundle"],
       "console": "integratedTerminal",
       "sourceMaps": true,

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -152,9 +152,7 @@ When using `--configLoader bundle` (the current default, though `native` is plan
 }
 ```
 
-This setting only applies to the JavaScript Debug Terminal; it does not affect launch configurations started from the Run and Debug view.
-
-If you start Vite from the Run and Debug view instead of a JavaScript Debug Terminal, put `resolveSourceMapLocations` in the launch configuration:
+This setting only applies to the JavaScript Debug Terminal, it does not affect launch configurations started from the Run and Debug view. To support this for the Run and Debug view, add the temporary directory in `.vscode/launch.json`:
 
 ```json
 {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -138,7 +138,7 @@ vite --configLoader native
 
 The native loader executes the original config file directly, so breakpoints in the config file and in plugin hooks such as `transform` map to the original source. It requires a runtime that supports the syntax used by your config file, such as Node.js 22.18+ for TypeScript files.
 
-When using the default `--configLoader bundle`, Vite generates an inline source map and writes the bundled config to `node_modules/.vite-temp` before loading it. If you need to use the bundled loader, add the temporary directory to the source map locations used by the VS Code JavaScript Debug Terminal:
+When using `--configLoader bundle` (the current default, though `native` is planned to become the default in a future major version), Vite generates an inline source map and writes the bundled config to `node_modules/.vite-temp` before loading it. If you need to use the bundled loader, add the temporary directory to the source map locations used by the VS Code JavaScript Debug Terminal:
 
 ```json
 {
@@ -152,23 +152,28 @@ When using the default `--configLoader bundle`, Vite generates an inline source 
 }
 ```
 
-This setting only allows the debugger to look for source maps in `.vite-temp`; it does not replace the native loader and may not make breakpoints resolve in every VS Code launch configuration.
+This setting only applies to the JavaScript Debug Terminal; it does not affect launch configurations started from the Run and Debug view.
 
 If you start Vite from the Run and Debug view instead of a JavaScript Debug Terminal, put `resolveSourceMapLocations` in the launch configuration:
 
 ```json
 {
-  "type": "node",
-  "request": "launch",
-  "name": "Vite",
-  "runtimeExecutable": "pnpm",
-  "runtimeArgs": ["exec", "vite", "--configLoader", "bundle"],
-  "console": "integratedTerminal",
-  "sourceMaps": true,
-  "resolveSourceMapLocations": [
-    "${workspaceFolder}/**",
-    "!**/node_modules/**",
-    "**/node_modules/.vite-temp/**"
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Vite",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["exec", "vite", "--configLoader", "bundle"],
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**",
+        "**/node_modules/.vite-temp/**"
+      ]
+    }
   ]
 }
 ```


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
~~The section about configuring source map locations for debugging the Vite config file in VS Code is no longer needed and has been removed.~~

Updated the description section for debugging plugins in VS Code.