### PR TITLE
fix(cli): keep positional args with profile flag

### DIFF
--- a/packages/vite/bin/profile.js
+++ b/packages/vite/bin/profile.js
@@ -1,0 +1,7 @@
+export function removeProfileFlag(argv) {
+  const profileIndex = argv.indexOf('--profile')
+  if (profileIndex > 0) {
+    argv.splice(profileIndex, 1)
+  }
+  return profileIndex
+}

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { performance } from 'node:perf_hooks'
 import module from 'node:module'
+import { removeProfileFlag } from './profile.js'
 
 if (!import.meta.url.includes('node_modules')) {
   if (!process.env.DEBUG_DISABLE_SOURCE_MAP) {
@@ -20,7 +21,6 @@ const debugIndex = process.argv.findIndex((arg) => /^(?:-d|--debug)$/.test(arg))
 const filterIndex = process.argv.findIndex((arg) =>
   /^(?:-f|--filter)$/.test(arg),
 )
-const profileIndex = process.argv.indexOf('--profile')
 
 if (debugIndex > 0) {
   let value = process.argv[debugIndex + 1]
@@ -62,12 +62,8 @@ function start() {
   return import('../dist/node/cli.js')
 }
 
+const profileIndex = removeProfileFlag(process.argv)
 if (profileIndex > 0) {
-  process.argv.splice(profileIndex, 1)
-  const next = process.argv[profileIndex]
-  if (next && next[0] !== '-') {
-    process.argv.splice(profileIndex, 1)
-  }
   const inspector = await import('node:inspector').then((r) => r.default)
   const session = (global.__vite_profile_session = new inspector.Session())
   session.connect()

--- a/packages/vite/src/node/__tests__/cliProfile.spec.ts
+++ b/packages/vite/src/node/__tests__/cliProfile.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { removeProfileFlag } from '../../../bin/profile.js'
+
+describe('profile cli flag', () => {
+  test('removes --profile without removing the root argument', () => {
+    const argv = ['node', 'vite', 'build', '--profile', 'app']
+
+    expect(removeProfileFlag(argv)).toBe(3)
+    expect(argv).toEqual(['node', 'vite', 'build', 'app'])
+  })
+
+  test('removes --profile without removing the command argument', () => {
+    const argv = ['node', 'vite', '--profile', 'build']
+
+    expect(removeProfileFlag(argv)).toBe(2)
+    expect(argv).toEqual(['node', 'vite', 'build'])
+  })
+})


### PR DESCRIPTION
### Description

Fixes #23032.

`--profile` is a boolean CLI flag, but `packages/vite/bin/vite.js` removed both the flag and the next non-flag argument before handing argv to cac. That meant commands like `vite build --profile app` built the current directory instead of `app`.

This extracts the flag stripping into a small helper and only removes `--profile` itself, preserving command/root positional arguments.

### Additional context

Added regression coverage for both:

- `vite build --profile app`
- `vite --profile build`

I also smoke-tested the real bin entry with a temporary app and confirmed `vite build --profile <root>` creates `<root>/dist/index.html`.

---

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#commit-convention).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Update the corresponding documentation if needed.
- [x] Add corresponding tests.

### Validation

- [x] `pnpm exec vitest run packages/vite/src/node/__tests__/cliProfile.spec.ts`
- [x] `pnpm exec eslint packages/vite/bin/vite.js packages/vite/bin/profile.js packages/vite/src/node/__tests__/cliProfile.spec.ts`
- [x] `pnpm exec oxfmt --check packages/vite/bin/vite.js packages/vite/bin/profile.js packages/vite/src/node/__tests__/cliProfile.spec.ts`
- [x] `pnpm --filter vite build-types-roll && pnpm --filter vite typecheck`
- [x] `node packages/vite/bin/vite.js build --profile <tmp>/app --logLevel error`