### PR TITLE
fix(hmr): remove hot data after prune

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -187,7 +187,9 @@ if (import.meta.hot) {
 
 ## `hot.data`
 
-The `import.meta.hot.data` object is persisted across different instances of the same updated module. It can be used to pass on information from a previous version of the module to the next one.
+Vite creates one `import.meta.hot.data` object for each module path. The object is persisted across successive instances of the same module during HMR. Mutations made during module execution or through the `data` argument passed to `hot.dispose` are visible to the next instance of the module.
+
+When a module is pruned, its `hot.dispose` and `hot.prune` callbacks receive the current data object. Vite clears the data after those callbacks complete. If the module is imported again later, it receives a new empty data object.
 
 Note that re-assignment of `data` itself is not supported. Instead, you should mutate properties of the `data` object so information added from other handlers are preserved.
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -214,20 +214,24 @@ export class HMRClient {
   // but they may have left behind side effects that need to be cleaned up
   // (e.g. style injections)
   public async prunePaths(paths: string[]): Promise<void> {
-    await Promise.all(
-      paths.map((path) => {
-        const disposer = this.disposeMap.get(path)
-        if (disposer) return disposer(this.dataMap.get(path))
-      }),
-    )
-    await Promise.all(
-      paths.map((path) => {
-        const fn = this.pruneMap.get(path)
-        if (fn) {
-          return fn(this.dataMap.get(path))
-        }
-      }),
-    )
+    try {
+      await Promise.all(
+        paths.map((path) => {
+          const disposer = this.disposeMap.get(path)
+          if (disposer) return disposer(this.dataMap.get(path))
+        }),
+      )
+      await Promise.all(
+        paths.map((path) => {
+          const fn = this.pruneMap.get(path)
+          if (fn) {
+            return fn(this.dataMap.get(path))
+          }
+        }),
+      )
+    } finally {
+      paths.forEach((path) => this.dataMap.delete(path))
+    }
   }
 
   protected warnFailedUpdate(err: Error, path: string | string[]): void {

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -115,6 +115,38 @@ describe.skipIf(isBuild)('hmr works correctly', () => {
     await expect.poll(() => el()).toMatch('3')
   })
 
+  test('hot data persists across module instances', async () => {
+    await untilConsoleLogAfter(
+      () =>
+        editFile('hotData.js', (code) =>
+          code.replace('const value = 1', 'const value = 2 '),
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(hot data) value from execution: 1',
+        '(hot data) value from dispose: 1',
+        updated('/hotData.js'),
+        '>>> vite:afterUpdate -- update',
+      ],
+      true,
+    )
+
+    await untilConsoleLogAfter(
+      () =>
+        editFile('hotData.js', (code) =>
+          code.replace('const value = 2', 'const value = 3  '),
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(hot data) value from execution: 2',
+        '(hot data) value from dispose: 2',
+        updated('/hotData.js'),
+        '>>> vite:afterUpdate -- update',
+      ],
+      true,
+    )
+  })
+
   test('accept dep', async () => {
     const el = () => hmr('.dep')
     await untilConsoleLogAfter(
@@ -789,13 +821,15 @@ test('should hmr when file is deleted and restored', async () => {
     .toMatch('parent:not-child')
 
   // restore the file
-  addFile(childFile, originalChildFileCode)
-  editFile(parentFile, (code) =>
-    code.replace(
-      "export const childValue = 'not-child'",
-      "export { value as childValue } from './child'",
-    ),
-  )
+  await untilConsoleLogAfter(() => {
+    addFile(childFile, originalChildFileCode)
+    editFile(parentFile, (code) =>
+      code.replace(
+        "export const childValue = 'not-child'",
+        "export { value as childValue } from './child'",
+      ),
+    )
+  }, 'file-delete-restore/child.js hot data after prune: undefined')
   await expect.poll(() => hmr('.file-delete-restore')).toMatch('parent:child')
 })
 

--- a/playground/hmr-ssr/file-delete-restore/child.js
+++ b/playground/hmr-ssr/file-delete-restore/child.js
@@ -3,6 +3,14 @@ import { rerender } from './runtime'
 export const value = 'child'
 
 if (import.meta.hot) {
+  if (globalThis.__vite_file_delete_restore_child_pruned) {
+    log(
+      `file-delete-restore/child.js hot data after prune: ${import.meta.hot.data.persisted}`,
+    )
+    delete globalThis.__vite_file_delete_restore_child_pruned
+  }
+  import.meta.hot.data.persisted = true
+
   import.meta.hot.accept((newMod) => {
     if (!newMod) return
 
@@ -15,5 +23,6 @@ if (import.meta.hot) {
 
   import.meta.hot.prune(() => {
     log('file-delete-restore/child.js is pruned')
+    globalThis.__vite_file_delete_restore_child_pruned = true
   })
 }

--- a/playground/hmr-ssr/hmr.ts
+++ b/playground/hmr-ssr/hmr.ts
@@ -1,5 +1,6 @@
 import { virtual } from 'virtual:file'
 import { foo as depFoo, nestedFoo } from './hmrDep'
+import './hotData'
 import './importing-updated'
 import './invalidation-circular-deps'
 import './invalidation/parent'

--- a/playground/hmr-ssr/hotData.js
+++ b/playground/hmr-ssr/hotData.js
@@ -1,0 +1,15 @@
+export const value = 1
+
+if (import.meta.hot) {
+  const data = import.meta.hot.data
+  if ('fromExecution' in data) {
+    log(`(hot data) value from execution: ${data.fromExecution}`)
+    log(`(hot data) value from dispose: ${data.fromDispose}`)
+  }
+  data.fromExecution = value
+
+  import.meta.hot.dispose((data) => {
+    data.fromDispose = value
+  })
+  import.meta.hot.accept()
+}

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -86,6 +86,38 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toMatch('3')
   })
 
+  test('hot data persists across module instances', async () => {
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hotData.js', (code) =>
+          code.replace('const value = 1', 'const value = 2 '),
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(hot data) value from execution: 1',
+        '(hot data) value from dispose: 1',
+        '[vite] hot updated: /hotData.js',
+        '>>> vite:afterUpdate -- update',
+      ],
+      true,
+    )
+
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hotData.js', (code) =>
+          code.replace('const value = 2', 'const value = 3  '),
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(hot data) value from execution: 2',
+        '(hot data) value from dispose: 2',
+        '[vite] hot updated: /hotData.js',
+        '>>> vite:afterUpdate -- update',
+      ],
+      true,
+    )
+  })
+
   test('accept dep', async () => {
     const el = await page.$('.dep')
     await untilBrowserLogAfter(
@@ -1022,13 +1054,15 @@ if (!isBuild) {
       .toMatch('parent:not-child')
 
     // restore the file
-    addFile(childFile, originalChildFileCode)
-    editFile(parentFile, (code) =>
-      code.replace(
-        "export const childValue = 'not-child'",
-        "export { value as childValue } from './child'",
-      ),
-    )
+    await untilBrowserLogAfter(() => {
+      addFile(childFile, originalChildFileCode)
+      editFile(parentFile, (code) =>
+        code.replace(
+          "export const childValue = 'not-child'",
+          "export { value as childValue } from './child'",
+        ),
+      )
+    }, 'file-delete-restore/child.js hot data after prune: undefined')
     await expect
       .poll(() => page.textContent('.file-delete-restore'))
       .toMatch('parent:child')

--- a/playground/hmr/file-delete-restore/child.js
+++ b/playground/hmr/file-delete-restore/child.js
@@ -3,6 +3,14 @@ import { rerender } from './runtime'
 export const value = 'child'
 
 if (import.meta.hot) {
+  if (globalThis.__vite_file_delete_restore_child_pruned) {
+    console.log(
+      `file-delete-restore/child.js hot data after prune: ${import.meta.hot.data.persisted}`,
+    )
+    delete globalThis.__vite_file_delete_restore_child_pruned
+  }
+  import.meta.hot.data.persisted = true
+
   import.meta.hot.accept((newMod) => {
     if (!newMod) return
 
@@ -15,5 +23,6 @@ if (import.meta.hot) {
 
   import.meta.hot.prune(() => {
     console.log('file-delete-restore/child.js is pruned')
+    globalThis.__vite_file_delete_restore_child_pruned = true
   })
 }

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -1,6 +1,7 @@
 import { virtual } from 'virtual:file'
 import { virtual as virtualDep } from 'virtual:file-dep'
 import { foo as depFoo, nestedFoo } from './hmrDep'
+import './hotData'
 import './importing-updated'
 import './invalidation-circular-deps'
 import './file-delete-restore'

--- a/playground/hmr/hotData.js
+++ b/playground/hmr/hotData.js
@@ -1,0 +1,15 @@
+export const value = 1
+
+if (import.meta.hot) {
+  const data = import.meta.hot.data
+  if ('fromExecution' in data) {
+    console.log(`(hot data) value from execution: ${data.fromExecution}`)
+    console.log(`(hot data) value from dispose: ${data.fromDispose}`)
+  }
+  data.fromExecution = value
+
+  import.meta.hot.dispose((data) => {
+    data.fromDispose = value
+  })
+  import.meta.hot.accept()
+}


### PR DESCRIPTION
The hot data was not removed after prune, but I think the expected behavior is to remove it so that the re-import receives a new hot data object.

refs #23001
