### PR TITLE
fix(css): don't re-run lightningcss visitor during minify (fix #23146)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -2,7 +2,6 @@ import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import type { InternalModuleFormat } from 'rolldown'
 import MagicString from 'magic-string'
-import { build } from '../../build'
 import { resolveConfig } from '../../config'
 import type { InlineConfig } from '../../config'
 import {
@@ -870,50 +869,5 @@ console.log("foo");`,
       "#!/usr/bin/env node
       injectCSS();"
     `)
-  })
-})
-
-describe('lightningcss minify', () => {
-  test('does not run the visitor again during minify', async () => {
-    let mediaQueryVisits = 0
-    await build({
-      root: path.resolve(dirname, '../packages/build-project'),
-      logLevel: 'silent',
-      css: {
-        transformer: 'lightningcss',
-        lightningcss: {
-          visitor: {
-            MediaQuery(query) {
-              mediaQueryVisits++
-              return query
-            },
-          },
-        },
-      },
-      build: {
-        write: false,
-        cssMinify: 'lightningcss',
-      },
-      plugins: [
-        {
-          name: 'test',
-          resolveId(id) {
-            if (id === 'entry.js' || id === 'style.css') {
-              return '\0' + id
-            }
-          },
-          load(id) {
-            if (id === '\0entry.js') {
-              return `import 'style.css'`
-            }
-            if (id === '\0style.css') {
-              return `@media (min-width: 100px) { a { color: red } }\n@media (min-width: 200px) { b { color: blue } }`
-            }
-          },
-        },
-      ],
-      input: 'entry.js',
-    })
-    expect(mediaQueryVisits).toBe(2)
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import type { InternalModuleFormat } from 'rolldown'
 import MagicString from 'magic-string'
+import { build } from '../../build'
 import { resolveConfig } from '../../config'
 import type { InlineConfig } from '../../config'
 import {
@@ -869,5 +870,50 @@ console.log("foo");`,
       "#!/usr/bin/env node
       injectCSS();"
     `)
+  })
+})
+
+describe('lightningcss minify', () => {
+  test('does not run the visitor again during minify', async () => {
+    let mediaQueryVisits = 0
+    await build({
+      root: path.resolve(dirname, '../packages/build-project'),
+      logLevel: 'silent',
+      css: {
+        transformer: 'lightningcss',
+        lightningcss: {
+          visitor: {
+            MediaQuery(query) {
+              mediaQueryVisits++
+              return query
+            },
+          },
+        },
+      },
+      build: {
+        write: false,
+        cssMinify: 'lightningcss',
+      },
+      plugins: [
+        {
+          name: 'test',
+          resolveId(id) {
+            if (id === 'entry.js' || id === 'style.css') {
+              return '\0' + id
+            }
+          },
+          load(id) {
+            if (id === '\0entry.js') {
+              return `import 'style.css'`
+            }
+            if (id === '\0style.css') {
+              return `@media (min-width: 100px) { a { color: red } }\n@media (min-width: 200px) { b { color: blue } }`
+            }
+          },
+        },
+      ],
+      input: 'entry.js',
+    })
+    expect(mediaQueryVisits).toBe(2)
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2320,18 +2320,16 @@ async function minifyCSS(
   }
 
   try {
-    // the lightningcss transformer already applied `visitor`/`customAtRules`, so don't run them again while minifying
-    const { visitor, customAtRules, ...lightningcssOptions } =
-      config.css.transformer === 'lightningcss'
-        ? (config.css.lightningcss ?? {})
-        : { ...config.css.lightningcss }
     const { code, warnings } = (await importLightningCSS()).transform({
-      ...lightningcssOptions,
+      ...config.css.lightningcss,
       targets: convertTargets(config.build.cssTarget),
-      cssModules: undefined,
       filename,
       code: Buffer.from(css),
       minify: true,
+      // the transforms should run in `compileLightningCSS` step
+      cssModules: undefined,
+      visitor: undefined,
+      customAtRules: undefined,
     })
 
     for (const warning of warnings) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2320,8 +2320,13 @@ async function minifyCSS(
   }
 
   try {
+    // the lightningcss transformer already applied `visitor`/`customAtRules`, so don't run them again while minifying
+    const { visitor, customAtRules, ...lightningcssOptions } =
+      config.css.transformer === 'lightningcss'
+        ? (config.css.lightningcss ?? {})
+        : { ...config.css.lightningcss }
     const { code, warnings } = (await importLightningCSS()).transform({
-      ...config.css.lightningcss,
+      ...lightningcssOptions,
       targets: convertTargets(config.build.cssTarget),
       cssModules: undefined,
       filename,

--- a/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
@@ -7,6 +7,7 @@ import {
   isBuild,
   isBundledDev,
   page,
+  readFile,
   viteTestUrl,
 } from '~utils'
 
@@ -76,6 +77,10 @@ test.runIf(isBuild)('minify css', async () => {
   const cssFile = findAssetFile(/index-[-\w]+\.css$/)
   expect(cssFile).toMatch('rgba(')
   expect(cssFile).not.toMatch('#ffff00b3')
+})
+
+test.runIf(isBuild)('does not run the visitor again during minify', () => {
+  expect(readFile('dist/media-query-visits.txt')).toBe('2')
 })
 
 test('css with external url', async () => {

--- a/playground/css-lightningcss/minify.css
+++ b/playground/css-lightningcss/minify.css
@@ -1,3 +1,15 @@
 .test-minify {
   color: rgba(255, 255, 0, 0.7);
 }
+
+@media (min-width: 100px) {
+  .test-media-query-1 {
+    color: red;
+  }
+}
+
+@media (min-width: 200px) {
+  .test-media-query-2 {
+    color: blue;
+  }
+}

--- a/playground/css-lightningcss/vite.config.js
+++ b/playground/css-lightningcss/vite.config.js
@@ -14,4 +14,35 @@ export default defineConfig({
     cssTarget: ['chrome61'],
     cssMinify: 'lightningcss',
   },
+  plugins: [testLightningcssVisitorDuringMinify()],
 })
+
+function testLightningcssVisitorDuringMinify() {
+  let mediaQueryVisits = 0
+
+  return {
+    name: 'test-lightningcss-visitor-during-minify',
+    apply: 'build',
+    config() {
+      return {
+        css: {
+          lightningcss: {
+            visitor: {
+              MediaQuery(query) {
+                mediaQueryVisits++
+                return query
+              },
+            },
+          },
+        },
+      }
+    },
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'media-query-visits.txt',
+        source: String(mediaQueryVisits),
+      })
+    },
+  }
+}


### PR DESCRIPTION
When `css.transformer` is `lightningcss`, a configured `css.lightningcss.visitor` runs twice over production CSS: once while bundling, then again during minify. `minifyCSS` spreads the whole `css.lightningcss` config into lightningcss's `transform()`, so the visitor and any `customAtRules` run a second time over CSS that was already transformed. If the visitor isn't idempotent it produces wrong output, and a visitor that throws on input it doesn't recognise can now throw during minify instead of during the transform pass. `build.cssMinify` defaults to lightningcss, so this is the default path.

The fix drops `visitor` and `customAtRules` from the options passed to the minify pass when the transformer is lightningcss, and keeps the target and format options.

Fixes #23146
