### PR TITLE
feat(bundled-dev): reload once after rebuild instead of via the fallback page

### DIFF
--- a/packages/vite/src/client/bundledDevClient.ts
+++ b/packages/vite/src/client/bundledDevClient.ts
@@ -7,7 +7,6 @@ import {
 import {
   base,
   clearOverlayOrReloadOnFirstUpdate,
-  pageReload,
   registerBundledDevClient,
   removeStyle,
   transport,
@@ -57,7 +56,6 @@ if (typeof DevRuntime !== 'undefined') {
     {
       base,
       beforeApply: clearOverlayOrReloadOnFirstUpdate,
-      pageReload,
     },
   )
   registerBundledDevClient(bundledDevHmrClient)

--- a/packages/vite/src/client/bundledDevHmrClient.ts
+++ b/packages/vite/src/client/bundledDevHmrClient.ts
@@ -30,12 +30,12 @@ export interface BundledDevHMRClientOptions {
   base: string
   /** returning `'reload'` aborts the apply — the hook reloads the page itself */
   beforeApply: () => 'reload' | 'continue'
-  pageReload: () => void
 }
 
 export class BundledDevHMRClient extends HMRClient {
   private applyQueue = Promise.resolve()
   private lastSeq = 0
+  private reloadPending = false
 
   constructor(
     logger: HMRLogger,
@@ -173,6 +173,7 @@ export class BundledDevHMRClient extends HMRClient {
     url,
     seq,
   }: BundledDevUpdatePayload): Promise<void> {
+    if (this.reloadPending) return
     if (seq !== this.lastSeq + 1) {
       this.requestFullReload(
         `hmr update sequence gap (expected ${this.lastSeq + 1}, got ${seq})`,
@@ -204,6 +205,7 @@ export class BundledDevHMRClient extends HMRClient {
   }
 
   private async applyInvalidate(id: string): Promise<void> {
+    if (this.reloadPending) return
     const firstInvalidatedBy = this.currentFirstInvalidatedBy ?? id
     const importers = this.runtime
       .getImporters(id)
@@ -296,8 +298,14 @@ export class BundledDevHMRClient extends HMRClient {
   }
 
   private requestFullReload(reason: string): void {
-    this.logger.debug(`full reload: ${reason}`)
-    this.options.pageReload()
+    if (this.reloadPending) return
+    this.reloadPending = true
+    this.logger.debug(`full reload needed: ${reason}`)
+    this.send({
+      type: 'custom',
+      event: 'vite:bundled-dev:reload-needed',
+      data: { reason },
+    })
   }
 }
 

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -74,6 +74,18 @@ export class BundledDev {
 
   private fullReloadPending = false
 
+  private reloadNeededClientIds = new Set<string>()
+  private debouncedReloadNeededFlush = debounce(20, () => {
+    if (this.lastBuildError || this.reloadNeededClientIds.size === 0) return
+    for (const clientId of this.reloadNeededClientIds) {
+      this.clients.get(clientId)?.send({ type: 'full-reload', path: '*' })
+    }
+    this.reloadNeededClientIds.clear()
+    this.environment.logger.info(colors.green(`page reload`), {
+      timestamp: true,
+    })
+  })
+
   private lastBuildError: Error | null = null
 
   memoryFiles: MemoryFiles = new MemoryFiles()
@@ -134,8 +146,26 @@ export class BundledDev {
       const clientId = this.clients.delete(client)
       if (clientId) {
         this.devEngine.removeClient(clientId)
+        this.reloadNeededClientIds.delete(clientId)
       }
     })
+    this.environment.hot.on(
+      'vite:bundled-dev:reload-needed',
+      (payload, client) => {
+        const clientId = this.clients.getId(client)
+        if (!clientId) return
+        debug?.(
+          `TRIGGER: client ${clientId} requested a page reload (${payload.reason})`,
+        )
+        this.environment.logger.info(
+          colors.green(`bundling for page reload `) +
+            colors.dim(payload.reason),
+          { clear: true, timestamp: true },
+        )
+        this.reloadNeededClientIds.add(clientId)
+        this.ensureOutputAndFlushReloadNeeded()
+      },
+    )
 
     this._devEngine = await dev(rolldownOptions, outputOptions, {
       onHmrUpdates: (result) => {
@@ -169,6 +199,12 @@ export class BundledDev {
             this.handleHmrOutput(client, changedFiles, update)
           }
         }
+        // an edit requested a reload but its rebuild failed, leaving the page
+        // waiting behind the error overlay. The fix produced this successful
+        // build — regenerate output now, or the page would never reload.
+        if (this.reloadNeededClientIds.size) {
+          this.ensureOutputAndFlushReloadNeeded()
+        }
       },
       onOutput: (result) => {
         if (result instanceof Error) {
@@ -194,6 +230,9 @@ export class BundledDev {
         if (this.fullReloadPending) {
           this.fullReloadPending = false
           this.debouncedFullReload()
+        }
+        if (this.reloadNeededClientIds.size) {
+          this.debouncedReloadNeededFlush()
         }
       },
       onAdditionalAssets: (result) => {
@@ -239,6 +278,13 @@ export class BundledDev {
       if (this._closed) return
       state = await this.devEngine.getBundleState()
     }
+  }
+
+  private ensureOutputAndFlushReloadNeeded(): void {
+    this.devEngine.ensureLatestBuildOutput().then(
+      () => this.debouncedReloadNeededFlush(),
+      () => {},
+    )
   }
 
   async triggerBundleRegenerationIfStale(): Promise<boolean> {
@@ -471,6 +517,10 @@ class Clients {
 
   get(id: string): NormalizedHotChannelClient | undefined {
     return this.idToClient.get(id)
+  }
+
+  getId(client: NormalizedHotChannelClient): string | undefined {
+    return this.clientToId.get(client)
   }
 
   getAll(): NormalizedHotChannelClient[] {

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -19,6 +19,8 @@ export interface CustomEventMap {
   'vite:forward-console': ForwardConsolePayload
   /** @internal */
   'vite:client-connected': { clientId: string }
+  /** @internal */
+  'vite:bundled-dev:reload-needed': { reason: string }
 
   // server events
   'vite:client:connect': undefined

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
+import type { Response } from 'playwright-chromium'
 import { expect, test, onTestFinished } from 'vitest'
 import {
   addFile,
@@ -368,6 +369,53 @@ if (isBuild) {
     await expect
       .poll(() => page.textContent('.dead-accept'))
       .toBe('dead-accept-updated')
+  })
+
+  test('a full reload navigates once, onto the rebuilt bundle', async () => {
+    const original = readFile('dead-accept.js')
+
+    // the client must not navigate on its own decision: it sends
+    // `vite:bundled-dev:reload-needed` and the server answers `full-reload`
+    // only after the rebuilt bundle is served — so the page never sees the
+    // bundling-fallback document and loads exactly once
+    let documentLoads = 0
+    let sawFallbackPage = false
+    const onResponse = async (response: Response) => {
+      if (response.request().resourceType() !== 'document') return
+      documentLoads++
+      if ((await response.text()).includes('__vite_is_fallback_page__')) {
+        sawFallbackPage = true
+      }
+    }
+    page.on('response', onResponse)
+    onTestFinished(async () => {
+      page.off('response', onResponse)
+      addFile('dead-accept.js', original)
+      await expect
+        .poll(() => page.textContent('.dead-accept'))
+        .toBe('dead-accept')
+    })
+
+    const serverLogIndex = serverLogs.length
+    editFile('dead-accept.js', (code) =>
+      code.replace("'dead-accept'", "'dead-accept-reloaded'"),
+    )
+    await expect
+      .poll(() => page.textContent('.dead-accept'))
+      .toBe('dead-accept-reloaded')
+
+    await expect
+      .poll(() =>
+        serverLogs
+          .slice(serverLogIndex)
+          .some((l) => l.includes('bundling for page reload')),
+      )
+      .toBe(true)
+
+    // give a hypothetical second navigation time to happen before counting
+    await setTimeout(300)
+    expect(documentLoads).toBe(1)
+    expect(sawFallbackPage).toBe(false)
   })
 
   test('editing a worker-only module without accept reloads the page', async () => {


### PR DESCRIPTION
### Description

In bundled dev, when an HMR update has no boundary, the client reloads the page. Today it reloads immediately: the rebuilt bundle does not exist yet, so the browser lands on the "Bundling in progress" fallback page and reloads a second time when the bundle is ready. Two navigations, with a visible spinner page between them.

As discussed with @sapphi-red: the client now reports its decision to the server instead of navigating. The server rebuilds the bundle first, then answers with `full-reload`. One navigation, straight onto the fresh bundle, and the fallback page no longer appears in the HMR flow.

Concrete example: edit an entry module that nothing accepts (`main.js`). The client walk finds no boundary and the flow is now:

```mermaid
sequenceDiagram
  participant S as server
  participant C as client
  S->>C: push {changedIds, url, seq}
  C->>C: walk finds no HMR boundary
  C->>S: vite:bundled-dev:reload-needed (page stays up)
  S->>S: rebuild bundle output
  S->>C: full-reload (requesters only)
  C->>C: one navigation onto the fresh bundle
```

How it works:

- **Client:** every reload decision funnels through `requestFullReload`. It now sends `vite:bundled-dev:reload-needed { reason }` once and stops applying further updates — the page is about to navigate. The navigation itself is the ordinary `full-reload` payload handling.
- **Server:** a new handler records the requesting client and calls `ensureLatestBuildOutput()`. Once the output is stored, it sends `full-reload` to the requesters only. Tabs that hot-applied the same patch are not reloaded (the previous completion reload was a broadcast).
- **Failed builds:** the request stays armed. Reloading during a failed build would navigate onto the last good bundle, and the change that triggered the reload would never arrive — the healing edit only ships a patch for its own files. Instead the error overlay stays on the still-open page, and the next successful build serves the reload.
- **Terminal:** `bundling for page reload <reason>` at request time and `page reload` when it is sent, replacing the information the fallback page used to show in the browser.
- The fallback page still exists where there is no page to keep showing: the initial build, and a manual refresh while output is stale.

Known limits:

- An edit landing between "reload sent" and the browser's document request can still hit the fallback page. This race existed before and is much narrower now.
- Not covered by e2e yet: the requester-only behavior with two tabs, and the failed-build path (it needs an output-stage failure, which playground fixtures cannot trigger deterministically).

### Tests

- New spec in `playground/hmr-full-bundle-mode`: one document load, no fallback document, and the server-side `bundling for page reload` log after a no-boundary edit. The log assertion is the discriminating check — on a small fixture the old flow can also finish rebuilding before the reload request arrives, so navigation counts alone pass on both behaviors. Verified to fail against the previous behavior and pass with this change.
- `playground/hmr-full-bundle-mode`: 19 passed, 1 pre-existing skip.
- Full `pnpm run test-serve-bundled`: 56 files / 333 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
