### PR TITLE
docs: balance inline code x-height

### DIFF
--- a/docs/.vitepress/theme/styles.css
+++ b/docs/.vitepress/theme/styles.css
@@ -16,3 +16,8 @@
 :root[data-theme='light'][data-variant='vite'] {
   --color-brand: #6b1eb9;
 }
+
+/* Balance KH Teka Mono's x-height with the surrounding body text. */
+.vp-doc :not(pre, h1, h2, h3, h4, h5, h6) > code {
+  font-size-adjust: 0.52;
+}


### PR DESCRIPTION
### Description

Fixes #22975.

Inline code uses KH Teka Mono at `0.875em`, which makes it appear smaller and lighter than the surrounding KH Teka body text. This adds a narrowly scoped `font-size-adjust: 0.52` so inline code has a more balanced perceived x-height without changing code blocks or heading code.

The value is based on browser font metrics: KH Teka has an x-height ratio of approximately `0.449`, while KH Teka Mono is approximately `0.504`. Accounting for the existing `0.875em` inline code size gives `0.449 / 0.875 ≈ 0.513`; `0.52` provides the closest practical visual match with only a small width change.

### Visual comparison

![Before and after comparison of inline code x-height](https://raw.githubusercontent.com/cxa/vite/e93bc31fa160afb71115c37c48ef07abb349ad56/pr-assets/vite-inline-code-comparison-052.png)

### Alternatives considered

- Increasing `--vp-code-font-size` would also resize code blocks and line numbers.
- Setting `font-weight: 500` changes weight but does not correct the perceived character size.
- Larger `font-size-adjust` values (`0.54`–`0.58`) overemphasized inline code and changed paragraph wrapping.

### Testing

- `pnpm exec oxfmt --check docs/.vitepress/theme/styles.css`
- `pnpm build`
- `pnpm docs-build`
- Compared the Getting Started paragraph before and after in Chromium at 2x device scale.

### Checklist

- Read the contributing guidelines.
- Checked open issues and PRs for duplicates.
- No separate documentation update is needed; this change only affects documentation presentation.
- A unit test is not included because this is a CSS font-metric adjustment; the full documentation build and visual comparison cover the affected path.




