### PR TITLE
fix(html): don't inline stylesheet links as data urls (fix #16372)

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -167,6 +167,8 @@ const noInlineLinkRels = new Set([
   'apple-touch-icon',
   'apple-touch-startup-image',
   'manifest',
+  // relative urls inside the stylesheet cannot be resolved against a data URL (#16372)
+  'stylesheet',
 ])
 
 export const isAsyncScriptMap: WeakMap<

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -271,6 +271,20 @@ describe('link with props', () => {
     await page.goto(viteTestUrl + '/link-props/index.html')
     expect(await getColor('h1')).toBe('red')
   })
+
+  test.runIf(isBuild)(
+    'stylesheet links are not inlined as data urls',
+    async () => {
+      await page.goto(viteTestUrl + '/link-props/index.html')
+      const hrefs = await page.$$eval('link[rel=stylesheet]', (els) =>
+        els.map((el) => el.getAttribute('href')),
+      )
+      expect(hrefs.length).toBe(2)
+      for (const href of hrefs) {
+        expect(href).not.toMatch(/^data:/)
+      }
+    },
+  )
 })
 
 describe.runIf(isServe)('SPA fallback', () => {


### PR DESCRIPTION
### Description

A `<link rel="stylesheet">` with a `media` or `disabled` attribute is not converted to a CSS import (#6748) and instead goes through the generic asset pipeline. When the stylesheet is smaller than `build.assetsInlineLimit`, it gets inlined as a base64 data URL. Relative `url()` references inside the stylesheet then break, because a data URL provides no base to resolve them against, as reported in #16372.

Since inlining a stylesheet is never safe for this reason, this adds `stylesheet` to the existing `noInlineLinkRels` set so such links are always emitted as files. This is the same rationale that already applies to `manifest` in that set.

Note that relative `url()` references inside these stylesheets are still not rewritten or emitted by the build (the file is copied as-is), which also affects stylesheets above the inline limit today. Routing these links through the CSS pipeline while preserving the tag is a larger change related to #17322, so this PR only fixes the data URL inlining.