### PR TITLE
docs: fix broken links in Environment API pages

### DIFF
--- a/docs/changes/ssr-using-modulerunner.md
+++ b/docs/changes/ssr-using-modulerunner.md
@@ -4,7 +4,7 @@
 Give us feedback at [Environment API feedback discussion](https://github.com/vitejs/vite/discussions/16358)
 :::
 
-`server.ssrLoadModule` has been replaced by importing from a [Module Runner](/guide/api-environment#modulerunner).
+`server.ssrLoadModule` has been replaced by importing from a [Module Runner](/guide/api-environment-runtimes#modulerunner).
 
 Affected scope: `Vite Plugin Authors`
 

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -19,7 +19,7 @@ Plugins run on a shared pipeline, but their hooks fall into two categories depen
 
 Global hooks are called a single time, independent of the configured environments. They handle app-wide concerns such as resolving the config or setting up the dev and preview servers, so `this.environment` is not relevant to them. Config resolution related hooks and server related hooks are global hooks.
 
-Per-environment hooks are called once for each environment, and expose the current environment through `this.environment` in their context. All [universal hooks](/guide/api-plugin#universal-hooks) are per-environment, as are other Vite-specific hooks that handle modules. However, note that `buildStart` and `buildEnd` are only called for the client environment without [the `perEnvironmentStartEndDuringDev: true` flag](##per-environment-state-in-plugins).
+Per-environment hooks are called once for each environment, and expose the current environment through `this.environment` in their context. All [Rolldown hooks](/guide/api-plugin#rolldown-hooks) are per-environment, as are other Vite-specific hooks that handle modules. However, note that `buildStart` and `buildEnd` are only called for the client environment without [the `perEnvironmentStartEndDuringDev: true` flag](#per-environment-state-in-plugins).
 
 ## Accessing the Current Environment in Hooks
 


### PR DESCRIPTION
### Description

Three dead links on the Environment API pages, verified against current `main`:

**`docs/guide/api-environment-plugins.md`** (both introduced in #22940):
- `[universal hooks](/guide/api-plugin#universal-hooks)` points at a heading that no longer exists — the section is now `## Rolldown Hooks` in `api-plugin.md`, which states the reciprocal fact ("All rolldown hooks are per-environment hooks"), so the link text is updated to match.
- `](##per-environment-state-in-plugins)` has a doubled `#`, producing a dead href. The target heading `## Per-environment State in Plugins` is in the same page.

**`docs/changes/ssr-using-modulerunner.md`**:
- `/guide/api-environment#modulerunner` — the `## ModuleRunner` section lives on `/guide/api-environment-runtimes` since the Environment API docs were split across pages, so the link currently lands at the top of a page with no such section.