### PR TITLE
test: config CJS module vars in ESM case

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1508,6 +1508,17 @@ describe('loadConfigFromFile', () => {
       `)
   })
 
+  test('cjs module vars are supported in esm', async () => {
+    const { config } = (await loadConfigFromFile(
+      {} as any,
+      path.resolve(fixtures, './cjs-module-vars-in-esm/vite.config.ts'),
+      path.resolve(fixtures, './cjs-module-vars-in-esm'),
+    ))!
+    const c = config as any
+    expect(c.dirname).toContain('cjs-module-vars-in-esm')
+    expect(c.filename).toContain('vite.config.ts')
+  })
+
   test('import.meta properties are supported', async () => {
     const { config } = (await loadConfigFromFile(
       {} as any,

--- a/packages/vite/src/node/__tests__/fixtures/config/cjs-module-vars-in-esm/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/config/cjs-module-vars-in-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/vite/src/node/__tests__/fixtures/config/cjs-module-vars-in-esm/vite.config.ts
+++ b/packages/vite/src/node/__tests__/fixtures/config/cjs-module-vars-in-esm/vite.config.ts
@@ -1,0 +1,4 @@
+export default {
+  dirname: __dirname,
+  filename: __filename,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/cjs-ssr-dep: {}
 
+  packages/vite/src/node/__tests__/fixtures/config/cjs-module-vars-in-esm: {}
+
   packages/vite/src/node/__tests__/fixtures/config/entry:
     dependencies:
       '@vite/test-config-plugin-module-condition':


### PR DESCRIPTION
Adds the test that covers the feature that was covered by the test removed in https://github.com/vitejs/vite-plugin-vue/pull/821