### PR TITLE
feat: provide interface for known environment names autocomplete

### DIFF
--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -32,7 +32,7 @@ export class PartialEnvironment {
   constructor(
     name: string,
     topLevelConfig: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = topLevelConfig.environments[name],
+    options: ResolvedEnvironmentOptions = topLevelConfig.environments[name]!,
   ) {
     // only allow some characters so that we can use name without escaping for directory names
     // and make users easier to access with `environments.*`
@@ -114,7 +114,7 @@ export class BaseEnvironment extends PartialEnvironment {
   constructor(
     name: string,
     config: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = config.environments[name],
+    options: ResolvedEnvironmentOptions = config.environments[name]!,
   ) {
     super(name, config, options)
   }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1834,7 +1834,7 @@ export async function createBuilder(
     // remove the default values that shouldn't be used at all once the config is resolved
     const environmentName = resolved.build.ssr ? 'ssr' : 'client'
     ;(resolved.build as ResolvedBuildOptions) = {
-      ...resolved.environments[environmentName].build,
+      ...resolved.environments[environmentName]!.build,
     }
   }
   const config = await resolveConfigToBuild(inlineConfig, patchConfig)
@@ -1929,7 +1929,7 @@ export async function createBuilder(
           // We can deprecate `config.build` in ResolvedConfig and push everyone to upgrade, and later
           // remove the default values that shouldn't be used at all once the config is resolved
           ;(resolved.build as ResolvedBuildOptions) = {
-            ...resolved.environments[environmentName].build,
+            ...resolved.environments[environmentName]!.build,
           }
         }
         const patchPlugins = (resolvedPlugins: Plugin[]) => {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -40,6 +40,7 @@ import type {
   InlineConfig,
   ResolvedConfig,
   ResolvedEnvironmentOptions,
+  KnownEnvironmentNames,
 } from './config'
 import { resolveConfig } from './config'
 import type { PartialEnvironment } from './baseEnvironment'
@@ -1769,7 +1770,7 @@ export class BuildEnvironment extends BaseEnvironment {
 }
 
 export interface ViteBuilder {
-  environments: Record<string, BuildEnvironment>
+  environments: Record<KnownEnvironmentNames, BuildEnvironment>
   config: ResolvedConfig
   buildApp(): Promise<void>
   build(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -364,6 +364,14 @@ export type DefaultEnvironmentOptions = Omit<
   resolve?: AllResolveOptions
 }
 
+export interface KnownEnvironment extends Record<string & {}, never> {
+  client: never
+  ssr: never
+}
+export type KnownEnvironmentNames = keyof KnownEnvironment
+
+export type EnvironmentsOptions = Partial<Record<KnownEnvironmentNames, EnvironmentOptions>>
+
 export interface UserConfig extends DefaultEnvironmentOptions {
   /**
    * Project root directory. Can be an absolute path, or a path relative from
@@ -532,7 +540,7 @@ export interface UserConfig extends DefaultEnvironmentOptions {
   /**
    * Environment overrides
    */
-  environments?: Record<string, EnvironmentOptions>
+  environments?: Partial<Record<KnownEnvironmentNames, EnvironmentOptions>>
   /**
    * Whether your application is a Single Page Application (SPA),
    * a Multi-Page Application (MPA), or Custom Application (SSR
@@ -756,7 +764,7 @@ export interface ResolvedConfig extends Readonly<
     appType: AppType
     experimental: RequiredExceptFor<ExperimentalOptions, 'renderBuiltUrl'>
     future: FutureOptions | undefined
-    environments: Record<string, ResolvedEnvironmentOptions>
+    environments: Record<KnownEnvironmentNames, ResolvedEnvironmentOptions>
     /** @internal injected by legacy plugin */
     isOutputOptionsForLegacyChunks?(
       outputOptions: NormalizedOutputOptions,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -370,7 +370,9 @@ export interface KnownEnvironment extends Record<string & {}, never> {
 }
 export type KnownEnvironmentNames = keyof KnownEnvironment
 
-export type EnvironmentsOptions = Partial<Record<KnownEnvironmentNames, EnvironmentOptions>>
+export type EnvironmentsOptions = Partial<
+  Record<KnownEnvironmentNames, EnvironmentOptions>
+>
 
 export interface UserConfig extends DefaultEnvironmentOptions {
   /**

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1704,18 +1704,18 @@ export async function resolveConfig(
   }
 
   for (const name of Object.keys(config.environments)) {
-    config.environments[name] = mergeConfig(
+    config.environments[name as KnownEnvironmentNames] = mergeConfig(
       name === 'client'
         ? defaultClientEnvironmentOptions
         : (deepClone(
             defaultNonClientEnvironmentOptions as object,
           ) as UserConfig),
-      config.environments[name],
+      config.environments[name as KnownEnvironmentNames]!,
     )
   }
 
   await runConfigEnvironmentHook(
-    config.environments,
+    config.environments as Record<string, EnvironmentOptions>,
     userPlugins,
     logger,
     configEnv,
@@ -1726,15 +1726,15 @@ export async function resolveConfig(
 
   // Backward compatibility: merge config.environments.client.resolve back into config.resolve
   config.resolve ??= {}
-  config.resolve.conditions = config.environments.client.resolve?.conditions
-  config.resolve.mainFields = config.environments.client.resolve?.mainFields
+  config.resolve.conditions = config.environments.client!.resolve?.conditions
+  config.resolve.mainFields = config.environments.client!.resolve?.mainFields
 
   const resolvedDefaultResolve = resolveResolveOptions(config.resolve, logger)
 
   const resolvedEnvironments: Record<string, ResolvedEnvironmentOptions> = {}
   for (const environmentName of Object.keys(config.environments)) {
     resolvedEnvironments[environmentName] = resolveEnvironmentOptions(
-      config.environments[environmentName],
+      config.environments[environmentName as KnownEnvironmentNames]!,
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
       resolvedRoot,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -370,7 +370,7 @@ export interface KnownEnvironment extends Record<string & {}, never> {
 }
 export type KnownEnvironmentNames = keyof KnownEnvironment
 
-export type EnvironmentsOptions = Partial<
+type EnvironmentsOptions = Partial<
   Record<KnownEnvironmentNames, EnvironmentOptions>
 >
 
@@ -542,7 +542,7 @@ export interface UserConfig extends DefaultEnvironmentOptions {
   /**
    * Environment overrides
    */
-  environments?: Partial<Record<KnownEnvironmentNames, EnvironmentOptions>>
+  environments?: EnvironmentsOptions
   /**
    * Whether your application is a Single Page Application (SPA),
    * a Multi-Page Application (MPA), or Custom Application (SSR
@@ -766,7 +766,9 @@ export interface ResolvedConfig extends Readonly<
     appType: AppType
     experimental: RequiredExceptFor<ExperimentalOptions, 'renderBuiltUrl'>
     future: FutureOptions | undefined
-    environments: Record<KnownEnvironmentNames, ResolvedEnvironmentOptions>
+    environments: Partial<
+      Record<KnownEnvironmentNames, ResolvedEnvironmentOptions>
+    >
     /** @internal injected by legacy plugin */
     isOutputOptionsForLegacyChunks?(
       outputOptions: NormalizedOutputOptions,
@@ -1426,7 +1428,8 @@ function resolveDepOptimizationOptions(
 
 async function setOptimizeDepsPluginNames(resolvedConfig: ResolvedConfig) {
   await Promise.all(
-    Object.values(resolvedConfig.environments).map(async (environment) => {
+    Object.values(resolvedConfig.environments).map(async (env) => {
+      const environment = env!
       const plugins = environment.optimizeDeps.rolldownOptions?.plugins ?? []
       const outputPlugins =
         environment.optimizeDeps.rolldownOptions?.output?.plugins ?? []
@@ -1731,10 +1734,15 @@ export async function resolveConfig(
 
   const resolvedDefaultResolve = resolveResolveOptions(config.resolve, logger)
 
-  const resolvedEnvironments: Record<string, ResolvedEnvironmentOptions> = {}
-  for (const environmentName of Object.keys(config.environments)) {
+  const resolvedEnvironments = {} as Record<
+    KnownEnvironmentNames,
+    ResolvedEnvironmentOptions
+  >
+  for (const environmentName of Object.keys(
+    config.environments,
+  ) as KnownEnvironmentNames[]) {
     resolvedEnvironments[environmentName] = resolveEnvironmentOptions(
-      config.environments[environmentName as KnownEnvironmentNames]!,
+      config.environments[environmentName]!,
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
       resolvedRoot,
@@ -1971,7 +1979,7 @@ export async function resolveConfig(
     >) = {
       ...workerResolved.environments,
       client: {
-        ...workerResolved.environments.client,
+        ...workerResolved.environments.client!,
         plugins: await resolveEnvironmentPlugins(
           new PartialEnvironment('client', workerResolved),
         ),
@@ -2213,7 +2221,7 @@ export async function resolveConfig(
   // downstream projects modifying the plugins in it. This may change
   // once the ecosystem is ready.
   for (const name of Object.keys(resolved.environments)) {
-    resolved.environments[name].plugins = await resolveEnvironmentPlugins(
+    resolved.environments[name]!.plugins = await resolveEnvironmentPlugins(
       new PartialEnvironment(name, resolved),
     )
   }

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -125,6 +125,8 @@ export type {
   EnvironmentOptions,
   DevEnvironmentOptions,
   ResolvedDevEnvironmentOptions,
+  KnownEnvironment,
+  KnownEnvironmentNames,
 } from './config'
 export type { HtmlAssetSource } from './assetSource'
 export type {

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -49,7 +49,7 @@ export async function resolvePlugins(
   const isBuild = config.command === 'build'
   const isWorker = config.isWorker
   const anyEnvBundled =
-    isBuild || Object.values(config.environments).some((env) => env.isBundled)
+    isBuild || Object.values(config.environments).some((env) => env?.isBundled)
   const buildPlugins = anyEnvBundled
     ? resolveBuildPlugins(config)
     : { pre: [], post: [] }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -139,7 +139,7 @@ export async function preview(
     true,
   )
 
-  const clientOutDir = config.environments.client.build.outDir
+  const clientOutDir = config.environments.client!.build.outDir
   const distDir = path.resolve(config.root, clientOutDir)
   if (
     !fs.existsSync(distDir) &&

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -580,7 +580,7 @@ export async function _createServer(
   await Promise.all(
     Object.entries(config.environments).map(
       async ([name, environmentOptions]) => {
-        const environment = await environmentOptions.dev.createEnvironment(
+        const environment = await environmentOptions!.dev.createEnvironment(
           name,
           config,
           {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -29,12 +29,7 @@ import {
   resolveHttpsConfig,
   setClientErrorHandler,
 } from '../http'
-import type {
-  HookHandler,
-  Plugin,
-} from '../plugin'
-import type { KnownEnvironmentNames } from '../config'
-import type { InlineConfig, ResolvedConfig } from '../config'
+import type { InlineConfig, ResolvedConfig, KnownEnvironmentNames } from '../config'
 import { isResolvedConfig, resolveConfig } from '../config'
 import {
   type Hostname,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -29,7 +29,11 @@ import {
   resolveHttpsConfig,
   setClientErrorHandler,
 } from '../http'
-import type { InlineConfig, ResolvedConfig, KnownEnvironmentNames } from '../config'
+import type {
+  InlineConfig,
+  ResolvedConfig,
+  KnownEnvironmentNames,
+} from '../config'
 import { isResolvedConfig, resolveConfig } from '../config'
 import {
   type Hostname,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -29,6 +29,11 @@ import {
   resolveHttpsConfig,
   setClientErrorHandler,
 } from '../http'
+import type {
+  HookHandler,
+  Plugin,
+} from '../plugin'
+import type { KnownEnvironmentNames } from '../config'
 import type { InlineConfig, ResolvedConfig } from '../config'
 import { isResolvedConfig, resolveConfig } from '../config'
 import {
@@ -340,7 +345,7 @@ export interface ViteDevServer {
   /**
    * Module execution environments attached to the Vite server.
    */
-  environments: Record<'client' | 'ssr' | (string & {}), DevEnvironment>
+  environments: Record<KnownEnvironmentNames, DevEnvironment>
   /**
    * Module graph that tracks the import relationships, url to file mapping
    * and hmr state.


### PR DESCRIPTION
## Description

Fixes #23075 

This PR implements the requested `KnownEnvironment` type and integrates it into `UserConfig`, `ResolvedConfig`, `ViteDevServer`, and `ViteBuilder`. By default it provides auto-completion for `client` and `ssr`, but frameworks can extend it by augmenting the `KnownEnvironment` interface in the `vite` module.

```typescript
declare module 'vite' {
  interface KnownEnvironment {
    myEnv: never
  }
}

