### PR TITLE
docs: remove nonexistent `RemoteEnvironmentTransport` import in environment API example

### DIFF
--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -356,7 +356,7 @@ const runner = new ModuleRunner(
 
 ```js [server.js]
 import { BroadcastChannel } from 'node:worker_threads'
-import { createServer, RemoteEnvironmentTransport, DevEnvironment } from 'vite'
+import { createServer, DevEnvironment } from 'vite'
 
 function createWorkerEnvironment(name, config, context) {
   const worker = new Worker('./worker.js')


### PR DESCRIPTION
In the Environment API runtimes guide, the `server.js` example imports `RemoteEnvironmentTransport`:

```js
import { createServer, RemoteEnvironmentTransport, DevEnvironment } from 'vite'
```

`RemoteEnvironmentTransport` is not exported from `vite` — it doesn't exist anywhere in the codebase — so copy-pasting this example throws `The requested module 'vite' does not provide an export named 'RemoteEnvironmentTransport'`. It's also unused in the example; only `createServer` and `DevEnvironment` (both real exports) are actually used. Removed the dead import.