### PR TITLE
fix(create-vite): update Qwik templates for Vite 8

### DIFF
--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -15,6 +15,6 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@builder.io/qwik": "^1.20.0"
+    "@qwik.dev/core": "^2.0.0-beta.38"
   }
 }

--- a/packages/create-vite/template-qwik-ts/src/app.tsx
+++ b/packages/create-vite/template-qwik-ts/src/app.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal } from '@builder.io/qwik'
+import { component$, useSignal } from '@qwik.dev/core'
 
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'

--- a/packages/create-vite/template-qwik-ts/src/main.tsx
+++ b/packages/create-vite/template-qwik-ts/src/main.tsx
@@ -1,6 +1,6 @@
-import '@builder.io/qwik/qwikloader.js'
+import '@qwik.dev/core/qwikloader.js'
 
-import { render } from '@builder.io/qwik'
+import { render } from '@qwik.dev/core'
 import './index.css'
 import { App } from './app.tsx'
 

--- a/packages/create-vite/template-qwik-ts/tsconfig.app.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.app.json
@@ -15,7 +15,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "@builder.io/qwik",
+    "jsxImportSource": "@qwik.dev/core",
 
     /* Linting */
     "noUnusedLocals": true,

--- a/packages/create-vite/template-qwik-ts/vite.config.ts
+++ b/packages/create-vite/template-qwik-ts/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import { qwikVite } from '@builder.io/qwik/optimizer'
+import { qwikVite } from '@qwik.dev/core/optimizer'
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -13,6 +13,6 @@
     "vite": "^8.1.5"
   },
   "dependencies": {
-    "@builder.io/qwik": "^1.20.0"
+    "@qwik.dev/core": "^2.0.0-beta.38"
   }
 }

--- a/packages/create-vite/template-qwik/src/app.jsx
+++ b/packages/create-vite/template-qwik/src/app.jsx
@@ -1,4 +1,4 @@
-import { component$, useSignal } from '@builder.io/qwik'
+import { component$, useSignal } from '@qwik.dev/core'
 
 import qwikLogo from './assets/qwik.svg'
 import viteLogo from './assets/vite.svg'

--- a/packages/create-vite/template-qwik/src/main.jsx
+++ b/packages/create-vite/template-qwik/src/main.jsx
@@ -1,6 +1,6 @@
-import '@builder.io/qwik/qwikloader.js'
+import '@qwik.dev/core/qwikloader.js'
 
-import { render } from '@builder.io/qwik'
+import { render } from '@qwik.dev/core'
 import './index.css'
 import { App } from './app.jsx'
 

--- a/packages/create-vite/template-qwik/vite.config.js
+++ b/packages/create-vite/template-qwik/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import { qwikVite } from '@builder.io/qwik/optimizer'
+import { qwikVite } from '@qwik.dev/core/optimizer'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary

Migrate the JavaScript and TypeScript Qwik starter templates from `@builder.io/qwik` v1 to the current `@qwik.dev/core` package while keeping Vite 8.

This updates the runtime, optimizer, loader, and TypeScript JSX import paths for the renamed Qwik v2 package.

## Root cause

The Qwik templates currently combine:

- `vite@^8.1.5`
- `@builder.io/qwik@^1.20.0`, whose Vite peer range is `>=5 <8`

As a result, npm rejects a freshly generated Qwik project with `ERESOLVE unable to resolve dependency tree`.

`@qwik.dev/core@2.0.0-beta.38` is the current npm `latest` release and supports `vite@>=6 <9`, so it resolves the incompatibility without downgrading Vite or disabling peer dependency validation.

## Validation

For both `template-qwik` and `template-qwik-ts`:

- copied the updated template into an isolated directory
- ran `npm install --package-lock=false --ignore-scripts`
- ran `npm run build`
- confirmed the build used Vite 8.1.5

The TypeScript template also completed its `tsc -b` step successfully.

An automated test was not added because the existing create-vite tests verify scaffolding but do not install every template's external dependency tree. The isolated install-and-build smoke tests directly cover this failure.
