### PR TITLE
fix(bundled-dev): preserve import.meta.hot.data across HMR updates

### DIFF
--- a/packages/vite/src/client/bundledDevHmrClient.ts
+++ b/packages/vite/src/client/bundledDevHmrClient.ts
@@ -162,12 +162,10 @@ export class BundledDevHMRClient extends HMRClient {
   }
 
   handleModuleCacheRemoval(id: string): void {
-    const data = {}
     const disposer = this.disposeMap.get(id)
     if (disposer) {
-      disposer(data)
+      disposer(this.dataMap.get(id))
     }
-    this.dataMap.set(id, data)
   }
 
   private async applyPush({

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -224,6 +224,25 @@ if (isBuild) {
     await expect.poll(() => page.textContent('.dynamic')).toBe('loaded')
   })
 
+  // placed before `invalidate` on purpose: that test's cleanup restores
+  // invalidation-child.js, whose `hot.invalidate()` propagates to a parent
+  // without a shipped factory and forces a full page reload — which would
+  // wipe the `hot.data` this test relies on.
+  test('preserves import.meta.hot.data across updates', async () => {
+    await expect.poll(() => page.textContent('.data-count')).toBe('1')
+    await expect.poll(() => page.textContent('.data-disposed')).toBe('0')
+
+    editFile('data.js', (code) => code.replace('// @hmr-bump', '// @hmr-bump1'))
+    await expect.poll(() => page.textContent('.data-count')).toBe('2')
+    await expect.poll(() => page.textContent('.data-disposed')).toBe('1')
+
+    editFile('data.js', (code) =>
+      code.replace('// @hmr-bump1', '// @hmr-bump12'),
+    )
+    await expect.poll(() => page.textContent('.data-count')).toBe('3')
+    await expect.poll(() => page.textContent('.data-disposed')).toBe('2')
+  })
+
   test('invalidate', async () => {
     const original = readFile('invalidation-child.js')
     onTestFinished(() => addFile('invalidation-child.js', original))

--- a/playground/hmr-full-bundle-mode/data.js
+++ b/playground/hmr-full-bundle-mode/data.js
@@ -1,0 +1,23 @@
+// verifies `import.meta.hot.data` persists across HMR updates (#23001)
+const data = import.meta.hot?.data ?? {}
+
+// direct mutation: must survive each update, so `count` keeps climbing
+data.count = (data.count ?? 0) + 1
+text('.data-count', data.count)
+
+// written by the dispose callback below: proves the disposer is handed the
+// *existing* data object rather than a freshly allocated one
+text('.data-disposed', data.disposed ?? 0)
+
+if (import.meta.hot) {
+  import.meta.hot.dispose((prev) => {
+    prev.disposed = (prev.disposed ?? 0) + 1
+  })
+  import.meta.hot.accept()
+}
+
+// @hmr-bump
+
+function text(el, value) {
+  document.querySelector(el).textContent = String(value)
+}

--- a/playground/hmr-full-bundle-mode/index.html
+++ b/playground/hmr-full-bundle-mode/index.html
@@ -10,6 +10,8 @@
 <div class="worker-plain"></div>
 <div class="dead-accept"></div>
 <div class="cycle"></div>
+<div class="data-count"></div>
+<div class="data-disposed"></div>
 <div>
   <button id="load-dynamic">Load dynamic</button>
   <div class="dynamic"></div>

--- a/playground/hmr-full-bundle-mode/main.js
+++ b/playground/hmr-full-bundle-mode/main.js
@@ -3,6 +3,7 @@ import './hmr-asset.js'
 import './invalidation-parent.js'
 import './dead-accept.js'
 import './cycle-a.js'
+import './data.js'
 import assetUrl from './asset.png'
 import WorkerQuery from './worker-query.js?worker'
 


### PR DESCRIPTION
## Description

Closes #23001.

In bundled-dev mode, `BundledDevHMRClient.handleModuleCacheRemoval` allocated a **fresh** object, handed it to the dispose callback, and overwrote the module's `dataMap` entry on every update:

```ts
handleModuleCacheRemoval(id: string): void {
  const data = {}
  const disposer = this.disposeMap.get(id)
  if (disposer) {
    disposer(data)
  }
  this.dataMap.set(id, data)
}
```

This dropped any direct mutation of `import.meta.hot.data` on every update and never showed the disposer the previous object — the inverse of Vite's [documented contract](https://vite.dev/guide/api-hmr#hot-data):

> The `import.meta.hot.data` object is persisted across different instances of the same updated module.

### Fix

Pass the **existing** `dataMap` entry to the disposer and leave it in place, so a re-executed module reuses the same object via the `HMRContext` constructor (`if (!dataMap.has(ownerPath)) dataMap.set(ownerPath, {})`). This mirrors the shared HMR client exactly ([`shared/hmr.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/shared/hmr.ts#L282-L284)):

```ts
handleModuleCacheRemoval(id: string): void {
  const disposer = this.disposeMap.get(id)
  if (disposer) {
    disposer(this.dataMap.get(id))
  }
}
```

### Test

Adds a `data.js` module to the `hmr-full-bundle-mode` playground that increments `hot.data.count` on each execution and a `disposed` counter inside its `dispose()` callback, plus a spec asserting both persist across successive updates (`1/0 → 2/1 → 3/2`). This covers both required behaviors: direct-mutation persistence and the disposer receiving the *existing* object.

The test is intentionally ordered before the `invalidate` test — that test's cleanup restores `invalidation-child.js`, whose `hot.invalidate()` propagates to a parent without a shipped factory and forces a full page reload that would otherwise wipe this test's `hot.data`.

`pnpm test-serve hmr-full-bundle-mode` passes.

> [!NOTE]
> Targets the `renovate/rolldown-related-dependencies` branch (rolldown 1.2.0 + client-side HMR #22883), since that branch carries the renamed `BundledDevHMRClient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)