### PR TITLE
fix(css): transform bundled dev ?url imports (fix #22863)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -9,6 +9,7 @@ import type {
   MinimalPluginContext,
   OutputAsset,
   OutputChunk,
+  PluginContext,
   RenderedChunk,
   RenderedModule,
   RollupError,
@@ -103,6 +104,7 @@ import {
   publicAssetUrlRE,
   publicFileToBuiltUrl,
   renderAssetUrlInJS,
+  toOutputFilePathInJSForBundledDev,
 } from './asset'
 import type { ESBuildOptions } from './esbuild'
 import { getChunkOriginalFileName } from './manifest'
@@ -319,6 +321,56 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
 
   let preprocessorWorkerController: PreprocessorWorkerController | undefined
 
+  function createCssUrlResolver(pluginContext: PluginContext): CssUrlResolver {
+    const { environment } = pluginContext
+    const resolveUrl = (url: string, importer?: string) =>
+      idResolver(environment, url, importer)
+
+    return async (url, importer) => {
+      const decodedUrl = decodeURI(url)
+      if (checkPublicFile(decodedUrl, config)) {
+        if (encodePublicUrlsInCSS(config)) {
+          return [publicFileToBuiltUrl(decodedUrl, config), undefined]
+        } else {
+          const base = joinUrlSegments(config.server.origin ?? '', config.base)
+          return [joinUrlSegments(base, decodedUrl), undefined]
+        }
+      }
+      const [id, fragment] = decodedUrl.split('#')
+      let resolved = await resolveUrl(id, importer)
+      if (resolved) {
+        if (fragment) resolved += '#' + fragment
+        let url = await fileToUrl(pluginContext, resolved)
+        if (!url.startsWith('data:') && environment.mode === 'dev') {
+          const mod = [
+            ...(environment.moduleGraph.getModulesByFile(resolved) ?? []),
+          ].find((mod) => mod.type === 'asset')
+          if (mod?.lastHMRTimestamp) {
+            url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
+          }
+        }
+        return [url, cleanUrl(resolved)]
+      }
+      if (config.command === 'build') {
+        const isExternal = config.build.rolldownOptions.external
+          ? resolveUserExternal(
+              config.build.rolldownOptions.external,
+              decodedUrl,
+              id,
+              false,
+            )
+          : false
+
+        if (!isExternal) {
+          config.logger.warnOnce(
+            `\n${decodedUrl} referenced in ${id} didn't resolve at build time, it will remain unchanged to be resolved at runtime`,
+          )
+        }
+      }
+      return [url, undefined]
+    }
+  }
+
   // warm up cache for resolved postcss config
   if (config.css.transformer !== 'lightningcss') {
     resolvePostcssConfig(config).catch(() => {
@@ -353,7 +405,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       filter: {
         id: CSS_LANGS_RE,
       },
-      handler(id) {
+      async handler(id) {
         if (urlRE.test(id)) {
           if (isModuleCSSRequest(id)) {
             throw new Error(
@@ -364,7 +416,6 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
           }
 
           // *.css?url
-          // in dev, it's handled by assets plugin.
           if (isBuild) {
             id = injectQuery(removeUrlQuery(id), 'transform-only')
             return (
@@ -373,6 +424,43 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
                 'hex',
               )}__"`
             )
+          }
+
+          if (this.environment.config.isBundled) {
+            const filename = cleanUrl(removeUrlQuery(id))
+            this.addWatchFile(filename)
+            const raw = await fsp.readFile(filename, 'utf-8')
+            const { code, deps } = await compileCSS(
+              this.environment,
+              filename,
+              raw,
+              preprocessorWorkerController!,
+              createCssUrlResolver(this),
+            )
+            if (deps) {
+              for (const dep of deps) {
+                this.addWatchFile(dep)
+              }
+            }
+
+            const referenceId = this.emitFile({
+              type: 'asset',
+              name: path.basename(filename, path.extname(filename)) + '.css',
+              originalFileName: normalizePath(
+                path.relative(config.root, filename),
+              ),
+              source: code,
+            })
+            const outputFilename = this.getFileName(referenceId)
+            const outputUrl = toOutputFilePathInJSForBundledDev(
+              this.environment,
+              outputFilename,
+            )
+            return {
+              code: `export default ${JSON.stringify(encodeURIPath(outputUrl))}`,
+              moduleSideEffects: false,
+              moduleType: 'js',
+            }
           }
         }
       },
@@ -386,58 +474,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       },
       async handler(raw, id) {
         const { environment } = this
-        const resolveUrl = (url: string, importer?: string) =>
-          idResolver(environment, url, importer)
-
-        const urlResolver: CssUrlResolver = async (url, importer) => {
-          const decodedUrl = decodeURI(url)
-          if (checkPublicFile(decodedUrl, config)) {
-            if (encodePublicUrlsInCSS(config)) {
-              return [publicFileToBuiltUrl(decodedUrl, config), undefined]
-            } else {
-              const base = joinUrlSegments(
-                config.server.origin ?? '',
-                config.base,
-              )
-              return [joinUrlSegments(base, decodedUrl), undefined]
-            }
-          }
-          const [id, fragment] = decodedUrl.split('#')
-          let resolved = await resolveUrl(id, importer)
-          if (resolved) {
-            if (fragment) resolved += '#' + fragment
-            let url = await fileToUrl(this, resolved)
-            // Inherit HMR timestamp if this asset was invalidated
-            if (!url.startsWith('data:') && this.environment.mode === 'dev') {
-              const mod = [
-                ...(this.environment.moduleGraph.getModulesByFile(resolved) ??
-                  []),
-              ].find((mod) => mod.type === 'asset')
-              if (mod?.lastHMRTimestamp) {
-                url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
-              }
-            }
-            return [url, cleanUrl(resolved)]
-          }
-          if (config.command === 'build') {
-            const isExternal = config.build.rolldownOptions.external
-              ? resolveUserExternal(
-                  config.build.rolldownOptions.external,
-                  decodedUrl, // use URL as id since id could not be resolved
-                  id,
-                  false,
-                )
-              : false
-
-            if (!isExternal) {
-              // #9800 If we cannot resolve the css url, leave a warning.
-              config.logger.warnOnce(
-                `\n${decodedUrl} referenced in ${id} didn't resolve at build time, it will remain unchanged to be resolved at runtime`,
-              )
-            }
-          }
-          return [url, undefined]
-        }
+        const urlResolver = createCssUrlResolver(this)
 
         const {
           code: css,

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -12,6 +12,22 @@ import {
 
 const assetUrl = /asset-[\w-]+\.png/
 
+async function expectCssUrlAsset(cssUrl: string, assetName: string) {
+  const cssResponse = await page
+    .context()
+    .request.get(new URL(cssUrl, page.url()).href)
+  expect(cssResponse.status()).toBe(200)
+  const css = await cssResponse.text()
+  expect(css).toMatch(new RegExp(`/assets/${assetName}-[\\w-]+\\.png`))
+
+  const assetPath = /url\(["']?([^"')]+)/.exec(css)?.[1]
+  expect(assetPath).toBeDefined()
+  const assetResponse = await page
+    .context()
+    .request.get(new URL(assetPath!, cssResponse.url()).href)
+  expect(assetResponse.status()).toBe(200)
+}
+
 if (isBuild) {
   test('should render', async () => {
     expect(await page.textContent('h1')).toContain('HMR Full Bundle Mode')
@@ -60,6 +76,25 @@ if (isBuild) {
     )
     await expect.poll(() => page.textContent('.app')).toBe('hello')
     await expect.poll(() => page.textContent('.asset')).toMatch(assetUrl)
+  })
+
+  test('transforms assets in CSS ?url imports', async () => {
+    const cssUrl = await page.textContent('.css-url')
+    expect(cssUrl).toMatch(/\/assets\/url-import-[\w-]+\.css/)
+    await expectCssUrlAsset(cssUrl!, 'asset')
+
+    const source = readFile('url-import.css')
+    onTestFinished(async () => {
+      addFile('url-import.css', source)
+      await expect.poll(() => page.textContent('.css-url')).toBe(cssUrl)
+    })
+    editFile('url-import.css', (code) =>
+      code.replace('./asset.png', './hmr-asset.png'),
+    )
+    await expect.poll(() => page.textContent('.css-url')).not.toBe(cssUrl)
+    const updatedCssUrl = await page.textContent('.css-url')
+    expect(updatedCssUrl).toMatch(/\/assets\/url-import-[\w-]+\.css/)
+    await expectCssUrlAsset(updatedCssUrl!, 'hmr-asset')
   })
 
   // BUNDLED -> GENERATE_HMR_PATCH -> BUNDLING -> BUNDLING -> BUNDLED

--- a/playground/hmr-full-bundle-mode/index.html
+++ b/playground/hmr-full-bundle-mode/index.html
@@ -3,6 +3,7 @@
 <div class="app"></div>
 <div class="hmr"></div>
 <div class="asset"></div>
+<div class="css-url"></div>
 <div class="hmr-asset"></div>
 <div class="worker-query"></div>
 <div class="worker-url"></div>

--- a/playground/hmr-full-bundle-mode/main.js
+++ b/playground/hmr-full-bundle-mode/main.js
@@ -5,10 +5,12 @@ import './dead-accept.js'
 import './cycle-a.js'
 import './data.js'
 import assetUrl from './asset.png'
+import cssUrl from './url-import.css?url'
 import WorkerQuery from './worker-query.js?worker'
 
 text('.app', 'hello')
 text('.asset', assetUrl)
+text('.css-url', cssUrl)
 
 const workerQuery = new WorkerQuery()
 workerQuery.postMessage('ping')

--- a/playground/hmr-full-bundle-mode/url-import.css
+++ b/playground/hmr-full-bundle-mode/url-import.css
@@ -1,0 +1,3 @@
+.url-import {
+  background: url('./asset.png');
+}


### PR DESCRIPTION
### Description

Fixes #22863.

In bundled dev mode, CSS imported with `?url` was emitted by the generic asset path without running the CSS transform pipeline. Nested `url()` references therefore remained as source-relative paths instead of becoming bundled assets.

CSS `?url` imports now reuse the existing CSS URL resolver, emit the transformed stylesheet, and watch both the source and its dependencies so a changed nested asset produces a new stylesheet URL through HMR.

### Tests

- `pnpm run test-serve hmr-full-bundle-mode`
- `pnpm exec vitest run packages/vite/src/node/__tests__/plugins/css.spec.ts`
- `pnpm run test-serve assets`
- `pnpm run test-build assets`
- `pnpm run build`
- Targeted ESLint and Oxfmt checks
