### PR TITLE
docs(changes): fix missing commas  and language mark in plugin examples

### DIFF
--- a/docs/changes/shared-plugins-during-build.md
+++ b/docs/changes/shared-plugins-during-build.md
@@ -54,7 +54,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
     },
     buildEnd() {
       console.log(this.environment.name, state.get(this.environment).count)
-    }
+    },
   }
 }
 ```
@@ -75,7 +75,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
     },
     buildEnd() {
       console.log(this.environment.name, state(this).count)
-    }
+    },
   }
 }
 ```

--- a/docs/changes/shared-plugins-during-build.md
+++ b/docs/changes/shared-plugins-during-build.md
@@ -40,7 +40,7 @@ function CountTransformedModulesPlugin() {
 
 If we instead want to count the number of transformed modules for each environment, we need to keep a map:
 
-```js
+```ts
 function PerEnvironmentCountTransformedModulesPlugin() {
   const state = new Map<Environment, { count: number }>()
   return {
@@ -48,7 +48,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
     perEnvironmentStartEndDuringDev: true,
     buildStart() {
       state.set(this.environment, { count: 0 })
-    }
+    },
     transform(id) {
       state.get(this.environment).count++
     },
@@ -61,7 +61,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
 
 To simplify this pattern, Vite exports a `perEnvironmentState` helper:
 
-```js
+```ts
 function PerEnvironmentCountTransformedModulesPlugin() {
   const state = perEnvironmentState<{ count: number }>(() => ({ count: 0 }))
   return {
@@ -69,7 +69,7 @@ function PerEnvironmentCountTransformedModulesPlugin() {
     perEnvironmentStartEndDuringDev: true,
     buildStart() {
       state(this).count = 0
-    }
+    },
     transform(id) {
       state(this).count++
     },


### PR DESCRIPTION
- Add missing commas
- Mark examples code as TypeScript