### PR TITLE
docs(config): correct cacheDir default fallback description

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -391,7 +391,7 @@ export interface UserConfig extends DefaultEnvironmentOptions {
    * the performance. You can use `--force` flag or manually delete the directory
    * to regenerate the cache files. The value can be either an absolute file
    * system path or a path relative to project root.
-   * Default to `.vite` when no `package.json` is detected.
+   * Default to `.vite` when neither a `package.json` nor a `node_modules` directory is detected.
    * @default 'node_modules/.vite'
    */
   cacheDir?: string


### PR DESCRIPTION
`cacheDir`'s JSDoc says it defaults to `.vite` when no `package.json` is detected, but the resolve logic only uses a bare `.vite` when there is also no `node_modules` directory. When `node_modules` exists (for example a Deno project using npm packages), the default is `node_modules/.vite`.

Updated the description to match the actual fallback.

refs #21777
