### PR TITLE
fix(hmr): preserve environment snapshot during server restart

### DIFF
--- a/packages/vite/src/node/server/__tests__/hmr.spec.ts
+++ b/packages/vite/src/node/server/__tests__/hmr.spec.ts
@@ -1,0 +1,42 @@
+import path from 'node:path'
+import { expect, onTestFinished, test } from 'vitest'
+import type { DevEnvironment } from '../environment'
+import { handleHMRUpdate } from '../hmr'
+import { createServer } from '../index'
+
+test('uses the environment snapshot when the server restarts during HMR', async () => {
+  let hookCalls = 0
+  const server = await createServer({
+    configFile: false,
+    root: import.meta.dirname,
+    logLevel: 'silent',
+    server: {
+      middlewareMode: true,
+      ws: false,
+    },
+    plugins: [
+      {
+        name: 'restart-during-hot-update',
+        async hotUpdate() {
+          if (hookCalls++ === 0) {
+            server.environments.client = {} as DevEnvironment
+            throw new Error('hot update interrupted by restart')
+          }
+        },
+      },
+    ],
+  })
+  const clientEnvironment = server.environments.client
+  onTestFinished(async () => {
+    server.environments.client = clientEnvironment
+    await server.close()
+  })
+
+  await expect(
+    handleHMRUpdate(
+      'update',
+      path.join(import.meta.dirname, 'fixture.js'),
+      server,
+    ),
+  ).resolves.toBeUndefined()
+})

--- a/packages/vite/src/node/server/__tests__/hmr.spec.ts
+++ b/packages/vite/src/node/server/__tests__/hmr.spec.ts
@@ -1,10 +1,9 @@
 import path from 'node:path'
 import { expect, onTestFinished, test } from 'vitest'
-import type { DevEnvironment } from '../environment'
 import { handleHMRUpdate } from '../hmr'
-import { createServer } from '../index'
+import { type ServerOptions, createServer } from '../index'
 
-test('uses the environment snapshot when the server restarts during HMR', async () => {
+async function testRestartDuringHotUpdate(serverOptions: ServerOptions = {}) {
   let hookCalls = 0
   const server = await createServer({
     configFile: false,
@@ -13,22 +12,21 @@ test('uses the environment snapshot when the server restarts during HMR', async 
     server: {
       middlewareMode: true,
       ws: false,
+      ...serverOptions,
     },
     plugins: [
       {
         name: 'restart-during-hot-update',
         async hotUpdate() {
           if (hookCalls++ === 0) {
-            server.environments.client = {} as DevEnvironment
+            await server.restart()
             throw new Error('hot update interrupted by restart')
           }
         },
       },
     ],
   })
-  const clientEnvironment = server.environments.client
   onTestFinished(async () => {
-    server.environments.client = clientEnvironment
     await server.close()
   })
 
@@ -39,4 +37,19 @@ test('uses the environment snapshot when the server restarts during HMR', async 
       server,
     ),
   ).resolves.toBeUndefined()
+}
+
+test('cancels HMR when the server restarts during a hot update', async () => {
+  await testRestartDuringHotUpdate()
+})
+
+test('does not schedule stale HMR with a custom environment handler', async () => {
+  let hotUpdateEnvironmentsCalls = 0
+  await testRestartDuringHotUpdate({
+    async hotUpdateEnvironments(server, hmr) {
+      hotUpdateEnvironmentsCalls++
+      await Promise.all(Object.values(server.environments).map(hmr))
+    },
+  })
+  expect(hotUpdateEnvironmentsCalls).toBe(0)
 })

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -416,7 +416,11 @@ export async function handleHMRUpdate(
   const { config } = server
   const mixedModuleGraph = ignoreDeprecationWarnings(() => server.moduleGraph)
 
-  const environments = Object.values(server.environments)
+  const environmentSnapshot = server.environments
+  const environments = Object.values(environmentSnapshot)
+  // A plugin hook may restart the server, replacing the environments and
+  // invalidating this HMR transaction.
+  const isStale = () => server.environments !== environmentSnapshot
   const shortFile = getShortName(file, config.root)
 
   const isConfig = file === config.configFile
@@ -509,14 +513,13 @@ export async function handleHMRUpdate(
   const clientHotUpdateOptions = hotMap.get(clientEnvironment)!.options
   const ssrHotUpdateOptions = hotMap.get(ssrEnvironment)?.options
   try {
-    for (const plugin of getSortedHotUpdatePlugins(
-      server.environments.client,
-    )) {
+    for (const plugin of getSortedHotUpdatePlugins(clientEnvironment)) {
       if (plugin.hotUpdate) {
         const filteredModules = await getHookHandler(plugin.hotUpdate).call(
           clientContext,
           clientHotUpdateOptions,
         )
+        if (isStale()) return
         if (filteredModules) {
           clientHotUpdateOptions.modules = filteredModules
           // Invalidate the hmrContext to force compat modules to be updated
@@ -552,6 +555,7 @@ export async function handleHMRUpdate(
         const filteredModules = await getHookHandler(
           plugin.handleHotUpdate!,
         ).call(contextForHandleHotUpdate, mixedHmrContext)
+        if (isStale()) return
         if (filteredModules) {
           mixedHmrContext.modules = filteredModules
           clientHotUpdateOptions.modules =
@@ -590,6 +594,7 @@ export async function handleHMRUpdate(
       }
     }
   } catch (error) {
+    if (isStale()) return
     hotMap.get(clientEnvironment)!.error = error
   }
 
@@ -604,17 +609,20 @@ export async function handleHMRUpdate(
             context,
             hot.options,
           )
+          if (isStale()) return
           if (filteredModules) {
             hot.options.modules = filteredModules
           }
         }
       }
     } catch (error) {
+      if (isStale()) return
       hot.error = error
     }
   }
 
   async function hmr(environment: DevEnvironment) {
+    if (isStale()) return
     try {
       const { options, error } = hotMap.get(environment)!
       if (error) {
@@ -654,11 +662,17 @@ export async function handleHMRUpdate(
     }
   }
 
+  if (isStale()) return
+
   const hotUpdateEnvironments =
     server.config.server.hotUpdateEnvironments ??
-    ((_server, hmr) => {
+    ((server, hmr) => {
       // Run HMR in parallel for all environments by default
-      return Promise.all(environments.map((environment) => hmr(environment)))
+      return Promise.all(
+        Object.values(server.environments).map((environment) =>
+          hmr(environment),
+        ),
+      )
     })
 
   await hotUpdateEnvironments(server, hmr)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -590,7 +590,7 @@ export async function handleHMRUpdate(
       }
     }
   } catch (error) {
-    hotMap.get(server.environments.client)!.error = error
+    hotMap.get(clientEnvironment)!.error = error
   }
 
   for (const environment of environments) {
@@ -656,13 +656,9 @@ export async function handleHMRUpdate(
 
   const hotUpdateEnvironments =
     server.config.server.hotUpdateEnvironments ??
-    ((server, hmr) => {
+    ((_server, hmr) => {
       // Run HMR in parallel for all environments by default
-      return Promise.all(
-        Object.values(server.environments).map((environment) =>
-          hmr(environment),
-        ),
-      )
+      return Promise.all(environments.map((environment) => hmr(environment)))
     })
 
   await hotUpdateEnvironments(server, hmr)


### PR DESCRIPTION
## Description

Fixes a race condition between an in-flight HMR update and a dev server restart.

When a config dependency or `.env` file changes, Vite may restart the server while another file update is still being processed. The HMR handler creates its `hotMap` from the environment instances available at the beginning of the update. However, after an awaited plugin hook, it previously accessed `server.environments.client` and later enumerated `server.environments` again.

If the server restarted in between, those properties referred to newly created environment instances that were not present in the original `hotMap`. This could cause Vite to crash while handling the original error:

```text
TypeError: Cannot set properties of undefined (setting error)
    at handleHMRUpdate
```

This PR keeps the environments used throughout the default HMR flow consistent with the snapshot captured at the beginning of `handleHMRUpdate`.

Specifically, it:

- records client hook errors against the captured client environment
- dispatches the default HMR update using the captured environment list
- adds a regression test that replaces the client environment during an async HMR hook

This prevents a concurrent server restart from mixing old and new environment instances and allows the original HMR error to be reported normally.

## Tests

- `pnpm exec vitest run packages/vite/src/node/server/__tests__/hmr.spec.ts`
- `pnpm exec eslint packages/vite/src/node/server/hmr.ts packages/vite/src/node/server/__tests__/hmr.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/server/hmr.ts packages/vite/src/node/server/__tests__/hmr.spec.ts`