### PR TITLE
feat(cli): support naming the CPU profile via --profile [name]

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -27,7 +27,7 @@ vite [root]
 | `-l, --logLevel <level>`  | info \| warn \| error \| silent (`string`)                                                                                                                                            |
 | `--clearScreen`           | Allow/disable clear screen when logging (`boolean`)                                                                                                                                   |
 | `--configLoader <loader>` | Use `bundle` to bundle the config with Rolldown, or `runner` (experimental) to process it on the fly, or `native` (experimental) to load using the native runtime (default: `bundle`) |
-| `--profile`               | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))                                                                    |
+| `--profile [name]`        | Start built-in Node.js inspector and write the profile to `<name>.cpuprofile` (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks)) (`boolean \| string`) |
 | `-d, --debug [feat]`      | Show debug logs (`string \| boolean`)                                                                                                                                                 |
 | `-f, --filter <filter>`   | Filter debug logs (`string`)                                                                                                                                                          |
 | `-m, --mode <mode>`       | Set env mode (`string`)                                                                                                                                                               |
@@ -66,7 +66,7 @@ vite build [root]
 | `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                                                                                            |
 | `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                                                                                   |
 | `--configLoader <loader>`      | Use `bundle` to bundle the config with Rolldown, or `runner` (experimental) to process it on the fly, or `native` (experimental) to load using the native runtime (default: `bundle`) |
-| `--profile`                    | Start built-in Node.js inspector (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks))                                                                    |
+| `--profile [name]`             | Start built-in Node.js inspector and write the profile to `<name>.cpuprofile` (check [Performance bottlenecks](/guide/troubleshooting#performance-bottlenecks)) (`boolean \| string`) |
 | `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                                                                                                 |
 | `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                                                                                          |
 | `-m, --mode <mode>`            | Set env mode (`string`)                                                                                                                                                               |

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -240,7 +240,7 @@ vite build --profile
 Once your application is opened in the browser, just await finish loading it and then go back to the terminal and press `p` key (will stop the Node.js inspector) then press `q` key to stop the dev server.
 :::
 
-Node.js inspector will generate `vite-profile-0.cpuprofile` in the root folder, go to https://www.speedscope.app/, and upload the CPU profile using the `BROWSE` button to inspect the result.
+Node.js inspector will generate `vite-profile-0.cpuprofile` in the root folder. You can pass `--profile <name>` (or `--profile=<name>`) to write `<name>.cpuprofile` instead. Go to https://www.speedscope.app/, and upload the CPU profile using the `BROWSE` button to inspect the result.
 
 You can install [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect), which lets you inspect the intermediate state of Vite plugins and can also help you to identify which plugins or middlewares are the bottleneck in your applications. The plugin can be used in both dev and build modes. Check the readme file for more details.
 

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -64,10 +64,6 @@ function start() {
 
 if (profileIndex > 0) {
   process.argv.splice(profileIndex, 1)
-  const next = process.argv[profileIndex]
-  if (next && next[0] !== '-') {
-    process.argv.splice(profileIndex, 1)
-  }
   const inspector = await import('node:inspector').then((r) => r.default)
   const session = (global.__vite_profile_session = new inspector.Session())
   session.connect()

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -20,7 +20,9 @@ const debugIndex = process.argv.findIndex((arg) => /^(?:-d|--debug)$/.test(arg))
 const filterIndex = process.argv.findIndex((arg) =>
   /^(?:-f|--filter)$/.test(arg),
 )
-const profileIndex = process.argv.indexOf('--profile')
+const profileIndex = process.argv.findIndex(
+  (arg) => arg === '--profile' || arg.startsWith('--profile='),
+)
 
 if (debugIndex > 0) {
   let value = process.argv[debugIndex + 1]
@@ -63,7 +65,20 @@ function start() {
 }
 
 if (profileIndex > 0) {
-  process.argv.splice(profileIndex, 1)
+  const [profileArg] = process.argv.splice(profileIndex, 1)
+  // `--profile [name]` writes the profile to `<name>.cpuprofile`. The value is
+  // optional and consumed like cac does for other `[optional]` value flags.
+  let profileName = profileArg.slice('--profile='.length)
+  if (!profileName) {
+    const next = process.argv[profileIndex]
+    if (next && next[0] !== '-') {
+      process.argv.splice(profileIndex, 1)
+      profileName = next
+    }
+  }
+  if (profileName) {
+    global.__vite_profile_name = profileName
+  }
   const inspector = await import('node:inspector').then((r) => r.default)
   const session = (global.__vite_profile_session = new inspector.Session())
   session.connect()

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -74,9 +74,14 @@ export const stopProfiler = (
     profileSession!.post('Profiler.stop', (err, { profile }) => {
       // Write profile to disk, upload, etc.
       if (!err) {
-        const outPath = path.resolve(
-          `./vite-profile-${profileCount++}.cpuprofile`,
-        )
+        const name = global.__vite_profile_name
+        const count = profileCount++
+        const fileName = name
+          ? count === 0
+            ? name
+            : `${name}-${count}`
+          : `vite-profile-${count}`
+        const outPath = path.resolve(`./${fileName}.cpuprofile`)
         fs.writeFileSync(outPath, JSON.stringify(profile))
         log(
           colors.yellow(

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -45,6 +45,7 @@ interface GlobalCLIOptions {
   logLevel?: LogLevel
   clearScreen?: boolean
   configLoader?: 'bundle' | 'runner' | 'native'
+  profile?: boolean | string
   d?: boolean | string
   debug?: boolean | string
   f?: string
@@ -119,6 +120,7 @@ function cleanGlobalCLIOptions<Options extends GlobalCLIOptions>(
   delete ret.logLevel
   delete ret.clearScreen
   delete ret.configLoader
+  delete ret.profile
   delete ret.d
   delete ret.debug
   delete ret.f
@@ -187,6 +189,10 @@ cli
   .option(
     '--configLoader <loader>',
     `[string] use 'bundle' to bundle the config with Rolldown, or 'runner' (experimental) to process it on the fly, or 'native' (experimental) to load using the native runtime (default: bundle)`,
+  )
+  .option(
+    '--profile [name]',
+    `[boolean | string] start built-in Node.js inspector`,
   )
   .option('-d, --debug [feat]', `[string | boolean] show debug logs`)
   .option('-f, --filter <filter>', `[string] filter debug logs`)

--- a/packages/vite/src/types/shims.d.ts
+++ b/packages/vite/src/types/shims.d.ts
@@ -26,4 +26,6 @@ declare module 'postcss-import' {
 // eslint-disable-next-line no-var
 declare var __vite_profile_session: import('node:inspector').Session | undefined
 // eslint-disable-next-line no-var
+declare var __vite_profile_name: string | undefined
+// eslint-disable-next-line no-var
 declare var __vite_start_time: number | undefined


### PR DESCRIPTION
closes #23032
closes #23033

`bin/vite.js` has always consumed the token after `--profile` as a value, but then discarded it: the profiler is started unconditionally and no code ever read the value. This made commands like `vite --profile my-app` silently drop `my-app`.

This PR gives the consumed value its intended meaning: `vite --profile <name>` (or `--profile=<name>`) writes the profile to `<name>.cpuprofile` instead of `vite-profile-0.cpuprofile`. Both forms are supported and the next token is consumed exactly like cac handles the other optional-value flags such as `--sourcemap [output]` and `--open [path]`, so there is no breaking change: the token was already consumed before, it just had no effect. A bare `--profile` (at the end of the command or followed by another flag) keeps the current default naming. When the profiler is stopped and restarted multiple times in dev with the `p` shortcut, later dumps get a counter suffix (`<name>-1.cpuprofile`, `<name>-2.cpuprofile`), matching the numbering of the default name.

The flag is now also declared in cac, so it finally shows up in `vite --help` like the other bin-preparsed flags (`--debug`, `--filter`), and `profile` is stripped in `cleanGlobalCLIOptions` so a `--no-profile` value cannot leak into sub-configs. Docs are synced in `docs/guide/cli.md` and the troubleshooting guide.

No test is included: `bin/vite.js` has no existing test coverage. Verified manually that `vite build --profile=myname <root>` and `vite build --profile myname <root>` both build `<root>` and write `myname.cpuprofile`, that a bare `--profile` still writes `vite-profile-0.cpuprofile`, and that `--profile [name]` appears in `vite --help`.