### PR TITLE
fix(bundledDev): skip plugin resolveId hooks for rolldown-lazy stub modules (fix #23124)

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -396,19 +396,39 @@ export class BundledDev {
     // https://github.com/vitejs/vite/issues/22651
     const plugins = await asyncFlatten([rolldownOptions.plugins])
     for (const plugin of plugins) {
-      const transform =
-        plugin && 'transform' in plugin ? plugin.transform : undefined
-      if (!transform) continue
-      const handler =
-        typeof transform === 'function' ? transform : transform.handler
-      const wrappedHandler: typeof handler = function (this, code, id, opts) {
-        if (id.includes('?rolldown-lazy=')) return null
-        return handler.call(this, code, id, opts)
+      if (!plugin) continue
+      const resolveId = 'resolveId' in plugin ? plugin.resolveId : undefined
+      if (resolveId) {
+        const handler =
+          typeof resolveId === 'function' ? resolveId : resolveId.handler
+        const wrappedHandler: typeof handler = function (
+          this,
+          source,
+          importer,
+          opts,
+        ) {
+          if (source.includes('?rolldown-lazy=')) return source
+          return handler.call(this, source, importer, opts)
+        }
+        if (typeof resolveId === 'function') {
+          ;(plugin as any).resolveId = wrappedHandler
+        } else {
+          resolveId.handler = wrappedHandler
+        }
       }
-      if (typeof transform === 'function') {
-        ;(plugin as any).transform = wrappedHandler
-      } else {
-        transform.handler = wrappedHandler
+      const transform = 'transform' in plugin ? plugin.transform : undefined
+      if (transform) {
+        const handler =
+          typeof transform === 'function' ? transform : transform.handler
+        const wrappedHandler: typeof handler = function (this, code, id, opts) {
+          if (id.includes('?rolldown-lazy=')) return null
+          return handler.call(this, code, id, opts)
+        }
+        if (typeof transform === 'function') {
+          ;(plugin as any).transform = wrappedHandler
+        } else {
+          transform.handler = wrappedHandler
+        }
       }
     }
     rolldownOptions.plugins = plugins

--- a/playground/hmr-full-bundle-mode/__tests__/virtual-lazy.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/virtual-lazy.spec.ts
@@ -1,0 +1,77 @@
+import path from 'node:path'
+import { type Plugin, type ViteDevServer, createServer } from 'vite'
+import { afterEach, describe, expect, test } from 'vitest'
+import { isServe } from '~utils'
+
+let server: ViteDevServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+})
+
+// A plugin virtual module reached through a dynamic import becomes a rolldown
+// lazy entry whose stub id carries `?rolldown-lazy=`. The plugin only matches its
+// own id, so `resolveId` returned null for the stub and the entry failed to
+// compile with `UNRESOLVED_ENTRY`.
+describe.runIf(isServe)('full bundle mode virtual lazy entry', () => {
+  test('compiles the lazy entry of a dynamically imported virtual module', async () => {
+    const errors: string[] = []
+    const virtualPlugin: Plugin = {
+      name: 'virtual-lazy',
+      resolveId(id) {
+        if (id === 'virtual:lazy-me') {
+          return '\0virtual:lazy-me'
+        }
+      },
+      load(id) {
+        if (id === '\0virtual:lazy-me') {
+          return 'export default "hello from a virtual module"'
+        }
+      },
+    }
+
+    server = await createServer({
+      root: path.resolve(import.meta.dirname, 'virtual-lazy'),
+      configFile: false,
+      logLevel: 'silent',
+      experimental: { bundledDev: true },
+      plugins: [virtualPlugin],
+      customLogger: {
+        info() {},
+        warn() {},
+        warnOnce() {},
+        error(msg) {
+          errors.push(msg)
+        },
+        clearScreen() {},
+        hasErrorLogged: () => false,
+        hasWarned: false,
+      },
+    })
+    await server.listen()
+
+    const bundledDev = server.environments.client.bundledDev!
+    // the lazy entry is created by the initial full build, so wait for it
+    await expect
+      .poll(() => bundledDev.memoryFiles.size, { timeout: 10000 })
+      .toBeGreaterThan(0)
+
+    const sizeBefore = bundledDev.memoryFiles.size
+    const result = await bundledDev.triggerLazyBundling(
+      '\0virtual:lazy-me?rolldown-lazy=1',
+      'test-client',
+    )
+    expect(result).toBeDefined()
+
+    // the compile runs a build; it must produce output instead of failing with
+    // UNRESOLVED_ENTRY
+    await expect
+      .poll(
+        () => errors.length > 0 || bundledDev.memoryFiles.size > sizeBefore,
+        { timeout: 10000 },
+      )
+      .toBe(true)
+    expect(errors).toEqual([])
+  })
+})

--- a/playground/hmr-full-bundle-mode/__tests__/virtual-lazy/index.html
+++ b/playground/hmr-full-bundle-mode/__tests__/virtual-lazy/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script type="module" src="/main.js"></script>

--- a/playground/hmr-full-bundle-mode/__tests__/virtual-lazy/main.js
+++ b/playground/hmr-full-bundle-mode/__tests__/virtual-lazy/main.js
@@ -1,0 +1,3 @@
+import('virtual:lazy-me').then((m) => {
+  document.querySelector('#app').textContent = m.default
+})


### PR DESCRIPTION
Under `experimental.bundledDev`, a plugin virtual module reached through a dynamic import becomes a Rolldown lazy entry whose stub id carries `?rolldown-lazy=`. A plugin only recognizes its own id, so its `resolveId` returns null for the stub and the entry fails to compile with `UNRESOLVED_ENTRY`. #22778 already wrapped `transform` to ignore these stub ids; this does the same for `resolveId`, resolving the stub to itself so the virtual module loads.

Fixes #23124
