### PR TITLE
feat(create-vite): add .editorconfig config to all templates

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -36,6 +36,7 @@ const createNonEmptyDir = (overrideFolder?: string) => {
 const fileNameMap: Record<string, string> = {
   _gitignore: '.gitignore',
   '_oxlintrc.json': '.oxlintrc.json',
+  _editorconfig: '.editorconfig',
 }
 
 // Vue 3 starter template

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -394,6 +394,7 @@ const TEMPLATES = FRAMEWORKS.map((f) => f.variants.map((v) => v.name)).reduce(
 const renameFiles: Record<string, string | undefined> = {
   _gitignore: '.gitignore',
   '_oxlintrc.json': '.oxlintrc.json',
+  _editorconfig: '.editorconfig',
 }
 
 const defaultTargetDir = 'vite-project'

--- a/packages/create-vite/template-lit-ts/_editorconfig
+++ b/packages/create-vite/template-lit-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-lit-ts/_editorconfig
+++ b/packages/create-vite/template-lit-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-lit/_editorconfig
+++ b/packages/create-vite/template-lit/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-lit/_editorconfig
+++ b/packages/create-vite/template-lit/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-preact-ts/_editorconfig
+++ b/packages/create-vite/template-preact-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-preact-ts/_editorconfig
+++ b/packages/create-vite/template-preact-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-preact/_editorconfig
+++ b/packages/create-vite/template-preact/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-preact/_editorconfig
+++ b/packages/create-vite/template-preact/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-qwik-ts/_editorconfig
+++ b/packages/create-vite/template-qwik-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-qwik-ts/_editorconfig
+++ b/packages/create-vite/template-qwik-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-qwik/_editorconfig
+++ b/packages/create-vite/template-qwik/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-qwik/_editorconfig
+++ b/packages/create-vite/template-qwik/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-react-ts/_editorconfig
+++ b/packages/create-vite/template-react-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-react-ts/_editorconfig
+++ b/packages/create-vite/template-react-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-react/_editorconfig
+++ b/packages/create-vite/template-react/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-react/_editorconfig
+++ b/packages/create-vite/template-react/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-solid-ts/_editorconfig
+++ b/packages/create-vite/template-solid-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-solid-ts/_editorconfig
+++ b/packages/create-vite/template-solid-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-solid/_editorconfig
+++ b/packages/create-vite/template-solid/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-solid/_editorconfig
+++ b/packages/create-vite/template-solid/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-svelte-ts/_editorconfig
+++ b/packages/create-vite/template-svelte-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-svelte-ts/_editorconfig
+++ b/packages/create-vite/template-svelte-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-svelte/_editorconfig
+++ b/packages/create-vite/template-svelte/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-svelte/_editorconfig
+++ b/packages/create-vite/template-svelte/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-vanilla-ts/_editorconfig
+++ b/packages/create-vite/template-vanilla-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-vanilla-ts/_editorconfig
+++ b/packages/create-vite/template-vanilla-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-vanilla/_editorconfig
+++ b/packages/create-vite/template-vanilla/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-vanilla/_editorconfig
+++ b/packages/create-vite/template-vanilla/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-vue-ts/_editorconfig
+++ b/packages/create-vite/template-vue-ts/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-vue-ts/_editorconfig
+++ b/packages/create-vite/template-vue-ts/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-vite/template-vue/_editorconfig
+++ b/packages/create-vite/template-vue/_editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/create-vite/template-vue/_editorconfig
+++ b/packages/create-vite/template-vue/_editorconfig
@@ -7,3 +7,9 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
`.editorconfig` is widely supported configuration for indention size, print width, etc. Without this file, VS Code may treat new js/ts files with 4 space indent, which is different from the templates (2 spaces).