### PR TITLE
fix(dev): treat empty url as '/' in transformIndexHtml (fix #18228)

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/indexHtml.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, onTestFinished, test } from 'vitest'
 import { createServer } from '../../../server'
 import { FS_PREFIX } from '../../../constants'
+import { unwrapId } from '../../../../shared/utils'
 
 const FIXTURE_DIR = path.resolve(import.meta.dirname, 'fixtures')
 const HTML_PATH = path.resolve(FIXTURE_DIR, 'root/index.html')
@@ -83,6 +84,31 @@ describe('indexHtml middleware — /@fs/ inline script proxy cache', () => {
       await server.environments.client.transformRequest(proxyModuleUrl)
 
     expect(result, 'proxy module should resolve without error').not.toBeNull()
+    expect(result!.code).toContain('module loaded')
+  })
+
+  test('inline <script type="module"> is loadable when transformIndexHtml is called with an empty url', async () => {
+    const server = await createTestServer()
+
+    // SSR integrations often derive the url with `req.originalUrl.replace(base, '')`,
+    // which produces '' for the root (#18228)
+    const transformed = await server.transformIndexHtml('', HTML_CONTENT)
+
+    const proxyUrlMatch = transformed.match(/src="([^"]*html-proxy[^"]*)"/)
+    expect(
+      proxyUrlMatch,
+      'devHtmlHook should rewrite the inline <script> to a ?html-proxy src',
+    ).toBeTruthy()
+
+    // the transform middleware unwraps /@id/ urls before transformRequest
+    const proxyModuleUrl = unwrapId(decodeURIComponent(proxyUrlMatch![1]))
+    const result =
+      await server.environments.client.transformRequest(proxyModuleUrl)
+
+    expect(
+      result,
+      'proxy module should resolve without a cache-miss error',
+    ).not.toBeNull()
     expect(result!.code).toContain('module loaded')
   })
 })

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -96,6 +96,11 @@ export function createDevHtmlTransformFn(
     html: string,
     originalUrl?: string,
   ): Promise<string> => {
+    // SSR integrations often derive the url by stripping the base from the
+    // request url, which produces '' for the root (#18228)
+    if (url === '') {
+      url = '/'
+    }
     return applyHtmlTransforms(html, transformHooks, pluginContext, {
       path: url,
       filename: getHtmlFilename(url, server),


### PR DESCRIPTION
### Description

Calling `server.transformIndexHtml('', html)` fails with `No matching HTML proxy module found from /?html-proxy&index=0.js` when the HTML contains an inline `<script type="module">`. The empty url is common in SSR middleware setups that derive the url with `req.originalUrl.replace(base, '')`, which produces `''` for the root, as reported in #18228.

With an empty url, `getHtmlFilename` resolves to the root directory itself, so `fs.existsSync(filename)` passes and `devHtmlHook` takes the real-file branch with an empty `proxyModulePath`. The inline script is then cached under the key `''`, but the browser request for `/?html-proxy&index=0.js` looks it up under `'/'`, so the load fails. This fixes it by treating `''` as `'/'` at the `transformIndexHtml` boundary, which takes the virtual html path that already exists for SSR integrations calling it with `'/'` (#7993) and produces consistent cache keys.

Note that relative imports inside such inline scripts still fail to resolve, since the importer is a virtual `\0/index.html` module without a filesystem location. That limitation applies equally to `transformIndexHtml('/', html)` today and is separate from the cache key mismatch; root-absolute imports like `/src/entry-client.js` work fully. Some reports in the issue thread describe Windows-specific path problems (long paths, drive casing) which are also not covered here.