### PR TITLE
perf(config): skip native config compat check when warning is ignored

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2485,10 +2485,7 @@ async function bundleAndLoadConfigFile(
     isESM,
   )
 
-  if (
-    bundled.nativeIncompatibilities.length > 0 &&
-    !process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING
-  ) {
+  if (bundled.nativeIncompatibilities.length > 0) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
       formatNativeConfigIncompatWarning(
@@ -2548,7 +2545,8 @@ async function bundleConfigFile(
     // this also aligns with other config loader behaviors
     tsconfig: false,
     plugins: [
-      createNativeConfigCompatPlugin(nativeIncompatibilities),
+      !process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING &&
+        createNativeConfigCompatPlugin(nativeIncompatibilities),
       {
         name: 'externalize-deps',
         resolveId: {


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
When VITE_CONFIG_NATIVE_IGNORE_WARNING is set, the native config compat plugin no longer runs the analysis and then suppresses the warning at output time. This avoids the parse overhead when the result would be discarded anyway.