### PR TITLE
fix(docs): normalize image paths for markdown-it-image-size on Windows

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -546,6 +546,18 @@ const config = defineConfig({
       md.use(markdownItImageSize, {
         publicDir: path.resolve(import.meta.dirname, '../public'),
       })
+      const imageRule = md.renderer.rules.image
+
+      if (imageRule) {
+        md.renderer.rules.image = (tokens, idx, options, env, self) => {
+          const normalizedEnv =
+            typeof env?.path === 'string'
+              ? { ...env, path: env.path.replaceAll('\\', '/') }
+              : env
+
+          return imageRule(tokens, idx, options, normalizedEnv, self)
+        }
+      }
       await graphvizMarkdownPlugin(md)
     },
   },


### PR DESCRIPTION
## What is this PR solving?

On Windows, starting the Vite documentation site produces `markdown-it-image-size` warnings for relative images such as
`../images/v3-docs.webp`.

<img width="987" height="519" alt="image" src="https://github.com/user-attachments/assets/af76a6f3-e12a-4470-9820-3f60e983222d" />

VitePress provides `env.path` with Windows path separators (`\`), while `markdown-it-image-size` expects `/` when determining the Markdown file's directory. The plugin therefore resolves relative images from the wrong directory and fails to add their `width` and `height` attributes.

This PR normalizes `env.path` before passing it to the image renderer. The normalization is scoped to `markdown-it-image-size` and does not mutate the shared Markdown environment.

## Related issues

None.

## Alternatives considered

 Fixing `markdown-it-image-size` upstream. I plan to submit an upstream PR to address the underlying issue. Until an upstream fix is released, this PR provides a scoped workaround for Vite contributors using Windows. I will continue tracking the upstream issue and submit a follow-up PR to remove this workaround once the fix is available.
