### PR TITLE
test: fix flaky legacy watch failure by workaround

### DIFF
--- a/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
+++ b/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
@@ -23,6 +23,8 @@ test.runIf(isBuild)('rebuilds styles only entry on change', async () => {
     originalContents.replace('#ff69b4', '#ffb6c1 '),
   )
   await notifyRebuildComplete(watcher)
+  // wait for both "output" to complete, workaround for https://github.com/rolldown/rolldown/issues/10613
+  await notifyRebuildComplete(watcher)
 
   const updatedManifest = readManifest('watch')
   expect(Object.keys(updatedManifest)).toHaveLength(numberOfManifestEntries)

--- a/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
+++ b/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import { expect, test } from 'vitest'
 import {
   editFile,
@@ -24,7 +25,7 @@ test.runIf(isBuild)('rebuilds styles only entry on change', async () => {
   )
   await notifyRebuildComplete(watcher)
   // wait for both "output" to complete, workaround for https://github.com/rolldown/rolldown/issues/10613
-  await notifyRebuildComplete(watcher)
+  await Promise.race([notifyRebuildComplete(watcher), setTimeout(100)])
 
   const updatedManifest = readManifest('watch')
   expect(Object.keys(updatedManifest)).toHaveLength(numberOfManifestEntries)


### PR DESCRIPTION
This PR tries to fix a flaky failure like:
```
 FAIL  playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts > rebuilds styles only entry on change
Error: ENOENT: no such file or directory, open '/home/runner/work/vite/vite/playground-temp/legacy/dist/watch/.vite/manifest.json'
 ❯ readManifest playground/test-utils.ts:257:8
    255| export function readManifest(base = ''): Manifest {
    256|   return JSON.parse(
    257|     fs.readFileSync(
       |        ^
    258|       path.join(testDir, 'dist', base, '.vite/manifest.json'),
    259|       'utf-8',
 ❯ playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts:27:27
```
https://github.com/vitejs/vite/actions/runs/30791262394/job/91892340367

This is probably happening because of https://github.com/rolldown/rolldown/issues/10613. Since `END` event happens for each output, the [`await notifyRebuildComplete(watcher)`](https://github.com/vitejs/vite/blob/35118e3640979263f97df269685d0ae94eb3c854/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts#L25) doesn't wait for the whole build completion.

