### PR TITLE
feat: add `input` to `server.fs.allow`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -2055,6 +2055,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual(['example.com'])
@@ -2066,6 +2067,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2081,6 +2083,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2096,6 +2099,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual(['example.com', 'test.com'])
@@ -2106,6 +2110,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: ['existing.com'] },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2120,6 +2125,7 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: true },
+      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toBe(true)
@@ -2132,6 +2138,7 @@ describe('resolveServerOptions', () => {
       const resolved = await resolveServerOptions(
         '/root',
         { allowedHosts: [] },
+        undefined,
         logger,
       )
       expect(resolved.allowedHosts).toEqual([])

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1235,6 +1235,35 @@ describe('resolveConfig', () => {
     })
   })
 
+  test('adds input to server.fs.allow by default', async () => {
+    const inputs = {
+      main: resolveInputFromRoot('src/a.ts'),
+      admin: resolveInputFromRoot('src/b.ts'),
+    }
+    const config = await resolveConfig(
+      { input: { main: 'src/a.ts', admin: 'src/b.ts' } },
+      'serve',
+    )
+
+    expect(config.server.fs.allow).toStrictEqual(
+      expect.arrayContaining(Object.values(inputs)),
+    )
+  })
+
+  test('does not add input to an explicit server.fs.allow', async () => {
+    const config = await resolveConfig(
+      {
+        input: 'src/main.ts',
+        server: { fs: { allow: ['src'] } },
+      },
+      'serve',
+    )
+
+    expect(config.server.fs.allow).not.toContain(
+      resolveInputFromRoot('src/main.ts'),
+    )
+  })
+
   test('reserves glob characters in input', async () => {
     const cases: { name: string; input: UserConfig['input'] }[] = [
       { name: 'wildcard', input: 'src/*.ts' },

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1250,20 +1250,6 @@ describe('resolveConfig', () => {
     )
   })
 
-  test('does not add input to an explicit server.fs.allow', async () => {
-    const config = await resolveConfig(
-      {
-        input: 'src/main.ts',
-        server: { fs: { allow: ['src'] } },
-      },
-      'serve',
-    )
-
-    expect(config.server.fs.allow).not.toContain(
-      resolveInputFromRoot('src/main.ts'),
-    )
-  })
-
   test('reserves glob characters in input', async () => {
     const cases: { name: string; input: UserConfig['input'] }[] = [
       { name: 'wildcard', input: 'src/*.ts' },

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1250,6 +1250,12 @@ describe('resolveConfig', () => {
     )
   })
 
+  test('adds the default index.html input to server.fs.allow', async () => {
+    const config = await resolveConfig({}, 'serve')
+
+    expect(config.server.fs.allow).toContain(resolveInputFromRoot('index.html'))
+  })
+
   test('reserves glob characters in input', async () => {
     const cases: { name: string; input: UserConfig['input'] }[] = [
       { name: 'wildcard', input: 'src/*.ts' },

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1865,7 +1865,13 @@ export async function resolveConfig(
         )
       : ''
 
-  const server = await resolveServerOptions(resolvedRoot, config.server, logger)
+  const input = resolveInput(config.input, resolvedRoot)
+  const server = await resolveServerOptions(
+    resolvedRoot,
+    config.server,
+    input,
+    logger,
+  )
 
   const builder = resolveBuilderOptions(config.builder)
 
@@ -2109,7 +2115,7 @@ export async function resolveConfig(
 
     ssr,
 
-    input: resolveInput(config.input, resolvedRoot),
+    input,
     optimizeDeps: backwardCompatibleOptimizeDeps,
     resolve: resolvedDefaultResolve,
     dev: resolvedDevEnvironmentOptions,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -14,7 +14,7 @@ import chokidar from 'chokidar'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import { determineAgent } from '@vercel/detect-agent'
 import { disableCache } from '@voidzero-dev/vite-task-client'
-import type { SourceMap } from 'rolldown'
+import type { InputOption, SourceMap } from 'rolldown'
 import type { ModuleRunner } from 'vite/module-runner'
 import type { FSWatcher, WatchOptions } from '#dep-types/chokidar'
 import type { Connect } from '#dep-types/connect'
@@ -1214,6 +1214,7 @@ const RESERVED_ALLOWED_HOSTS_CHARACTERS_RE = /[\\"']/
 export async function resolveServerOptions(
   root: string,
   raw: ServerOptions | undefined,
+  input: InputOption | undefined,
   logger: Logger,
 ): Promise<ResolvedServerOptions> {
   const _server = mergeWithDefaults(
@@ -1243,6 +1244,7 @@ export async function resolveServerOptions(
   }
 
   let allowDirs = server.fs.allow
+  allowDirs.push(...getInputPaths(input))
 
   const cwd = searchForPackageRoot(root)
   if (process.versions.pnp) {
@@ -1341,6 +1343,12 @@ export async function resolveServerOptions(
   }
 
   return server
+}
+
+function getInputPaths(input: ResolvedConfig['input']): string[] {
+  if (input == null) return []
+  if (typeof input === 'string') return [input]
+  return Array.isArray(input) ? input : Object.values(input)
 }
 
 async function restartServer(server: ViteDevServer) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1244,7 +1244,7 @@ export async function resolveServerOptions(
   }
 
   let allowDirs = server.fs.allow
-  allowDirs.push(...getInputPaths(input))
+  allowDirs.push(...getInputPaths(root, input))
 
   const cwd = searchForPackageRoot(root)
   if (process.versions.pnp) {
@@ -1345,8 +1345,8 @@ export async function resolveServerOptions(
   return server
 }
 
-function getInputPaths(input: ResolvedConfig['input']): string[] {
-  if (input == null) return []
+function getInputPaths(root: string, input: ResolvedConfig['input']): string[] {
+  if (input == null) return [path.resolve(root, 'index.html')]
   if (typeof input === 'string') return [input]
   return Array.isArray(input) ? input : Object.values(input)
 }


### PR DESCRIPTION
Since the `input` is part of the module graph, add it to `server.fs.allow` similarly to the imported modules in a module.