### PR TITLE
fix(module-runner): keep stack trace interception working when `Object.prototype` is frozen

### DIFF
--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -330,7 +330,9 @@ function CallSiteToString(this: CallSite) {
 }
 
 function cloneCallSite(frame: CallSite) {
-  const object = {} as CallSite
+  // null prototype so assigning `constructor` below doesn't throw
+  // when user code has frozen `Object.prototype`
+  const object = Object.create(null) as CallSite
   Object.getOwnPropertyNames(Object.getPrototypeOf(frame)).forEach((name) => {
     const key = name as keyof CallSite
     // @ts-expect-error difficult to type

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -92,6 +92,41 @@ describe('module runner initialization', async () => {
     )
   })
 
+  it('stack traces work when Object.prototype is frozen', async ({
+    runner,
+    server,
+  }) => {
+    const methodError = await getError(async () => {
+      const mod = await runner.import('/fixtures/throws-error-method.ts')
+      mod.throwError()
+    })
+
+    // simulate `Object.freeze(Object.prototype)` in user code without
+    // permanently freezing it for the other tests in this worker: assigning
+    // an inherited `constructor` throws exactly like it does when frozen
+    const original = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      'constructor',
+    )!
+    Object.defineProperty(Object.prototype, 'constructor', {
+      configurable: true,
+      get: () => original.value,
+      set: () => {
+        throw new TypeError(
+          `Cannot assign to read only property 'constructor' of object '#<Object>'`,
+        )
+      },
+    })
+    try {
+      // reading `.stack` for the first time invokes `prepareStackTrace`
+      expect(serializeStack(server, methodError)).toBe(
+        '    at Module.throwError (<root>/fixtures/throws-error-method.ts:6:9)',
+      )
+    } finally {
+      Object.defineProperty(Object.prototype, 'constructor', original)
+    }
+  })
+
   it('deep stacktrace', async ({ runner, server }) => {
     const methodError = await getError(async () => {
       const mod = await runner.import('/fixtures/has-error-deep.ts')


### PR DESCRIPTION
### Description

`cloneCallSite` copies every own property of `CallSite.prototype`, including `constructor`, onto a plain object. If user code ran `Object.freeze(Object.prototype)`, that assignment throws on the first `error.stack` read, breaking the `prepareStackTrace` sourcemap interceptor. This clones onto a null-prototype object instead.

Fixes vitest-dev/vscode#798 (Vitest test collection crashing when `includeTaskLocation` is enabled).
