### PR TITLE
fix: reduce Windows 8.3-short-name detection false-positives

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
@@ -29,36 +29,36 @@ describe('isFileInTargetPath', () => {
 })
 
 describe('looksLikeWindowsShortNamePath', () => {
-  const shortNamePaths = {
+  const shortNamePaths = [
     // classic 8.3 short names
-    'C:/PROGRA~1/x': true,
-    'C:/PROGRA~1': true,
-    'C:/LONGFI~1.TXT': true,
-    'C:/MICROS~2/foo': true,
+    'C:/PROGRA~1/x',
+    'C:/PROGRA~1',
+    'C:/LONGFI~1.TXT',
+    'C:/MICROS~2/foo',
     // short-name-looking directory ancestor, not just the basename
-    'C:/foo/DOCUME~1/bar.js': true,
-  }
-  const legitimateTildePaths = {
+    'C:/foo/DOCUME~1/bar.js',
+  ]
+  const legitimateTildePaths = [
     // real-world case from the reported issue: `~` not followed by a digit
-    'C:/project/dist/0~rslib-runtime.js': false,
+    'C:/project/dist/0~rslib-runtime.js',
     // ancestor directory containing a tilde that isn't short-name shaped
-    'C:/Users/foo~bar/project/index.js': false,
+    'C:/Users/foo~bar/project/index.js',
     // tilde-prefixed name with no short-name-style prefix/digit suffix
-    'C:/Users/foo/~backup/index.js': false,
+    'C:/Users/foo/~backup/index.js',
     // prefix longer than the 6 characters a short name can have
-    'C:/project/confirmations~2/index.js': false,
+    'C:/project/confirmations~2/index.js',
     // no tilde at all
-    'C:/Users/foo/project/index.js': false,
-  }
+    'C:/Users/foo/project/index.js',
+  ]
 
-  for (const [filePath, expected] of Object.entries(shortNamePaths)) {
-    test(`looksLikeWindowsShortNamePath("${filePath}") is ${expected}`, () => {
-      expect(looksLikeWindowsShortNamePath(filePath)).toBe(expected)
+  for (const filePath of shortNamePaths) {
+    test(`looksLikeWindowsShortNamePath("${filePath}") is true`, () => {
+      expect(looksLikeWindowsShortNamePath(filePath)).toBe(true)
     })
   }
-  for (const [filePath, expected] of Object.entries(legitimateTildePaths)) {
-    test(`looksLikeWindowsShortNamePath("${filePath}") is ${expected}`, () => {
-      expect(looksLikeWindowsShortNamePath(filePath)).toBe(expected)
+  for (const filePath of legitimateTildePaths) {
+    test(`looksLikeWindowsShortNamePath("${filePath}") is false`, () => {
+      expect(looksLikeWindowsShortNamePath(filePath)).toBe(false)
     })
   }
 })

--- a/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { isFileInTargetPath } from '../static'
+import { isFileInTargetPath, looksLikeWindowsShortNamePath } from '../static'
 
 describe('isFileInTargetPath', () => {
   const cases = {
@@ -25,5 +25,40 @@ describe('isFileInTargetPath', () => {
         expect(isFileInTargetPath(parent, child)).toBe(expected)
       })
     }
+  }
+})
+
+describe('looksLikeWindowsShortNamePath', () => {
+  const shortNamePaths = {
+    // classic 8.3 short names
+    'C:/PROGRA~1/x': true,
+    'C:/PROGRA~1': true,
+    'C:/LONGFI~1.TXT': true,
+    'C:/MICROS~2/foo': true,
+    // short-name-looking directory ancestor, not just the basename
+    'C:/foo/DOCUME~1/bar.js': true,
+  }
+  const legitimateTildePaths = {
+    // real-world case from the reported issue: `~` not followed by a digit
+    'C:/project/dist/0~rslib-runtime.js': false,
+    // ancestor directory containing a tilde that isn't short-name shaped
+    'C:/Users/foo~bar/project/index.js': false,
+    // tilde-prefixed name with no short-name-style prefix/digit suffix
+    'C:/Users/foo/~backup/index.js': false,
+    // prefix longer than the 6 characters a short name can have
+    'C:/project/confirmations~2/index.js': false,
+    // no tilde at all
+    'C:/Users/foo/project/index.js': false,
+  }
+
+  for (const [filePath, expected] of Object.entries(shortNamePaths)) {
+    test(`looksLikeWindowsShortNamePath("${filePath}") is ${expected}`, () => {
+      expect(looksLikeWindowsShortNamePath(filePath)).toBe(expected)
+    })
+  }
+  for (const [filePath, expected] of Object.entries(legitimateTildePaths)) {
+    test(`looksLikeWindowsShortNamePath("${filePath}") is ${expected}`, () => {
+      expect(looksLikeWindowsShortNamePath(filePath)).toBe(expected)
+    })
   }
 })

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -287,6 +287,24 @@ export function isFileInTargetPath(
 }
 
 const windowsDriveRE = /^[A-Z]:/i
+// A Windows 8.3 "short name" segment looks like `NAME~1` or `NAME~1.EXT`: at
+// most 6 non-`~`/`.` characters, a `~`, then digits, within a single path
+// segment. Matching only this shape (rather than any `~`) still blocks the
+// short-name aliasing bypass while allowing filenames that merely contain a
+// tilde, e.g. `0~rslib-runtime.js`.
+const windowsShortNameSegmentRE = /^[^~.]{1,6}~\d+(?:\.[^~.]{0,3})?$/
+
+/**
+ * Warning: parameters are not validated, only works with normalized absolute paths
+ */
+export function looksLikeWindowsShortNamePath(filePath: string): boolean {
+  return (
+    filePath.includes('~') &&
+    filePath
+      .split('/')
+      .some((segment) => windowsShortNameSegmentRE.test(segment))
+  )
+}
 
 /**
  * Warning: parameters are not validated, only works with normalized absolute paths
@@ -299,9 +317,10 @@ export function isFileLoadingAllowed(
 
   if (!fs.strict) return true
 
-  if (isWindows && filePath.includes('~')) {
-    // `~` is used for Windows 8.3 short names, which can be used to bypass the check.
-    // While is it valid to have files with `~` in the path, we disallow it to be safe.
+  if (isWindows && looksLikeWindowsShortNamePath(filePath)) {
+    // Windows 8.3 short names (e.g. `PROGRA~1`) can alias a different long
+    // path and bypass `safeModulePaths`/`fs.allow` prefix checks, so reject
+    // paths that look like one.
     return false
   }
 

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -319,8 +319,10 @@ export function isFileLoadingAllowed(
 
   if (isWindows && looksLikeWindowsShortNamePath(filePath)) {
     // Windows 8.3 short names (e.g. `PROGRA~1`) can alias a different long
-    // path and bypass `safeModulePaths`/`fs.allow` prefix checks, so reject
-    // paths that look like one.
+    // path and can be used to bypass the check.
+    // While it is valid to have files named similar to automatically generated
+    // short names, it is unlikely that a user would create them, so we
+    // disallow them to be safe.
     return false
   }
 


### PR DESCRIPTION
### Description

Fixes a Windows dev-server file allow-list false negative where a legitimate resolved file path containing `~` is rejected before `safeModulePaths` / `server.fs.allow` can be considered.

Root cause: the 8.3-short-name guard used `filePath.includes('~')`, which catches ordinary tilde-containing directories or filenames even though the security concern is specifically a Windows 8.3 alias segment such as `PROGRA~1`.

This PR narrows the guard to path segments that look like Windows 8.3 short-name aliases, while keeping the existing protections for true short-name-style paths.

Fixes #22892

### Verification

Local checks run:

- `pnpm --filter vite build`
- `pnpm run test-unit static`

CI evidence on the PR is green for the relevant matrix, including:

- `Build&Test: node-24.15.0, windows-latest`
- Ubuntu/macOS Build&Test jobs
- `Lint: node-24, ubuntu-latest`
- `Semantic Pull Request`
- `zizmor`

### Risk / compatibility

The change is Windows-specific and keeps rejecting segments that match the 8.3 alias shape. It only allows ordinary long-path names containing `~` to proceed to the existing `safeModulePaths`, deny-glob, and `server.fs.allow` checks.

### Reviewer note

cc @sapphi-red since this follows up on the Windows alternate-path guard from #22572.

### Additional context

AI assistance was used while preparing this patch; Harsh reviewed the diff and ran the checks listed above.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related issue(s)/PR(s) if any.
- [x] Provide a description of the changes in this PR.

### Tests

- [x] `pnpm --filter vite build`
- [x] `pnpm run test-unit static`
