### PR TITLE
fix: support resolving top-level input option with plugins

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -112,6 +112,36 @@ describe('build', () => {
     expect(chunk?.code).toContain('from-top-level-input')
   })
 
+  test('top-level input can be a virtual module for build', async () => {
+    const input = 'virtual:entry'
+    const resolvedInput = `\0${input}`
+    const result = (await build({
+      root: resolve(dirname, 'packages/build-project'),
+      logLevel: 'silent',
+      input,
+      build: {
+        write: false,
+      },
+      plugins: [
+        {
+          name: 'virtual-entry',
+          resolveId(id) {
+            if (id === input) {
+              return resolvedInput
+            }
+          },
+          load(id) {
+            if (id === resolvedInput) {
+              return `console.log('from-virtual-top-level-input')`
+            }
+          },
+        },
+      ],
+    })) as RolldownOutput
+    const chunk = result.output.find((o) => o.type === 'chunk')
+    expect(chunk?.code).toContain('from-virtual-top-level-input')
+  })
+
   test('file hash should change when pure css chunk changes', async () => {
     const buildProject = async (cssColor: string) => {
       return (await build({

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1175,16 +1175,11 @@ describe('resolveConfig', () => {
     )
   })
 
-  const resolveInputFromRoot = (p: string) =>
-    normalizePath(path.resolve(process.cwd(), p))
-
   test('top-level input applies to the client environment only (non-inherit)', async () => {
     const config = await resolveConfig({ input: 'src/main.ts' }, 'serve')
 
-    expect(config.input).toBe(resolveInputFromRoot('src/main.ts'))
-    expect(config.environments.client.input).toBe(
-      resolveInputFromRoot('src/main.ts'),
-    )
+    expect(config.input).toBe('src/main.ts')
+    expect(config.environments.client.input).toBe('src/main.ts')
     expect(
       config.environments.client.build.rolldownOptions.input,
     ).toBeUndefined()
@@ -1203,57 +1198,29 @@ describe('resolveConfig', () => {
       'serve',
     )
 
-    expect(config.environments.client.input).toBe(
-      resolveInputFromRoot('src/main.ts'),
-    )
-    expect(config.environments.ssr.input).toBe(
-      resolveInputFromRoot('src/entry-server.ts'),
-    )
+    expect(config.environments.client.input).toBe('src/main.ts')
+    expect(config.environments.ssr.input).toBe('src/entry-server.ts')
   })
 
-  test('resolves array input to absolute paths', async () => {
+  test('keeps array input relative to the root', async () => {
     const config = await resolveConfig(
       { input: ['src/a.ts', 'src/b.ts'] },
       'serve',
     )
 
-    expect(config.environments.client.input).toEqual([
-      resolveInputFromRoot('src/a.ts'),
-      resolveInputFromRoot('src/b.ts'),
-    ])
+    expect(config.environments.client.input).toEqual(['src/a.ts', 'src/b.ts'])
   })
 
-  test('resolves record input to absolute paths', async () => {
+  test('keeps record input relative to the root', async () => {
     const config = await resolveConfig(
       { input: { main: 'src/a.ts', admin: 'src/b.ts' } },
       'serve',
     )
 
     expect(config.environments.client.input).toEqual({
-      main: resolveInputFromRoot('src/a.ts'),
-      admin: resolveInputFromRoot('src/b.ts'),
+      main: 'src/a.ts',
+      admin: 'src/b.ts',
     })
-  })
-
-  test('adds input to server.fs.allow by default', async () => {
-    const inputs = {
-      main: resolveInputFromRoot('src/a.ts'),
-      admin: resolveInputFromRoot('src/b.ts'),
-    }
-    const config = await resolveConfig(
-      { input: { main: 'src/a.ts', admin: 'src/b.ts' } },
-      'serve',
-    )
-
-    expect(config.server.fs.allow).toStrictEqual(
-      expect.arrayContaining(Object.values(inputs)),
-    )
-  })
-
-  test('adds the default index.html input to server.fs.allow', async () => {
-    const config = await resolveConfig({}, 'serve')
-
-    expect(config.server.fs.allow).toContain(resolveInputFromRoot('index.html'))
   })
 
   test('reserves glob characters in input', async () => {
@@ -1286,17 +1253,17 @@ describe('resolveConfig', () => {
       {
         name: 'glob',
         input: 'src/\\*.ts',
-        expected: resolveInputFromRoot('src/*.ts'),
+        expected: 'src/*.ts',
       },
       {
         name: 'array element',
         input: ['src/\\*.ts'],
-        expected: [resolveInputFromRoot('src/*.ts')],
+        expected: ['src/*.ts'],
       },
       {
         name: 'record',
         input: { main: 'src/\\*.ts' },
-        expected: { main: resolveInputFromRoot('src/*.ts') },
+        expected: { main: 'src/*.ts' },
       },
     ]
 
@@ -1319,14 +1286,14 @@ describe('resolveConfig', () => {
       {
         name: 'special characters',
         input: 'src/a-b_c$.ts',
-        expected: resolveInputFromRoot('src/a-b_c$.ts'),
+        expected: 'src/a-b_c$.ts',
       },
       ...(isWindows
         ? [
             {
               name: 'windows path',
               input: 'src\\foo.ts',
-              expected: resolveInputFromRoot('src/foo.ts'),
+              expected: 'src\\foo.ts',
             },
           ]
         : []),
@@ -2047,7 +2014,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual(['example.com'])
@@ -2059,7 +2025,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2075,7 +2040,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2091,7 +2055,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: [] },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual(['example.com', 'test.com'])
@@ -2102,7 +2065,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: ['existing.com'] },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toEqual([
@@ -2117,7 +2079,6 @@ describe('resolveServerOptions', () => {
     const resolved = await resolveServerOptions(
       '/root',
       { allowedHosts: true },
-      undefined,
       logger,
     )
     expect(resolved.allowedHosts).toBe(true)
@@ -2130,7 +2091,6 @@ describe('resolveServerOptions', () => {
       const resolved = await resolveServerOptions(
         '/root',
         { allowedHosts: [] },
-        undefined,
         logger,
       )
       expect(resolved.allowedHosts).toEqual([])

--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import path from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { ResolvedServerUrls } from 'vite'
 import { createServer, resolveConfig } from '..'
 import type { ViteDevServer } from '..'
 import { promiseWithResolvers } from '../../shared/utils'
+import { createLogger } from '../logger'
+import { normalizePath } from '../utils'
 
 describe('resolveBuildEnvironmentOptions in dev', () => {
   test('build.rolldownOptions should not have input in lib', async () => {
@@ -26,6 +29,129 @@ describe('the dev server', () => {
 
   afterEach(async () => {
     await server?.close()
+  })
+
+  test('resolves each environment input as a safe module', async () => {
+    const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
+    const clientEntry = normalizePath(path.join(root, 'client-entry.js'))
+    const ssrEntry = normalizePath(path.join(root, 'ssr-entry.js'))
+
+    server = await createServer({
+      configFile: false,
+      root,
+      input: 'virtual:client-entry',
+      environments: {
+        ssr: { input: { main: 'virtual:ssr-entry' } },
+      },
+      optimizeDeps: { noDiscovery: true },
+      server: { fs: { allow: [] }, middlewareMode: true, ws: false },
+      plugins: [
+        {
+          name: 'resolve-environment-entries',
+          resolveId(id) {
+            if (id === `virtual:${this.environment.name}-entry`) {
+              return this.environment.name === 'client' ? clientEntry : ssrEntry
+            }
+          },
+        },
+      ],
+    })
+
+    expect(server.config.safeModulePaths).toStrictEqual(new Set([clientEntry]))
+    await server.environments.ssr.pluginContainer.buildStart()
+    expect(server.config.safeModulePaths).toStrictEqual(
+      new Set([clientEntry, ssrEntry]),
+    )
+  })
+
+  test('does not mark an external environment input as safe', async () => {
+    const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
+    const externalEntry = normalizePath(path.join(root, 'external-entry.js'))
+
+    server = await createServer({
+      configFile: false,
+      root,
+      input: 'virtual:external-entry',
+      optimizeDeps: { noDiscovery: true },
+      server: { fs: { allow: [] }, middlewareMode: true, ws: false },
+      plugins: [
+        {
+          name: 'external-environment-entry',
+          resolveId(id) {
+            if (id === 'virtual:external-entry') {
+              return { id: externalEntry, external: true }
+            }
+          },
+        },
+      ],
+    })
+
+    expect(server.config.safeModulePaths).not.toContain(externalEntry)
+  })
+
+  test('silently resolves index.html as the fallback for every environment', async () => {
+    const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
+    const clientEntry = normalizePath(path.join(root, 'client-index.html'))
+    const resolvedEnvironments = new Set<string>()
+    const logger = createLogger('silent')
+    logger.warn = vi.fn()
+
+    server = await createServer({
+      configFile: false,
+      root,
+      customLogger: logger,
+      optimizeDeps: { noDiscovery: true },
+      server: { fs: { allow: [] }, middlewareMode: true, ws: false },
+      plugins: [
+        {
+          name: 'resolve-environment-index',
+          resolveId(id) {
+            if (id !== 'index.html') return
+            resolvedEnvironments.add(this.environment.name)
+            if (this.environment.name === 'ssr') {
+              throw new Error('ssr does not have an HTML entry')
+            }
+            return clientEntry
+          },
+        },
+      ],
+    })
+
+    expect(resolvedEnvironments).toStrictEqual(new Set(['client']))
+    await server.environments.ssr.pluginContainer.buildStart()
+    expect(resolvedEnvironments).toStrictEqual(new Set(['client', 'ssr']))
+    expect(server.config.safeModulePaths).toStrictEqual(new Set([clientEntry]))
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  test('does not ignore buildStart errors while resolving fallback inputs', async () => {
+    server = await createServer({
+      configFile: false,
+      root: path.join(import.meta.dirname, 'fixtures', 'input-option'),
+      logLevel: 'silent',
+      optimizeDeps: { noDiscovery: true },
+      plugins: [
+        {
+          name: 'failing-build-start',
+          perEnvironmentStartEndDuringDev: true,
+          buildStart() {
+            if (this.environment.name === 'ssr') {
+              throw new Error('buildStart failed')
+            }
+          },
+        },
+      ],
+      server: {
+        fs: { allow: [] },
+        middlewareMode: true,
+        watch: null,
+        ws: false,
+      },
+    })
+
+    await expect(
+      server.environments.ssr.pluginContainer.buildStart(),
+    ).rejects.toThrow('buildStart failed')
   })
 
   test('resolves the server URLs before the httpServer listening events are called', async () => {

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -160,14 +160,17 @@ test('scan jsx-runtime', async (ctx) => {
       },
     },
   })
+  ctx.onTestFinished(() => server.close())
 
   // start server to ensure optimizer run
   await server.listen()
-  ctx.onTestFinished(() => server.close())
 
   const runner = createServerModuleRunner(server.environments.ssr, {
     hmr: { logger: false },
   })
+
+  // The dependency scan should be able to finish before the first request.
+  await server.environments.ssr.depsOptimizer?.scanProcessing
 
   // flush initial optimizer by importing any file
   await runner.import('./entry-no-jsx.js')

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -7,7 +7,11 @@ import {
   scanImports,
   scriptRE,
 } from '../optimizer/scan'
-import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
+import {
+  multilineCommentsRE,
+  normalizePath,
+  singlelineCommentsRE,
+} from '../utils'
 import { createServer, createServerModuleRunner } from '..'
 
 describe('optimizer-scan:script-test', () => {
@@ -224,6 +228,41 @@ test('top-level input is used as the entry for dep scanning', async (ctx) => {
     logLevel: 'error',
     root: path.join(import.meta.dirname, 'fixtures', 'input-option'),
     input: 'entry.js',
+    optimizeDeps: {
+      force: true,
+      noDiscovery: false,
+    },
+  })
+  ctx.onTestFinished(() => server.close())
+
+  const { cancel, result } = scanImports(
+    devToScanEnvironment(server.environments.client),
+  )
+  ctx.onTestFinished(cancel)
+
+  const scanResult = await result
+  expect(scanResult.deps).toHaveProperty('vue')
+})
+
+test('top-level input can be resolved by a plugin for dep scanning', async (ctx) => {
+  const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
+  const input = 'virtual:entry'
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'error',
+    root,
+    input,
+    plugins: [
+      {
+        name: 'virtual-entry',
+        enforce: 'pre',
+        resolveId(id, _importer) {
+          if (id === input) {
+            return normalizePath(path.resolve(root, 'entry.js'))
+          }
+        },
+      },
+    ],
     optimizeDeps: {
       force: true,
       noDiscovery: false,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -621,9 +621,7 @@ export function resolveRolldownOptions(
     : typeof options.ssr === 'string'
       ? resolve(options.ssr)
       : options.rolldownOptions.input ||
-        (topLevelInput != null
-          ? topLevelInput // top-level `input` is already resolved in resolveConfig
-          : resolve('index.html'))
+        (topLevelInput ?? resolve('index.html'))
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -923,27 +923,21 @@ const configDefaults = Object.freeze({
   appType: 'spa',
 } satisfies UserConfig)
 
-function resolveInput(
+function normalizeInput(
   input: InputOption | undefined,
-  root: string,
 ): InputOption | undefined {
   if (input === undefined) {
     return undefined
   }
   if (typeof input === 'string') {
-    const unescapedInput = unescapeGlobCharacters(input)
-    return normalizePath(path.resolve(root, unescapedInput))
+    return unescapeGlobCharacters(input)
   }
   if (Array.isArray(input)) {
-    return input.map((inp) => {
-      const unescapedInput = unescapeGlobCharacters(inp)
-      return normalizePath(path.resolve(root, unescapedInput))
-    })
+    return input.map(unescapeGlobCharacters)
   }
   const resolved: Record<string, string> = {}
   for (const key in input) {
-    const unescapedInput = unescapeGlobCharacters(input[key])
-    resolved[key] = normalizePath(path.resolve(root, unescapedInput))
+    resolved[key] = unescapeGlobCharacters(input[key])
   }
   return resolved
 }
@@ -996,7 +990,6 @@ function resolveEnvironmentOptions(
   options: EnvironmentOptions,
   alias: Alias[],
   preserveSymlinks: boolean,
-  root: string,
   forceOptimizeDeps: boolean | undefined,
   logger: Logger,
   environmentName: string,
@@ -1044,7 +1037,7 @@ function resolveEnvironmentOptions(
     isSsrTargetWebworkerEnvironment,
   )
   return {
-    input: resolveInput(options.input, root),
+    input: normalizeInput(options.input),
     define: options.define,
     resolve,
     keepProcessEnv:
@@ -1727,7 +1720,6 @@ export async function resolveConfig(
       config.environments[environmentName],
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
-      resolvedRoot,
       inlineConfig.forceOptimizeDeps,
       logger,
       environmentName,
@@ -1865,13 +1857,8 @@ export async function resolveConfig(
         )
       : ''
 
-  const input = resolveInput(config.input, resolvedRoot)
-  const server = await resolveServerOptions(
-    resolvedRoot,
-    config.server,
-    input,
-    logger,
-  )
+  const input = normalizeInput(config.input)
+  const server = await resolveServerOptions(resolvedRoot, config.server, logger)
 
   const builder = resolveBuilderOptions(config.builder)
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -214,19 +214,13 @@ async function computeEntries(environment: ScanEnvironment) {
   let entries: string[] = []
 
   const explicitEntryPatterns = environment.config.optimizeDeps.entries
-  const buildInput =
+  const input =
     environment.config.input ?? environment.config.build.rolldownOptions.input
 
   if (explicitEntryPatterns) {
     entries = await globEntries(explicitEntryPatterns, environment)
-  } else if (buildInput) {
+  } else if (input) {
     const resolvePath = async (p: string) => {
-      if (environment.config.input) {
-        // input is already resolved in resolveConfig
-        return p
-      }
-      // `build.rollupOptions.input` is resolved from the root (not `process.cwd()`)
-      // by the build, so resolve it from the root here too by not passing an importer.
       const id = (
         await environment.pluginContainer.resolveId(p, undefined, {
           isEntry: true,
@@ -240,12 +234,12 @@ async function computeEntries(environment: ScanEnvironment) {
       }
       return id
     }
-    if (typeof buildInput === 'string') {
-      entries = [await resolvePath(buildInput)]
-    } else if (Array.isArray(buildInput)) {
-      entries = await Promise.all(buildInput.map(resolvePath))
-    } else if (isObject(buildInput)) {
-      entries = await Promise.all(Object.values(buildInput).map(resolvePath))
+    if (typeof input === 'string') {
+      entries = [await resolvePath(input)]
+    } else if (Array.isArray(input)) {
+      entries = await Promise.all(input.map(resolvePath))
+    } else if (isObject(input)) {
+      entries = await Promise.all(Object.values(input).map(resolvePath))
     } else {
       throw new Error('invalid rolldownOptions.input value.')
     }

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -331,6 +331,7 @@ describe('plugin container', () => {
         const plugin: Plugin = {
           name: 'p1',
           async resolveId(id, importer) {
+            if (id !== '/x.js') return
             calledCount++
             if (calledCount <= 1) {
               return await this.resolve(id, importer, { skipSelf: true })

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -238,6 +238,10 @@ export class DevEnvironment extends BaseEnvironment {
         entries.map((entry) =>
           this.pluginContainer.resolveId(entry, undefined, {
             isEntry: true,
+            // Avoid a deadlock when the dependency scanner triggers the first
+            // buildStart. Normal resolution waits for the scan to finish,
+            // while the scan is waiting for buildStart to finish.
+            scan: true,
           }),
         ),
       )

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import colors from 'picocolors'
 import type { FetchFunctionOptions, FetchResult } from 'vite/module-runner'
 import type { FSWatcher } from '#dep-types/chokidar'
@@ -16,7 +17,7 @@ import {
   createExplicitDepsOptimizer,
 } from '../optimizer/optimizer'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
-import { promiseWithResolvers } from '../../shared/utils'
+import { cleanUrl, promiseWithResolvers } from '../../shared/utils'
 import type { ViteDevServer } from '../server'
 import { EnvironmentModuleGraph } from './moduleGraph'
 import type { EnvironmentModuleNode } from './moduleGraph'
@@ -218,6 +219,43 @@ export class DevEnvironment extends BaseEnvironment {
       this.config.plugins,
       options?.watcher,
     )
+  }
+
+  /** @internal */
+  async _registerInputsAsSafeModules(): Promise<void> {
+    const input = this.config.input
+    const entries =
+      input == null
+        ? ['index.html']
+        : typeof input === 'string'
+          ? [input]
+          : Array.isArray(input)
+            ? input
+            : Object.values(input)
+
+    const resolveEntries = async () => {
+      const resolvedEntries = await Promise.all(
+        entries.map((entry) =>
+          this.pluginContainer.resolveId(entry, undefined, {
+            isEntry: true,
+          }),
+        ),
+      )
+      for (const resolved of resolvedEntries) {
+        if (resolved && !resolved.external) {
+          const resolvedId = cleanUrl(resolved.id)
+          if (path.isAbsolute(resolvedId)) {
+            this.getTopLevelConfig().safeModulePaths.add(resolvedId)
+          }
+        }
+      }
+    }
+
+    if (input == null) {
+      await resolveEntries().catch(() => {})
+    } else {
+      await resolveEntries()
+    }
   }
 
   /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -14,7 +14,7 @@ import chokidar from 'chokidar'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import { determineAgent } from '@vercel/detect-agent'
 import { disableCache } from '@voidzero-dev/vite-task-client'
-import type { InputOption, SourceMap } from 'rolldown'
+import type { SourceMap } from 'rolldown'
 import type { ModuleRunner } from 'vite/module-runner'
 import type { FSWatcher, WatchOptions } from '#dep-types/chokidar'
 import type { Connect } from '#dep-types/connect'
@@ -1214,7 +1214,6 @@ const RESERVED_ALLOWED_HOSTS_CHARACTERS_RE = /[\\"']/
 export async function resolveServerOptions(
   root: string,
   raw: ServerOptions | undefined,
-  input: InputOption | undefined,
   logger: Logger,
 ): Promise<ResolvedServerOptions> {
   const _server = mergeWithDefaults(
@@ -1244,7 +1243,6 @@ export async function resolveServerOptions(
   }
 
   let allowDirs = server.fs.allow
-  allowDirs.push(...getInputPaths(root, input))
 
   const cwd = searchForPackageRoot(root)
   if (process.versions.pnp) {
@@ -1343,12 +1341,6 @@ export async function resolveServerOptions(
   }
 
   return server
-}
-
-function getInputPaths(root: string, input: ResolvedConfig['input']): string[] {
-  if (input == null) return [path.resolve(root, 'index.html')]
-  if (typeof input === 'string') return [input]
-  return Array.isArray(input) ? input : Object.values(input)
 }
 
 async function restartServer(server: ViteDevServer) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -334,7 +334,7 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
     }
     this._started = true
     const config = this.environment.getTopLevelConfig()
-    this._buildStartPromise = this.handleHookPromise(
+    const hookPromise = this.handleHookPromise(
       this.hookParallel(
         'buildStart',
         (plugin) => this._getPluginContext(plugin),
@@ -345,6 +345,12 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
           plugin.perEnvironmentStartEndDuringDev,
       ),
     ) as Promise<void>
+    this._buildStartPromise = (async () => {
+      await hookPromise
+      if (this.environment.mode === 'dev') {
+        await this.environment._registerInputsAsSafeModules()
+      }
+    })()
     await this._buildStartPromise
     this._buildStartPromise = undefined
   }


### PR DESCRIPTION
The top-level input option was always resolved from the `root`. But that makes it impossible to specify a virtual module.

This PR fixes that by removing the resolution that happened in resolveConfig.

refs #22642, #23035

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
