### PR TITLE
docs: fix missing articles in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi! We're really excited that you're interested in contributing to Vite! Before 
 
 ## Repo Setup
 
-To develop locally, fork the Vite repository and clone it in your local machine. The Vite repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). You can find the required pnpm version in `package.json` under the `packageManager` key.
+To develop locally, fork the Vite repository and clone it to your local machine. The Vite repo is a monorepo using pnpm workspaces. The package manager used to install and link dependencies must be [pnpm](https://pnpm.io/). You can find the required pnpm version in `package.json` under the `packageManager` key.
 
 To develop and test the core `vite` package:
 
@@ -33,7 +33,7 @@ git config --local blame.ignoreRevsFile .git-blame-ignore-revs
 
 To develop the `docs/` site:
 
-1. Run `pnpm run build` in Vite's root folder. This will generate the types for `twoslash` to work in the code examples. If the types are not available, errors will be logged in step 2 but does not prevent the site from working.
+1. Run `pnpm run build` in Vite's root folder. This will generate the types for `twoslash` to work in the code examples. If the types are not available, errors will be logged in step 2 but will not prevent the site from working.
 
 2. Run `pnpm run docs` in Vite's root folder.
 
@@ -79,7 +79,7 @@ We already have many config options, and we should avoid fixing an issue by addi
 
 - is really worth addressing
 - can be fixed with a smarter default
-- has workaround using existing options
+- has a workaround using existing options
 - can be addressed with a plugin instead
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - 🔩 Universal Plugin Interface
 - 🔑 Fully Typed APIs
 
-Vite (French word for "quick", pronounced [`/viːt/`](https://cdn.jsdelivr.net/gh/vitejs/vite@main/docs/public/vite.mp3), like "veet") is a build tool that aims to provide a faster and leaner development experience for modern web projects. It consists of two major parts:
+Vite (a French word for "quick", pronounced [`/viːt/`](https://cdn.jsdelivr.net/gh/vitejs/vite@main/docs/public/vite.mp3), like "veet") is a build tool that aims to provide a faster and leaner development experience for modern web projects. It consists of two major parts:
 
 - A dev server that provides [rich feature enhancements](https://vite.dev/guide/features) over [native ES modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), for example extremely fast [Hot Module Replacement (HMR)](https://vite.dev/guide/features#hot-module-replacement).
 
@@ -52,7 +52,7 @@ In addition, Vite is highly extensible via its [Plugin API](https://vite.dev/gui
 
 ## Contribution
 
-See [Contributing Guide](CONTRIBUTING.md).
+See the [Contributing Guide](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Description
This PR fixes missing article formatting in `README.md`.

## Details
1. Added missing indefinite article (`Vite (French word for "quick"` $\to$ `Vite (a French word for "quick"`).
2. Added missing definite article (`See Contributing Guide` $\to$ `See the Contributing Guide`).