### PR TITLE
fix(optimizer): resolve pending discovered dep processing on close before init (fix #23143)

### DIFF
--- a/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
@@ -90,3 +90,70 @@ test('does not crash when a dep is discovered before the server starts listening
   await ssr.depsOptimizer?.scanProcessing
   expect(errors).toStrictEqual([])
 })
+
+// regression test for https://github.com/vitejs/vite/issues/23143
+// When a module importing a bare specifier is transformed through the JS API
+// before server.listen() is called, the dep is discovered and a pending warmup
+// request is issued for the optimized dep. That warmup waits on the dep's
+// processing promise, which is never resolved because depsOptimizer.init() has
+// not run. server.close() then waits forever for the pending warmup request.
+// The fix is for depsOptimizer.close() to resolve the processing promise so
+// in-flight requests can unblock during shutdown.
+test('resolves discovered dep processing promise on close before init', async () => {
+  const errors: string[] = []
+  const logger = createLogger('error')
+  logger.error = (msg) => {
+    errors.push(typeof msg === 'string' ? msg : String(msg))
+  }
+
+  server = await createServer({
+    configFile: false,
+    customLogger: logger,
+    root: path.join(
+      import.meta.dirname,
+      '../fixtures/optimizer-discover-before-listen',
+    ),
+    cacheDir: 'node_modules/.vite-client-close',
+    environments: {
+      client: {
+        dev: {
+          preTransformRequests: false,
+        },
+        optimizeDeps: {
+          // ensure no cached metadata/file is reused so the dep is discovered
+          // and its processing promise stays unresolved until close()
+          force: true,
+          noDiscovery: false,
+        },
+      },
+    },
+  })
+
+  const client = server.environments.client
+
+  // Transform a module importing a bare specifier before the server is listening.
+  // This discovers the dep and leaves its processing promise pending because
+  // depsOptimizer.init() is deferred to listen().
+  await client.transformRequest('/entry.js')
+
+  const info = client.depsOptimizer?.metadata.discovered?.vue
+  expect(info).toBeDefined()
+
+  // The dep's processing promise should still be pending at this point.
+  const resolvedBeforeClose = await Promise.race([
+    info!.processing,
+    setTimeout(500, false),
+  ])
+  expect(resolvedBeforeClose).toBe(false)
+
+  // close() should resolve the processing promise so any in-flight or future
+  // requests waiting on it (including server.close()) can unblock.
+  await client.depsOptimizer?.close()
+
+  const resolvedAfterClose = await Promise.race([
+    info!.processing,
+    setTimeout(500, false),
+  ])
+  expect(resolvedAfterClose).toBeUndefined()
+  expect(errors).toStrictEqual([])
+})

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -152,6 +152,15 @@ export function createDepsOptimizer(
       depsOptimizer.scanProcessing,
       optimizationResult?.cancel(),
     ])
+
+    // When a dependency is discovered before depsOptimizer.init() runs
+    // (e.g. a transform is requested through the JS API before listen()),
+    // depOptimizationProcessing.promise is never resolved because the
+    // optimizer never starts a run. Resolve it here so in-flight requests
+    // waiting on the dep's processing promise can unblock during close()
+    // instead of causing server.close() to hang forever.
+    depOptimizationProcessing.resolve()
+    resolveEnqueuedProcessingPromises()
   }
 
   let initState: 'idle' | 'initializing' | 'initialized' = 'idle'


### PR DESCRIPTION
### Description

When a dependency is discovered through the JS API before `depsOptimizer.init()` runs (i.e. before `server.listen()`), the dep's `processing` promise is never resolved because `registerMissingImport()` only starts an optimize run when `initState === 'initialized'`. Any in-flight request awaiting that processing promise then blocks `DevEnvironment.close()`'s pending-request loop, causing `server.close()` to hang forever.

This PR resolves the current `depOptimizationProcessing` promise and any queued processing promises in `depsOptimizer.close()`, mirroring the safety net already used in `runOptimizer()`'s closed branches. This unblocks in-flight requests during shutdown.

fixes #23143

### Alternatives

- We could also allow a run to start on close, but resolving the pending promises is a smaller, safer change that only affects the shutdown path.

### Test plan

- Added a regression test in `packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts` that discovers a dep before `init()` and asserts `depsOptimizer.close()` resolves its pending `processing` promise.
- `pnpm test-unit packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts` passes.
- `pnpm --filter=./packages/vite exec tsc -p src/node` passes.