### PR TITLE
test(bundled-dev): wait for updates after edits in enabled playgrounds

### DIFF
--- a/playground/hmr-root/__tests__/hmr-root.spec.ts
+++ b/playground/hmr-root/__tests__/hmr-root.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from 'vitest'
 
-import { editFile, isServe, page } from '~utils'
+import { editFile, isServe, page, withPageReload } from '~utils'
 
 test.runIf(isServe)('should watch files outside root', async () => {
   expect(await page.textContent('#foo')).toBe('foo')
-  editFile('foo.js', (code) => code.replace("'foo'", "'foobar'"))
-  await page.waitForEvent('load')
-  await expect.poll(() => page.textContent('#foo')).toBe('foobar')
+  await withPageReload(() =>
+    editFile('foo.js', (code) => code.replace("'foo'", "'foobar'")),
+  )
+  expect(await page.textContent('#foo')).toBe('foobar')
 })

--- a/playground/json/__tests__/csr/json-csr.spec.ts
+++ b/playground/json/__tests__/csr/json-csr.spec.ts
@@ -3,7 +3,14 @@ import { expect, test } from 'vitest'
 import deepJson from 'vue/package.json'
 import testJson from '../../test.json'
 import hmrJson from '../../hmr.json'
-import { editFile, isBuild, isBundledDev, isServe, page } from '~utils'
+import {
+  editFile,
+  isBuild,
+  isBundledDev,
+  isServe,
+  page,
+  withPageReload,
+} from '~utils'
 
 const stringified = JSON.stringify(testJson)
 const deepStringified = JSON.stringify(deepJson)
@@ -56,10 +63,10 @@ test('require(json) returns object without default export', async () => {
 test.runIf(isServe)('should full reload', async () => {
   expect(await page.textContent('.hmr')).toBe(hmrStringified)
 
-  editFile('hmr.json', (code) =>
-    code.replace('"this is hmr json"', '"this is hmr update json"'),
+  await withPageReload(() =>
+    editFile('hmr.json', (code) =>
+      code.replace('"this is hmr json"', '"this is hmr update json"'),
+    ),
   )
-  await expect
-    .poll(() => page.textContent('.hmr'))
-    .toMatch('"this is hmr update json"')
+  expect(await page.textContent('.hmr')).toMatch('"this is hmr update json"')
 })

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { setTimeout } from 'node:timers/promises'
 import { describe, expect, test } from 'vitest'
 import { port, serverLogs } from './serve'
-import { editFile, isServe, page } from '~utils'
+import { editFile, isServe, page, withPageReload } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -76,11 +76,11 @@ describe.runIf(isServe)('hmr', () => {
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[success]')
 
-    const loadPromise = page.waitForEvent('load')
-    editFile('src/importedVirtual.js', (code) =>
-      code.replace('[success]', '[wow]'),
+    await withPageReload(() =>
+      editFile('src/importedVirtual.js', (code) =>
+        code.replace('[success]', '[wow]'),
+      ),
     )
-    await loadPromise
 
     await expect
       .poll(async () => {


### PR DESCRIPTION
### Description

Follow-up to #23097. Sweeps every playground that already runs under bundled dev for test code that races an edit's effect, and converts it to the harness helpers:

- `json-csr > should full reload` — the reload was awaited with a one-shot pattern; it failed CI on a slow runner (macOS node-24) because the reload chain was still in flight. Now `withPageReload`.
- `hmr-root` — `page.waitForEvent('load')` was registered after the edit, so a fast reload could be missed. Now `withPageReload`.
- `ssr-html > handle virtual module updates` — manual load-promise pattern. Now `withPageReload` (trailing poll kept: this playground runs a middleware-mode server without the bundled-dev tracker, so settling degrades to a plain load wait).

Every other mutation site in the enabled playgrounds already waits correctly (`expect.poll`, `untilUpdated`, build-watch `notifyRebuildComplete`, or is excluded under bundled dev); the full list of checked-and-left sites is in the review notes. All three changed playgrounds verified green under bundled dev and plain serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)