### PR TITLE
docs(static-deploy): update outdated Cloudflare and Render links

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -213,7 +213,7 @@ Cloudflare Pages gives you a way to deploy directly to Cloudflare without having
 
 After your project has been imported and deployed, all subsequent pushes to branches will generate [Preview Deployments](https://developers.cloudflare.com/pages/platform/preview-deployments/) unless specified not to in your [branch build controls](https://developers.cloudflare.com/pages/platform/branch-build-controls/). All changes to the Production Branch (commonly "main") will result in a Production Deployment.
 
-You can also add custom domains and handle custom build settings on Pages. Learn more about [Cloudflare Pages Git Integration](https://developers.cloudflare.com/pages/get-started/#manage-your-site).
+You can also add custom domains and handle custom build settings on Pages. Learn more about [Cloudflare Pages Git Integration](https://developers.cloudflare.com/pages/configuration/git-integration/).
 
 ## Google Firebase
 
@@ -288,7 +288,7 @@ You can deploy your Vite app as a Static Site on [Render](https://render.com/).
 
 5. Click **Create Static Site**. Your app should be deployed at `https://<PROJECTNAME>.onrender.com/`.
 
-By default, any new commit pushed to the specified branch will automatically trigger a new deployment. [Auto-Deploy](https://render.com/docs/deploys#toggling-auto-deploy-for-a-service) can be configured in the project settings.
+By default, any new commit pushed to the specified branch will automatically trigger a new deployment. [Auto-Deploy](https://render.com/docs/deploys#configuring-auto-deploys) can be configured in the project settings.
 
 You can also add a [custom domain](https://render.com/docs/custom-domains) to your project.
 


### PR DESCRIPTION
In guide/static-deploy.md, the Cloudflare and Render documentation links contain outdated anchors. The #manage-your-site anchor in the Cloudflare link no longer exists and therefore cannot navigate readers to the Git integration information described in the text, so the link should be updated to https://developers.cloudflare.com/pages/configuration/git-integration/. Similarly, the #toggling-auto-deploy-for-a-service anchor in the Render link has been removed and should be replaced with the current #configuring-auto-deploys anchor, resulting in https://render.com/docs/deploys#configuring-auto-deploys