### PR TITLE
fix(server): honor If-None-Match for static files

### DIFF
--- a/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
+++ b/packages/vite/src/node/server/middlewares/__tests__/static.spec.ts
@@ -1,5 +1,48 @@
-import { describe, expect, test } from 'vitest'
+import { createServer as createHttpServer } from 'node:http'
+import path from 'node:path'
+import sirv from 'sirv'
+import { describe, expect, onTestFinished, test } from 'vitest'
 import { isFileInTargetPath } from '../static'
+
+test('static files use weak comparison for If-None-Match', async () => {
+  const root = path.resolve(import.meta.dirname, 'fixtures/root')
+  const serve = sirv(root, { dev: true, etag: true })
+  const server = createHttpServer(serve)
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  onTestFinished(() => server.close())
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected the test server to listen on a TCP port')
+  }
+  const url = `http://127.0.0.1:${address.port}/index.html`
+  const initial = await fetch(url)
+  const etag = initial.headers.get('etag')
+  expect(etag).toMatch(/^W\//)
+
+  const strongEtag = etag!.slice(2)
+  for (const ifNoneMatch of [
+    etag!,
+    strongEtag,
+    `"other,tag", ${strongEtag}`,
+    '*',
+  ]) {
+    const response = await fetch(url, {
+      headers: { 'If-None-Match': ifNoneMatch },
+    })
+    expect(response.status).toBe(304)
+  }
+
+  const nonMatching = await fetch(url, {
+    headers: { 'If-None-Match': '"other"' },
+  })
+  expect(nonMatching.status).toBe(200)
+
+  const malformed = await fetch(url, {
+    headers: { 'If-None-Match': '"unterminated' },
+  })
+  expect(malformed.status).toBe(200)
+})
 
 describe('isFileInTargetPath', () => {
   const cases = {

--- a/patches/sirv@3.0.2.patch
+++ b/patches/sirv@3.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/build.js b/build.js
-index 3734120d67745ff83b2df07fa5d0a40dcb92a69b..bd57f693ac2bd4555a12e7a5436fb9524789ef66 100644
+index 3734120d67745ff83b2df07fa5d0a40dcb92a69b..3c99eea2034c748929ae2a4626a8df37ee627e11 100644
 --- a/build.js
 +++ b/build.js
 @@ -35,7 +35,7 @@ function viaCache(cache, uri, extns) {
@@ -19,7 +19,48 @@ index 3734120d67745ff83b2df07fa5d0a40dcb92a69b..bd57f693ac2bd4555a12e7a5436fb952
  			headers = toHeaders(name, stats, isEtag);
  			headers['Cache-Control'] = isEtag ? 'no-cache' : 'no-store';
  			return { abs, stats, headers };
-@@ -164,7 +165,7 @@ module.exports = function (dir, opts={}) {
+@@ -57,6 +58,40 @@ function is404(req, res) {
+ 	return (res.statusCode=404,res.end());
+ }
+ 
++function matchesIfNoneMatch(value, etag) {
++	if (!value) return false;
++	if (Array.isArray(value)) value = value.join(',');
++	if (value.trim() === '*') return true;
++
++	let i=0, matched=false;
++	let current = etag.startsWith('W/') ? etag.slice(2) : etag;
++	while (i < value.length) {
++		while (value[i] === ' ' || value[i] === '\t' || value[i] === ',') i++;
++		if (i >= value.length) return matched;
++
++		let start=i;
++		if (value.startsWith('W/', i)) i += 2;
++		if (value[i++] !== '"') return false;
++
++		while (i < value.length && value[i] !== '"') {
++			let code = value.charCodeAt(i++);
++			if (code !== 0x21 && !(code >= 0x23 && code <= 0x7e) && !(code >= 0x80 && code <= 0xff)) {
++				return false;
++			}
++		}
++		if (value[i++] !== '"') return false;
++
++		let candidate = value.slice(start, i);
++		if (candidate.startsWith('W/')) candidate = candidate.slice(2);
++		if (candidate === current) matched = true;
++
++		while (value[i] === ' ' || value[i] === '\t') i++;
++		if (i >= value.length) return matched;
++		if (value[i++] !== ',') return false;
++	}
++	return matched;
++}
++
+ function send(req, res, file, stats, headers) {
+ 	let code=200, tmp, opts={};
+ 	headers = { ...headers };
+@@ -164,7 +199,7 @@ module.exports = function (dir, opts={}) {
  		});
  	}
  
@@ -28,7 +69,7 @@ index 3734120d67745ff83b2df07fa5d0a40dcb92a69b..bd57f693ac2bd4555a12e7a5436fb952
  
  	return function (req, res, next) {
  		let extns = [''];
-@@ -179,7 +180,7 @@ module.exports = function (dir, opts={}) {
+@@ -179,10 +214,10 @@ module.exports = function (dir, opts={}) {
  			catch (err) { /* malform uri */ }
  		}
  
@@ -36,9 +77,13 @@ index 3734120d67745ff83b2df07fa5d0a40dcb92a69b..bd57f693ac2bd4555a12e7a5436fb952
 +		let data = lookup(pathname, extns, opts.shouldServe) || isSPA && !isMatch(pathname, ignores) && lookup(fallback, extns, opts.shouldServe);
  		if (!data) return next ? next() : isNotFound(req, res);
  
- 		if (isEtag && req.headers['if-none-match'] === data.headers['ETag']) {
+-		if (isEtag && req.headers['if-none-match'] === data.headers['ETag']) {
++		if (isEtag && matchesIfNoneMatch(req.headers['if-none-match'], data.headers['ETag'])) {
+ 			res.writeHead(304);
+ 			return res.end();
+ 		}
 diff --git a/build.mjs b/build.mjs
-index 2f866d5216c951ec125f2044af070fa6b530e375..d5335bfbb16e23b57385c1a83226611e29c39093 100644
+index 2f866d5216c951ec125f2044af070fa6b530e375..e1037448096cff13ff1192f381388ece31cbfa7b 100644
 --- a/build.mjs
 +++ b/build.mjs
 @@ -35,7 +35,7 @@ function viaCache(cache, uri, extns) {
@@ -58,7 +103,48 @@ index 2f866d5216c951ec125f2044af070fa6b530e375..d5335bfbb16e23b57385c1a83226611e
  			headers = toHeaders(name, stats, isEtag);
  			headers['Cache-Control'] = isEtag ? 'no-cache' : 'no-store';
  			return { abs, stats, headers };
-@@ -164,7 +165,7 @@ export default function (dir, opts={}) {
+@@ -57,6 +58,40 @@ function is404(req, res) {
+ 	return (res.statusCode=404,res.end());
+ }
+ 
++function matchesIfNoneMatch(value, etag) {
++	if (!value) return false;
++	if (Array.isArray(value)) value = value.join(',');
++	if (value.trim() === '*') return true;
++
++	let i=0, matched=false;
++	let current = etag.startsWith('W/') ? etag.slice(2) : etag;
++	while (i < value.length) {
++		while (value[i] === ' ' || value[i] === '\t' || value[i] === ',') i++;
++		if (i >= value.length) return matched;
++
++		let start=i;
++		if (value.startsWith('W/', i)) i += 2;
++		if (value[i++] !== '"') return false;
++
++		while (i < value.length && value[i] !== '"') {
++			let code = value.charCodeAt(i++);
++			if (code !== 0x21 && !(code >= 0x23 && code <= 0x7e) && !(code >= 0x80 && code <= 0xff)) {
++				return false;
++			}
++		}
++		if (value[i++] !== '"') return false;
++
++		let candidate = value.slice(start, i);
++		if (candidate.startsWith('W/')) candidate = candidate.slice(2);
++		if (candidate === current) matched = true;
++
++		while (value[i] === ' ' || value[i] === '\t') i++;
++		if (i >= value.length) return matched;
++		if (value[i++] !== ',') return false;
++	}
++	return matched;
++}
++
+ function send(req, res, file, stats, headers) {
+ 	let code=200, tmp, opts={};
+ 	headers = { ...headers };
+@@ -164,7 +199,7 @@ export default function (dir, opts={}) {
  		});
  	}
  
@@ -67,7 +153,7 @@ index 2f866d5216c951ec125f2044af070fa6b530e375..d5335bfbb16e23b57385c1a83226611e
  
  	return function (req, res, next) {
  		let extns = [''];
-@@ -179,7 +180,7 @@ export default function (dir, opts={}) {
+@@ -179,10 +214,10 @@ export default function (dir, opts={}) {
  			catch (err) { /* malform uri */ }
  		}
  
@@ -75,7 +161,11 @@ index 2f866d5216c951ec125f2044af070fa6b530e375..d5335bfbb16e23b57385c1a83226611e
 +		let data = lookup(pathname, extns, opts.shouldServe) || isSPA && !isMatch(pathname, ignores) && lookup(fallback, extns, opts.shouldServe);
  		if (!data) return next ? next() : isNotFound(req, res);
  
- 		if (isEtag && req.headers['if-none-match'] === data.headers['ETag']) {
+-		if (isEtag && req.headers['if-none-match'] === data.headers['ETag']) {
++		if (isEtag && matchesIfNoneMatch(req.headers['if-none-match'], data.headers['ETag'])) {
+ 			res.writeHead(304);
+ 			return res.end();
+ 		}
 diff --git a/index.d.mts b/index.d.mts
 index 8bfe364f1db2d1382c56a9b75a014579083cfa70..a8dfa1c473ff15c979bbfbc28c3630a12e222c3a 100644
 --- a/index.d.mts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ patchedDependencies:
     hash: 49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889
     path: patches/dotenv-expand@13.0.0.patch
   sirv@3.0.2:
-    hash: c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95
+    hash: c71ba792332acb050f56fed53bb33a12a9262af518c783d90226a4718527beab
     path: patches/sirv@3.0.2.patch
 
 importers:
@@ -412,7 +412,7 @@ importers:
         version: 1.100.0(source-map-js@1.2.1)
       sirv:
         specifier: ^3.0.2
-        version: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
+        version: 3.0.2(patch_hash=c71ba792332acb050f56fed53bb33a12a9262af518c783d90226a4718527beab)
       strip-literal:
         specifier: ^3.1.0
         version: 3.1.0
@@ -978,7 +978,7 @@ importers:
     devDependencies:
       sirv:
         specifier: ^3.0.2
-        version: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
+        version: 3.0.2(patch_hash=c71ba792332acb050f56fed53bb33a12a9262af518c783d90226a4718527beab)
 
   playground/minify:
     dependencies:
@@ -1571,7 +1571,7 @@ importers:
         version: 5.2.1(ms@2.1.3)
       sirv:
         specifier: ^3.0.2
-        version: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
+        version: 3.0.2(patch_hash=c71ba792332acb050f56fed53bb33a12a9262af518c783d90226a4718527beab)
 
   playground/ssr-conditions/external: {}
 
@@ -13653,7 +13653,7 @@ snapshots:
 
   simple-git-hooks@2.13.1: {}
 
-  sirv@3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95):
+  sirv@3.0.2(patch_hash=c71ba792332acb050f56fed53bb33a12a9262af518c783d90226a4718527beab):
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1


### PR DESCRIPTION
Vite serves public and static files through `sirv` with `etag: true`.

In `sirv@3.0.2`, conditional requests currently use an exact comparison:

```js
req.headers['if-none-match'] === data.headers['ETag']
```

This misses valid `If-None-Match` requests using an equivalent strong ETag, a validator list, or `*`, causing Vite to return `200` instead of `304`.

RFC 9110 requires weak comparison for `If-None-Match`.

This PR updates Vite's existing `sirv@3.0.2` patch with a small `matchesIfNoneMatch()` parser. It:

- ignores the `W/` prefix during comparison
- checks every ETag in a validator list
- handles `*`
- preserves commas inside quoted opaque tags
- leaves malformed and nonmatching validators untouched

## Benefits

- Makes Vite's static-file responses follow HTTP conditional-request semantics.
- Avoids unnecessary `200` responses and file transfers when `304` is appropriate.
- Improves behavior for service workers, proxies, development tools, and custom HTTP clients.
- Applies to both the Vite dev and preview servers.
- Avoids requiring downstream frameworks to maintain their own static-file ETag workarounds.
- Adds no filesystem scanning or request-path indexing.
- Does not affect ordinary requests without an `If-None-Match` header.

Tests cover exact weak tags, equivalent strong tags, validator lists, wildcards, malformed values, and nonmatching values.

## Validation

- `pnpm exec vitest run packages/vite/src/node/server/middlewares/__tests__/static.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm install --frozen-lockfile --lockfile-only`
