### PR TITLE
docs: remove `@experimental` from `resolve.tsconfigPaths` JSDoc

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -112,7 +112,6 @@ export interface ResolveOptions extends EnvironmentResolveOptions {
    * Enable tsconfig paths resolution
    *
    * @default false
-   * @experimental
    */
   tsconfigPaths?: boolean
 }


### PR DESCRIPTION
This was experimental in rolldown-vite, but when vite v8 was announced it wasn't marked as experimental. I think it's stable enough now, and cannot change it anyways, so I've removed the `@experimental` in the JSDoc.

close #23004

