### PR TITLE
test: reduce logs

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1798,6 +1798,7 @@ describe('loadConfigFromFile', () => {
         { command: 'build', mode: 'production' },
         undefined,
         root,
+        'silent',
       )
       expect(result).toBeTruthy()
       expect(result?.config).toStrictEqual({ define: { foo: 1 } })
@@ -1910,6 +1911,7 @@ describe('loadConfigFromFile', () => {
       {} as any,
       path.resolve(fixtures, './cjs-module-vars-in-esm/vite.config.ts'),
       path.resolve(fixtures, './cjs-module-vars-in-esm'),
+      'silent',
     ))!
     const c = config as any
     expect(c.dirname).toContain('cjs-module-vars-in-esm')

--- a/packages/vite/src/node/__tests__/fixtures/config/shebang-crlf/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/config/shebang-crlf/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/vite/src/node/__tests__/fixtures/config/shebang/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/config/shebang/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -1,60 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`fixture > transform 1`] = `
-"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import * as __vite_glob_28_0 from "./.foo/test.ts";import "../../../../../../types/importMeta";
+"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import * as __vite_glob_28_0 from "./.foo/test.ts";// NOTE: \`#types/importMeta\` does not work as \`src/node/__tests__/package.json\` shadows the root
+// \`package.json\` and does not declare the subpath import.
+import "../../../../../../types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
+// prettier-ignore
 export const basicWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+// prettier-ignore
 export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
-
-});
-export const basicEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
-
-}
-);
-export const basicEagerWithObjectValues = Object.values(
-  [__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2
-
-]
-);
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2});
+export const basicEagerWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+export const basicEagerWithObjectValues = Object.values([__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2]);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
-export const ignoreWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0}
-);
-export const ignoreWithObjectValues = Object.values(
-  [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
-);
+export const ignoreWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0});
+export const ignoreWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts")]);
 export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_9_0,"./modules/b.ts": __vite_glob_9_1,"./modules/index.ts": __vite_glob_9_2
 
 
 });
-export const namedEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
+export const namedEagerWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
-
-}
-);
-export const namedEagerWithObjectValues = Object.values(
-  [__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
-
-
-]
-);
-export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
-export const namedDefaultWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
+export const namedEagerWithObjectValues = Object.values([__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
 
-}
-);
-export const namedDefaultWithObjectValues = Object.values(
-  [() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])
 
-]
-);
+]);
+export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])});
+export const namedDefaultWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+export const namedDefaultWithObjectValues = Object.values([() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])]);
 export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_15_0,"./modules/b.ts": __vite_glob_15_1
+
 
 
 });
@@ -74,8 +51,6 @@ export const customQueryString = /* #__PURE__ */ Object.assign({"./sibling.ts": 
 export const customQueryObject = /* #__PURE__ */ Object.assign({"./sibling.ts": () => import("./sibling.ts?foo=bar&raw=true")
 
 
-
-
 });
 export const parent = /* #__PURE__ */ Object.assign({
 
@@ -85,80 +60,51 @@ export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/fixture-b/a.ts
 
 
 });
-export const cleverCwd1 = /* #__PURE__ */ Object.assign({"./node_modules/framework/pages/hello.page.js": () => import("./node_modules/framework/pages/hello.page.js")
-
-});
+export const cleverCwd1 = /* #__PURE__ */ Object.assign({"./node_modules/framework/pages/hello.page.js": () => import("./node_modules/framework/pages/hello.page.js")});
 export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts")
 
 
 
 });
 export const customBase = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts"),"./sibling.ts": () => import("./sibling.ts")});
-export const customRootBase = /* #__PURE__ */ Object.assign({"./a.ts": () => import("../fixture-b/a.ts"),"./b.ts": () => import("../fixture-b/b.ts"),"./index.ts": () => import("../fixture-b/index.ts")
-
-});
-export const customBaseParent = /* #__PURE__ */ Object.assign({"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts"),"../fixture-b/index.ts": () => import("../fixture-b/index.ts")
-
-});
+export const customRootBase = /* #__PURE__ */ Object.assign({"./a.ts": () => import("../fixture-b/a.ts"),"./b.ts": () => import("../fixture-b/b.ts"),"./index.ts": () => import("../fixture-b/index.ts")});
+export const customBaseParent = /* #__PURE__ */ Object.assign({"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts"),"../fixture-b/index.ts": () => import("../fixture-b/index.ts")});
 export const dotFolder = /* #__PURE__ */ Object.assign({"./.foo/test.ts": __vite_glob_28_0});
 "
 `;
 
 exports[`fixture > transform with restoreQueryExtension 1`] = `
-"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import * as __vite_glob_28_0 from "./.foo/test.ts";import "../../../../../../types/importMeta";
+"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import * as __vite_glob_28_0 from "./.foo/test.ts";// NOTE: \`#types/importMeta\` does not work as \`src/node/__tests__/package.json\` shadows the root
+// \`package.json\` and does not declare the subpath import.
+import "../../../../../../types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
+// prettier-ignore
 export const basicWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+// prettier-ignore
 export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
-
-});
-export const basicEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
-
-}
-);
-export const basicEagerWithObjectValues = Object.values(
-  [__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2
-
-]
-);
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2});
+export const basicEagerWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+export const basicEagerWithObjectValues = Object.values([__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2]);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
-export const ignoreWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0}
-);
-export const ignoreWithObjectValues = Object.values(
-  [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
-);
+export const ignoreWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0});
+export const ignoreWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts")]);
 export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_9_0,"./modules/b.ts": __vite_glob_9_1,"./modules/index.ts": __vite_glob_9_2
 
 
 });
-export const namedEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
+export const namedEagerWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
-
-}
-);
-export const namedEagerWithObjectValues = Object.values(
-  [__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
-
-
-]
-);
-export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
-export const namedDefaultWithObjectKeys = Object.keys(
-  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
+export const namedEagerWithObjectValues = Object.values([__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
 
-}
-);
-export const namedDefaultWithObjectValues = Object.values(
-  [() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])
 
-]
-);
+]);
+export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])});
+export const namedDefaultWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
+export const namedDefaultWithObjectValues = Object.values([() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])]);
 export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_15_0,"./modules/b.ts": __vite_glob_15_1
+
 
 
 });
@@ -178,8 +124,6 @@ export const customQueryString = /* #__PURE__ */ Object.assign({"./sibling.ts": 
 export const customQueryObject = /* #__PURE__ */ Object.assign({"./sibling.ts": () => import("./sibling.ts?foo=bar&raw=true&lang.ts")
 
 
-
-
 });
 export const parent = /* #__PURE__ */ Object.assign({
 
@@ -189,21 +133,15 @@ export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/fixture-b/a.ts
 
 
 });
-export const cleverCwd1 = /* #__PURE__ */ Object.assign({"./node_modules/framework/pages/hello.page.js": () => import("./node_modules/framework/pages/hello.page.js")
-
-});
+export const cleverCwd1 = /* #__PURE__ */ Object.assign({"./node_modules/framework/pages/hello.page.js": () => import("./node_modules/framework/pages/hello.page.js")});
 export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts")
 
 
 
 });
 export const customBase = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts"),"./sibling.ts": () => import("./sibling.ts")});
-export const customRootBase = /* #__PURE__ */ Object.assign({"./a.ts": () => import("../fixture-b/a.ts"),"./b.ts": () => import("../fixture-b/b.ts"),"./index.ts": () => import("../fixture-b/index.ts")
-
-});
-export const customBaseParent = /* #__PURE__ */ Object.assign({"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts"),"../fixture-b/index.ts": () => import("../fixture-b/index.ts")
-
-});
+export const customRootBase = /* #__PURE__ */ Object.assign({"./a.ts": () => import("../fixture-b/a.ts"),"./b.ts": () => import("../fixture-b/b.ts"),"./index.ts": () => import("../fixture-b/index.ts")});
+export const customBaseParent = /* #__PURE__ */ Object.assign({"../fixture-b/a.ts": () => import("../fixture-b/a.ts"),"../fixture-b/b.ts": () => import("../fixture-b/b.ts"),"../fixture-b/index.ts": () => import("../fixture-b/index.ts")});
 export const dotFolder = /* #__PURE__ */ Object.assign({"./.foo/test.ts": __vite_glob_28_0});
 "
 `;

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import { promises as fs } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { transformGlobImport } from '../../../plugins/importMetaGlob'
-import { transformWithEsbuild } from '../../../plugins/esbuild'
+import { transformWithOxc } from '../../../plugins/oxc'
 
 describe('fixture', async () => {
   const resolveId = (id: string) => id
@@ -10,9 +10,8 @@ describe('fixture', async () => {
 
   it('transform', async () => {
     const id = resolve(import.meta.dirname, './fixture-a/index.ts')
-    const code = (
-      await transformWithEsbuild(await fs.readFile(id, 'utf-8'), id)
-    ).code
+    const code = (await transformWithOxc(await fs.readFile(id, 'utf-8'), id))
+      .code
 
     expect(
       (await transformGlobImport(code, id, root, resolveId))?.s.toString(),
@@ -81,9 +80,8 @@ describe('fixture', async () => {
 
   it('transform with restoreQueryExtension', async () => {
     const id = resolve(import.meta.dirname, './fixture-a/index.ts')
-    const code = (
-      await transformWithEsbuild(await fs.readFile(id, 'utf-8'), id)
-    ).code
+    const code = (await transformWithOxc(await fs.readFile(id, 'utf-8'), id))
+      .code
 
     expect(
       (

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { assert, expect, test } from 'vitest'
 import type { SourceMap } from 'rolldown'
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
-import { transformWithEsbuild } from '../../plugins/esbuild'
+import { transformWithOxc } from '../../plugins/oxc'
 import { ssrTransform } from '../ssrTransform'
 import { createServer } from '../..'
 
@@ -1067,15 +1067,17 @@ test('jsx', async () => {
   }
   `
   const id = '/foo.jsx'
-  const result = await transformWithEsbuild(code, id)
+  const result = await transformWithOxc(code, id, {
+    jsx: { runtime: 'classic' },
+  })
   expect(await ssrTransformSimpleCode(result.code, '/foo.jsx'))
     .toMatchInlineSnapshot(`
       "const __vite_ssr_import_0__ = await __vite_ssr_import__("react", {"importedNames":["default"]});
       const __vite_ssr_import_1__ = await __vite_ssr_import__("foo", {"importedNames":["Foo","Slot"]});
 
 
-      function Bar({ Slot: Slot2 = /* @__PURE__ */ __vite_ssr_import_0__.default.createElement((0,__vite_ssr_import_1__.Foo), null) }) {
-        return /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(__vite_ssr_import_0__.default.Fragment, null, /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(Slot2, null));
+      function Bar({ Slot = /* @__PURE__ */ __vite_ssr_import_0__.default.createElement((0,__vite_ssr_import_1__.Foo), null) }) {
+      	return /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(__vite_ssr_import_0__.default.Fragment, null, /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(Slot, null));
       }
       "
     `)
@@ -1103,7 +1105,7 @@ export function fn1() {
 
 // https://github.com/vitest-dev/vitest/issues/1141
 test('export default expression', async () => {
-  // esbuild transform result of following TS code
+  // Oxc transform result of following TS code
   // export default <MyFn> function getRandom() {
   //   return Math.random()
   // }

--- a/playground/fs-serve/root/windows83Filename.ts
+++ b/playground/fs-serve/root/windows83Filename.ts
@@ -5,7 +5,7 @@ function getWindows83ShortName(inputPath: string): string | undefined {
   try {
     const result = execSync(
       `powershell -Command "(New-Object -ComObject Scripting.FileSystemObject).GetFile('${inputPath}').ShortPath"`,
-      { encoding: 'utf-8', stdio: 'ignore' },
+      { encoding: 'utf-8', stdio: 'pipe' },
     ).trim()
     return result !== inputPath && result.includes('~') ? result : undefined
   } catch {

--- a/playground/fs-serve/root/windows83Filename.ts
+++ b/playground/fs-serve/root/windows83Filename.ts
@@ -5,7 +5,7 @@ function getWindows83ShortName(inputPath: string): string | undefined {
   try {
     const result = execSync(
       `powershell -Command "(New-Object -ComObject Scripting.FileSystemObject).GetFile('${inputPath}').ShortPath"`,
-      { encoding: 'utf-8' },
+      { encoding: 'utf-8', stdio: 'ignore' },
     ).trim()
     return result !== inputPath && result.includes('~') ? result : undefined
   } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,10 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/config/plugin-module-condition: {}
 
+  packages/vite/src/node/__tests__/fixtures/config/shebang: {}
+
+  packages/vite/src/node/__tests__/fixtures/config/shebang-crlf: {}
+
   packages/vite/src/node/__tests__/fixtures/config/siblings:
     devDependencies:
       '@types/lodash':


### PR DESCRIPTION
Modify the tests to reduce unrelated logs.
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - ESM syntax in a file loaded as CommonJS (vite.config.js:1:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```
```
`transformWithEsbuild` is deprecated and will be removed in the future. Please migrate to `transformWithOxc`.
```
```
/bin/sh: 1: powershell: not found
```