### PR TITLE
fix(build): read chunk import map from environment (fix #23119)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -5,6 +5,7 @@ import colors from 'picocolors'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type {
   LogLevel,
+  OutputAsset,
   OutputChunk,
   OutputOptions,
   RolldownOptions,
@@ -1019,6 +1020,95 @@ test.for([true, false])(
     ).toEqual([1, 8, 1, 8])
   },
 )
+
+function virtualPlugin(modules: Record<string, string>) {
+  return {
+    name: 'virtual-test-modules',
+    resolveId(id: string) {
+      if (id in modules) return id
+    },
+    load(id: string) {
+      return modules[id]
+    },
+  }
+}
+
+test('uses environment chunkImportMap config with shared plugins', async () => {
+  const builder = await createBuilder({
+    root: resolve(dirname, 'packages/build-project'),
+    logLevel: 'silent',
+    configFile: false,
+    build: {
+      write: false,
+    },
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: true,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    builder: {
+      sharedPlugins: true,
+    },
+    plugins: [
+      virtualPlugin({
+        '/entry.js': `import('./dynamic.js')`,
+        './dynamic.js': `import './dynamic.css'\nexport const value = 'dynamic'`,
+        './dynamic.css': `.dynamic { color: red }`,
+      }),
+    ],
+  })
+
+  const result = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+  const entryChunk = result.output.find(
+    (file): file is OutputChunk => file.type === 'chunk' && file.isEntry,
+  )!
+  const importMap = result.output.find(
+    (file): file is OutputAsset => file.fileName === 'importmap.json',
+  )!
+
+  expect(JSON.parse(importMap.source.toString()).imports).not.toEqual({})
+  expect(entryChunk.code).toContain('__vite__mapDeps([0,1])')
+  expect(entryChunk.code).toContain('.css')
+})
+
+test('skips chunk import map injection when an environment opts out', async () => {
+  const builder = await createBuilder({
+    root: resolve(dirname, 'packages/build-project'),
+    logLevel: 'silent',
+    configFile: false,
+    build: {
+      chunkImportMap: true,
+      write: false,
+    },
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: false,
+        },
+      },
+    },
+    builder: {
+      sharedPlugins: true,
+    },
+    plugins: [virtualPlugin({ 'entry.js': `console.log('entry')` })],
+  })
+
+  const result = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+  const html = result.output.find(
+    (file): file is OutputAsset => file.fileName === 'index.html',
+  )!
+
+  expect(html.source.toString()).not.toContain('type="importmap"')
+})
 
 test('sharedConfigBuild and emitAssets', async () => {
   const root = resolve(dirname, 'fixtures/shared-config-build/emitAssets')

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1074,35 +1074,42 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
       // With `cssCodeSplit: false`, CSS is emitted as a single stylesheet in the HTML,
       // so this per-chunk import map handling is irrelevant.
-      if (config.build.chunkImportMap && chunkCssReferences.size) {
+      const environmentConfig = this.environment.config
+
+      if (environmentConfig.build.chunkImportMap && chunkCssReferences.size) {
         // The import map hash identifies the JS chunk independently of its content.
         // Since each chunk has at most one extracted CSS sidecar, we can reuse that
         // stable identity with a `.css` extension while mapping it to the CSS content hash.
-        const importMap = getImportMap(bundle, config)!
-        const importMapReverseMapping = Object.fromEntries(
-          Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
-        )
-        const chunksByPreliminaryFileName = new Map(
-          Object.values(bundle)
-            .filter((output): output is OutputChunk => output.type === 'chunk')
-            .map((chunk) => [chunk.preliminaryFileName, chunk]),
-        )
+        const importMap = getImportMap(bundle, environmentConfig)
+        if (importMap) {
+          const importMapReverseMapping = Object.fromEntries(
+            Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
+          )
+          const chunksByPreliminaryFileName = new Map(
+            Object.values(bundle)
+              .filter(
+                (output): output is OutputChunk => output.type === 'chunk',
+              )
+              .map((chunk) => [chunk.preliminaryFileName, chunk]),
+          )
 
-        for (const [chunkFileName, referenceId] of chunkCssReferences) {
-          const chunk = chunksByPreliminaryFileName.get(chunkFileName)
-          if (!chunk) continue
+          for (const [chunkFileName, referenceId] of chunkCssReferences) {
+            const chunk = chunksByPreliminaryFileName.get(chunkFileName)
+            if (!chunk) continue
 
-          const stableChunkFileName =
-            importMapReverseMapping[chunk.fileName] ?? chunk.fileName
-          const extension = path.posix.extname(stableChunkFileName)
-          const stableCssFileName = `${stableChunkFileName.slice(
-            0,
-            extension ? -extension.length : undefined,
-          )}.css`
-          importMap.content.imports[config.base + stableCssFileName] =
-            config.base + this.getFileName(referenceId)
+            const stableChunkFileName =
+              importMapReverseMapping[chunk.fileName] ?? chunk.fileName
+            const extension = path.posix.extname(stableChunkFileName)
+            const stableCssFileName = `${stableChunkFileName.slice(
+              0,
+              extension ? -extension.length : undefined,
+            )}.css`
+            importMap.content.imports[
+              environmentConfig.base + stableCssFileName
+            ] = environmentConfig.base + this.getFileName(referenceId)
+          }
+          importMap.asset.source = JSON.stringify(importMap.content)
         }
-        importMap.asset.source = JSON.stringify(importMap.content)
       }
 
       // remove empty css chunks and their imports
@@ -1125,11 +1132,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           .filter(Boolean)
 
         let importMapReverseMapping: Record<string, string> | undefined
-        if (config.build.chunkImportMap) {
-          const importMap = getImportMap(bundle, config)!
-          importMapReverseMapping = Object.fromEntries(
-            Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
-          )
+        if (environmentConfig.build.chunkImportMap) {
+          const importMap = getImportMap(bundle, environmentConfig)
+          if (importMap) {
+            importMapReverseMapping = Object.fromEntries(
+              Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
+            )
+          }
         }
         const pureCssChunkNamesInCode = importMapReverseMapping
           ? pureCssChunkNames.map(

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -418,7 +418,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   preHooks.unshift(preImportMapHook(config))
   preHooks.push(htmlEnvHook(config))
   postHooks.push(injectNonceAttributeTagHook(config))
-  postHooks.push(postImportMapHook(config))
   const processedHtml = perEnvironmentState(() => new Map<string, string>())
 
   const isExcludedUrl = (url: string) =>
@@ -1029,7 +1028,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         }
         result = await applyHtmlTransforms(
           result,
-          [...normalHooks, ...postHooks],
+          [
+            ...normalHooks,
+            ...postHooks,
+            postImportMapHook(this.environment.config),
+          ],
           this,
           {
             path: '/' + relativeUrlPath,
@@ -1234,7 +1237,10 @@ export function postImportMapHook(
 
     if (chunkImportMapEnabled) {
       const nonce = config.html?.cspNonce
-      const importMap = bundle![getImportMapFilename(config)] as OutputAsset
+      const importMap = bundle![getImportMapFilename(config)] as
+        | OutputAsset
+        | undefined
+      if (!importMap) return html
       const importMapHtml = serializeTag({
         tag: 'script',
         attrs: { type: 'importmap', ...(nonce ? { nonce } : {}) },

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -352,25 +352,28 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
         }
         return
       }
-      const buildSourcemap = this.environment.config.build.sourcemap
-      const { modulePreload } = this.environment.config.build
+      const environmentConfig = this.environment.config
+      const buildSourcemap = environmentConfig.build.sourcemap
+      const { modulePreload } = environmentConfig.build
 
       let importMapMapping: Record<string, string> | undefined
       let importMapReverseMapping: Record<string, string> | undefined
-      if (config.build.chunkImportMap) {
-        const importMap = getImportMap(bundle, config)!
-        importMapMapping = importMap.mapping
-        importMapReverseMapping = Object.fromEntries(
-          Object.entries(importMapMapping).map(([k, v]) => [v, k]),
-        )
+      if (environmentConfig.build.chunkImportMap) {
+        const importMap = getImportMap(bundle, environmentConfig)
+        if (importMap) {
+          importMapMapping = importMap.mapping
+          importMapReverseMapping = Object.fromEntries(
+            Object.entries(importMapMapping).map(([k, v]) => [v, k]),
+          )
 
-        if (config.isOutputOptionsForLegacyChunks?.(opts)) {
-          this.emitFile({
-            type: 'asset',
-            fileName: 'importmap.legacy.json',
-            source: importMap.asset.source,
-          })
-          delete bundle[getImportMapFilename(config)]
+          if (environmentConfig.isOutputOptionsForLegacyChunks?.(opts)) {
+            this.emitFile({
+              type: 'asset',
+              fileName: 'importmap.legacy.json',
+              source: importMap.asset.source,
+            })
+            delete bundle[getImportMapFilename(environmentConfig)]
+          }
         }
       }
 


### PR DESCRIPTION
Fixes #23119

This makes the chunk import map build hooks read `build.chunkImportMap` from the active environment config instead of the root config captured when shared plugin instances are used. With `builder.sharedPlugins`, an environment-level `build.chunkImportMap: true` now lets `vite:build-import-analysis` read the generated import map and produce preload dependency lists for dynamic chunks and their CSS. The CSS post-processing and HTML import-map injection paths also use the environment config and skip missing import-map assets, so an environment that opts out does not crash when another config scope enables the option. Regression coverage exercises both the shared-plugin environment enablement path and the environment opt-out path.

Validation:

- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install` passed
- `pnpm exec vitest run packages/vite/src/node/__tests__/build.spec.ts -t 'chunk import map|chunkImportMap'` passed under Node v24.4.1
- `pnpm run build` passed under Node v24.4.1
- `pnpm run lint` passed under Node v24.4.1
- `pnpm run typecheck` passed under Node v24.4.1
- `git diff --check` passed

Blockers:

- `pnpm install` without `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` could not complete locally because the `playwright-chromium` browser download failed with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`. I did not run the full browser-backed `pnpm test` suite locally for that reason.
