### PR TITLE
docs(guide): fix 'at least 2.5 years ago' wording on browser support

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,7 +24,7 @@ You can learn more about the rationale behind the project in the [Why Vite](./wh
 
 During development, Vite assumes that a modern browser is used. This means the browser supports most of the latest JavaScript and CSS features. For that reason, Vite sets [`esnext` as the transform target](https://oxc.rs/docs/guide/usage/transformer/lowering.html#target). This prevents syntax lowering, letting Vite serve modules as close as possible to the original source code. Vite injects some runtime code to make the development server work. This code uses features included in [Baseline](https://web-platform-dx.github.io/web-features/) Newly Available at the time of each major release (2026-01-01 for this major).
 
-For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. These are browsers that were released at least 2.5 years ago. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
+For production builds, Vite by default targets [Baseline](https://web-platform-dx.github.io/web-features/) Widely Available browsers. That means Vite only uses web features that have been available across all major browsers for at least 2.5 years. The target can be lowered via configuration. Additionally, legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
 
 ## Trying Vite Online
 


### PR DESCRIPTION
Closes #21144. Rewords the "browsers released at least 2.5 years ago" sentence. Per the issue, "at least 2.5 years ago" was backwards — Vite's production target is Baseline Widely Available (features available for 2.5+ years across all major browsers), not "browsers that are at least 2.5 years old." Used mstange's own suggested wording, minor polish. Docs-only, 1 line.