### PR TITLE
fix: don't swallow the positional argument after `--profile`

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -64,10 +64,6 @@ function start() {
 
 if (profileIndex > 0) {
   process.argv.splice(profileIndex, 1)
-  const next = process.argv[profileIndex]
-  if (next && next[0] !== '-') {
-    process.argv.splice(profileIndex, 1)
-  }
   const inspector = await import('node:inspector').then((r) => r.default)
   const session = (global.__vite_profile_session = new inspector.Session())
   session.connect()


### PR DESCRIPTION
fixes #23032

`bin/vite.js` strips `--profile` from `process.argv` before cac parses it, but it also removed the next non-flag token, as if the flag took a value. `--profile` never takes a value: the profiler is started unconditionally and no code reads a value for it. So the extra splice only swallowed real positionals. For example, `vite --profile my-app` silently started the dev server in the current directory instead of `my-app`, and `vite --profile build` started a dev server instead of building. Writing the flag after the positional was unaffected, which is why this went unnoticed.

No test is included: `bin/vite.js` has no existing test coverage and the change only deletes dead logic. Verified manually that `vite build --profile <root>` now builds `<root>` (the CPU profile is still written) and that the flag-last form behaves the same as before.