### PR TITLE
fix(bundledDev): complete hotUpdate hook context

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -8,15 +8,23 @@ import type { RolldownOutput } from 'rolldown'
 import colors from 'picocolors'
 import getEtag from 'etag'
 import { ChunkMetadataMap, resolveRolldownOptions } from '../build'
+import type { Plugin } from '../plugin'
 import { getHmrImplementation } from '../plugins/clientInjections'
 import {
   asyncFlatten,
   createDebugger,
   formatAndTruncateFileList,
+  monotonicDateNow,
 } from '../utils'
 import type { DevEnvironment } from './environment'
-import { type NormalizedHotChannelClient, debugHmr, getShortName } from './hmr'
+import {
+  type NormalizedHotChannelClient,
+  debugHmr,
+  getShortName,
+  readModifiedFile,
+} from './hmr'
 import { prepareError } from './middlewares/error'
+import type { ViteDevServer } from '.'
 
 const debug = createDebugger('vite:full-bundle-mode')
 
@@ -107,10 +115,10 @@ export class BundledDev {
 
   private pendingPayloadFilenames = new Set<string>()
 
-  async listen(): Promise<void> {
+  async listen(server: ViteDevServer): Promise<void> {
     this._closed = false
     debug?.('INITIAL: setup bundle options')
-    const rolldownOptions = await this.getRolldownOptions()
+    const rolldownOptions = await this.getRolldownOptions(server)
     // NOTE: only single outputOptions is supported here
     if (
       Array.isArray(rolldownOptions.output) &&
@@ -368,7 +376,7 @@ export class BundledDev {
     }
   }
 
-  private async getRolldownOptions() {
+  private async getRolldownOptions(server: ViteDevServer) {
     const chunkMetadataMap = new ChunkMetadataMap()
     const rolldownOptions = resolveRolldownOptions(
       this.environment,
@@ -396,6 +404,25 @@ export class BundledDev {
     // https://github.com/vitejs/vite/issues/22651
     const plugins = await asyncFlatten([rolldownOptions.plugins])
     for (const plugin of plugins) {
+      const vitePlugin = plugin as Plugin | undefined
+      const hotUpdate = vitePlugin?.hotUpdate
+      if (hotUpdate) {
+        const handler =
+          typeof hotUpdate === 'function' ? hotUpdate : hotUpdate.handler
+        const wrappedHandler: typeof handler = function (this, options) {
+          return handler.call(this, {
+            ...options,
+            timestamp: monotonicDateNow(),
+            read: () => readModifiedFile(options.file),
+            server,
+          })
+        }
+        vitePlugin.hotUpdate =
+          typeof hotUpdate === 'function'
+            ? wrappedHandler
+            : { ...hotUpdate, handler: wrappedHandler }
+      }
+
       const transform =
         plugin && 'transform' in plugin ? plugin.transform : undefined
       if (!transform) continue

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -270,7 +270,10 @@ export class DevEnvironment extends BaseEnvironment {
    */
   async listen(server: ViteDevServer): Promise<void> {
     this.hot.listen()
-    await Promise.all([this.bundledDev?.listen(), this.depsOptimizer?.init()])
+    await Promise.all([
+      this.bundledDev?.listen(server),
+      this.depsOptimizer?.init(),
+    ])
     warmupFiles(server, this)
   }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -1143,7 +1143,7 @@ function error(pos: number) {
 // vitejs/vite#610 when hot-reloading Vue files, we read immediately on file
 // change event and sometimes this can be too early and get an empty buffer.
 // Poll until the file's modified time has changed before reading again.
-async function readModifiedFile(file: string): Promise<string> {
+export async function readModifiedFile(file: string): Promise<string> {
   const content = await fsp.readFile(file, 'utf-8')
   if (!content) {
     const mtime = (await fsp.stat(file)).mtimeMs

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -1,6 +1,9 @@
 import { setTimeout } from 'node:timers/promises'
+import path from 'node:path'
+import { type Plugin, normalizePath } from 'vite'
 import type { Response } from 'playwright-chromium'
 import { expect, test, onTestFinished } from 'vitest'
+import type { HotUpdateContextApi } from '../vite.config'
 import {
   addFile,
   browserLogs,
@@ -9,6 +12,8 @@ import {
   page,
   readFile,
   serverLogs,
+  testDir,
+  viteServer,
 } from '~utils'
 
 const assetUrl = /asset-[\w-]+\.png/
@@ -34,6 +39,46 @@ if (isBuild) {
       .poll(() => page.textContent('.worker-query'))
       .toBe('worker-query')
     await expect.poll(() => page.textContent('.worker-url')).toBe('worker-url')
+  })
+
+  test('hotUpdate receives the complete Vite context', async () => {
+    const original = readFile('hmr.js')
+    onTestFinished(() => addFile('hmr.js', original))
+    const plugins = [
+      'capture-function-hot-update-context',
+      'capture-object-hot-update-context',
+    ].map(
+      (name) =>
+        viteServer.config.plugins.find((plugin) => plugin.name === name) as
+          | Plugin<HotUpdateContextApi>
+          | undefined,
+    )
+
+    const beforeUpdate = Date.now()
+    editFile('hmr.js', (code) =>
+      code.replace("const foo = 'hello'", "const foo = 'context-update'"),
+    )
+    await expect
+      .poll(() => plugins.map((plugin) => plugin?.api?.content))
+      .toEqual([
+        expect.stringContaining("const foo = 'context-update'"),
+        expect.stringContaining("const foo = 'context-update'"),
+      ])
+
+    for (const plugin of plugins) {
+      expect(plugin?.api?.options).toMatchObject({
+        type: expect.stringMatching(/^(create|update)$/),
+        file: normalizePath(path.resolve(testDir, 'hmr.js')),
+        timestamp: expect.any(Number),
+        modules: expect.any(Array),
+        read: expect.any(Function),
+        server: viteServer,
+      })
+      expect(plugin!.api!.options!.timestamp).toBeGreaterThanOrEqual(
+        beforeUpdate,
+      )
+    }
+    expect(plugins[1]!.api!.callOrder).toBeLessThan(plugins[0]!.api!.callOrder!)
   })
 
   // BUNDLED -> GENERATE_HMR_PATCH -> BUNDLING -> BUNDLE_ERROR -> BUNDLING -> BUNDLED

--- a/playground/hmr-full-bundle-mode/vite.config.ts
+++ b/playground/hmr-full-bundle-mode/vite.config.ts
@@ -1,4 +1,10 @@
-import { type Plugin, defineConfig } from 'vite'
+import { type HotUpdateOptions, type Plugin, defineConfig } from 'vite'
+
+export interface HotUpdateContextApi {
+  options?: HotUpdateOptions
+  content?: string
+  callOrder?: number
+}
 
 export default defineConfig({
   experimental: {
@@ -8,8 +14,41 @@ export default defineConfig({
     // emit assets as files instead of inlining, for the new-asset HMR test
     assetsInlineLimit: 0,
   },
-  plugins: [waitBundleCompleteUntilAccess(), delayTransformComment()],
+  plugins: [
+    waitBundleCompleteUntilAccess(),
+    delayTransformComment(),
+    ...captureHotUpdateContexts(),
+  ],
 })
+
+function captureHotUpdateContexts(): Plugin<HotUpdateContextApi>[] {
+  const functionApi: HotUpdateContextApi = {}
+  const objectApi: HotUpdateContextApi = {}
+  let callIndex = 0
+  return [
+    {
+      name: 'capture-function-hot-update-context',
+      api: functionApi,
+      async hotUpdate(options) {
+        functionApi.callOrder = callIndex++
+        functionApi.options = options
+        functionApi.content = await options.read()
+      },
+    },
+    {
+      name: 'capture-object-hot-update-context',
+      api: objectApi,
+      hotUpdate: {
+        order: 'pre',
+        async handler(options) {
+          objectApi.callOrder = callIndex++
+          objectApi.options = options
+          objectApi.content = await options.read()
+        },
+      },
+    },
+  ]
+}
 
 function waitBundleCompleteUntilAccess(): Plugin {
   let resolvers: PromiseWithResolvers<void>


### PR DESCRIPTION
## Summary

- provide `server`, `timestamp`, and `read` to plugin `hotUpdate` hooks in bundled dev mode
- preserve function and object hook forms, including hook ordering
- add regression coverage for the complete hook context

Rolldown's DevEngine supplies only `type`, `file`, and `modules`, so Vite now augments that context before invoking plugins. This restores the documented contract and prevents plugins that use the dev server or file reader from failing during updates.

Fixes #23125

## Testing

- `pnpm build`
- `pnpm --filter vite typecheck`
- `pnpm test-unit`
- `pnpm run test-serve-bundled hmr-full-bundle-mode`
- ESLint and formatting checks for the changed files
