### PR TITLE
test: add proxy middleware tests

### DIFF
--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -266,3 +266,146 @@ describe('port detection', () => {
     expect(warnMessages).toContainEqual(expect.stringContaining('wildcard'))
   })
 })
+
+// Self-signed certificate for HTTPS + proxy coexistence tests (PR #20869).
+// Generated with: openssl req -x509 -newkey rsa:2048 -days 36500 -nodes \
+//   -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1"
+const TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDOjCCAiKgAwIBAgIURwLyJ6H1gdm/vSng8zTsWfIFrcYwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDcyNDA4MzMwMFoYDzIxMjYw
+NjMwMDgzMzAwWjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCz17JAFQEP6dldprscRvMkVt7YtIRjR08vgrRMxqRZ
+BXWxqB5ImY/jEHXcAi+P8qrmb/CtWDgjBrMhxjiTwGtJgUa317XuYaOukN5HBEDm
+Zd+OvhbugPTQPfDrIY4aKj8hYRy/54Fx1UpdYSOO5ZbXpRgcNlSlT7T2Q1evA+1N
+NUkx+3U2b5BrszVG2+SopmqtxHjtimuZSeC6PyGpZHMWjNR8tthmtWTgGm7GCe0H
+QG+u1gcnvfpIlSwR2oLcoiUgbaFM30oqcHfm73qtPw0Fv7z5b0uUnId8TMgSlFFJ
+hqZZA6SUSnBbBRxeKeBVYqYPrTzV0U7/y2cMQYm0f82dAgMBAAGjgYEwfzAdBgNV
+HQ4EFgQUt93CQYb8orySo0Etb6mhigDd3EYwHwYDVR0jBBgwFoAUt93CQYb8oryS
+o0Etb6mhigDd3EYwDwYDVR0TAQH/BAUwAwEB/zAsBgNVHREEJTAjgglsb2NhbGhv
+c3SHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAEwDQYJKoZIhvcNAQELBQADggEBAG0C
+eJDmmgCjvAg9hnYIXD7kaeK7P93uB9ViE/VndIEfshrK6pzrGmCI0IW1ci5S8TQp
+qcMwEuxB53FocATOlWX081DY49zWqWhF3GEZ+b7JrZVkiDgV18MvTgPa/VQQYFAu
+NBiCxLDyCGf+2zee5Lj6caTLaXEp4atF2AewFT3B/APuxnMkDkIbCwXAb6Si3Ryw
+fcLIUx0/z0Z5yQwcwpa2OVsyi/3FkZkZvoNXdLLp0uGZiaGE0WS57iLrWnpcaB6R
+WlaeKzTWRcZRZ8x9MbrM6TjvaEIpFVgrUCBl1zHMlgdzMyvA385SjdRmOU2P2lBh
+LVImOU50DjaJBvHxovk=
+-----END CERTIFICATE-----`
+
+const TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCz17JAFQEP6dld
+prscRvMkVt7YtIRjR08vgrRMxqRZBXWxqB5ImY/jEHXcAi+P8qrmb/CtWDgjBrMh
+xjiTwGtJgUa317XuYaOukN5HBEDmZd+OvhbugPTQPfDrIY4aKj8hYRy/54Fx1Upd
+YSOO5ZbXpRgcNlSlT7T2Q1evA+1NNUkx+3U2b5BrszVG2+SopmqtxHjtimuZSeC6
+PyGpZHMWjNR8tthmtWTgGm7GCe0HQG+u1gcnvfpIlSwR2oLcoiUgbaFM30oqcHfm
+73qtPw0Fv7z5b0uUnId8TMgSlFFJhqZZA6SUSnBbBRxeKeBVYqYPrTzV0U7/y2cM
+QYm0f82dAgMBAAECggEADecYeOBmzZ52rEkNtpjm26H6O5HGQ4/UAkiTZvVa59Ax
+PK5SG6tWC+f42deIFROzEc9eMWMG1pus+2kXH0JFHlCScUyJXEf2CbJZ90QlPupp
+3DS7vG0BqpuEkANvDdIYQUdVm/bp8y0u64XCjvMWtHhRzdSGufotyMqEm8YCRpvn
+uELlUrLyn7VG8yEY1m4B2i34DPM79bMNJyL3SJmN3T23W0rM33iA57ddNiYjm5L2
+JBNIofTIkDGscnt2hJZyzNNg2aNm8TOkE4lG3ORNJxbki7b55TOkfk2/tzH6ekml
+YOPIn53uY2AKF4FrmH0b4lbhzHi2K6HrFFcc1v7zYQKBgQDh6kT7uXurBcpq/iPI
+uGWqxFMDHmKgbntQ2csWtA94MLPoOQgyd+thnLebFzHSYOpz9XGRTsDQ53wzgSXN
+slUjf2ledkxVuqVsYoVbkln27OOTP5eZvFrHJuVs4e0mDAoEC9H/88yaC6/TWvGV
+rlSlCYJ/ecZaQV+XtEh0LYWh+QKBgQDLysFtQ3hRZbZUDs9SHQNgJhZ6dka46Zsy
+mz0P6lMe5vJPIjTyluHX/6331haFP4NSoiCY0Z/OoRKsQfOZqF+7tz2cnJZCrTUt
+R2hMkr4tHm7NNYvi4hmLjLiw7MGyV855pgzuwCD2oiV+h5ToRqRpcjpc+02jujkC
+LiQ+gFWxxQKBgQC44H6TgbcyvgpohJHEMSMCHKfSZYtQvxkrkRAiBDikozaXVBTh
+OEHoH9ghk1myUJ2NR88omsowKz/45jeJnecOpbYVF7pgbd3yVK3NwnbdG/8hAWmO
+5hVj5PDbqgfomvGXXhT84QcPCYFZ9ZK+a2vZo26n43/vXJBeFas1aAt0AQKBgC1a
+ZSuk3Uz4HticJyV2EX8/WrdMRTb3vjNH+xHkqzTwXrKfwTrPu1kvrI7AVWi4Fsi4
+DhsUY8U/cYFmeAkVQKDtCcglzQbvtyrpflu0OKCf6ja/GO+YM+krmxq8xeqjwe6u
+tqgXl/5rXX7IO6pptkNFSZnRz5iFZBSJIkXKl8elAoGBAIIgeCK4MB+0NJQuUPF0
+PDI8MCC3Trj/EK0KfwgaGFk+j9jkuHmQ9SZPVlSjlwaZP6haTeMrdiucS6/O2nTC
+1AxPE93Ns/xrQrOawoiPkBYkuE2AZaCTRWipXRgRGmJgAks/dFgOGD7tiNlGKCt3
+nFcoELjS7IoZJS9ONMkF4ema
+-----END PRIVATE KEY-----`
+
+describe('https + proxy', () => {
+  let viteServer: ViteDevServer | null = null
+  let backend: http.Server | null = null
+
+  afterEach(async () => {
+    if (viteServer) {
+      await viteServer.close()
+      viteServer = null
+    }
+    if (backend) {
+      await new Promise<void>((resolve) => backend!.close(() => resolve()))
+      backend = null
+    }
+  })
+
+  test('supports HTTPS (HTTP/2) and proxy simultaneously', async () => {
+    // Start a plain HTTP backend that the proxy will forward to
+    backend = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('backend:/test')
+    })
+    await new Promise<void>((resolve) =>
+      backend!.listen(0, '127.0.0.1', resolve),
+    )
+    const backendPort = (backend.address() as net.AddressInfo).port
+    const backendUrl = `http://127.0.0.1:${backendPort}`
+
+    // Create a Vite dev server with both HTTPS and proxy enabled.
+    // Before PR #20869, this would downgrade to TLS-only (HTTP/1) because
+    // http-proxy didn't support HTTP/2 servers. With http-proxy-3, both
+    // work together.
+    viteServer = await createServer({
+      root: import.meta.dirname,
+      optimizeDeps,
+      logLevel: 'silent',
+      server: {
+        port: BASE_PORT + 10,
+        strictPort: true,
+        ws: false,
+        https: { cert: TEST_CERT, key: TEST_KEY },
+        proxy: {
+          '/api': {
+            target: backendUrl,
+            changeOrigin: true,
+          },
+        },
+      },
+    })
+    await viteServer.listen()
+
+    // Verify the server is using HTTP/2 (not downgraded to HTTP/1).
+    // Before PR #20868, using https + proxy would fall back to a plain
+    // https.createServer (HTTP/1) instead of http2.createSecureServer.
+    const httpServer = viteServer.httpServer!
+    expect(httpServer.constructor.name).toBe('Http2SecureServer')
+
+    // Verify proxy works through the HTTP/2 server.
+    // Use http2 client to verify HTTP/2 is actually negotiated.
+    const h2 = await import('node:http2')
+    const port = (httpServer.address() as net.AddressInfo).port
+    const client = h2.connect(`https://localhost:${port}`, {
+      rejectUnauthorized: false,
+    })
+
+    // Wait for the client to connect before sending the request
+    await new Promise<void>((resolve, reject) => {
+      client.on('connect', resolve)
+      client.on('error', reject)
+    })
+
+    const res = await new Promise<{ status: number; body: string }>(
+      (resolve, reject) => {
+        const req = client.request({ ':path': '/api/test' })
+        req.on('response', (headers) => {
+          let body = ''
+          req.on('data', (chunk: Buffer) => (body += chunk.toString()))
+          req.on('end', () => resolve({ status: headers[':status']!, body }))
+        })
+        req.on('error', reject)
+        req.end()
+      },
+    )
+
+    client.close()
+
+    expect(res.status).toBe(200)
+    expect(res.body).toBe('backend:/test')
+  })
+})

--- a/playground/proxy-middleware/__tests__/proxy-middleware.spec.ts
+++ b/playground/proxy-middleware/__tests__/proxy-middleware.spec.ts
@@ -1,0 +1,169 @@
+import http from 'node:http'
+import crypto from 'node:crypto'
+import { URL } from 'node:url'
+import { expect, test } from 'vitest'
+import { viteTestUrl } from '~utils'
+
+/**
+ * Sends a raw WebSocket upgrade request with custom headers and reads
+ * the first text frame from the server response.
+ */
+function sendWsUpgrade(
+  serverUrl: string,
+  path: string,
+  headers: Record<string, string>,
+): Promise<string> {
+  const url = new URL(serverUrl)
+  const key = crypto.randomBytes(16).toString('base64')
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      hostname: url.hostname,
+      port: url.port,
+      path,
+      method: 'GET',
+      headers: {
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        'Sec-WebSocket-Version': '13',
+        'Sec-WebSocket-Key': key,
+        ...headers,
+      },
+    })
+
+    const timeout = setTimeout(
+      () => reject(new Error('ws upgrade timeout')),
+      5000,
+    )
+
+    req.on('upgrade', (_res, socket) => {
+      clearTimeout(timeout)
+      // Read the first WebSocket frame from the upgraded socket.
+      socket.once('data', (data) => {
+        // Frame format: byte 0 = opcode, byte 1 = payload length (assume < 126)
+        const payloadLen = data[1] & 0x7f
+        const payload = data.subarray(2, 2 + payloadLen).toString()
+        socket.destroy()
+        resolve(payload)
+      })
+    })
+
+    req.on('response', (res) => {
+      clearTimeout(timeout)
+      let body = ''
+      res.on('data', (d) => (body += d))
+      res.on('end', () =>
+        reject(
+          new Error(
+            `got HTTP ${res.statusCode} instead of upgrade: ${body.slice(0, 200)}`,
+          ),
+        ),
+      )
+    })
+
+    req.on('error', (err) => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+
+    req.end()
+  })
+}
+
+test('proxies basic GET request', async () => {
+  const res = await fetch(viteTestUrl + '/api/test')
+  expect(res.status).toBe(200)
+  const text = await res.text()
+  expect(text).toBe('backend:/api/test')
+})
+
+test('rewrites the path', async () => {
+  const res = await fetch(viteTestUrl + '/rewrite/foo')
+  expect(res.status).toBe(200)
+  const text = await res.text()
+  // rewrite replaces /rewrite with /api, so backend sees /api/foo
+  expect(text).toBe('backend:/api/foo')
+})
+
+test('injects custom headers', async () => {
+  const res = await fetch(viteTestUrl + '/headers/echo-headers')
+  expect(res.status).toBe(200)
+  const headers = (await res.json()) as Record<string, string>
+  // header names are lowercased by Node.js
+  expect(headers['x-injected']).toBe('injected-value')
+})
+
+test('proxy auth overrides client Authorization header', async () => {
+  // When the proxy is configured with `auth`, the configured credentials
+  // should override any Authorization header sent by the client.
+  // This is a regression test for #20312, fixed by http-proxy-3.
+  const res = await fetch(viteTestUrl + '/auth/echo-headers', {
+    headers: {
+      authorization: 'Bearer client-token',
+    },
+  })
+  expect(res.status).toBe(200)
+  const headers = (await res.json()) as Record<string, string>
+  // The backend should receive Basic auth from the proxy config,
+  // not the client's Bearer token.
+  expect(headers.authorization).toBe(
+    `Basic ${Buffer.from('user1:pass1').toString('base64')}`,
+  )
+})
+
+test('pipes a large response body correctly', async () => {
+  const res = await fetch(viteTestUrl + '/big')
+  expect(res.status).toBe(200)
+  const text = await res.text()
+  // 16 chunks × 64 KB = 1 MB
+  expect(text.length).toBe(16 * 64 * 1024)
+  expect(text).toMatch(/^x+$/)
+})
+
+test('returns 502 on proxy error', async () => {
+  const res = await fetch(viteTestUrl + '/error')
+  expect(res.status).toBe(502)
+})
+
+test('handles 204 No Content', async () => {
+  const res = await fetch(viteTestUrl + '/no-content')
+  expect(res.status).toBe(204)
+  expect(await res.text()).toBe('')
+})
+
+test('handles client abort without server crash', async () => {
+  const controller = new AbortController()
+  const res = await fetch(viteTestUrl + '/slow', {
+    signal: controller.signal,
+  })
+
+  // start reading the body, then abort mid-stream
+  const reader = res.body!.getReader()
+  await reader.read() // consume first chunk
+  await new Promise((r) => setTimeout(r, 100))
+  controller.abort()
+
+  // reading should fail due to abort
+  await expect(reader.read()).rejects.toThrow()
+
+  // verify the dev server is still alive and serving normally
+  const afterRes = await fetch(viteTestUrl + '/api/after-abort')
+  expect(afterRes.status).toBe(200)
+  expect(await afterRes.text()).toBe('backend:/api/after-abort')
+})
+
+test('rewriteWsOrigin rewrites the Origin header to match the target', async () => {
+  // Send a raw WebSocket upgrade request with a custom Origin header.
+  // With rewriteWsOrigin: true, the proxy rewrites Origin to the target URL.
+  // The backend WS server sends back the Origin it received as a text frame.
+  const wsOrigin = await sendWsUpgrade(viteTestUrl, '/ws-origin', {
+    origin: 'http://localhost:9630',
+  })
+
+  // The backend echoes `ws-origin:<received-origin>`. With rewriteWsOrigin,
+  // the origin should be rewritten to the backend URL (`ws://127.0.0.1:<port>`),
+  // not the Vite dev server URL (`http://localhost:9630`).
+  expect(wsOrigin).toMatch(/^ws-origin:ws:\/\/127\.0\.0\.1:\d+$/)
+  // ensure it's not the original origin we sent
+  expect(wsOrigin).not.toContain('localhost:9630')
+})

--- a/playground/proxy-middleware/__tests__/proxy-middleware.spec.ts
+++ b/playground/proxy-middleware/__tests__/proxy-middleware.spec.ts
@@ -1,74 +1,5 @@
-import http from 'node:http'
-import crypto from 'node:crypto'
-import { URL } from 'node:url'
 import { expect, test } from 'vitest'
 import { viteTestUrl } from '~utils'
-
-/**
- * Sends a raw WebSocket upgrade request with custom headers and reads
- * the first text frame from the server response.
- */
-function sendWsUpgrade(
-  serverUrl: string,
-  path: string,
-  headers: Record<string, string>,
-): Promise<string> {
-  const url = new URL(serverUrl)
-  const key = crypto.randomBytes(16).toString('base64')
-
-  return new Promise((resolve, reject) => {
-    const req = http.request({
-      hostname: url.hostname,
-      port: url.port,
-      path,
-      method: 'GET',
-      headers: {
-        Connection: 'Upgrade',
-        Upgrade: 'websocket',
-        'Sec-WebSocket-Version': '13',
-        'Sec-WebSocket-Key': key,
-        ...headers,
-      },
-    })
-
-    const timeout = setTimeout(
-      () => reject(new Error('ws upgrade timeout')),
-      5000,
-    )
-
-    req.on('upgrade', (_res, socket) => {
-      clearTimeout(timeout)
-      // Read the first WebSocket frame from the upgraded socket.
-      socket.once('data', (data) => {
-        // Frame format: byte 0 = opcode, byte 1 = payload length (assume < 126)
-        const payloadLen = data[1] & 0x7f
-        const payload = data.subarray(2, 2 + payloadLen).toString()
-        socket.destroy()
-        resolve(payload)
-      })
-    })
-
-    req.on('response', (res) => {
-      clearTimeout(timeout)
-      let body = ''
-      res.on('data', (d) => (body += d))
-      res.on('end', () =>
-        reject(
-          new Error(
-            `got HTTP ${res.statusCode} instead of upgrade: ${body.slice(0, 200)}`,
-          ),
-        ),
-      )
-    })
-
-    req.on('error', (err) => {
-      clearTimeout(timeout)
-      reject(err)
-    })
-
-    req.end()
-  })
-}
 
 test('proxies basic GET request', async () => {
   const res = await fetch(viteTestUrl + '/api/test')
@@ -150,20 +81,4 @@ test('handles client abort without server crash', async () => {
   const afterRes = await fetch(viteTestUrl + '/api/after-abort')
   expect(afterRes.status).toBe(200)
   expect(await afterRes.text()).toBe('backend:/api/after-abort')
-})
-
-test('rewriteWsOrigin rewrites the Origin header to match the target', async () => {
-  // Send a raw WebSocket upgrade request with a custom Origin header.
-  // With rewriteWsOrigin: true, the proxy rewrites Origin to the target URL.
-  // The backend WS server sends back the Origin it received as a text frame.
-  const wsOrigin = await sendWsUpgrade(viteTestUrl, '/ws-origin', {
-    origin: 'http://localhost:9630',
-  })
-
-  // The backend echoes `ws-origin:<received-origin>`. With rewriteWsOrigin,
-  // the origin should be rewritten to the backend URL (`ws://127.0.0.1:<port>`),
-  // not the Vite dev server URL (`http://localhost:9630`).
-  expect(wsOrigin).toMatch(/^ws-origin:ws:\/\/127\.0\.0\.1:\d+$/)
-  // ensure it's not the original origin we sent
-  expect(wsOrigin).not.toContain('localhost:9630')
 })

--- a/playground/proxy-middleware/__tests__/serve.ts
+++ b/playground/proxy-middleware/__tests__/serve.ts
@@ -1,0 +1,169 @@
+// this is automatically detected by playground/vitestSetup.ts and will replace
+// the default e2e test serve behavior
+
+import http from 'node:http'
+import crypto from 'node:crypto'
+import type { AddressInfo } from 'node:net'
+import { ports, rootDir, setViteUrl } from '~utils'
+
+// Stores the Origin header seen by the backend WS server for verification.
+let lastWsOrigin: string | undefined
+
+// --- backend HTTP server for web proxy tests ---
+const backend = http.createServer((req, res) => {
+  const url = req.url!
+
+  if (url === '/echo-headers') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(req.headers))
+    return
+  }
+
+  if (url === '/slow') {
+    // Respond slowly so the client can abort mid-response, triggering
+    // the `proxyRes` close cleanup path in the proxy middleware.
+    res.writeHead(200, {
+      'Content-Type': 'text/plain',
+      'Transfer-Encoding': 'chunked',
+    })
+    res.write('first chunk\n')
+    setTimeout(() => {
+      res.write('second chunk\n')
+      res.end()
+    }, 2000)
+    return
+  }
+
+  if (url === '/big') {
+    // Send a large response body (1 MB) so the client receives it in
+    // multiple chunks, exercising the full piping path through http-proxy-3.
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    const chunk = 'x'.repeat(64 * 1024) // 64 KB
+    for (let i = 0; i < 16; i++) {
+      res.write(chunk)
+    }
+    res.end()
+    return
+  }
+
+  if (url === '/status-204') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/plain' })
+  res.end(`backend:${url}`)
+})
+
+// --- backend WebSocket server (manual handshake) for ws proxy tests ---
+backend.on('upgrade', (req, socket, _head) => {
+  // Capture the Origin header so tests can verify rewriteWsOrigin behavior.
+  lastWsOrigin = req.headers.origin
+
+  // Minimal RFC 6455 handshake — no ws library needed.
+  const key = req.headers['sec-websocket-key'] as string
+  const accept = crypto
+    .createHash('sha1')
+    .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64')
+
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n` +
+      '\r\n',
+  )
+
+  // Send a simple text frame with the origin we received.
+  const payload = Buffer.from(`ws-origin:${lastWsOrigin ?? 'none'}`)
+  const frame = Buffer.alloc(2 + payload.length)
+  frame[0] = 0x81 // FIN + text frame
+  frame[1] = payload.length // assume < 126 bytes
+  payload.copy(frame, 2)
+  socket.write(frame)
+  // Keep the socket open briefly to ensure the data is piped through
+  // the proxy before closing. The proxy's pipe will handle cleanup.
+  setTimeout(() => socket.end(), 1000)
+})
+
+export async function serve(): Promise<{ close(): Promise<void> }> {
+  const vite = await import('vite')
+
+  await new Promise<void>((resolve) => backend.listen(0, '127.0.0.1', resolve))
+  const backendPort = (backend.address() as AddressInfo).port
+  const backendUrl = `http://127.0.0.1:${backendPort}`
+  const backendWsUrl = `ws://127.0.0.1:${backendPort}`
+
+  const server = await vite.createServer({
+    root: rootDir,
+    logLevel: 'silent',
+    server: {
+      port: ports['proxy-middleware'],
+      proxy: {
+        // basic proxying — verifies the core web() path works
+        '/api': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+        // proxy with path rewrite
+        '/rewrite': {
+          target: backendUrl,
+          rewrite: (path) => path.replace(/^\/rewrite/, '/api'),
+        },
+        // proxy that forwards custom headers to the backend
+        '/headers': {
+          target: backendUrl,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/headers/, ''),
+          headers: {
+            'x-injected': 'injected-value',
+          },
+        },
+        // proxy returning a large body (full pipe path)
+        '/big': {
+          target: backendUrl,
+        },
+        // proxy to a slow endpoint — used for abort / cleanup test
+        '/slow': {
+          target: backendUrl,
+        },
+        // proxy to a non-existent host — triggers the error handler → 502
+        '/error': {
+          target: 'http://127.0.0.1:1', // port 1 should always fail
+        },
+        // proxy to a 204 response
+        '/no-content': {
+          target: backendUrl,
+          rewrite: (path) => path.replace(/^\/no-content/, '/status-204'),
+        },
+        // ws proxy with rewriteWsOrigin — rewrites the Origin header to
+        // match the target URL
+        '/ws-origin': {
+          target: backendWsUrl,
+          ws: true,
+          rewriteWsOrigin: true,
+        },
+        // proxy with auth — verifies that the configured auth overrides
+        // any Authorization header sent by the client (fixes #20312)
+        '/auth': {
+          target: backendUrl,
+          rewrite: (path) => path.replace(/^\/auth/, ''),
+          auth: 'user1:pass1',
+        },
+      },
+    },
+  })
+
+  await server.listen()
+  const viteUrl = server.resolvedUrls.local[0].replace(/\/$/, '')
+  setViteUrl(viteUrl)
+
+  return {
+    async close() {
+      await server.close()
+      await new Promise<void>((resolve) => backend.close(() => resolve()))
+    },
+  }
+}

--- a/playground/proxy-middleware/__tests__/serve.ts
+++ b/playground/proxy-middleware/__tests__/serve.ts
@@ -2,12 +2,8 @@
 // the default e2e test serve behavior
 
 import http from 'node:http'
-import crypto from 'node:crypto'
 import type { AddressInfo } from 'node:net'
 import { ports, rootDir, setViteUrl } from '~utils'
-
-// Stores the Origin header seen by the backend WS server for verification.
-let lastWsOrigin: string | undefined
 
 // --- backend HTTP server for web proxy tests ---
 const backend = http.createServer((req, res) => {
@@ -56,45 +52,12 @@ const backend = http.createServer((req, res) => {
   res.end(`backend:${url}`)
 })
 
-// --- backend WebSocket server (manual handshake) for ws proxy tests ---
-backend.on('upgrade', (req, socket, _head) => {
-  // Capture the Origin header so tests can verify rewriteWsOrigin behavior.
-  lastWsOrigin = req.headers.origin
-
-  // Minimal RFC 6455 handshake — no ws library needed.
-  const key = req.headers['sec-websocket-key'] as string
-  const accept = crypto
-    .createHash('sha1')
-    .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
-    .digest('base64')
-
-  socket.write(
-    'HTTP/1.1 101 Switching Protocols\r\n' +
-      'Upgrade: websocket\r\n' +
-      'Connection: Upgrade\r\n' +
-      `Sec-WebSocket-Accept: ${accept}\r\n` +
-      '\r\n',
-  )
-
-  // Send a simple text frame with the origin we received.
-  const payload = Buffer.from(`ws-origin:${lastWsOrigin ?? 'none'}`)
-  const frame = Buffer.alloc(2 + payload.length)
-  frame[0] = 0x81 // FIN + text frame
-  frame[1] = payload.length // assume < 126 bytes
-  payload.copy(frame, 2)
-  socket.write(frame)
-  // Keep the socket open briefly to ensure the data is piped through
-  // the proxy before closing. The proxy's pipe will handle cleanup.
-  setTimeout(() => socket.end(), 1000)
-})
-
 export async function serve(): Promise<{ close(): Promise<void> }> {
   const vite = await import('vite')
 
   await new Promise<void>((resolve) => backend.listen(0, '127.0.0.1', resolve))
   const backendPort = (backend.address() as AddressInfo).port
   const backendUrl = `http://127.0.0.1:${backendPort}`
-  const backendWsUrl = `ws://127.0.0.1:${backendPort}`
 
   const server = await vite.createServer({
     root: rootDir,
@@ -137,13 +100,6 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
         '/no-content': {
           target: backendUrl,
           rewrite: (path) => path.replace(/^\/no-content/, '/status-204'),
-        },
-        // ws proxy with rewriteWsOrigin — rewrites the Origin header to
-        // match the target URL
-        '/ws-origin': {
-          target: backendWsUrl,
-          ws: true,
-          rewriteWsOrigin: true,
         },
         // proxy with auth — verifies that the configured auth overrides
         // any Authorization header sent by the client (fixes #20312)

--- a/playground/proxy-middleware/index.html
+++ b/playground/proxy-middleware/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>proxy-middleware</title>
+  </head>
+  <body>
+    proxy-middleware playground
+  </body>
+</html>

--- a/playground/proxy-middleware/package.json
+++ b/playground/proxy-middleware/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-proxy-middleware",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -45,6 +45,7 @@ export const ports = {
   'ssr-hmr': 9609, // not imported but used in `hmr-ssr/__tests__/hmr.spec.ts`
   'proxy-hmr': 9616, // not imported but used in `proxy-hmr/vite.config.js`
   'proxy-hmr/other-app': 9617, // not imported but used in `proxy-hmr/other-app/vite.config.js`
+  'proxy-middleware': 9630, // not imported but used in `proxy-middleware/__tests__/serve.ts`
   'ssr-conditions': 9620,
   'css/postcss-caching': 5005,
   'css/postcss-plugins-different-dir': 5006,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1393,6 +1393,8 @@ importers:
 
   playground/proxy-hmr/other-app: {}
 
+  playground/proxy-middleware: {}
+
   playground/resolve:
     dependencies:
       '@babel/runtime':


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
Add playground/proxy-middleware and a unit test in http.spec.ts to cover scenarios not exercised by existing proxy-bypass/proxy-hmr playgrounds, verifying the http-proxy → http-proxy-3 migration (#20402) and its related issue fixes. 

Although there are unit tests on the http-proxy-3 side, I think it is valuable to add test cases on the vite side as much as possible to avoid potential regression issues or the possibility of switching to other dependencies in the future.

Refs #20402, #20312, #20869

***Note: The test cases in this PR are generated by AI. Although they have passed local testing and been verified, unexpected situations may occur. Please note this, reviewers.***