### PR TITLE
fix(deps): resolve bare asset urls in optimized deps (fix #23045)

### DIFF
--- a/packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts
@@ -8,10 +8,14 @@ async function createRolldownDepPluginTransform(cacheDir: string) {
     optimizeDeps: { extensions: [] },
     server: { fs: { allow: [] } },
     resolve: { builtins: [] },
-    createResolver: () => ({}),
+    createResolver: () => async (id: string) =>
+      id === 'the-dependency/worker.js'
+        ? '/root/node_modules/the-dependency/worker.js'
+        : undefined,
   }
 
   const mockEnvironment = {
+    name: 'client',
     config: baseConfig,
     getTopLevelConfig: () => baseConfig,
   } as any
@@ -72,6 +76,17 @@ describe('rolldownDepPlugin transform', async () => {
     expect(
       await transform(code, '/root/node_modules/my-lib/index.js'),
     ).toBeUndefined()
+  })
+
+  test('resolves bare asset URLs from optimized deps', async () => {
+    expect(
+      await transform(
+        "new URL('the-dependency/worker.js', import.meta.url)",
+        '/root/node_modules/my-lib/index.js',
+      ),
+    ).toMatchInlineSnapshot(
+      `"new URL('' + "../../node_modules/the-dependency/worker.js", import.meta.url)"`,
+    )
   })
 
   test('skips dynamic template strings', async () => {

--- a/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/rolldownDepPlugin.ts
@@ -316,7 +316,7 @@ export function rolldownDepPlugin(
         filter: {
           code: assetImportMetaUrlRE,
         },
-        handler(code, id) {
+        async handler(code, id) {
           let s: MagicString | undefined
           const re = new RegExp(assetImportMetaUrlRE)
           const cleanString = stripLiteral(code)
@@ -340,11 +340,15 @@ export function rolldownDepPlugin(
               continue
             }
 
-            if (!s) s = new MagicString(code)
+            // we resolve the URL from the original library file (id) and then
+            // rewrite it relative to the bundle (deps) directory.
+            const absolutePath =
+              url[0] === '.'
+                ? path.resolve(path.dirname(id), url)
+                : await resolve(url, id, 'import-statement')
+            if (!absolutePath) continue
 
-            // we resolve the relative path from the original library file (id) and
-            // then rewrite it relative to the bundle (deps) directory.
-            const absolutePath = path.resolve(path.dirname(id), url)
+            if (!s) s = new MagicString(code)
             const relativePath = path.relative(bundleOutputDir, absolutePath)
             const normalizedRelativePath = normalizePath(relativePath)
             s.update(


### PR DESCRIPTION
### Description

Fixes #23045.

When the dep optimizer rewrites `new URL(..., import.meta.url)` inside optimized dependency code, it handled every non-absolute/non-external URL with `path.resolve(path.dirname(id), url)`. That works for relative URLs like `./worker.js`, but it treats bare specifiers like `the-dependency/worker.js` as if they were relative to the importing package file.

This keeps the existing relative path behavior, but resolves bare asset URLs through Vite's dependency resolver before rewriting the URL relative to the optimized deps output directory.

### Additional context

Added a regression test for a dependency file using:

```js
new URL('the-dependency/worker.js', import.meta.url)
```

The rewritten URL now points back through `node_modules/the-dependency/worker.js` instead of `node_modules/my-lib/the-dependency/worker.js`.

---

### What is the purpose of this pull request?

- Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/CONTRIBUTING.md#commit-convention).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Update the corresponding documentation if needed.
- [x] Add corresponding tests.

### Validation

- [x] `pnpm exec vitest run packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts`
- [x] `pnpm exec eslint packages/vite/src/node/optimizer/rolldownDepPlugin.ts packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts`
- [x] `pnpm exec oxfmt --check packages/vite/src/node/optimizer/rolldownDepPlugin.ts packages/vite/src/node/__tests__/optimizer/rolldownDepPlugin.spec.ts`
- [x] `pnpm --filter vite build-types-roll && pnpm --filter vite typecheck`