### PR TITLE
fix(legacy): don't use newer syntax when minifying legacy chunks

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -538,6 +538,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           minify: resolveLegacyOutputMinify(
             config.build.minify,
             supportsLegacyOxcMinification,
+            // Don't use newer syntax for legacy chunks
+            'es2015',
           ),
         }
       }

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -123,6 +123,17 @@ describe.runIf(isBuild)('build', () => {
     expect(findAssetFile(/polyfills-legacy/)).toMatch(terserPattern)
   })
 
+  test('should not use newer syntax when minifying legacy chunks', () => {
+    // The playground targets IE 11, so babel lowers the legacy chunks to ES5.
+    // The minifier must not reintroduce syntax newer than its `es2015` compress
+    // target: `try {} catch (e) {}` must not be collapsed to `try {} catch {}`
+    // (ES2019) and optional chaining (ES2020) must not appear.
+    const mainLegacyChunk = findAssetFile(/chunk-main-legacy/)
+    expect(mainLegacyChunk).toMatch(/catch\s*\(/)
+    expect(mainLegacyChunk).not.toMatch(/catch\s*\{/)
+    expect(mainLegacyChunk).not.toMatch(/\w\?\.\w/)
+  })
+
   test('should emit css file', async () => {
     expect(
       listAssets().some((filename) => filename.endsWith('.css')),


### PR DESCRIPTION
fixes https://github.com/vitejs/vite/issues/23016

Legacy chunks are lowered by babel according to `targets`, but their output `minify` option was resolved without a compress target (`minify: true`), so the minifier inherited the modern compress target from `transform.target` and re-introduced newer syntax into the legacy chunks — e.g. `try {} catch (e) {}` collapsed to `try {} catch {}` (ES2019) — breaking exactly the browsers that run the legacy bundle. This passes `'es2015'` for the legacy chunk outputs, the same way #22939 did for the legacy polyfill chunks.

Includes a build test asserting the legacy main chunk keeps `catch (` and contains no optional catch binding / optional chaining; it fails without this change.
