### PR TITLE
docs: fix stale v6.3.1 playground links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,14 +183,14 @@ Note: The test build environment uses a [different default set of Vite config](h
 
 ### Extending the Test Suite
 
-To add new tests, you should find a related playground to the fix or feature (or create a new one). As an example, static assets loading is tested in the [assets playground](https://github.com/vitejs/vite/tree/main/playground/assets). In this Vite app, there is a test for `?raw` imports with [a section defined in the `index.html` for it](https://github.com/vitejs/vite/blob/v6.3.1/playground/assets/index.html#L266-L267):
+To add new tests, you should find a related playground to the fix or feature (or create a new one). As an example, static assets loading is tested in the [assets playground](https://github.com/vitejs/vite/tree/main/playground/assets). In this Vite app, there is a test for `?raw` imports with [a section defined in the `index.html` for it](https://github.com/vitejs/vite/blob/main/playground/assets/index.html#L270-L271):
 
 ```html
 <h2>?raw import</h2>
 <code class="raw"></code>
 ```
 
-This will be modified [with the result of a file import](https://github.com/vitejs/vite/blob/v6.3.1/playground/assets/index.html#L543-L544):
+This will be modified [with the result of a file import](https://github.com/vitejs/vite/blob/main/playground/assets/index.html#L557-L558):
 
 ```js
 import rawSvg from './nested/fragment.svg?raw'
@@ -205,7 +205,7 @@ function text(el, text) {
 }
 ```
 
-In the [spec tests](https://github.com/vitejs/vite/blob/v6.3.1/playground/assets/__tests__/assets.spec.ts#L469-L471), the modifications to the DOM listed above are used to test this feature:
+In the [spec tests](https://github.com/vitejs/vite/blob/main/playground/assets/__tests__/assets.spec.ts#L483-L485), the modifications to the DOM listed above are used to test this feature:
 
 ```js
 test('?raw import', async () => {


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

## Summary

The "Extending the Test Suite" section in `CONTRIBUTING.md` still links three playground examples to the old `v6.3.1` tag. Sibling links in the same section already use `main`. Current repo tip is on the Vite 8 line, and the cited line numbers no longer match `main`.

Updated all three links to `blob/main/...` with corrected line anchors verified against current `playground/assets/index.html` and `assets.spec.ts`:

- `index.html` `?raw` section: `#L266-L267` → `#L270-L271`
- `index.html` import block: `#L543-L544` → `#L557-L558`
- `assets.spec.ts` test: `#L469-L471` → `#L483-L485`

No tests included — docs-only link correction. Related prior work (#22084) refreshed other Vite 8 version mentions in CONTRIBUTING but missed these three playground deep-links.


Made with [Cursor](https://cursor.com)