### PR TITLE
fix(glob): support multiple fallback paths in resolve.tsconfigPaths

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { isAbsolute, posix } from 'node:path'
 import picomatch from 'picomatch'
 import { stripLiteral } from 'strip-literal'
@@ -345,11 +346,11 @@ export async function parseImportGlob(
       )
     }
 
-    const globsResolved = await Promise.all(
+    const globsResolved = (await Promise.all(
       globs.map((glob) =>
         toAbsoluteGlob(glob, root, importer, resolveId, options.base),
       ),
-    )
+    )).flat()
     const isRelative = globs.every((i) => '.!'.includes(i[0]))
     const sliceCode = cleanCode.slice(0, start)
     const onlyKeys = objectKeysRE.test(sliceCode)
@@ -647,7 +648,7 @@ export async function toAbsoluteGlob(
   importer: string | undefined,
   resolveId: IdResolver,
   base?: string,
-): Promise<string> {
+): Promise<string[]> {
   let pre = ''
   if (glob[0] === '!') {
     pre = '!'
@@ -668,12 +669,35 @@ export async function toAbsoluteGlob(
     dir = importer ? globSafePath(dirname(importer)) : root
   }
 
-  if (glob[0] === '/') return pre + posix.join(root, glob.slice(1))
-  if (glob.startsWith('./')) return pre + posix.join(dir, glob.slice(2))
-  if (glob.startsWith('../')) return pre + posix.join(dir, glob)
-  if (glob.startsWith('**')) return pre + glob
+  if (glob[0] === '/') return [pre + posix.join(root, glob.slice(1))]
+  if (glob.startsWith('./')) return [pre + posix.join(dir, glob.slice(2))]
+  if (glob.startsWith('../')) return [pre + posix.join(dir, glob)]
+  if (glob.startsWith('**')) return [pre + glob]
 
   const isSubImportsPattern = glob[0] === '#' && glob.includes('*')
+
+  const resolvedGlobs: string[] = []
+  if (!isSubImportsPattern && importer) {
+    const tsconfigResult = loadTsconfigPaths(importer)
+    if (tsconfigResult) {
+      const expanded = expandTsconfigPaths(glob, tsconfigResult.paths)
+      if (expanded.length > 1) {
+        for (const exp of expanded) {
+          let absoluteExp = exp
+          if (exp.startsWith('.')) {
+             absoluteExp = posix.join(tsconfigResult.dir, exp)
+          }
+          const resolved = normalizePath(
+            (await resolveId(absoluteExp, importer, { custom: { 'vite:import-glob': { isSubImportsPattern } } })) || absoluteExp
+          )
+          if (isAbsolute(resolved)) {
+            resolvedGlobs.push(pre + globSafeResolvedPath(resolved, absoluteExp))
+          }
+        }
+        if (resolvedGlobs.length > 0) return resolvedGlobs
+      }
+    }
+  }
 
   const resolved = normalizePath(
     (await resolveId(glob, importer, {
@@ -681,7 +705,7 @@ export async function toAbsoluteGlob(
     })) || glob,
   )
   if (isAbsolute(resolved)) {
-    return pre + globSafeResolvedPath(resolved, glob)
+    return [pre + globSafeResolvedPath(resolved, glob)]
   }
 
   throw new Error(
@@ -722,4 +746,47 @@ export function getCommonBase(globsResolved: string[]): null | string {
 export function isVirtualModule(id: string): boolean {
   // https://vite.dev/guide/api-plugin.html#virtual-modules-convention
   return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
+}
+
+function loadTsconfigPaths(importer: string): { dir: string, paths: Record<string, string[]> } | null {
+  let dir = posix.dirname(importer)
+  const root = posix.parse(dir).root
+  while (dir !== root) {
+    const tsconfigPath = posix.join(dir, 'tsconfig.json')
+    if (fs.existsSync(tsconfigPath)) {
+      try {
+        const content = fs.readFileSync(tsconfigPath, 'utf-8')
+        const stripped = content.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '')
+        const parsed = JSON.parse(stripped)
+        if (parsed.compilerOptions?.paths) {
+          return { dir, paths: parsed.compilerOptions.paths }
+        }
+        return null
+      } catch (e) {
+        return null
+      }
+    }
+    dir = posix.dirname(dir)
+  }
+  return null
+}
+
+function expandTsconfigPaths(glob: string, paths: Record<string, string[]>): string[] {
+  for (const [key, values] of Object.entries(paths)) {
+    if (key.endsWith('/*')) {
+      const prefix = key.slice(0, -2)
+      if (glob.startsWith(prefix + '/')) {
+        const suffix = glob.slice(prefix.length + 1)
+        return values.map(val => {
+          if (val.endsWith('/*')) {
+            return val.slice(0, -2) + '/' + suffix
+          }
+          return val
+        })
+      }
+    } else if (key === glob) {
+      return values
+    }
+  }
+  return [glob]
 }

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -762,7 +762,7 @@ function loadTsconfigPaths(importer: string): { dir: string, paths: Record<strin
           return { dir, paths: parsed.compilerOptions.paths }
         }
         return null
-      } catch (e) {
+      } catch {
         return null
       }
     }

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -346,11 +346,13 @@ export async function parseImportGlob(
       )
     }
 
-    const globsResolved = (await Promise.all(
-      globs.map((glob) =>
-        toAbsoluteGlob(glob, root, importer, resolveId, options.base),
-      ),
-    )).flat()
+    const globsResolved = (
+      await Promise.all(
+        globs.map((glob) =>
+          toAbsoluteGlob(glob, root, importer, resolveId, options.base),
+        ),
+      )
+    ).flat()
     const isRelative = globs.every((i) => '.!'.includes(i[0]))
     const sliceCode = cleanCode.slice(0, start)
     const onlyKeys = objectKeysRE.test(sliceCode)
@@ -685,13 +687,17 @@ export async function toAbsoluteGlob(
         for (const exp of expanded) {
           let absoluteExp = exp
           if (exp.startsWith('.')) {
-             absoluteExp = posix.join(tsconfigResult.dir, exp)
+            absoluteExp = posix.join(tsconfigResult.dir, exp)
           }
           const resolved = normalizePath(
-            (await resolveId(absoluteExp, importer, { custom: { 'vite:import-glob': { isSubImportsPattern } } })) || absoluteExp
+            (await resolveId(absoluteExp, importer, {
+              custom: { 'vite:import-glob': { isSubImportsPattern } },
+            })) || absoluteExp,
           )
           if (isAbsolute(resolved)) {
-            resolvedGlobs.push(pre + globSafeResolvedPath(resolved, absoluteExp))
+            resolvedGlobs.push(
+              pre + globSafeResolvedPath(resolved, absoluteExp),
+            )
           }
         }
         if (resolvedGlobs.length > 0) return resolvedGlobs
@@ -748,7 +754,9 @@ export function isVirtualModule(id: string): boolean {
   return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
 }
 
-function loadTsconfigPaths(importer: string): { dir: string, paths: Record<string, string[]> } | null {
+function loadTsconfigPaths(
+  importer: string,
+): { dir: string; paths: Record<string, string[]> } | null {
   let dir = posix.dirname(importer)
   const root = posix.parse(dir).root
   while (dir !== root) {
@@ -771,13 +779,16 @@ function loadTsconfigPaths(importer: string): { dir: string, paths: Record<strin
   return null
 }
 
-function expandTsconfigPaths(glob: string, paths: Record<string, string[]>): string[] {
+function expandTsconfigPaths(
+  glob: string,
+  paths: Record<string, string[]>,
+): string[] {
   for (const [key, values] of Object.entries(paths)) {
     if (key.endsWith('/*')) {
       const prefix = key.slice(0, -2)
       if (glob.startsWith(prefix + '/')) {
         const suffix = glob.slice(prefix.length + 1)
-        return values.map(val => {
+        return values.map((val) => {
           if (val.endsWith('/*')) {
             return val.slice(0, -2) + '/' + suffix
           }


### PR DESCRIPTION
Fixes #23021
### What is this PR solving?
Currently, when `import.meta.glob` is used alongside `resolve.tsconfigPaths`, and a user configures multiple fallback directories for an alias in their `tsconfig.json` (e.g., `"@/*": ["./src2/*", "./src/*"]`), the glob matcher only looks into the very first successfully resolved directory. This occurs because the underlying `resolveId` hook expects a single string return value, meaning any subsequent fallback paths are discarded. 
This PR addresses the issue directly in `importMetaGlob.ts` by manually parsing the local `tsconfig.json` and expanding alias-based globs into an array of absolute globs for every configured fallback path. By updating `toAbsoluteGlob` to return a `Promise<string[]>` and flattening the results, the expanded paths are passed seamlessly to `tinyglobby`, which correctly merges the file lists from all fallback directories.
### What other alternatives have you explored?
We considered modifying the internal `oxc-resolver` bindings or the `vite:resolve` plugin to somehow return arrays of paths, but that would break the standard plugin `resolveId` contract. Handling the multiple fallback expansions strictly within the glob transformation logic limits the scope of the change and is significantly safer.
### Are there any parts you think require more attention from reviewers?
I implemented a lightweight `tsconfig.json` parsing utility (`loadTsconfigPaths`) within `importMetaGlob.ts` to locate the config relative to the importer. I'd appreciate feedback on whether this matches the maintainers' preferred approach for accessing `compilerOptions.paths` in this context, or if there is a cached configuration object that could be exposed here instead.