### PR TITLE
fix(types): allow proxy socket path targets

### DIFF
--- a/packages/vite/src/node/__tests_dts__/config.ts
+++ b/packages/vite/src/node/__tests_dts__/config.ts
@@ -62,6 +62,18 @@ defineConfig(() => ({
   unknownProperty: 1, // we cannot catch invalid option for this case, ideally we should
 }))
 
+defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: {
+          socketPath: '/tmp/backend.sock',
+        },
+      },
+    },
+  },
+})
+
 // @ts-expect-error --- nested invalid option `build.unknown` should error
 defineConfig(() => ({
   base: '',

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -8,7 +8,22 @@ import type { HttpServer } from '..'
 
 const debug = createDebugger('vite:proxy')
 
-export interface ProxyOptions extends httpProxy.ServerOptions {
+type HttpProxyTargetDetailed = Extract<
+  httpProxy.ProxyTarget,
+  { socketPath?: string }
+>
+
+type SocketPathProxyTarget = Omit<HttpProxyTargetDetailed, 'host' | 'port'> & {
+  socketPath: string
+  host?: string
+  port?: number
+}
+
+type ProxyOptionsTarget = httpProxy.ProxyTarget | SocketPathProxyTarget
+
+export interface ProxyOptions extends Omit<httpProxy.ServerOptions, 'target'> {
+  /** URL string, URL object, host/port object or Unix socket target. */
+  target?: ProxyOptionsTarget
   /**
    * rewrite path
    */
@@ -88,7 +103,7 @@ export function proxyMiddleware(
     if (typeof opts === 'string') {
       opts = { target: opts, changeOrigin: true }
     }
-    const proxy = httpProxy.createProxyServer(opts)
+    const proxy = httpProxy.createProxyServer(opts as httpProxy.ServerOptions)
 
     if (opts.configure) {
       opts.configure(proxy, opts)


### PR DESCRIPTION
### Description

Fixes #21484.

Vite's proxy runtime can pass socket path targets through to http-proxy-3, but the public `ProxyOptions` type currently requires `host` and `port` for object targets. This relaxes the Vite-facing target type to allow Unix socket targets with only `socketPath`.

### Additional context

Added a DTS coverage case for:

```ts
defineConfig({
  server: {
    proxy: {
      '/api': {
        target: { socketPath: '/tmp/backend.sock' },
      },
    },
  },
})
```

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related tests.

### Validation

- `pnpm --filter vite typecheck`
- `pnpm exec eslint packages/vite/src/node/server/middlewares/proxy.ts packages/vite/src/node/__tests_dts__/config.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/server/middlewares/proxy.ts packages/vite/src/node/__tests_dts__/config.ts`
