### PR TITLE
test(bundled-dev): enable html playground

### DIFF
--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -4,6 +4,7 @@ import {
   editFile,
   getColor,
   isBuild,
+  isBundledDev,
   isServe,
   page,
   serverLogs,
@@ -43,7 +44,8 @@ function testPage(isNested: boolean) {
     expect(await page.textContent('body p.inject')).toBe('This is injected')
   })
 
-  test('server only transform', async () => {
+  // bundled dev: transformIndexHtml runs at bundle time without ctx.server (vitejs/vite#23028)
+  test.skipIf(isBundledDev)('server only transform', async () => {
     if (!isBuild) {
       expect(await page.textContent('body p.server')).toMatch(
         'injected only during dev',
@@ -53,7 +55,8 @@ function testPage(isNested: boolean) {
     }
   })
 
-  test('build only transform', async () => {
+  // bundled dev: bundle-time transformIndexHtml sets ctx.bundle, so the build-only tag is injected in dev too (vitejs/vite#23028)
+  test.skipIf(isBundledDev)('build only transform', async () => {
     if (isBuild) {
       expect(await page.textContent('body p.build')).toMatch(
         'injected only during build',
@@ -283,7 +286,8 @@ describe.runIf(isServe)('SPA fallback', () => {
   })
 })
 
-describe.runIf(isServe)('invalid', () => {
+// bundled dev: invalid*.html are not bundle inputs, so they fall back to index.html (200) and are never parsed — no 500 or error overlay (vitejs/vite#23028)
+describe.runIf(isServe && !isBundledDev)('invalid', () => {
   test('should be 500 with overlay', async () => {
     const response = await page.goto(viteTestUrl + '/invalid.html')
     expect(response.status()).toBe(500)
@@ -431,7 +435,8 @@ describe('relative input', () => {
   })
 })
 
-describe.runIf(isServe)('warmup', () => {
+// bundled dev: server.moduleGraph stays empty by design (the bundle owns transforms), so warmup is not observable through it (vitejs/vite#23028)
+describe.runIf(isServe && !isBundledDev)('warmup', () => {
   test('should warmup /warmup/warm.js', async () => {
     // warmup transform files async during server startup, so the module check
     // here might take a while to load

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -4,6 +4,7 @@ import {
   editFile,
   getColor,
   isBuild,
+  isBundled,
   isBundledDev,
   isServe,
   page,
@@ -44,7 +45,8 @@ function testPage(isNested: boolean) {
     expect(await page.textContent('body p.inject')).toBe('This is injected')
   })
 
-  // bundled dev: transformIndexHtml runs at bundle time without ctx.server (vitejs/vite#23028)
+  // bundled dev runs transformIndexHtml while bundling, and ctx.server is not
+  // set there. Hooks read that as a build (vitejs/vite#23028)
   test.skipIf(isBundledDev)('server only transform', async () => {
     if (!isBuild) {
       expect(await page.textContent('body p.server')).toMatch(
@@ -55,7 +57,9 @@ function testPage(isNested: boolean) {
     }
   })
 
-  // bundled dev: bundle-time transformIndexHtml sets ctx.bundle, so the build-only tag is injected in dev too (vitejs/vite#23028)
+  // bundled dev runs transformIndexHtml while bundling, which sets ctx.bundle.
+  // The tag meant only for build is therefore added in dev too
+  // (vitejs/vite#23028)
   test.skipIf(isBundledDev)('build only transform', async () => {
     if (isBuild) {
       expect(await page.textContent('body p.build')).toMatch(
@@ -286,8 +290,10 @@ describe.runIf(isServe)('SPA fallback', () => {
   })
 })
 
-// bundled dev: invalid*.html are not bundle inputs, so they fall back to index.html (200) and are never parsed — no 500 or error overlay (vitejs/vite#23028)
-describe.runIf(isServe && !isBundledDev)('invalid', () => {
+// bundled dev does not take invalid*.html as bundle inputs. A request for one
+// falls back to index.html with status 200, and the file is never parsed.
+// So there is no 500 answer and no error overlay (vitejs/vite#23028)
+describe.runIf(!isBundled)('invalid', () => {
   test('should be 500 with overlay', async () => {
     const response = await page.goto(viteTestUrl + '/invalid.html')
     expect(response.status()).toBe(500)
@@ -435,8 +441,9 @@ describe('relative input', () => {
   })
 })
 
-// bundled dev: server.moduleGraph stays empty by design (the bundle owns transforms), so warmup is not observable through it (vitejs/vite#23028)
-describe.runIf(isServe && !isBundledDev)('warmup', () => {
+// bundled dev keeps server.moduleGraph empty by design, because the bundle
+// does the transforms. Warmup cannot be seen through it (vitejs/vite#23028)
+describe.runIf(!isBundled)('warmup', () => {
   test('should warmup /warmup/warm.js', async () => {
     // warmup transform files async during server startup, so the module check
     // here might take a while to load

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -81,8 +81,8 @@ function testPage(isNested: boolean) {
   })
 
   test('css', async () => {
-    expect(await getColor('h1')).toBe(isNested ? 'red' : 'blue')
-    expect(await getColor('p')).toBe('grey')
+    await expect.poll(() => getColor('h1')).toBe(isNested ? 'red' : 'blue')
+    await expect.poll(() => getColor('p')).toBe('grey')
   })
 
   if (isNested) {

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -5,7 +5,6 @@ import {
   getColor,
   isBuild,
   isBundled,
-  isBundledDev,
   isServe,
   page,
   serverLogs,
@@ -45,10 +44,8 @@ function testPage(isNested: boolean) {
     expect(await page.textContent('body p.inject')).toBe('This is injected')
   })
 
-  // bundled dev runs transformIndexHtml while bundling, and ctx.server is not
-  // set there. Hooks read that as a build (vitejs/vite#23028)
-  test.skipIf(isBundledDev)('server only transform', async () => {
-    if (!isBuild) {
+  test('server only transform', async () => {
+    if (!isBundled) {
       expect(await page.textContent('body p.server')).toMatch(
         'injected only during dev',
       )
@@ -57,11 +54,8 @@ function testPage(isNested: boolean) {
     }
   })
 
-  // bundled dev runs transformIndexHtml while bundling, which sets ctx.bundle.
-  // The tag meant only for build is therefore added in dev too
-  // (vitejs/vite#23028)
-  test.skipIf(isBundledDev)('build only transform', async () => {
-    if (isBuild) {
+  test('build only transform', async () => {
+    if (isBundled) {
       expect(await page.textContent('body p.build')).toMatch(
         'injected only during build',
       )
@@ -290,9 +284,6 @@ describe.runIf(isServe)('SPA fallback', () => {
   })
 })
 
-// bundled dev does not take invalid*.html as bundle inputs. A request for one
-// falls back to index.html with status 200, and the file is never parsed.
-// So there is no 500 answer and no error overlay (vitejs/vite#23028)
 describe.runIf(!isBundled)('invalid', () => {
   test('should be 500 with overlay', async () => {
     const response = await page.goto(viteTestUrl + '/invalid.html')
@@ -441,8 +432,6 @@ describe('relative input', () => {
   })
 })
 
-// bundled dev keeps server.moduleGraph empty by design, because the bundle
-// does the transforms. Warmup cannot be seen through it (vitejs/vite#23028)
 describe.runIf(!isBundled)('warmup', () => {
   test('should warmup /warmup/warm.js', async () => {
     // warmup transform files async during server startup, so the module check

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -47,7 +47,7 @@ function testPage(isNested: boolean) {
   test('server only transform', async () => {
     if (!isBundled) {
       expect(await page.textContent('body p.server')).toMatch(
-        'injected only during dev',
+        'injected only when unbundled',
       )
     } else {
       expect(await page.innerHTML('body')).not.toMatch('p class="server"')
@@ -57,7 +57,7 @@ function testPage(isNested: boolean) {
   test('build only transform', async () => {
     if (isBundled) {
       expect(await page.textContent('body p.build')).toMatch(
-        'injected only during build',
+        'injected only when bundled',
       )
     } else {
       expect(await page.innerHTML('body')).not.toMatch('p class="build"')

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -145,7 +145,7 @@ ${
             {
               tag: 'p',
               attrs: { class: 'server' },
-              children: 'This is injected only during dev',
+              children: 'This is injected only when unbundled',
               injectTo: 'body',
             },
           ]
@@ -160,7 +160,7 @@ ${
             {
               tag: 'p',
               attrs: { class: 'build' },
-              children: 'This is injected only during build',
+              children: 'This is injected only when bundled',
               injectTo: 'body',
             },
           ]

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -22,7 +22,6 @@ const bundledDevExclude = [
   './playground/fs-serve/__tests__/deny/fs-serve-deny.spec.ts',
   './playground/fs-serve/__tests__/fs-serve.spec.ts',
   './playground/hmr/__tests__/hmr.spec.ts',
-  './playground/html/__tests__/html.spec.ts',
   './playground/js-sourcemap/__tests__/js-sourcemap.spec.ts',
   './playground/legacy/__tests__/chunk-importmap/legacy-chunk-importmap.spec.ts',
   './playground/object-hooks/__tests__/object-hooks.spec.ts',


### PR DESCRIPTION
### Description

Enables the html playground under bundled dev by removing it from `bundledDevExclude`.

`server only transform` / `build only transform` (×3 pages each) run in every mode: under bundled dev `transformIndexHtml` runs at bundle time with `ctx.bundle` set and no `ctx.server`, so hooks classify the run as build. The tests assert that build-shaped outcome via `isBundled` (#23028).

Disabled cases:

- the `invalid` describe (5): `invalid*.html` files are not bundle inputs, fall back to index.html (200), and are never parsed — no 500 or overlay
- `warmup` (1): `server.moduleGraph` is empty under bundled dev

Verified: `pnpm test-serve-bundled` 48 passed / 14 skipped; `pnpm test-serve` and `pnpm test-build` 54 passed / 8 skipped each.

Part of #23028.
