### PR TITLE
fix(ssr): preserve crlf hashbang hoist position

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1155,6 +1155,18 @@ import foo from "foo"`,
   `)
 })
 
+test('import hoisted after hashbang with CRLF line endings', async () => {
+  const transformed = await ssrTransformSimpleCode(
+    '#!/usr/bin/env node\r\nconsole.log(foo);\r\nimport foo from "foo"',
+  )
+
+  expect(
+    transformed?.startsWith(
+      '#!/usr/bin/env node\r\nconst __vite_ssr_import_0__',
+    ),
+  ).toBe(true)
+})
+
 test('identity function helper injected after hashbang', async () => {
   expect(
     await ssrTransformSimpleCode(

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -2002,7 +2002,7 @@ export function formatAndTruncateFileList(files: string[]): {
   return { formatted: log, truncated }
 }
 
-const hashbangRE = /^#!.*\n/
+const hashbangRE = /^#![^\r\n\u2028\u2029]*(?:\r\n|[\r\n\u2028\u2029])?/
 
 // find the start of the file, after the hashbang
 export function getFileStartIndex(code: string): number {


### PR DESCRIPTION
### Description

Fixes #23034.

`getFileStartIndex` now recognizes hashbang lines with CRLF and other JavaScript line terminators, so SSR/import-analysis hoists injected code after the hashbang instead of before it on Windows-style checkouts.

This also keeps the existing behavior for hashbangs without a trailing newline.

### Additional context

Added a regression test that transforms a CRLF hashbang file and asserts the hoisted SSR import stays after the full `\r\n` sequence.

---

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#commit-convention).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Update the corresponding documentation if needed.
- [x] Add corresponding tests.

### Validation

- [x] `pnpm exec vitest run packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts`
- [x] `pnpm exec eslint packages/vite/src/node/utils.ts packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts`
- [x] `pnpm exec oxfmt --check packages/vite/src/node/utils.ts packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts`
- [x] `pnpm --filter vite build-types-roll && pnpm --filter vite typecheck`