### PR TITLE
fix(server): serve custom HTML input correctly with bundledDev (#23007)

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -58,6 +58,10 @@ export class MemoryFiles {
   clear(): void {
     this.files.clear()
   }
+
+  keys(): IterableIterator<string> {
+    return this.files.keys()
+  }
 }
 
 export class BundledDev {

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -65,6 +65,14 @@ export function htmlFallbackMiddleware(
         debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`)
         req.url = newUrl
         return next()
+      } else if (memoryFiles && !memoryFiles.has('index.html')) {
+        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) => f.endsWith('.html'))
+        if (htmlFiles.length === 1) {
+          const newUrl = url + htmlFiles[0]
+          debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`)
+          req.url = newUrl
+          return next()
+        }
       }
     }
     // non-trailing slash should check for fallback .html
@@ -78,8 +86,15 @@ export function htmlFallbackMiddleware(
     }
 
     if (spaFallback) {
-      debug?.(`Rewriting ${req.method} ${req.url} to /index.html`)
-      req.url = '/index.html'
+      let fallbackUrl = '/index.html'
+      if (memoryFiles && !memoryFiles.has('index.html')) {
+        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) => f.endsWith('.html'))
+        if (htmlFiles.length === 1) {
+          fallbackUrl = '/' + htmlFiles[0]
+        }
+      }
+      debug?.(`Rewriting ${req.method} ${req.url} to ${fallbackUrl}`)
+      req.url = fallbackUrl
     }
 
     next()

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -66,7 +66,9 @@ export function htmlFallbackMiddleware(
         req.url = newUrl
         return next()
       } else if (memoryFiles && !memoryFiles.has('index.html')) {
-        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) => f.endsWith('.html'))
+        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) =>
+          f.endsWith('.html'),
+        )
         if (htmlFiles.length === 1) {
           const newUrl = url + htmlFiles[0]
           debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`)
@@ -88,7 +90,9 @@ export function htmlFallbackMiddleware(
     if (spaFallback) {
       let fallbackUrl = '/index.html'
       if (memoryFiles && !memoryFiles.has('index.html')) {
-        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) => f.endsWith('.html'))
+        const htmlFiles = Array.from(memoryFiles.keys()).filter((f) =>
+          f.endsWith('.html'),
+        )
         if (htmlFiles.length === 1) {
           fallbackUrl = '/' + htmlFiles[0]
         }


### PR DESCRIPTION
Fixes #23007

### Description
When `experimental.bundledDev` is enabled alongside a custom HTML input (via `build.rolldownOptions.input`), the dev server previously returned a `404 Not Found` when accessing the root (`/`) or when falling back via the SPA router. This happens because the fallback middleware strictly looks up `index.html` in `memoryFiles`, and since the custom input generates a different HTML file (e.g. `index-export.html`), it fails to resolve.

This PR implements **Fallback Mapping** to ensure parity with standard dev behavior:
- Exposes `memoryFiles.keys()` from `BundledDev` to allow introspection.
- Updates `htmlFallbackMiddleware`: when `index.html` is absent in memory but exactly one `.html` file is found, it automatically rewrites both the root `/` and SPA fallbacks to this single HTML entry.

### Validation
Verified manually that a custom input `main: './index-export.html'` now successfully loads at `http://localhost:5173/` instead of 404ing.
