### PR TITLE
docs: explain monorepo watch setup

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -307,6 +307,31 @@ File system watcher options to pass on to [chokidar](https://github.com/paulmill
 
 The Vite server watcher watches the `root` and skips the `.git/`, `node_modules/`, `test-results/`, and Vite's `cacheDir` and `build.outDir` directories by default. When updating a watched file, Vite will apply HMR and update the page only if needed.
 
+In a monorepo, files outside the configured `root` are not watched automatically. If a package needs to react to changes in another workspace package, add the external source directories in a plugin:
+
+```js
+import path from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'watch-workspace-package',
+      configureServer(server) {
+        server.watcher.add(
+          path.resolve(import.meta.dirname, '../shared-package/src'),
+        )
+      },
+    },
+  ],
+  server: {
+    watch: {
+      ignored: ['**/.yarn/**', '**/.wireit/**'],
+    },
+  },
+})
+```
+
 If set to `null`, no files will be watched. [`server.watcher`](/guide/api-javascript.html#vitedevserver) will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
 
 ::: warning Watching files in `node_modules`


### PR DESCRIPTION
### Description

Fixes #15250.

Adds a short note to `server.watch` explaining that Vite watches the configured `root` by default and that files outside that root in a monorepo need to be added explicitly. The example uses a small `configureServer` plugin to add another workspace package's source directory to `server.watcher` and shows how cache folders can still be ignored through `server.watch.ignored`.

### What is the purpose of this pull request?

- Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.

### Validation

- `pnpm exec oxfmt --check docs/config/server-options.md`
- `pnpm --filter vite build-bundle`
- `pnpm --filter vite build-types-roll`
- `pnpm --dir docs docs-build`
