### PR TITLE
fix(create-vite): ignore --eslint for non-React templates instead of crashing

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -227,6 +227,23 @@ test('scaffolds React template with ESLint when --eslint is passed', () => {
   expect(pkg).toContain('"lint": "eslint ."')
 })
 
+test('ignores --eslint with a warning for non-React templates', () => {
+  const { stdout, stderr } = run(
+    [projectName, '--template', 'vue', '--eslint'],
+    {
+      cwd: import.meta.dirname,
+    },
+  )
+  expect(stdout).toContain(
+    '`--eslint` is only supported for React templates and will be ignored',
+  )
+  expect(stderr).not.toContain('ENOENT')
+
+  const generatedFiles = fs.readdirSync(genPath).sort()
+  expect(templateFiles).toEqual(generatedFiles)
+  expect(fs.existsSync(path.join(genPath, 'eslint.config.js'))).toBe(false)
+})
+
 test('works with the -t alias', () => {
   const { stdout } = run(
     [

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -630,6 +630,12 @@ async function init() {
   // 5. Ask whether to use ESLint instead of Oxlint (React templates only)
   const isReactTemplate = template === 'react' || template === 'react-ts'
   let eslint = argEslint
+  if (!isReactTemplate && eslint) {
+    prompts.log.warn(
+      '`--eslint` is only supported for React templates and will be ignored',
+    )
+    eslint = false
+  }
   if (isReactTemplate && eslint === undefined) {
     if (interactive) {
       const eslintResult = await prompts.select({


### PR DESCRIPTION
fixes https://github.com/vitejs/vite/issues/23017

`--eslint` is documented as React-only, but only the interactive prompt was gated on React templates: passing the flag explicitly with any other template still ran `setupEslint`, which crashes on `fs.rmSync('.oxlintrc.json')` (only the React templates ship that file), leaving a half-scaffolded project while still exiting with code 0. The flag is now resolved per its documented semantics — for non-React templates it is ignored with a warning. This also covers the `react-compiler` templates, which don't ship `.oxlintrc.json` either.

Includes a CLI test: `vue` + `--eslint` prints the warning, scaffolds the full template, and emits no error; it fails without this change.
