### PR TITLE
fix(importAnalysis): interop imports injected into optimized dep files by plugins

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -597,8 +597,15 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
             if (url !== specifier) {
               let rewriteDone = false
+              // imports emitted by the optimizer are always relative and
+              // already have the correct shape. bare imports inside an
+              // optimized dep file come from plugins transforming the served
+              // file (e.g. @rollup/plugin-inject) and still need interop.
+              const isOptimizerEmittedImport =
+                depsOptimizer?.isOptimizedDepFile(importer) &&
+                specifier[0] === '.'
               if (
-                !depsOptimizer?.isOptimizedDepFile(importer) &&
+                !isOptimizerEmittedImport &&
                 depsOptimizer?.isOptimizedDepFile(resolvedId) &&
                 !optimizedDepChunkRE.test(resolvedId)
               ) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -597,13 +597,16 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
             if (url !== specifier) {
               let rewriteDone = false
-              // imports emitted by the optimizer are always relative and
-              // already have the correct shape. bare imports inside an
-              // optimized dep file come from plugins transforming the served
-              // file (e.g. @rollup/plugin-inject) and still need interop.
+              // optimizer-emitted imports resolve to the sibling file they
+              // name; imports injected by plugins (e.g. @rollup/plugin-inject)
+              // still need interop
               const isOptimizerEmittedImport =
                 depsOptimizer?.isOptimizedDepFile(importer) &&
-                specifier[0] === '.'
+                specifier[0] === '.' &&
+                path.posix.resolve(
+                  path.posix.dirname(cleanUrl(importer)),
+                  specifier,
+                ) === cleanUrl(resolvedId)
               if (
                 !isOptimizerEmittedImport &&
                 depsOptimizer?.isOptimizedDepFile(resolvedId) &&

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -603,9 +603,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               const isOptimizerEmittedImport =
                 depsOptimizer?.isOptimizedDepFile(importer) &&
                 specifier[0] === '.' &&
-                path.posix.resolve(
-                  path.posix.dirname(cleanUrl(importer)),
-                  specifier,
+                normalizePath(
+                  path.resolve(path.dirname(cleanUrl(importer)), specifier),
                 ) === cleanUrl(resolvedId)
               if (
                 !isOptimizerEmittedImport &&

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -602,10 +602,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               // still need interop
               const isOptimizerEmittedImport =
                 depsOptimizer?.isOptimizedDepFile(importer) &&
-                specifier[0] === '.' &&
-                normalizePath(
-                  path.resolve(path.dirname(cleanUrl(importer)), specifier),
-                ) === cleanUrl(resolvedId)
+                specifier[0] === '.'
               if (
                 !isOptimizerEmittedImport &&
                 depsOptimizer?.isOptimizedDepFile(resolvedId) &&

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -43,6 +43,15 @@ test('default import from cjs (cjs-dep-cjs-compiled-from-cjs)', async () => {
     .toBe('ok')
 })
 
+test.runIf(isServe)(
+  'named import injected into an optimized dep by a plugin (dep-with-injected-import)',
+  async () => {
+    await expect
+      .poll(() => page.textContent('.injected-import-in-optimized-dep'))
+      .toBe('msg from injected cjs import')
+  },
+)
+
 test('dynamic imports from cjs dep (react)', async () => {
   await expect
     .poll(() => page.textContent('.cjs-dynamic button'))

--- a/playground/optimize-deps/dep-cjs-for-injected-import/index.js
+++ b/playground/optimize-deps/dep-cjs-for-injected-import/index.js
@@ -1,0 +1,2 @@
+'use strict'
+exports.msg = 'msg from injected cjs import'

--- a/playground/optimize-deps/dep-cjs-for-injected-import/package.json
+++ b/playground/optimize-deps/dep-cjs-for-injected-import/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-dep-cjs-for-injected-import",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/playground/optimize-deps/dep-with-injected-import/index.js
+++ b/playground/optimize-deps/dep-with-injected-import/index.js
@@ -1,0 +1,5 @@
+// `injectedMsg` is not defined here. injectImportIntoOptimizedDep() in
+// vite.config.js injects its import into the optimized output of this dep.
+export function getInjectedMsg() {
+  return injectedMsg
+}

--- a/playground/optimize-deps/dep-with-injected-import/package.json
+++ b/playground/optimize-deps/dep-with-injected-import/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-dep-with-injected-import",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -15,6 +15,10 @@
 
 <script type="module" src="./cjs.js"></script>
 
+<h2>Named import injected into an optimized dep by a plugin</h2>
+<div class="injected-import-in-optimized-dep"></div>
+<script type="module" src="./injected-import.js"></script>
+
 <h2>CommonJS dynamic import default + named (react)</h2>
 <div class="cjs-dynamic"></div>
 <h2>CommonJS dynamic import named (phoenix)</h2>

--- a/playground/optimize-deps/injected-import.js
+++ b/playground/optimize-deps/injected-import.js
@@ -1,0 +1,8 @@
+import { getInjectedMsg } from '@vitejs/test-dep-with-injected-import'
+
+try {
+  document.querySelector('.injected-import-in-optimized-dep').textContent =
+    getInjectedMsg()
+} catch {
+  // the import is only injected in dev where the dep optimizer runs
+}

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -17,6 +17,8 @@
     "@vitejs/test-dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "@vitejs/test-dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "@vitejs/test-dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
+    "@vitejs/test-dep-cjs-for-injected-import": "file:./dep-cjs-for-injected-import",
+    "@vitejs/test-dep-with-injected-import": "file:./dep-with-injected-import",
     "@vitejs/test-dep-cjs-with-assets": "file:./dep-cjs-with-assets",
     "@vitejs/test-dep-cjs-with-es-module-flag": "file:./dep-cjs-with-es-module-flag",
     "@vitejs/test-dep-cjs-with-external-deps": "file:./dep-cjs-with-external-deps",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -27,6 +27,9 @@ export default defineConfig({
       '@vitejs/test-dep-optimize-with-glob/**/*.js',
       '@vitejs/test-dep-cjs-with-external-deps',
       '@vitejs/test-dep-cjs-with-es-module-flag',
+      // only referenced by the import that injectImportIntoOptimizedDep()
+      // adds at serve time, so the scanner can never discover it
+      '@vitejs/test-dep-cjs-for-injected-import',
     ],
     exclude: [
       '@vitejs/test-nested-exclude',
@@ -58,6 +61,7 @@ export default defineConfig({
     testVue(),
     notjs(),
     virtualModulePlugin(),
+    injectImportIntoOptimizedDep(),
     {
       name: 'test-astro',
       transform(code, id) {
@@ -130,6 +134,26 @@ function notjs() {
       if (id.endsWith('.notjs')) {
         code = code.replace('<notjs>', '').replace('</notjs>', '')
         return { code }
+      }
+    },
+  }
+}
+
+// Injects a named import of a CJS dep into the served output of an optimized
+// dep, like @rollup/plugin-inject does when providing `Buffer` / `process`
+function injectImportIntoOptimizedDep() {
+  return {
+    name: 'inject-import-into-optimized-dep',
+    transform(code, id) {
+      if (
+        /\.vite[\\/]deps[\\/].*test-dep-with-injected-import/.test(id) &&
+        !code.includes('test-dep-cjs-for-injected-import')
+      ) {
+        return {
+          code:
+            `import { msg as injectedMsg } from '@vitejs/test-dep-cjs-for-injected-import';\n` +
+            code,
+        }
       }
     },
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,6 +1086,9 @@ importers:
       '@vitejs/test-dep-cjs-external-package-omit-js-suffix':
         specifier: file:./dep-cjs-external-package-omit-js-suffix
         version: file:playground/optimize-deps/dep-cjs-external-package-omit-js-suffix
+      '@vitejs/test-dep-cjs-for-injected-import':
+        specifier: file:./dep-cjs-for-injected-import
+        version: file:playground/optimize-deps/dep-cjs-for-injected-import
       '@vitejs/test-dep-cjs-require-css-main-field':
         specifier: file:./dep-cjs-require-css-main-field
         version: file:playground/optimize-deps/dep-cjs-require-css-main-field
@@ -1164,6 +1167,9 @@ importers:
       '@vitejs/test-dep-with-dynamic-import':
         specifier: file:./dep-with-dynamic-import
         version: file:playground/optimize-deps/dep-with-dynamic-import
+      '@vitejs/test-dep-with-injected-import':
+        specifier: file:./dep-with-injected-import
+        version: file:playground/optimize-deps/dep-with-injected-import
       '@vitejs/test-dep-with-optional-peer-dep':
         specifier: file:./dep-with-optional-peer-dep
         version: file:playground/optimize-deps/dep-with-optional-peer-dep
@@ -1241,6 +1247,8 @@ importers:
   playground/optimize-deps/dep-cjs-css-main-field: {}
 
   playground/optimize-deps/dep-cjs-external-package-omit-js-suffix: {}
+
+  playground/optimize-deps/dep-cjs-for-injected-import: {}
 
   playground/optimize-deps/dep-cjs-require-css-main-field:
     dependencies:
@@ -1320,6 +1328,8 @@ importers:
   playground/optimize-deps/dep-with-builtin-module-esm: {}
 
   playground/optimize-deps/dep-with-dynamic-import: {}
+
+  playground/optimize-deps/dep-with-injected-import: {}
 
   playground/optimize-deps/dep-with-optional-peer-dep: {}
 
@@ -4411,6 +4421,9 @@ packages:
   '@vitejs/test-dep-cjs-external-package-omit-js-suffix@file:playground/optimize-deps/dep-cjs-external-package-omit-js-suffix':
     resolution: {directory: playground/optimize-deps/dep-cjs-external-package-omit-js-suffix, type: directory}
 
+  '@vitejs/test-dep-cjs-for-injected-import@file:playground/optimize-deps/dep-cjs-for-injected-import':
+    resolution: {directory: playground/optimize-deps/dep-cjs-for-injected-import, type: directory}
+
   '@vitejs/test-dep-cjs-require-css-main-field@file:playground/optimize-deps/dep-cjs-require-css-main-field':
     resolution: {directory: playground/optimize-deps/dep-cjs-require-css-main-field, type: directory}
 
@@ -4524,6 +4537,9 @@ packages:
 
   '@vitejs/test-dep-with-dynamic-import@file:playground/optimize-deps/dep-with-dynamic-import':
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
+
+  '@vitejs/test-dep-with-injected-import@file:playground/optimize-deps/dep-with-injected-import':
+    resolution: {directory: playground/optimize-deps/dep-with-injected-import, type: directory}
 
   '@vitejs/test-dep-with-optional-peer-dep-cjs@file:playground/optimize-deps/dep-with-optional-peer-dep-cjs':
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-cjs, type: directory}
@@ -10389,6 +10405,8 @@ snapshots:
 
   '@vitejs/test-dep-cjs-external-package-omit-js-suffix@file:playground/optimize-deps/dep-cjs-external-package-omit-js-suffix': {}
 
+  '@vitejs/test-dep-cjs-for-injected-import@file:playground/optimize-deps/dep-cjs-for-injected-import': {}
+
   '@vitejs/test-dep-cjs-require-css-main-field@file:playground/optimize-deps/dep-cjs-require-css-main-field':
     dependencies:
       '@vitejs/test-dep-cjs-css-main-field': file:playground/optimize-deps/dep-cjs-css-main-field
@@ -10487,6 +10505,8 @@ snapshots:
   '@vitejs/test-dep-with-builtin-module-esm@file:playground/optimize-deps/dep-with-builtin-module-esm': {}
 
   '@vitejs/test-dep-with-dynamic-import@file:playground/optimize-deps/dep-with-dynamic-import': {}
+
+  '@vitejs/test-dep-with-injected-import@file:playground/optimize-deps/dep-with-injected-import': {}
 
   '@vitejs/test-dep-with-optional-peer-dep-cjs@file:playground/optimize-deps/dep-with-optional-peer-dep-cjs': {}
 


### PR DESCRIPTION
### Description

This fixes the root cause of rolldown/rolldown#10392, where vitest browser runs hang forever on Vite 8 when `@rollup/plugin-inject` is in the plugin list. The reporter suspected a deadlock in rolldown's dep optimizer, but rolldown is fine. What actually happens is an unhandled module error in the browser:

```
SyntaxError: The requested module '/.../deps/buffer.js' does not provide an export named 'Buffer'
```

The chain is:

1. In dev, optimized dep files are served through the plugin transform pipeline, so a plugin like `@rollup/plugin-inject` can add imports to them. chai for example references the bare global `Buffer`, so the plugin prepends `import { Buffer } from "buffer"` to the served chunk.
2. The injected specifier resolves to the optimized `buffer.js`, whose only export is `export default require_buffer()`, so the named import needs the CJS interop rewrite from import analysis.
3. Since the rolldown-vite rolldown 1.0.0-beta.53 bump (vitejs/rolldown-vite#537), import analysis skips the interop rewrite whenever the importer is itself an optimized dep file. The named import reaches the browser untouched and throws. In the vitest browser case the broken chunk sits in the tester's own dependency graph, so the page never boots and the run hangs with no visible error, which is why it was reported as a deadlock.

Vite 7 handled this fine because the `!depsOptimizer?.isOptimizedDepFile(importer)` condition did not exist there. The condition was added for a real reason: rolldown's optimizer emits dep entry files that import other dep entries directly, for example `expect-type.js` importing `./vitest_n_expect-type.js` with the exact binding shape it generated, and interop rewriting those would corrupt them. esbuild never produced that shape, since its shared chunks are named `chunk-*` and were already excluded by `optimizedDepChunkRE`.

The guard is broader than what it protects, though. Every import the optimizer emits is relative. A bare specifier inside a served dep file can only come from a plugin transform, and it still needs interop. This PR narrows the skip to relative specifiers, which restores the Vite 7 behavior for plugin injected imports while keeping the protection for optimizer emitted ones.

You can see the bug without vitest or a browser. With a config containing `optimizeDeps.include: ['buffer', 'chai']` and the inject plugin, curl the served chai chunk from the dev server.

Before, the chunk starts with a named import that would throw in the browser:

```js
import { Buffer as Buffer } from "/@fs/.../node_modules/.vite/deps/buffer.js?v=c242a31b";
```

After, it gets the same interop rewrite Vite 7 applied:

```js
const Buffer = __vite__cjsImport0_buffer["Buffer"];import __vite__cjsImport0_buffer from "/@fs/.../node_modules/.vite/deps/buffer.js?v=98b0b1d1";
```

The optimizer's own relative imports, such as the `rolldown-runtime` import inside `buffer.js`, stay untouched.

The added playground test fails on main and passes with this change. I also verified the original vitest browser reproduction from the rolldown issue: with this patch the previously hanging run completes with 2 passing tests in about 2 seconds, and the control config without the plugin still passes.

close https://github.com/rolldown/rolldown/issues/10392
