### PR TITLE
docs: docs: copy buttons on vite.dev have no accessible name (WCAG 4.1.2, axe button-name, critical)

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -28,6 +28,29 @@ export default {
     app.component('ScrimbaLink', ScrimbaLink)
     app.use(TwoslashFloatingVue)
 
+    const labelCopyButtons = (root: ParentNode = document) => {
+      root.querySelectorAll<HTMLButtonElement>('button.copy').forEach((button) => {
+        button.setAttribute('aria-label', 'Copy code')
+        button.setAttribute('title', 'Copy code')
+      })
+    }
+
+    if (typeof window !== 'undefined') {
+      labelCopyButtons()
+
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          mutation.addedNodes.forEach((node) => {
+            if (node instanceof Element) {
+              labelCopyButtons(node)
+            }
+          })
+        }
+      })
+
+      observer.observe(document.body, { childList: true, subtree: true })
+    }
+
     Theme.enhanceApp(ctx)
   },
 }


### PR DESCRIPTION
## Summary

Addresses #23122: docs: copy buttons on vite.dev have no accessible name (WCAG 4.1.2, axe button-name, critical)

## Changed files

- `docs/.vitepress/theme/index.ts`

## Validation

- `git diff --check`: passed

Fixes #23122
