### PR TITLE
fix(server): retain buffered hmr errors

### DIFF
--- a/packages/vite/src/node/__tests__/ws.spec.ts
+++ b/packages/vite/src/node/__tests__/ws.spec.ts
@@ -1,0 +1,100 @@
+import type { AddressInfo } from 'node:net'
+import { afterEach, describe, expect, test } from 'vitest'
+import WebSocket from 'ws'
+import { createServer } from '..'
+import type { ViteDevServer } from '..'
+import type { ErrorPayload } from '#types/hmrPayload'
+
+const optimizeDeps = {
+  noDiscovery: true,
+  include: [],
+}
+
+describe('websocket server', () => {
+  let server: ViteDevServer | undefined
+  const sockets: WebSocket[] = []
+
+  afterEach(async () => {
+    for (const socket of sockets) {
+      socket.close()
+    }
+    sockets.length = 0
+    await server?.close()
+    server = undefined
+  })
+
+  function connectHmrClient() {
+    const address = server!.httpServer!.address() as AddressInfo
+    const token = server!.config.webSocketToken
+    const socket = new WebSocket(
+      `ws://localhost:${address.port}/?token=${token}`,
+      ['vite-hmr'],
+    )
+    sockets.push(socket)
+
+    return socket
+  }
+
+  function waitForPayload(socket: WebSocket, type: string) {
+    return new Promise<any>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        socket.off('error', onError)
+        socket.off('message', onMessage)
+        reject(new Error(`Timed out waiting for ${type} payload`))
+      }, 1000)
+
+      function onError(error: Error) {
+        clearTimeout(timeout)
+        socket.off('message', onMessage)
+        reject(error)
+      }
+
+      function onMessage(raw: WebSocket.RawData) {
+        const payload = JSON.parse(String(raw))
+        if (payload.type === type) {
+          clearTimeout(timeout)
+          socket.off('error', onError)
+          socket.off('message', onMessage)
+          resolve(payload)
+        }
+      }
+
+      socket.on('error', onError)
+      socket.on('message', onMessage)
+    })
+  }
+
+  test('sends the current error payload to clients that connect later', async () => {
+    server = await createServer({
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      optimizeDeps,
+      server: {
+        port: 0,
+        strictPort: true,
+      },
+    })
+    await server.listen()
+
+    const firstClient = connectHmrClient()
+    await waitForPayload(firstClient, 'connected')
+
+    const payload: ErrorPayload = {
+      type: 'error',
+      err: {
+        message: 'Unexpected token',
+        stack: 'Error: Unexpected token',
+      },
+    }
+
+    const firstError = waitForPayload(firstClient, 'error')
+    server.ws.send(payload)
+    await expect(firstError).resolves.toMatchObject(payload)
+
+    const secondClient = connectHmrClient()
+    const secondError = waitForPayload(secondClient, 'error')
+    await waitForPayload(secondClient, 'connected')
+
+    await expect(secondError).resolves.toMatchObject(payload)
+  })
+})

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -323,7 +323,9 @@ export function createWebSocketServer(
     socket.send(JSON.stringify({ type: 'connected' }))
     if (bufferedMessage) {
       socket.send(JSON.stringify(bufferedMessage))
-      bufferedMessage = null
+      if (bufferedMessage.type === 'full-reload') {
+        bufferedMessage = null
+      }
     }
   })
 
@@ -376,12 +378,13 @@ export function createWebSocketServer(
   const normalizedHotChannel = normalizeHotChannel(
     {
       send(payload) {
-        if (
-          (payload.type === 'error' || payload.type === 'full-reload') &&
-          !wss.clients.size
-        ) {
+        if (payload.type === 'error') {
+          bufferedMessage = payload
+        } else if (payload.type === 'full-reload' && !wss.clients.size) {
           bufferedMessage = payload
           return
+        } else {
+          bufferedMessage = null
         }
 
         const stringified = JSON.stringify(payload)


### PR DESCRIPTION
### Description

Fixes #19710.

When an HMR error is sent while at least one client is already connected, Vite currently broadcasts the error but doesn't keep it as the current buffered message. A later tab can then connect after the failed transform and only receive the `connected` payload, leaving it on a blank page without the error overlay.

This keeps the latest error payload buffered until a non-error HMR payload is sent. Full reload payloads keep the previous one-shot behavior when they were buffered because no clients existed yet.

### Additional context

Added a WebSocket regression test that:

1. connects the first HMR client
2. sends an error payload
3. connects a second HMR client afterwards
4. verifies the second client receives the same error payload

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide related tests.

### Validation

- `pnpm exec vitest run packages/vite/src/node/__tests__/ws.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm exec eslint packages/vite/src/node/server/ws.ts packages/vite/src/node/__tests__/ws.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/server/ws.ts packages/vite/src/node/__tests__/ws.spec.ts`
