### PR TITLE
fix(html): support .htm as html (fix #10997)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -295,7 +295,7 @@ async function handleMessage(payload: HotPayload) {
       }
       await activeHmrClient.notifyListeners('vite:beforeFullReload', payload)
       if (hasDocument) {
-        if (payload.path && payload.path.endsWith('.html')) {
+        if (payload.path && /\.(?:html|htm)$/.test(payload.path)) {
           // if html file is edited, only reload the page if the browser is
           // currently on that page.
           const pagePath = decodeURI(location.pathname)

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -75,6 +75,7 @@ import {
   createDebugger,
   displayTime,
   getPkgName,
+  isHTMLRequest,
   joinUrlSegments,
   mergeConfig,
   mergeWithDefaults,
@@ -627,7 +628,7 @@ export function resolveRolldownOptions(
       : options.rolldownOptions.input ||
         (topLevelInput ?? resolve('index.html'))
 
-  if (ssr && typeof input === 'string' && input.endsWith('.html')) {
+  if (ssr && typeof input === 'string' && isHTMLRequest(input)) {
     throw new Error(
       `rolldownOptions.input should not be an html file when building for SSR. ` +
         `Please specify a dedicated SSR entry.`,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -31,6 +31,7 @@ import {
   dataUrlRE,
   deepClone,
   externalRE,
+  isHTMLRequest,
   isInNodeModules,
   isObject,
   isOptimizable,
@@ -100,7 +101,7 @@ export function devToScanEnvironment(
 
 const debug = createDebugger('vite:deps')
 
-const htmlTypesRE = /\.(?:html|vue|svelte|astro|imba)$/
+const htmlTypesRE = /\.(?:html|htm|vue|svelte|astro|imba)$/
 
 // A simple regex to detect import sources. This is only used on
 // <script lang="ts"> blocks in vue (setup only) or svelte files, since
@@ -244,7 +245,7 @@ async function computeEntries(environment: ScanEnvironment) {
       throw new Error('invalid rolldownOptions.input value.')
     }
   } else {
-    entries = await globEntries('**/*.html', environment)
+    entries = await globEntries(['**/*.html', '**/*.htm'], environment)
   }
 
   // Non-supported entry file types and virtual files should not be scanned for
@@ -457,7 +458,7 @@ function rolldownScanPlugin(
     let raw = await fsp.readFile(id, 'utf-8')
     // Avoid matching the content of the comment
     raw = raw.replace(commentRE, '<!---->')
-    const isHtml = id.endsWith('.html')
+    const isHtml = isHTMLRequest(id)
     let js = ''
     let scriptId = 0
     const matches = raw.matchAll(scriptRE)

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -36,6 +36,7 @@ import {
   encodeURIPath,
   getHash,
   injectQuery,
+  isHTMLRequest,
   joinUrlSegments,
   normalizePath,
   rawRE,
@@ -737,7 +738,7 @@ function shouldInline(
     if (buildPluginContext.getModuleInfo(id)?.isEntry) return false
   }
   if (forceInline !== undefined) return forceInline
-  if (file.endsWith('.html')) return false
+  if (isHTMLRequest(file)) return false
   // Don't inline SVG with fragments, as they are meant to be reused
   if (file.endsWith('.svg') && id.includes('#')) return false
   let limit: number

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -2,8 +2,7 @@ import { transformSync } from 'rolldown/utils'
 import type { ResolvedConfig } from '../config'
 import type { Environment } from '../environment'
 import type { Plugin } from '../plugin'
-import { escapeRegex, isCSSRequest } from '../utils'
-import { isHTMLRequest } from './html'
+import { escapeRegex, isCSSRequest, isHTMLRequest } from '../utils'
 
 const nonJsRe = /\.json(?:$|\?)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -33,6 +33,7 @@ import {
   encodeURIPath,
   generateCodeFrame,
   getHash,
+  htmlExtensionRE,
   isCSSRequest,
   isDataUrl,
   isExternalUrl,
@@ -65,7 +66,6 @@ const inlineCSSRE = /__VITE_INLINE_CSS__([a-z\d]{8}_\d+)__/g
 // Do not allow preceding '.', but do allow preceding '...' for spread operations
 const inlineImportRE =
   /(?<!(?<!\.\.)\.)\bimport\s*\(("(?:[^"]|(?<=\\)")*"|'(?:[^']|(?<=\\)')*')\)/dg
-const htmlLangRE = /\.(?:html|htm)$/
 const spaceRe = /[\t\n\f\r ]/
 
 const importMapRE =
@@ -80,9 +80,6 @@ const importMapAppendRE = new RegExp(
 )
 
 export const isHTMLProxy = (id: string): boolean => isHtmlProxyRE.test(id)
-
-export const isHTMLRequest = (request: string): boolean =>
-  htmlLangRE.test(request)
 
 // HTML Proxy Caches are stored by config -> filePath -> index
 export const htmlProxyMap: WeakMap<
@@ -436,7 +433,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     },
 
     transform: {
-      filter: { id: /\.html$/ },
+      filter: { id: htmlExtensionRE },
       async handler(html, id) {
         id = normalizePath(id)
         const relativeUrlPath = normalizePath(path.relative(config.root, id))

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -44,6 +44,7 @@ import {
   isBuiltin,
   isDataUrl,
   isExternalUrl,
+  isHTMLRequest,
   isInNodeModules,
   isObject,
   isOptimizable,
@@ -426,7 +427,7 @@ function optimizerResolvePlugin(
           ...resolveOptions,
           scan: resolveOpts.scan ?? resolveOptions.scan,
         }
-        options.preferRelative ||= importer?.endsWith('.html')
+        options.preferRelative ||= !!importer && isHTMLRequest(importer)
 
         // resolve pre-bundled deps requests, these could be resolved by
         // tryFileResolve or /fs/ resolution but these files may not yet

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -24,6 +24,7 @@ import { isExplicitImportRequired } from '../plugins/importAnalysis'
 import {
   createDebugger,
   formatAndTruncateFileList,
+  isHTMLRequest,
   monotonicDateNow,
   normalizePath,
 } from '../utils'
@@ -630,7 +631,7 @@ export async function handleHMRUpdate(
       }
       if (!options.modules.length) {
         // html file cannot be hot updated
-        if (file.endsWith('.html') && environment.name === 'client') {
+        if (isHTMLRequest(file) && environment.name === 'client') {
           environment.logger.info(
             colors.green(`page reload `) + colors.dim(shortFile),
             {
@@ -746,7 +747,7 @@ export function updateModules(
 
   // html file cannot be hot updated because it may be used as the template for a top-level request response.
   const isClientHtmlChange =
-    file.endsWith('.html') &&
+    isHTMLRequest(file) &&
     environment.name === 'client' &&
     // if the html file is imported as a module, we assume that this file is
     // not used as the template for top-level request response

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type { Connect } from '#dep-types/connect'
 import { cleanUrl } from '../../../shared/utils'
-import { createDebugger, joinUrlSegments } from '../../utils'
+import { createDebugger, isHTMLRequest, joinUrlSegments } from '../../utils'
 import type { DevEnvironment } from '../environment'
 
 const debug = createDebugger('vite:html-fallback')
@@ -51,7 +51,7 @@ export function htmlFallbackMiddleware(
 
     // .html files are not handled by serveStaticMiddleware
     // so we need to check if the file exists
-    if (pathname.endsWith('.html')) {
+    if (isHTMLRequest(pathname)) {
       if (checkFileExists(pathname)) {
         debug?.(`Rewriting ${req.method} ${req.url} to ${url}`)
         req.url = url

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -37,6 +37,7 @@ import {
   injectQuery,
   isCSSRequest,
   isDevServer,
+  isHTMLRequest,
   isJSRequest,
   isParentDirectory,
   joinUrlSegments,
@@ -463,7 +464,11 @@ export function indexHtmlMiddleware(
 
     const url = req.url && cleanUrl(req.url)
     // htmlFallbackMiddleware appends '.html' to URLs
-    if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
+    if (
+      url &&
+      isHTMLRequest(url) &&
+      req.headers['sec-fetch-dest'] !== 'script'
+    ) {
       if (fullBundle) {
         let pathname
         try {

--- a/packages/vite/src/node/server/middlewares/memoryFiles.ts
+++ b/packages/vite/src/node/server/middlewares/memoryFiles.ts
@@ -2,6 +2,7 @@ import * as mrmime from 'mrmime'
 import type { Connect } from '#dep-types/connect'
 import type { ViteDevServer } from '..'
 import { cleanUrl } from '../../../shared/utils'
+import { isHTMLRequest } from '../../utils'
 
 export function memoryFilesMiddleware(
   server: ViteDevServer,
@@ -15,7 +16,7 @@ export function memoryFilesMiddleware(
 
   return function viteMemoryFilesMiddleware(req, res, next) {
     const cleanedUrl = cleanUrl(req.url!)
-    if (cleanedUrl.endsWith('.html')) {
+    if (isHTMLRequest(cleanedUrl)) {
       return next()
     }
 

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -17,6 +17,7 @@ import {
   decodeURIIfPossible,
   fsPathFromUrl,
   isFileReadable,
+  isHTMLRequest,
   isImportRequest,
   isInternalRequest,
   isParentDirectory,
@@ -142,7 +143,7 @@ export function serveStaticMiddleware(
     const cleanedUrl = cleanUrl(req.url!)
     if (
       cleanedUrl.endsWith('/') ||
-      path.extname(cleanedUrl) === '.html' ||
+      isHTMLRequest(cleanedUrl) ||
       isInternalRequest(req.url!) ||
       // skip url starting with // as these will be interpreted as
       // scheme relative URLs by new URL() and will not be a valid file path

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -4,7 +4,7 @@ import colors from 'picocolors'
 import { glob, isDynamicPattern } from 'tinyglobby'
 import { FS_PREFIX } from '../constants'
 import type { ViteDevServer } from '../index'
-import { normalizePath } from '../utils'
+import { isHTMLRequest, normalizePath } from '../utils'
 import type { DevEnvironment } from './environment'
 
 export function warmupFiles(
@@ -27,7 +27,7 @@ async function warmupFile(
   // transform html with the `transformIndexHtml` hook as Vite internals would
   // pre-transform the imported JS modules linked. this may cause `transformIndexHtml`
   // plugins to be executed twice, but that's probably fine.
-  if (file.endsWith('.html')) {
+  if (isHTMLRequest(file)) {
     const url = htmlFileToUrl(file, server.config.root)
     if (url) {
       try {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -305,6 +305,10 @@ export const isJSRequest = (url: string): boolean => {
 export const isCSSRequest = (request: string): boolean =>
   CSS_LANGS_RE.test(request)
 
+export const htmlExtensionRE: RegExp = /\.(?:html|htm)$/
+export const isHTMLRequest = (request: string): boolean =>
+  htmlExtensionRE.test(request)
+
 const importQueryRE = /(\?|&)import=?(?:&|$)/
 const directRequestRE = /(\?|&)direct=?(?:&|$)/
 const internalPrefixes = [

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -365,6 +365,15 @@ describe('Valid HTML', () => {
   })
 })
 
+describe('.htm extension', () => {
+  test('is treated the same as .html', async () => {
+    await page.goto(viteTestUrl + '/htm-extension.htm')
+    expect(await page.textContent('.htm-extension')).toBe('htm extension')
+    expect(await page.$('head meta[name=viewport]')).toBeTruthy()
+    expect(browserLogs).toContain('shared from main')
+  })
+})
+
 describe('env', () => {
   beforeAll(async () => {
     await page.goto(viteTestUrl + '/env.html')

--- a/playground/html/htm-extension.htm
+++ b/playground/html/htm-extension.htm
@@ -1,0 +1,2 @@
+<h1 class="htm-extension">htm extension</h1>
+<script type="module" src="./main.js"></script>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -40,6 +40,7 @@ const input = {
     process.cwd(),
     resolve(dirname, 'relative-input.html'),
   ),
+  htmExtension: resolve(dirname, 'htm-extension.htm'),
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Description

Vite currently only recognizes `.html` files as HTML entry points. `.htm` is an equally valid, commonly used HTML extension (see [RFC 2854](https://datatracker.ietf.org/doc/html/rfc2854) and the [IANA media type registration](https://www.iana.org/assignments/media-types/text/html)), but using it currently breaks the build with a parse error, since most of the internal `.html`-only checks don't recognize it.

This PR makes `.htm` behave the same as `.html` everywhere Vite treats HTML specially:

- HTML transform plugin (build) — the `filter: { id: /\.html$/ }` on `vite:build-html`'s `transform` hook didn't match `.htm`, so `.htm` files were never processed as HTML and fell through to being parsed as JS, causing the reported parse error.
- Dev server: HMR (full-reload detection), static/index-html middlewares, html-fallback middleware, in-memory bundled-dev files, and warmup pre-transform.
- Build: SSR entry validation, dependency optimizer's HTML entry glob and script-tag scanning.
- Asset/resolve plugins: inline-asset exclusion and `preferRelative` resolution for HTML importers.

To avoid duplicating the extension check in a dozen places, the existing `isHTMLRequest` helper (previously private to `plugins/html.ts` and only used in `plugins/define.ts`) was moved to `node/utils.ts` (alongside the analogous `isJSRequest`/`isCSSRequest`) and its regex now matches `.html|.htm`. All the call sites above were switched from ad-hoc `.endsWith('.html')` checks to this shared helper.

fixes #10997

## Alternatives explored

- A minimal fix (just the one line the issue reporter pointed at in the HTML transform hook) was considered, but it only fixes the build-time parse error while leaving `.htm` behaving inconsistently in dev mode (HMR, static serving, fallback). Since the issue title is "Support parsing `.htm` **as same as** `.html`", full parity felt like the correct scope rather than a partial fix.

## Tests

Added a `.htm` entry (`playground/html/htm-extension.htm`) wired into `playground/html/vite.config.js`'s `rolldownOptions.input`, plus a new test in `playground/html/__tests__/html.spec.ts` (`.htm extension`) that verifies:
- the page loads and renders content
- `transformIndexHtml` plugins still run on it (pre-transform head injection)
- its `<script type="module">` entry is processed and executed

This test fails on `main` with a parse error in build mode (`vite:build-html` never touches `.htm` so it's fed to the JS/JSX parser) and passes with this PR's changes, in both serve and build mode.
