### PR TITLE
chore(playground): include legacy dir in tsconfig for type checking

### DIFF
--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/vite*config*", "**/*.ts"],
-  "exclude": ["**/dist/**", "./legacy/**", "./resolve-tsconfig-paths/**"],
+  "exclude": ["**/dist/**", "./resolve-tsconfig-paths/**"],
   "compilerOptions": {
     "checkJs": true,
     "target": "es2023",


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
Excluding `./legacy/**` will result in the following error in VS Code.

<img width="1466" height="484" alt="image" src="https://github.com/user-attachments/assets/aa418ff7-48af-4eef-81ec-27adcc0767b9" />
