### PR TITLE
fix(client): show overlay for HMR import errors

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -198,10 +198,28 @@ const hmrClient = new HMRClient(
         }
         return await importPromise
       },
+  {
+    onUpdateError: handleHMRUpdateError,
+  },
 )
 transport.connect!(createHMRHandler(handleMessage))
 
 setupForwardConsoleHandler(transport, forwardConsole)
+
+async function handleHMRUpdateError(error: Error, path: string | string[]) {
+  const payload: ErrorPayload = {
+    type: 'error',
+    err: {
+      message: error.message,
+      stack: error.stack ?? '',
+      id: Array.isArray(path) ? path.join(', ') : path,
+    },
+  }
+  await hmrClient.notifyListeners('vite:error', payload)
+  if (hasDocument && enableOverlay) {
+    createErrorOverlay(payload.err)
+  }
+}
 
 async function handleMessage(payload: HotPayload) {
   switch (payload.type) {

--- a/packages/vite/src/shared/__tests__/hmr.spec.ts
+++ b/packages/vite/src/shared/__tests__/hmr.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { Update } from '#types/hmrPayload'
+import { HMRClient, HMRContext } from '../hmr'
+
+describe('HMRClient', () => {
+  test('reports errors thrown while importing an updated module', async () => {
+    const error = new SyntaxError(
+      "The requested module './dep.js' does not provide an export named 'value'",
+    )
+    const onUpdateError = vi.fn()
+    const client = new HMRClient(
+      { error: vi.fn(), debug: vi.fn() },
+      { send: vi.fn() },
+      async () => {
+        throw error
+      },
+      { onUpdateError },
+    )
+
+    new HMRContext(client, '/entry.js').accept()
+
+    const update: Update = {
+      type: 'js-update',
+      path: '/entry.js',
+      acceptedPath: '/entry.js',
+      timestamp: Date.now(),
+    }
+    await client.queueUpdate(update)
+
+    expect(onUpdateError).toHaveBeenCalledOnce()
+    expect(onUpdateError).toHaveBeenCalledWith(error, '/entry.js')
+  })
+})

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -21,6 +21,13 @@ export interface HMRLogger {
   debug(...msg: unknown[]): void
 }
 
+export interface HMRClientOptions {
+  onUpdateError?: (
+    error: Error,
+    path: string | string[],
+  ) => void | Promise<void>
+}
+
 export class HMRContext implements ViteHotContext {
   private newListeners: CustomListenersMap
 
@@ -182,6 +189,7 @@ export class HMRClient {
     private transport: NormalizedModuleRunnerTransport,
     // This allows implementing reloading via different methods depending on the environment
     private importUpdatedModule: (update: Update) => Promise<ModuleNamespace>,
+    private options: HMRClientOptions = {},
   ) {}
 
   public async notifyListeners<T extends string>(
@@ -285,7 +293,9 @@ export class HMRClient {
       try {
         fetchedModule = await this.importUpdatedModule(update)
       } catch (e) {
-        this.warnFailedUpdate(e, acceptedPath)
+        const error = e instanceof Error ? e : new Error(String(e))
+        this.warnFailedUpdate(error, acceptedPath)
+        await this.options.onUpdateError?.(error, acceptedPath)
       }
     }
 

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -897,6 +897,26 @@ if (!isBuild) {
     }, [/500/, /connected/])
   })
 
+  test('shows an error overlay when an HMR update fails to import a module', async () => {
+    const file = 'importing-updated/b.js'
+    const existingImport = "import a from './a.js'"
+    const invalidImport = "import { missing } from './a.js'"
+
+    await page.goto(viteTestUrl)
+    expect(await page.isVisible('vite-error-overlay')).toBe(false)
+
+    editFile(file, (code) => code.replace(existingImport, invalidImport))
+    const overlay = await page.waitForSelector('vite-error-overlay')
+    const message = await overlay.$$eval(
+      '.message-body',
+      (elements) => elements[0].textContent,
+    )
+    expect(message).toContain('does not provide an export')
+
+    editFile(file, (code) => code.replace(invalidImport, existingImport))
+    await expect.poll(() => page.isVisible('vite-error-overlay')).toBe(false)
+  })
+
   test('should hmr when file is deleted and restored', async () => {
     await page.goto(viteTestUrl)
 


### PR DESCRIPTION
## Description

When the client applies an HMR update, `importUpdatedModule()` can fail during
module evaluation or linking. This includes errors such as importing a named
export that the updated dependency does not provide.

These failures are currently caught by `HMRClient.fetchUpdate()` and only
reported through `warnFailedUpdate()`. Unlike server-side transform errors,
they do not reach the existing `vite:error` event or the error overlay. This
can leave the page in a partially updated state while the relevant diagnostic
is only available in the browser console.

This change adds an optional update-error callback to the shared HMR client.
The browser client uses it to normalize the original exception into the
existing `ErrorPayload` shape, notify `vite:error` listeners, and display the
standard error overlay when enabled.

The change is limited to failures that occur while applying HMR updates. It
does not add static import validation or change initial page-load error
handling.

The implementation intentionally does not classify failures by matching
browser-specific error message text such as `fetch`. The wording differs
between browsers, and a fetch failure can also represent a real failed module
update rather than a transient server restart. All failed HMR imports are
therefore reported consistently; transport-aware suppression can be addressed
separately if a reliable connection-state signal is introduced.

## Alternatives considered

A plugin can wrap `console.error` or inject a global browser error listener.
Those approaches depend on logging details or browser-specific module error
reporting and do not consistently preserve the original HMR update context.
Handling the error where `importUpdatedModule()` rejects keeps the shared HMR
implementation environment-agnostic while allowing the browser client to use
its existing error pipeline.

## Tests

- Added a unit test verifying that module import errors reach the optional HMR
  update-error callback.
- Added a browser regression test verifying that an invalid named import added
  during HMR displays the standard overlay and that a subsequent valid update
  clears it.
- `pnpm exec vitest run packages/vite/src/shared/__tests__/hmr.spec.ts`
- `pnpm test-serve hmr`
- `pnpm --filter vite build`
- `pnpm --filter vite typecheck`
- ESLint on all modified source and test files
