### PR TITLE
fix: don't percent-encode IPv6 brackets in absolute URLs (fix #23108)

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   asyncFlatten,
   bareImportRE,
   combineSourcemaps,
+  encodeURIPath,
   extractHostnamesFromCerts,
   extractHostnamesFromSubjectAltName,
   flattenId,
@@ -1215,5 +1216,43 @@ describe('resolveServerUrls', () => {
 
     expect(result.network).toStrictEqual(['http://10.0.0.5:3000/'])
     expect(result.networkInterfaceNames).toStrictEqual([undefined])
+  })
+})
+
+describe('encodeURIPath', () => {
+  test('encodes characters that are unsafe in a path', () => {
+    expect(encodeURIPath('/assets/a b.svg')).toBe('/assets/a%20b.svg')
+    expect(encodeURIPath('/assets/a"b.svg')).toBe('/assets/a%22b.svg')
+  })
+
+  test('leaves the part after ? or # alone', () => {
+    expect(encodeURIPath('/assets/a b.svg?foo bar')).toBe(
+      '/assets/a%20b.svg?foo bar',
+    )
+  })
+
+  test('returns data URIs untouched', () => {
+    expect(encodeURIPath('data:image/svg+xml,<svg />')).toBe(
+      'data:image/svg+xml,<svg />',
+    )
+  })
+
+  test('does not percent-encode the brackets of an IPv6 host', () => {
+    // `[` and `]` delimit an IPv6 host (RFC 3986 3.2.2) rather than being data to
+    // escape, but they are outside encodeURI's unreserved set. When server.origin
+    // is an IPv6 literal the whole absolute URL reaches this helper, so encoding
+    // them corrupts the authority and the result no longer parses as a URL.
+    expect(encodeURIPath('http://[::1]:5173/src/assets/vite.svg')).toBe(
+      'http://[::1]:5173/src/assets/vite.svg',
+    )
+    expect(encodeURIPath('http://[::1]:5173/src/a b.svg')).toBe(
+      'http://[::1]:5173/src/a%20b.svg',
+    )
+  })
+
+  test('still encodes the path of an absolute URL', () => {
+    expect(encodeURIPath('http://127.0.0.1:5173/src/a b.svg')).toBe(
+      'http://127.0.0.1:5173/src/a%20b.svg',
+    )
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1883,13 +1883,25 @@ export function displayTime(time: number): string {
 }
 
 /**
+ * Matches the `scheme://authority` prefix of an absolute URL, so it can be held back
+ * from `encodeURI`. `encodeURI` escapes `[` and `]`, which delimit an IPv6 host rather
+ * than being data (RFC 3986 3.2.2) — encoding them leaves an authority that no longer
+ * parses, and Firefox rejects the result outright.
+ */
+const urlOriginRE = /^[a-z][a-z0-9+.-]*:\/\/[^/?#]*/i
+
+/**
  * Encodes the URI path portion (ignores part after ? or #)
+ *
+ * Callers pass an absolute URL when `server.origin` is configured, so only the path
+ * that follows the origin is encoded.
  */
 export function encodeURIPath(uri: string): string {
   if (uri.startsWith('data:')) return uri
   const filePath = cleanUrl(uri)
   const postfix = filePath !== uri ? uri.slice(filePath.length) : ''
-  return encodeURI(filePath) + postfix
+  const origin = filePath.match(urlOriginRE)?.[0] ?? ''
+  return origin + encodeURI(filePath.slice(origin.length)) + postfix
 }
 
 /**


### PR DESCRIPTION
### Description

`encodeURIPath` runs `encodeURI` over its whole input. `[` and `]` are outside `encodeURI`'s unreserved set, so an absolute URL whose host is an IPv6 literal comes back with its authority escaped:

```js
encodeURI('http://[::1]:5173/src/assets/vite.svg')
// → 'http://%5B::1%5D:5173/src/assets/vite.svg'
```

which is exactly the value reported in #23108. Those brackets delimit the host under RFC 3986 §3.2.2 rather than being data to escape, so the result no longer parses as a URL and Firefox rejects it from `fetch()`. `new URL('http://[::1]:5173/x').href` keeps them literal. Only IPv6 surfaces this because an IPv4 authority has nothing for `encodeURI` to escape.

The helper documents itself as encoding "the URI path portion", but callers hand it a full URL once `server.origin` is set — `toOutputFilePathInJS` joins the origin on — and `encodeURI` then walks the authority too.

### Fix

Hold back a leading `scheme://authority` and encode only what follows.

Checked against the inputs the helper actually sees; **only the IPv6 cases change**:

| input | before | after |
|---|---|---|
| `http://[::1]:5173/src/assets/vite.svg` | `http://%5B::1%5D:5173/…` | `http://[::1]:5173/…` ✅ |
| `http://[::1]:5173/src/a b.svg` | `http://%5B::1%5D:5173/src/a%20b.svg` | `http://[::1]:5173/src/a%20b.svg` ✅ |
| `http://127.0.0.1:5173/src/a b.svg` | unchanged | unchanged |
| `/assets/a b.svg` | unchanged | unchanged |
| `/assets/a b.svg?foo bar` | unchanged | unchanged |
| `data:image/svg+xml,<svg />` | unchanged | unchanged |
| `./relative/a b.svg` | unchanged | unchanged |
| `file:///usr/vite/a b.svg` | unchanged | unchanged |

That matters because `encodeURIPath` has call sites in `asset.ts`, `css.ts`, `html.ts` and `worker.ts`, all of which receive an absolute URL when `server.origin` is set — so the single fix covers `?url` imports, CSS url() rewriting, HTML attributes and workers alike.

**Deliberate scope note:** the pattern requires a scheme, so a protocol-relative origin (`//[::1]:5173/…`) still encodes its brackets. `server.origin` takes a scheme in practice, and widening the pattern risks misreading a path that merely begins with `//`. Happy to extend it if you'd prefer.

Two alternative fix locations, in case you'd rather scope it differently: at the `toOutputFilePathInJS` call site, or by normalising `server.origin` when it's resolved.

### Tests

Added an `encodeURIPath` block to `utils.spec.ts` — the helper had no direct coverage. One test proves the bug; the rest pin existing behaviour so a future change to the origin handling can't quietly regress path encoding, the `?`/`#` postfix, or `data:` passthrough.

Verified the bug test fails without the src change:

```
× does not percent-encode the brackets of an IPv6 host
  AssertionError: expected 'http://%5B::1%5D:5173/src/assets/vite…'
                        to be 'http://[::1]:5173/src/assets/vite.svg'
```

### Verification

- `117` tests pass in `utils.spec.ts`; `637` across the 43 files in `src/node/__tests__`
- `pnpm format`, `pnpm lint`, `pnpm typecheck` all clean
- `pnpm test-unit` has 23 pre-existing failures in `packages/create-vite`, unrelated to this change — confirmed identical on a clean tree with this patch stashed