### PR TITLE
fix(bundled-dev): serve lazy chunk sourcemaps

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -331,6 +331,15 @@ export class BundledDev {
     )
     const result = await this.devEngine.compileEntry(moduleId, clientId)
     this.pendingPayloadFilenames.add(result.filename)
+    // Serve the chunk's sourcemap, the same way an eager chunk's and an HMR
+    // patch's maps are served. The chunk's relative `sourceMappingURL` resolves
+    // against the URL it is imported from, `/@vite/lazy?...`, so register the map
+    // under that directory for the reference to reach it.
+    if (result.sourcemapFilename && result.sourcemap) {
+      this.memoryFiles.set(`@vite/${result.sourcemapFilename}`, {
+        source: result.sourcemap,
+      })
+    }
     return result
   }
 

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -298,8 +298,25 @@ if (isBuild) {
   })
 
   test('lazy bundling', async () => {
+    const responsePromise = page.waitForResponse(/\/@vite\/lazy\?/)
     await page.click('#load-dynamic')
     await expect.poll(() => page.textContent('.dynamic')).toBe('loaded')
+
+    // the lazy chunk names a `.map` file that only exists in memory; the dev
+    // server has to register it, otherwise the reference 404s and the module
+    // cannot be mapped back to its source. The reference is relative and a lazy
+    // chunk is imported from `/@vite/lazy?...`, so it resolves under `/@vite/`.
+    const response = await responsePromise
+    const code = await response.text()
+    const url = code.match(/\/\/# sourceMappingURL=(.+)$/m)?.[1]
+    expect(url).toMatch(/^lazy_compile_\d+\.js\.map$/)
+
+    const mapResponse = await fetch(new URL(url!, response.url()))
+    expect(mapResponse.status).toBe(200)
+    const map = await mapResponse.json()
+    expect(map.version).toBe(3)
+    expect(map.sources.some((s: string) => s.endsWith('dynamic.js'))).toBe(true)
+    expect(map.mappings.length).toBeGreaterThan(0)
   })
 
   // placed before `invalidate` on purpose: that test's cleanup restores


### PR DESCRIPTION
This is the Vite side of a two-part fix; the rolldown half landed in [rolldown/rolldown#10386](https://github.com/rolldown/rolldown/pull/10386) and shipped in rolldown 1.2.1, which `main` already pins.

## What this solves

In bundled dev mode, a lazily compiled chunk is served from `/@vite/lazy?...` and ends with a `//# sourceMappingURL=lazy_compile_N.js.map` reference — but that `.map` was never registered anywhere, so the browser gets a 404 and the module can't be mapped back to its source.

Eager chunks (`storeOutputFiles`) and HMR patches already register their maps in `memoryFiles`; lazy chunks were the only path missing it. This registers the lazy chunk's map the same way.

The reference is relative and the chunk is imported from `/@vite/lazy?...`, so it resolves under `/@vite/`. The map is registered under that directory for the reference to reach it — no rewrite of the emitted chunk is needed.

rolldown#10386 is the companion fix: it makes the map's *content* correct (it previously mapped to post-transform positions instead of the source the user wrote) and makes `compileEntry` actually return the map (`sourcemap` / `sourcemapFilename`). With both, lazy chunks get correct, reachable sourcemaps under Vite's default `output.sourcemap = true`.

## Alternatives explored

- **Inline the map as a `data:` URL** (Vite's classic dev approach). Rejected: eager chunks and HMR patches in bundled dev are served as separate `.map` files, so inlining would make lazy chunks the odd one out. Keeping the separate-file approach is consistent with the rest of bundled dev.
- **Rewrite the chunk's `sourceMappingURL` to an absolute `/lazy_compile_N.js.map`.** Works, but depends on a fragile string replace of the exact comment format. Registering the map under the `/@vite/` directory instead needs no rewrite and keeps rolldown's emitted reference untouched.

## Reviewer attention

- The `@vite/` prefix on the map key mirrors the `/@vite/lazy?...` import path that rolldown's proxy template hardcodes and that the lazy-bundling middleware already matches on. It isn't extracted to a shared constant — that string is currently duplicated (middleware + here) with its source of truth in rolldown; happy to pull it into a constant if preferred.
- The test lives in the existing `hmr-full-bundle-mode` playground: the `lazy bundling` test now also asserts the map is served (`200`) and maps back to `dynamic.js`. It fails without this change (the reference 404s, and the map fetch returns the HTML fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
