### PR TITLE
fix(bundledDev): print build errors to the terminal when an HMR update fails

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -140,6 +140,12 @@ export class BundledDev {
     this._devEngine = await dev(rolldownOptions, outputOptions, {
       onHmrUpdates: (result) => {
         if (result instanceof Error) {
+          this.environment.logger.error(
+            colors.red(`✘ Build error: ${result.message}`),
+            {
+              error: result,
+            },
+          )
           // TODO: send to the specific client
           for (const client of this.clients.getAll()) {
             client.send({

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -1,6 +1,14 @@
 import { setTimeout } from 'node:timers/promises'
 import { expect, test, onTestFinished } from 'vitest'
-import { addFile, browserLogs, editFile, isBuild, page, readFile } from '~utils'
+import {
+  addFile,
+  browserLogs,
+  editFile,
+  isBuild,
+  page,
+  readFile,
+  serverLogs,
+} from '~utils'
 
 const assetUrl = /asset-[\w-]+\.png/
 
@@ -80,10 +88,14 @@ if (isBuild) {
   // BUNDLED -> GENERATING_HMR_PATCH -> BUNDLED
   test('handle generate hmr patch error', async () => {
     await expect.poll(() => page.textContent('.hmr')).toBe('hello')
+    const lastServerLogIndex = serverLogs.length
     editFile('hmr.js', (code) =>
       code.replace("const foo = 'hello'", "const foo = 'hello"),
     )
     await expect.poll(() => page.isVisible('vite-error-overlay')).toBe(true)
+    await expect
+      .poll(() => serverLogs.slice(lastServerLogIndex).join('\n'))
+      .toContain('Build error')
 
     editFile('hmr.js', (code) =>
       code.replace("const foo = 'hello", "const foo = 'hello'"),


### PR DESCRIPTION
### Description

In bundled dev mode (`experimental.bundledDev`), when a file change breaks the build (for example an import path that cannot be resolved), the error is only shown in the browser overlay. The terminal prints nothing.

Expected behavior is the same as normal dev mode: every failed build prints the error in the terminal, and after the file is fixed the terminal shows the recovery (`hmr update` / `page reload`).

The cause is that the two dev engine callbacks handle errors differently:

- The `onOutput` error branch logs `✘ Build error` to the terminal and sends the overlay.
- The `onHmrUpdates` error branch only sends the overlay.

With the default rebuild strategy, a file change only generates HMR updates, so a failed rebuild goes through `onHmrUpdates` and the terminal stays silent.

This PR adds the same `✘ Build error` logging to the `onHmrUpdates` error branch.

Before:

```
(nothing is printed on a failed HMR rebuild)
```

After:

```
✘ Build error: Build failed with 1 error:

[UNRESOLVED_IMPORT] Could not resolve './src/components/HelloWorld.vue' in src/App.vue
   ╭─[ src/App.vue:2:24 ]
   │
 2 │ import HelloWorld from "./src/components/HelloWorld.vue";
   │                        ────────────────┬────────────────
   │                                        ╰────────────────── Module not found.
───╯
```

Also added a `serverLogs` assertion to the existing `handle generate hmr patch error` playground test. The assertion fails without this fix and passes with it.

closes rolldown/rolldown#10136
