### PR TITLE
fix(create-vite): keep Qwik templates within supported Vite range

### DIFF
--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^24.13.3",
     "serve": "^14.2.6",
     "typescript": "~6.0.2",
-    "vite": "^8.1.5"
+    "vite": "^7.3.6"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.20.0"

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "serve": "^14.2.6",
-    "vite": "^8.1.5"
+    "vite": "^7.3.6"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.20.0"


### PR DESCRIPTION
## Summary

Keep the JavaScript and TypeScript Qwik starter templates on Vite 7, the newest Vite major supported by the current stable Qwik release.

## Root cause

`create-vite@9.1.1` generates the Qwik templates with `vite@^8.1.5` and `@builder.io/qwik@^1.20.0`. Qwik 1.20.0 declares `vite@">=5 <8"` as a peer dependency, so npm rejects a freshly generated project with `ERESOLVE unable to resolve dependency tree`.

There is no newer stable Qwik release with Vite 8 in its peer range. Using `vite@^7.3.6` keeps the templates on the latest compatible Vite major without disabling peer dependency validation.

## Validation

- Reproduced the npm `ERESOLVE` failure with the current `template-qwik`.
- Copied each updated template into an isolated directory.
- Ran `npm install --package-lock=false --ignore-scripts` for `template-qwik` and `template-qwik-ts`.
- Ran `npm run build` successfully for both templates with Vite 7.3.6.

An automated test was not added because the existing create-vite tests verify scaffolding but do not install every generated template's external dependency tree. The isolated install-and-build smoke tests directly cover this peer-resolution failure.
