### PR TITLE
fix(config): exclude virtual modules from native config compat check

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1780,9 +1780,21 @@ describe('loadConfigFromFile', () => {
     })
 
     test('does not warn for a .mts config under a type: commonjs package', async () => {
-      expect(
-        await loadWithWarnings('mts-config', 'vite.config.mts'),
-      ).toHaveLength(0)
+      // The native config compat check resolves the format of rolldown's
+      // internal virtual module (`\0rolldown/runtime.js`) against the nearest
+      // package.json, which falls back to the process cwd. Run from the
+      // commonjs fixture root so the test does not depend on where the test
+      // runner was started.
+      const root = path.resolve(compatRoot, 'mts-config')
+      const originalCwd = process.cwd()
+      process.chdir(root)
+      try {
+        expect(
+          await loadWithWarnings('mts-config', 'vite.config.mts'),
+        ).toHaveLength(0)
+      } finally {
+        process.chdir(originalCwd)
+      }
     })
   })
 

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1778,24 +1778,6 @@ describe('loadConfigFromFile', () => {
         ]
       `)
     })
-
-    test('does not warn for a .mts config under a type: commonjs package', async () => {
-      // The native config compat check resolves the format of rolldown's
-      // internal virtual module (`\0rolldown/runtime.js`) against the nearest
-      // package.json, which falls back to the process cwd. Run from the
-      // commonjs fixture root so the test does not depend on where the test
-      // runner was started.
-      const root = path.resolve(compatRoot, 'mts-config')
-      const originalCwd = process.cwd()
-      process.chdir(root)
-      try {
-        expect(
-          await loadWithWarnings('mts-config', 'vite.config.mts'),
-        ).toHaveLength(0)
-      } finally {
-        process.chdir(originalCwd)
-      }
-    })
   })
 
   describe('load default files', () => {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1778,6 +1778,12 @@ describe('loadConfigFromFile', () => {
         ]
       `)
     })
+
+    test('does not warn for a .mts config under a type: commonjs package', async () => {
+      expect(
+        await loadWithWarnings('mts-config', 'vite.config.mts'),
+      ).toHaveLength(0)
+    })
   })
 
   describe('load default files', () => {

--- a/packages/vite/src/node/__tests__/fixtures/config/native-compat/mts-config/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/config/native-compat/mts-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vitejs/test-native-compat-mts",
+  "type": "commonjs",
+  "private": true
+}

--- a/packages/vite/src/node/__tests__/fixtures/config/native-compat/mts-config/vite.config.mts
+++ b/packages/vite/src/node/__tests__/fixtures/config/native-compat/mts-config/vite.config.mts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({})

--- a/packages/vite/src/node/nativeConfigCompat.ts
+++ b/packages/vite/src/node/nativeConfigCompat.ts
@@ -218,7 +218,11 @@ export function createNativeConfigCompatPlugin(
     name: 'vite:native-config-compat-check',
     transform: {
       filter: {
-        id: { include: /\.[cm]?[jt]sx?$/, exclude: /^\0/ },
+        id: {
+          include: /\.[cm]?[jt]sx?$/,
+          // exclude rolldown runtime
+          exclude: /^\0/,
+        },
       },
       async handler(code, id) {
         const isESM =

--- a/packages/vite/src/node/nativeConfigCompat.ts
+++ b/packages/vite/src/node/nativeConfigCompat.ts
@@ -218,7 +218,7 @@ export function createNativeConfigCompatPlugin(
     name: 'vite:native-config-compat-check',
     transform: {
       filter: {
-        id: /\.[cm]?[jt]sx?$/,
+        id: { include: /\.[cm]?[jt]sx?$/, exclude: /^\0/ },
       },
       async handler(code, id) {
         const isESM =

--- a/packages/vite/src/node/nativeConfigCompat.ts
+++ b/packages/vite/src/node/nativeConfigCompat.ts
@@ -217,7 +217,9 @@ export function createNativeConfigCompatPlugin(
   return {
     name: 'vite:native-config-compat-check',
     transform: {
-      filter: { id: /\.[cm]?[jt]sx?$/ },
+      filter: {
+        id: { include: /\.[cm]?[jt]sx?$/, exclude: /^\0/ },
+      },
       async handler(code, id) {
         const isESM =
           typeof process.versions.deno === 'string' || isFilePathESM(id)

--- a/packages/vite/src/node/nativeConfigCompat.ts
+++ b/packages/vite/src/node/nativeConfigCompat.ts
@@ -218,7 +218,7 @@ export function createNativeConfigCompatPlugin(
     name: 'vite:native-config-compat-check',
     transform: {
       filter: {
-        id: { include: /\.[cm]?[jt]sx?$/, exclude: /^\0/ },
+        id: /\.[cm]?[jt]sx?$/,
       },
       async handler(code, id) {
         const isESM =

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -430,6 +430,13 @@ export function isFilePathESM(
     return true
   } else if (/\.c[jt]s$/.test(filePath)) {
     return false
+  } else if (filePath.startsWith('\0')) {
+    // treat virtual modules as ESM
+    return true
+  } else if (!path.isAbsolute(filePath)) {
+    // should not rely on `process.cwd()` as that would depend on
+    // the environment and make it unreproducible
+    return false
   } else {
     // check package.json for type: "module"
     try {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -460,6 +460,15 @@ export function isFilePathFormatExplicit(
   if (/\.[mc][jt]s$/.test(filePath)) {
     return true
   }
+  if (filePath.startsWith('\0')) {
+    // treat virtual modules as ESM
+    return true
+  }
+  if (!path.isAbsolute(filePath)) {
+    // should not rely on `process.cwd()` as that would depend on
+    // the environment and make it unreproducible
+    return false
+  }
   try {
     const pkg = findNearestPackageData(path.dirname(filePath), packageCache)
     return pkg?.data.type === 'module' || pkg?.data.type === 'commonjs'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/config/native-compat/esm-in-commonjs-pkg: {}
 
+  packages/vite/src/node/__tests__/fixtures/config/native-compat/mts-config: {}
+
   packages/vite/src/node/__tests__/fixtures/config/native-import: {}
 
   packages/vite/src/node/__tests__/fixtures/config/plugin-module-condition: {}


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

The `createNativeConfigCompatPlugin` transform filter matched all modules ending with a JS/TS extension, including Rolldown's internal virtual module `\0rolldown/runtime.js`. Since `isFilePathESM` could not identify this virtual module as ESM, it was incorrectly flagged as CJS containing ESM syntax, producing a false-positive `esm-syntax-in-cjs` warning when bundling `.mts` config files.

Refer to #22850

The code modified in this PR may conflict with #22964. After merging one, the other may need to have the conflict resolved.