### PR TITLE
docs: fix examples, links, and inline code formatting

### DIFF
--- a/docs/blog/announcing-vite8-1.md
+++ b/docs/blog/announcing-vite8-1.md
@@ -164,7 +164,7 @@ export default defineConfig({
   html: {
     additionalAssetSources: {
       'html-import': {
-        srcAttributes: 'src',
+        srcAttributes: ['src'],
       },
       img: {
         srcAttributes: ['data-src-dark', 'data-src-light'],

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -234,7 +234,7 @@ If it matches one of the following conditions, the `default` import is the `modu
 
 - The importer is `.mjs` or `.mts`.
 - The closest `package.json` for the importer has a `type` field set to `module`.
-- The `module.exports.__esModule` value of the importee CJS module is not set to true.
+- The `module.exports.__esModule` value of the importee CJS module is not set to `true`.
 
 ::: details The previous behavior
 
@@ -242,11 +242,11 @@ In development, if it matches one of the following conditions, the `default` imp
 
 - _The importer is included in the dependency optimization_ and `.mjs` or `.mts`.
 - _The importer is included in the dependency optimization_ and the closest `package.json` for the importer has a `type` field set to `module`.
-- The `module.exports.__esModule` value of the importee CJS module is not set to true.
+- The `module.exports.__esModule` value of the importee CJS module is not set to `true`.
 
 In build, the conditions were:
 
-- The `module.exports.__esModule` value of the importee CJS module is not set to true.
+- The `module.exports.__esModule` value of the importee CJS module is not set to `true`.
 - _`default` property of `module.exports` does not exist_.
 
 (assuming [`build.commonjsOptions.defaultIsModuleExports`](https://github.com/rollup/plugins/tree/master/packages/commonjs#defaultismoduleexports) is not changed from the default `'auto'`)

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -362,7 +362,7 @@ These breaking changes are expected to only affect a minority of use cases:
 - Passing the same browser with multiple versions of it to `build.target` option now errors: esbuild selects the latest version of it, which was probably not what you intended.
 - Missing support by Rolldown: The following features are not supported by Rolldown and are no longer supported by Vite.
   - `build.rollupOptions.output.format: 'system'` ([rolldown#2387](https://github.com/rolldown/rolldown/issues/2387))
-  - `build.rollupOptions.output.format: 'amd'` ([rolldown#2387](https://github.com/rolldown/rolldown/issues/2528))
+  - `build.rollupOptions.output.format: 'amd'` ([rolldown#2528](https://github.com/rolldown/rolldown/issues/2528))
   - `shouldTransformCachedModule` hook ([rolldown#4389](https://github.com/rolldown/rolldown/issues/4389))
   - `resolveImportMeta` hook ([rolldown#1010](https://github.com/rolldown/rolldown/issues/1010))
   - `renderDynamicImport` hook ([rolldown#4532](https://github.com/rolldown/rolldown/issues/4532))


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->


- Update the `additionalAssetSources` example in the Vite 8.1 announcement by changing `srcAttributes` from a string to the expected array format.
- Format the boolean value `true` as inline code.
- Correct the displayed Rolldown issue number for the unsupported AMD output format from `rolldown#2387` to `rolldown#2528`, matching the linked issue.
