### PR TITLE
test(bundled-dev): wait for first bundle and client before assertions

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -25,7 +25,7 @@ import type {
   RolldownWatcherEvent,
   RollupError,
 } from 'rolldown'
-import { beforeAll, expect, inject } from 'vitest'
+import { beforeAll, expect, inject, vi } from 'vitest'
 
 // #region serializer
 
@@ -308,14 +308,11 @@ export async function startDefaultServe(): Promise<void> {
       // `initialBuildCompleted` / `lastBuildError` are private — the harness
       // reaches in rather than widening the public API for tests only.
       const bundledDev = server.environments.client.bundledDev as any
-      const deadline = Date.now() + 40_000
-      while (
-        bundledDev &&
-        !bundledDev.initialBuildCompleted &&
-        !bundledDev.lastBuildError &&
-        Date.now() < deadline
-      ) {
-        await new Promise((r) => setTimeout(r, 50))
+      if (bundledDev) {
+        await vi.waitUntil(
+          () => bundledDev.initialBuildCompleted || bundledDev.lastBuildError,
+          { timeout: 40_000 },
+        )
       }
       if (bundledDev?.initialBuildCompleted) {
         await page
@@ -327,15 +324,26 @@ export async function startDefaultServe(): Promise<void> {
           .catch(() => {})
         // TODO: workaround — an edit fired while no client is connected is
         // dropped (vitejs/vite#23028). Remove this wait once the server
-        // buffers updates for clients that connect later.
-        const clientDeadline = Date.now() + 10_000
-        while (Date.now() < clientDeadline) {
-          const clientId = await page
-            .evaluate(() => (globalThis as any).__rolldown_runtime__?.clientId)
-            .catch(() => undefined)
-          if (clientId && bundledDev.clients?.get(clientId)) break
-          await new Promise((r) => setTimeout(r, 50))
-        }
+        // buffers updates for clients that connect later. A page that never
+        // loads the client runtime (e.g. SSR-rendered pages) cannot register
+        // a client; a fully loaded page with no runtime counts as settled.
+        await vi.waitUntil(
+          async () => {
+            const state = await page
+              .evaluate(() => ({
+                loaded: document.readyState === 'complete',
+                hasRuntime: !!(globalThis as any).__rolldown_runtime__,
+                clientId: (globalThis as any).__rolldown_runtime__?.clientId,
+              }))
+              .catch(() => undefined)
+            if (!state) return false
+            if (state.clientId && bundledDev.clients?.get(state.clientId)) {
+              return true
+            }
+            return state.loaded && !state.hasRuntime
+          },
+          { timeout: 10_000 },
+        )
       }
     }
   } else {

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -72,6 +72,7 @@ export const isServe = !isBuild
  * don't pass under bundled dev yet.
  */
 export const isBundledDev = isServe && !!process.env.VITE_TEST_BUNDLED_DEV
+export const isBundled = isBuild || isBundledDev
 export const isWindows = process.platform === 'win32'
 export const viteBinPath = path.posix.join(
   workspaceRoot,

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -299,17 +299,44 @@ export async function startDefaultServe(): Promise<void> {
     await page.goto(viteTestUrl)
     // bundled dev serves a self-reloading fallback page until the first
     // bundle completes; tests must not assert against that placeholder.
-    // Bounded: a playground whose first bundle fails keeps the fallback
-    // forever, and its tests are expected to handle that state themselves.
+    // Wait server-side for the first build to settle (success or error) so
+    // slow builds (e.g. many HTML inputs) don't race a fixed page timeout.
+    // A playground whose first bundle fails keeps the fallback page, and its
+    // tests are expected to handle that state themselves.
     // hmr-full-bundle-mode is exempt — it asserts the fallback page itself.
     if (isBundledDev && testName !== 'hmr-full-bundle-mode') {
-      await page
-        .waitForFunction(
-          () => !(globalThis as any).__vite_is_fallback_page__,
-          undefined,
-          { timeout: 15_000 },
-        )
-        .catch(() => {})
+      // `initialBuildCompleted` / `lastBuildError` are private — the harness
+      // reaches in rather than widening the public API for tests only.
+      const bundledDev = server.environments.client.bundledDev as any
+      const deadline = Date.now() + 40_000
+      while (
+        bundledDev &&
+        !bundledDev.initialBuildCompleted &&
+        !bundledDev.lastBuildError &&
+        Date.now() < deadline
+      ) {
+        await new Promise((r) => setTimeout(r, 50))
+      }
+      if (bundledDev?.initialBuildCompleted) {
+        await page
+          .waitForFunction(
+            () => !(globalThis as any).__vite_is_fallback_page__,
+            undefined,
+            { timeout: 15_000 },
+          )
+          .catch(() => {})
+        // TODO: workaround — an edit fired while no client is connected is
+        // dropped (vitejs/vite#23028). Remove this wait once the server
+        // buffers updates for clients that connect later.
+        const clientDeadline = Date.now() + 10_000
+        while (Date.now() < clientDeadline) {
+          const clientId = await page
+            .evaluate(() => (globalThis as any).__rolldown_runtime__?.clientId)
+            .catch(() => undefined)
+          if (clientId && bundledDev.clients?.get(clientId)) break
+          await new Promise((r) => setTimeout(r, 50))
+        }
+      }
     }
   } else {
     process.env.VITE_INLINE = 'inline-build'


### PR DESCRIPTION
### Description

Under bundled dev (`VITE_TEST_BUNDLED_DEV=1`), the harness waited for the fallback page to swap with a fixed 15s page poll. Two races slipped through it: a slow first bundle (e.g. the html playground bundles ~30 HTML inputs) could outlive the fixed wait, and a test that edits a file right after navigation could fire while no HMR client is connected yet — such an update is dropped entirely and the test polls forever.

The wait is now three bounded steps:

1. poll the server until the first build settles (success or error), instead of guessing with a fixed timeout
2. wait for the fallback page to swap to the real page
3. wait until this page's own client is registered on the server (checking the page's concrete client id, so the fallback page's stale entry does not count)

Step 3 is marked as a workaround (TODO in the code) — the real fix is buffering updates while no client is connected and flushing on reconnect (#23028).

With this in place, the html playground's 16 bundled-dev failures disappear with zero assertion changes. Follow-up PRs that enable more playgrounds under bundled dev are based on this one.

Part of #23028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)