### PR TITLE
perf(css): look up pure CSS chunks through a Set

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1121,8 +1121,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const pureCssChunkNames = [...pureCssChunks]
           .map((pureCssChunk) => prelimaryNameToChunkMap[pureCssChunk.fileName])
           .filter(Boolean)
-        // Looked up once per import of every chunk below, so keep it as a set:
-        // scanning the array made that loop cost chunks x imports x pureCssChunks.
         const pureCssChunkNameSet = new Set(pureCssChunkNames)
 
         let importMapReverseMapping: Record<string, string> | undefined

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1121,6 +1121,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const pureCssChunkNames = [...pureCssChunks]
           .map((pureCssChunk) => prelimaryNameToChunkMap[pureCssChunk.fileName])
           .filter(Boolean)
+        // Looked up once per import of every chunk below, so keep it as a set:
+        // scanning the array made that loop cost chunks x imports x pureCssChunks.
+        const pureCssChunkNameSet = new Set(pureCssChunkNames)
 
         let importMapReverseMapping: Record<string, string> | undefined
         if (config.build.chunkImportMap) {
@@ -1148,7 +1151,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             // and also register the emitted CSS files under the importer
             // chunks instead.
             chunk.imports = chunk.imports.filter((file) => {
-              if (pureCssChunkNames.includes(file)) {
+              if (pureCssChunkNameSet.has(file)) {
                 const { importedCss, importedAssets } = (
                   bundle[file] as OutputChunk
                 ).viteMetadata!


### PR DESCRIPTION
### Description

In `generateBundle` of the CSS plugin, every chunk in the bundle has its imports filtered, and each import asks `pureCssChunkNames.includes(file)`. That scans the array on every question, so the loop costs `chunks × imports × pureCssChunks`.

This builds the name set once and asks the set instead. The array is still kept — `pureCssChunkNamesInCode` and the `forEach` below both use it — so this only adds one `new Set(...)`.

Same names, same membership test, no behaviour change.

### Measurements

Same loop shape, 15% of chunks pure CSS. Both versions run on the same data, **the results are compared for equality at every size and the script throws on a mismatch**, then timed as a median of repeated runs with before/after crossed twice so JIT and thermal drift cannot favour one side.

| chunks | imports/chunk | pure CSS | current | with a Set | |
|---:|---:|---:|---:|---:|---:|
| 50 | 5 | 8 | 0.012 ms | 0.014 ms | **0.84x** |
| 200 | 8 | 29 | 0.066 ms | 0.029 ms | 2.26x |
| 600 | 12 | 86 | 0.684 ms | 0.123 ms | 5.57x |
| 1,500 | 15 | 215 | 5.259 ms | 0.503 ms | 10.45x |
| 4,000 | 20 | 572 | 47.475 ms | 1.478 ms | 32.12x |

**The small end first, since it is the part that argues against this change**: below roughly 100 chunks, building the set costs slightly more than the scans it saves. That is 2 microseconds, once per build, so I would not call it a regression anyone can observe — but the break-even is real and I would rather show it than only show the 4,000-chunk row.

### What I could not verify locally

The unit tests need `vite` to be built first (`vite/dist/node/index.js`), which I did not have set up, so I did not run the suite — relying on CI for it. `tsc --noEmit` on `packages/vite` reports nothing for `css.ts` (the only error is `scripts/benchCircularImport.ts` failing to resolve `vite`, which is the same missing build and unrelated to this change).

<details>
<summary>Reproduction script</summary>

```js
// node bench.mjs
function makeBundle(chunks, importsPerChunk, pureRatio) {
  const names = Array.from({ length: chunks }, (_, i) => `assets/chunk-${i}.js`)
  const pure = names.filter((_, i) => i % Math.max(1, Math.round(1 / pureRatio)) === 0)
  const bundle = {}
  for (let i = 0; i < chunks; i++) {
    const imports = []
    for (let k = 0; k < importsPerChunk; k++) imports.push(names[(i * 7 + k * 13) % chunks])
    bundle[names[i]] = { type: 'chunk', imports }
  }
  return { bundle, pure }
}

function before({ bundle, pure }) {
  const pureCssChunkNames = pure
  const out = []
  for (const file in bundle) {
    const chunk = bundle[file]
    if (chunk.type === 'chunk') {
      let hit = 0
      const kept = chunk.imports.filter((f) => {
        if (pureCssChunkNames.includes(f)) { hit++; return false }
        return true
      })
      out.push(kept.length + ':' + hit)
    }
  }
  return out
}

function after({ bundle, pure }) {
  const pureCssChunkNameSet = new Set(pure)
  const out = []
  for (const file in bundle) {
    const chunk = bundle[file]
    if (chunk.type === 'chunk') {
      let hit = 0
      const kept = chunk.imports.filter((f) => {
        if (pureCssChunkNameSet.has(f)) { hit++; return false }
        return true
      })
      out.push(kept.length + ':' + hit)
    }
  }
  return out
}

const median = (a) => { const s = [...a].sort((x, y) => x - y); return s[s.length >> 1] }
const time = (fn, d, reps) => {
  const t = []
  for (let i = 0; i < reps; i++) { const s = performance.now(); fn(d); t.push(performance.now() - s) }
  return median(t)
}

console.log('chunks  imports  pureCSS   before(ms)   after(ms)  ratio')
for (const [C, I] of [[50, 5], [200, 8], [600, 12], [1500, 15], [4000, 20]]) {
  const d = makeBundle(C, I, 0.15)
  if (JSON.stringify(before(d)) !== JSON.stringify(after(d))) throw new Error(`mismatch at ${C}`)
  const reps = C <= 600 ? 41 : 15
  const b1 = time(before, d, reps), a1 = time(after, d, reps)
  const b2 = time(before, d, reps), a2 = time(after, d, reps)
  const bt = Math.min(b1, b2), at = Math.min(a1, a2)
  console.log(`${String(C).padStart(6)}${String(I).padStart(9)}${String(d.pure.length).padStart(9)}` +
    `${bt.toFixed(3).padStart(13)}${at.toFixed(3).padStart(12)}${(bt / at).toFixed(2).padStart(7)}x`)
}
```

</details>
