### PR TITLE
fix(server): skip missing public dir watch path

### DIFF
--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,7 +1,8 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { type ViteDevServer, createServer } from '../index'
+import { resolveConfig } from '../../config'
+import { type ViteDevServer, createServer, getServerWatchPaths } from '../index'
 
 const stubGetWatchedCode = /\(\)\s*\{\s*return this;\s*\}/
 
@@ -52,5 +53,21 @@ describe('watcher configuration', () => {
         ]),
       )
     })
+  })
+
+  it('does not watch a missing public directory explicitly', async () => {
+    const root = fileURLToPath(
+      new URL('./fixtures/watcher/nested-root', import.meta.url),
+    )
+    const missingPublicDir = resolve(root, '../missing-public')
+    const config = await resolveConfig(
+      {
+        root,
+        publicDir: missingPublicDir,
+      },
+      'serve',
+    )
+
+    expect(getServerWatchPaths(config)).not.toContain(missingPublicDir)
   })
 })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -483,6 +483,18 @@ export function createServer(
   return _createServer(inlineConfig, { listen: true })
 }
 
+export function getServerWatchPaths(config: ResolvedConfig): string[] {
+  const { root, publicDir } = config
+  return [
+    ...(config.experimental.bundledDev ? [] : [root]),
+    ...config.configFileDependencies,
+    ...getEnvFilesForMode(config.mode, config.envDir),
+    // Watch the public directory explicitly because it might be outside
+    // of the root directory.
+    ...(publicDir && fs.existsSync(publicDir) ? [publicDir] : []),
+  ]
+}
+
 export async function _createServer(
   inlineConfig: ResolvedConfig | InlineConfig | undefined = {},
   options: {
@@ -557,15 +569,7 @@ export async function _createServer(
   const watchEnabled = serverConfig.watch !== null
   const watcher = watchEnabled
     ? (chokidar.watch(
-        // config file dependencies and env file might be outside of root
-        [
-          ...(config.experimental.bundledDev ? [] : [root]),
-          ...config.configFileDependencies,
-          ...getEnvFilesForMode(config.mode, config.envDir),
-          // Watch the public directory explicitly because it might be outside
-          // of the root directory.
-          ...(publicDir && publicFiles ? [publicDir] : []),
-        ],
+        getServerWatchPaths(config),
 
         resolvedWatchOptions,
       ) as FSWatcher)


### PR DESCRIPTION
### Description

Fixes #19864.

When `publicDir` points to a missing directory, Vite currently still passes that missing path to `chokidar.watch()`. On some watcher backends this can interfere with recursive watching under the project root, so regular source file changes may stop producing HMR updates.

This keeps the existing behavior for an existing `publicDir`, including an empty one, but skips adding the extra public directory watch path when the directory does not exist.

### Additional context

Added watcher coverage around the paths Vite passes into `chokidar.watch()` so a missing `publicDir` is not included explicitly.

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related tests.

### Validation

- `pnpm exec vitest run packages/vite/src/node/server/__tests__/watcher.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm exec eslint packages/vite/src/node/server/index.ts packages/vite/src/node/server/__tests__/watcher.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/server/index.ts packages/vite/src/node/server/__tests__/watcher.spec.ts`
