### PR TITLE
fix(server): use a random port when port is 0

### DIFF
--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -296,4 +296,51 @@ describe('port detection', () => {
     expect(address).toStrictEqual(expect.objectContaining({ port: BASE_PORT }))
     expect(warnMessages).toContainEqual(expect.stringContaining('wildcard'))
   })
+
+  describe('port reuse on restart', () => {
+    test('reuses the OS-assigned port on restart when port is 0', async () => {
+      viteServer = await createServer({
+        root: import.meta.dirname,
+        optimizeDeps,
+        logLevel: 'silent',
+        server: { port: 0, ws: false },
+      })
+      await viteServer.listen()
+
+      const address = viteServer.httpServer!.address() as net.AddressInfo
+      const assignedPort = address.port
+
+      await viteServer.restart()
+
+      expect(viteServer.httpServer!.address()).toStrictEqual(
+        expect.objectContaining({ port: assignedPort }),
+      )
+    })
+
+    test('reuses the listened port when retrying after a failed listen', async () => {
+      await using blockingServer = await createSimpleServer(
+        BASE_PORT,
+        'localhost',
+      )
+
+      viteServer = await createServer({
+        root: import.meta.dirname,
+        optimizeDeps,
+        logLevel: 'silent',
+        server: { port: BASE_PORT, ws: false },
+      })
+      await viteServer.listen()
+
+      const address = viteServer.httpServer!.address() as net.AddressInfo
+      const assignedPort = address.port
+
+      await blockingServer[Symbol.asyncDispose]()
+
+      await viteServer.restart()
+
+      expect(viteServer.httpServer!.address()).toStrictEqual(
+        expect.objectContaining({ port: assignedPort }),
+      )
+    })
+  })
 })

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -48,38 +48,36 @@ describe('port detection', () => {
   }
 
   describe('port fallback', () => {
-    test.each([0, BASE_PORT])(
-      'uses the same port on every interface when port is %i',
-      async (configPort) => {
-        using listen = vi.spyOn(net.Server.prototype, 'listen')
+    test('uses the same ephemeral port on every interface', async () => {
+      using listen = vi.spyOn(net.Server.prototype, 'listen')
 
-        viteServer = await createServer({
-          root: import.meta.dirname,
-          optimizeDeps,
-          logLevel: 'silent',
-          server: { port: configPort, ws: false },
-        })
-        await viteServer.listen()
+      viteServer = await createServer({
+        root: import.meta.dirname,
+        optimizeDeps,
+        logLevel: 'silent',
+        server: { port: 0, ws: false },
+      })
+      await viteServer.listen()
 
-        const address = viteServer.httpServer!.address()
-        expect(address).toStrictEqual(
-          expect.objectContaining({ port: expect.any(Number) }),
-        )
-        const assignedPort = (address as net.AddressInfo).port
-        expect(viteServer._currentServerPort).toBe(assignedPort)
-        const [firstWildcardHost, ...remainingWildcardHosts] = wildcardHosts
-        expect(
-          listen.mock.calls.map(([port, host]) => ({ port, host })),
-        ).toStrictEqual([
-          { port: configPort, host: firstWildcardHost },
-          ...remainingWildcardHosts.map((host) => ({
-            port: assignedPort,
-            host,
-          })),
-          { port: assignedPort, host: 'localhost' },
-        ])
-      },
-    )
+      const address = viteServer.httpServer!.address()
+      expect(address).toStrictEqual(
+        expect.objectContaining({ port: expect.any(Number) }),
+      )
+      const assignedPort = (address as net.AddressInfo).port
+      expect(viteServer._currentServerPort).toBe(assignedPort)
+      const [firstWildcardHost, ...remainingWildcardHosts] = wildcardHosts
+      expect(
+        listen.mock.calls.map(([port, host]) => ({ port, host })),
+      ).toStrictEqual([
+        { port: 0, host: firstWildcardHost },
+        ...remainingWildcardHosts.map((host) => ({
+          port: assignedPort,
+          host,
+        })),
+        { port: assignedPort, host: 'localhost' }, // Check configured host
+        { port: assignedPort, host: 'localhost' }, // Bind HTTP server
+      ])
+    })
 
     test('detects port conflict', async () => {
       await using _blockingServer = await createSimpleServer(

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -60,8 +60,12 @@ describe('port detection', () => {
 
       const address = viteServer.httpServer!.address()
       expect(listen.mock.calls[0]?.[0]).toBe(0)
+      expect(address).toStrictEqual(
+        expect.objectContaining({ port: expect.any(Number) }),
+      )
       expect(viteServer._currentServerPort).toBe(
-        typeof address === 'object' && address ? address.port : undefined,
+        // already checked that address is an object with port
+        (address as net.AddressInfo).port,
       )
     })
 

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -48,6 +48,23 @@ describe('port detection', () => {
   }
 
   describe('port fallback', () => {
+    test('uses an OS-assigned port when port is 0', async () => {
+      viteServer = await createServer({
+        root: import.meta.dirname,
+        optimizeDeps,
+        logLevel: 'silent',
+        server: { port: 0, ws: false },
+      })
+      const listen = vi.spyOn(viteServer.httpServer!, 'listen')
+      await viteServer.listen()
+
+      const address = viteServer.httpServer!.address()
+      expect(listen.mock.calls[0]?.[0]).toBe(0)
+      expect(viteServer._currentServerPort).toBe(
+        typeof address === 'object' && address ? address.port : undefined,
+      )
+    })
+
     test('detects port conflict', async () => {
       await using _blockingServer = await createSimpleServer(
         BASE_PORT,

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -48,26 +48,38 @@ describe('port detection', () => {
   }
 
   describe('port fallback', () => {
-    test('uses an OS-assigned port when port is 0', async () => {
-      viteServer = await createServer({
-        root: import.meta.dirname,
-        optimizeDeps,
-        logLevel: 'silent',
-        server: { port: 0, ws: false },
-      })
-      const listen = vi.spyOn(viteServer.httpServer!, 'listen')
-      await viteServer.listen()
+    test.each([0, BASE_PORT])(
+      'uses the same port on every interface when port is %i',
+      async (configPort) => {
+        using listen = vi.spyOn(net.Server.prototype, 'listen')
 
-      const address = viteServer.httpServer!.address()
-      expect(listen.mock.calls[0]?.[0]).toBe(0)
-      expect(address).toStrictEqual(
-        expect.objectContaining({ port: expect.any(Number) }),
-      )
-      expect(viteServer._currentServerPort).toBe(
-        // already checked that address is an object with port
-        (address as net.AddressInfo).port,
-      )
-    })
+        viteServer = await createServer({
+          root: import.meta.dirname,
+          optimizeDeps,
+          logLevel: 'silent',
+          server: { port: configPort, ws: false },
+        })
+        await viteServer.listen()
+
+        const address = viteServer.httpServer!.address()
+        expect(address).toStrictEqual(
+          expect.objectContaining({ port: expect.any(Number) }),
+        )
+        const assignedPort = (address as net.AddressInfo).port
+        expect(viteServer._currentServerPort).toBe(assignedPort)
+        const [firstWildcardHost, ...remainingWildcardHosts] = wildcardHosts
+        expect(
+          listen.mock.calls.map(([port, host]) => ({ port, host })),
+        ).toStrictEqual([
+          { port: configPort, host: firstWildcardHost },
+          ...remainingWildcardHosts.map((host) => ({
+            port: assignedPort,
+            host,
+          })),
+          { port: assignedPort, host: 'localhost' },
+        ])
+      },
+    )
 
     test('detects port conflict', async () => {
       await using _blockingServer = await createSimpleServer(

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -166,12 +166,15 @@ async function readFileIfExists(value?: string | Buffer | any[]) {
 
 // Let the OS select an ephemeral port on the first wildcard interface, then
 // verify that same concrete port is available on every remaining interface.
-async function getAvailableEphemeralPort(): Promise<number | null> {
+async function getAvailableEphemeralPort(
+  specifiedHost?: string,
+): Promise<number | null> {
   for (let attempt = 0; attempt < 3; attempt++) {
     // Passing 0 asks the OS for a new candidate on every attempt.
     let port = 0
     let available = true
-    for (const host of wildcardHosts) {
+    for (const host of [...wildcardHosts, specifiedHost]) {
+      if (typeof host !== 'string') continue
       // Gracefully handle errors (e.g., IPv6 disabled on the system)
       const availablePort = await tryListen(port, host).catch(() => port)
       if (availablePort == null) {
@@ -256,7 +259,7 @@ export async function httpServerStart(
   const { port: startPort, strictPort, host, logger } = serverOptions
 
   if (startPort === 0) {
-    const port = await getAvailableEphemeralPort()
+    const port = await getAvailableEphemeralPort(host)
     if (port == null) {
       throw new Error('No available ephemeral port found')
     }

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -167,7 +167,7 @@ async function readFileIfExists(value?: string | Buffer | any[]) {
 // Let the OS select an ephemeral port on the first wildcard interface, then
 // verify that same concrete port is available on every remaining interface.
 async function getAvailableEphemeralPort(
-  specifiedHost?: string,
+  specifiedHost: string | undefined,
 ): Promise<number | null> {
   for (let attempt = 0; attempt < 3; attempt++) {
     // Passing 0 asks the OS for a new candidate on every attempt.
@@ -176,7 +176,6 @@ async function getAvailableEphemeralPort(
     let port = 0
     let available = true
     for (const host of [...wildcardHosts, specifiedHost]) {
-      if (typeof host !== 'string') continue
       // Gracefully handle errors (e.g., IPv6 disabled on the system)
       const availablePort = await tryListen(port, host).catch(() => port)
       if (availablePort == null) {
@@ -200,7 +199,10 @@ async function isPortAvailable(port: number): Promise<boolean> {
   return true
 }
 
-function tryListen(port: number, host: string): Promise<number | null> {
+function tryListen(
+  port: number,
+  host: string | undefined,
+): Promise<number | null> {
   return new Promise((resolve) => {
     const server = net.createServer()
     server.once('error', (e: NodeJS.ErrnoException) => {

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -171,6 +171,8 @@ async function getAvailableEphemeralPort(
 ): Promise<number | null> {
   for (let attempt = 0; attempt < 3; attempt++) {
     // Passing 0 asks the OS for a new candidate on every attempt.
+    // We assume that the OS will return a different candidate on every attempt,
+    // which does not always hold true, but it should be fine for most cases.
     let port = 0
     let available = true
     for (const host of [...wildcardHosts, specifiedHost]) {
@@ -271,6 +273,7 @@ export async function httpServerStart(
     if (result.error.code !== 'EADDRINUSE') {
       throw result.error
     }
+    // this can happen if the port was listened by other process between getAvailableEphemeralPort and tryBindServer
     throw new Error(`Port ${port} is already in use`)
   }
 

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -192,7 +192,8 @@ async function tryBindServer(
   port: number,
   host: string | undefined,
 ): Promise<
-  { success: true } | { success: false; error: NodeJS.ErrnoException }
+  | { success: true; port: number }
+  | { success: false; error: NodeJS.ErrnoException }
 > {
   return new Promise((resolve) => {
     const onError = (e: NodeJS.ErrnoException) => {
@@ -203,7 +204,11 @@ async function tryBindServer(
     const onListening = () => {
       httpServer.off('error', onError)
       httpServer.off('listening', onListening)
-      resolve({ success: true })
+      const address = httpServer.address()
+      resolve({
+        success: true,
+        port: typeof address === 'object' && address ? address.port : port,
+      })
     }
 
     httpServer.on('error', onError)
@@ -244,7 +249,7 @@ export async function httpServerStart(
             ),
           )
         }
-        return port
+        return result.port
       }
       if (result.error.code !== 'EADDRINUSE') {
         throw result.error
@@ -255,7 +260,7 @@ export async function httpServerStart(
     if (portAvailableOnWildcard) {
       const result = await tryBindServer(httpServer, port, host)
       if (result.success) {
-        return port
+        return result.port
       }
       if (result.error.code !== 'EADDRINUSE') {
         throw result.error

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -164,6 +164,27 @@ async function readFileIfExists(value?: string | Buffer | any[]) {
   return value
 }
 
+// Let the OS select an ephemeral port on the first wildcard interface, then
+// verify that same concrete port is available on every remaining interface.
+async function getAvailableEphemeralPort(): Promise<number | null> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    // Passing 0 asks the OS for a new candidate on every attempt.
+    let port = 0
+    let available = true
+    for (const host of wildcardHosts) {
+      // Gracefully handle errors (e.g., IPv6 disabled on the system)
+      const availablePort = await tryListen(port, host).catch(() => port)
+      if (availablePort == null) {
+        available = false
+        break
+      }
+      port = availablePort
+    }
+    if (available) return port
+  }
+  return null
+}
+
 // Check if a port is available on wildcard addresses (0.0.0.0, ::)
 async function isPortAvailable(port: number): Promise<boolean> {
   for (const host of wildcardHosts) {
@@ -174,14 +195,17 @@ async function isPortAvailable(port: number): Promise<boolean> {
   return true
 }
 
-function tryListen(port: number, host: string): Promise<boolean> {
+function tryListen(port: number, host: string): Promise<number | null> {
   return new Promise((resolve) => {
     const server = net.createServer()
     server.once('error', (e: NodeJS.ErrnoException) => {
-      server.close(() => resolve(e.code !== 'EADDRINUSE'))
+      server.close(() => resolve(e.code === 'EADDRINUSE' ? null : port))
     })
     server.once('listening', () => {
-      server.close(() => resolve(true))
+      const address = server.address()
+      server.close(() =>
+        resolve(typeof address === 'object' && address ? address.port : port),
+      )
     })
     server.listen(port, host)
   })
@@ -230,6 +254,22 @@ export async function httpServerStart(
   },
 ): Promise<number> {
   const { port: startPort, strictPort, host, logger } = serverOptions
+
+  if (startPort === 0) {
+    const port = await getAvailableEphemeralPort()
+    if (port == null) {
+      throw new Error('No available ephemeral port found')
+    }
+
+    const result = await tryBindServer(httpServer, port, host)
+    if (result.success) {
+      return result.port
+    }
+    if (result.error.code !== 'EADDRINUSE') {
+      throw result.error
+    }
+    throw new Error(`Port ${port} is already in use`)
+  }
 
   for (let port = startPort; port <= MAX_PORT; port++) {
     // Pre-check port availability on wildcard addresses (0.0.0.0, ::)

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -223,8 +223,7 @@ async function tryBindServer(
   port: number,
   host: string | undefined,
 ): Promise<
-  | { success: true; port: number }
-  | { success: false; error: NodeJS.ErrnoException }
+  { success: true } | { success: false; error: NodeJS.ErrnoException }
 > {
   return new Promise((resolve) => {
     const onError = (e: NodeJS.ErrnoException) => {
@@ -235,11 +234,7 @@ async function tryBindServer(
     const onListening = () => {
       httpServer.off('error', onError)
       httpServer.off('listening', onListening)
-      const address = httpServer.address()
-      resolve({
-        success: true,
-        port: typeof address === 'object' && address ? address.port : port,
-      })
+      resolve({ success: true })
     }
 
     httpServer.on('error', onError)
@@ -270,7 +265,7 @@ export async function httpServerStart(
 
     const result = await tryBindServer(httpServer, port, host)
     if (result.success) {
-      return result.port
+      return port
     }
     if (result.error.code !== 'EADDRINUSE') {
       throw result.error
@@ -297,7 +292,7 @@ export async function httpServerStart(
             ),
           )
         }
-        return result.port
+        return port
       }
       if (result.error.code !== 'EADDRINUSE') {
         throw result.error
@@ -308,7 +303,7 @@ export async function httpServerStart(
     if (portAvailableOnWildcard) {
       const result = await tryBindServer(httpServer, port, host)
       if (result.success) {
-        return result.port
+        return port
       }
       if (result.error.code !== 'EADDRINUSE') {
         throw result.error

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1110,11 +1110,11 @@ async function startServer(
   const configPort = inlinePort ?? options.port
   // When using non strict port for the dev server, the running port can be different from the config one.
   // When restarting, the original port may be available but to avoid a switch of URL for the running
-  // browser tabs, we enforce the previously used port, expect if the config port changed.
+  // browser tabs, we enforce the previously used port, except if the config port changed.
   const port =
-    (typeof configPort !== 'number' || configPort === server._configServerPort
-      ? server._currentServerPort
-      : configPort) ?? DEFAULT_DEV_PORT
+    configPort === server._configServerPort
+      ? (server._currentServerPort ?? configPort)
+      : configPort
   server._configServerPort = configPort
 
   const serverPort = await httpServerStart(httpServer, {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1112,7 +1112,7 @@ async function startServer(
   // When restarting, the original port may be available but to avoid a switch of URL for the running
   // browser tabs, we enforce the previously used port, expect if the config port changed.
   const port =
-    (!configPort || configPort === server._configServerPort
+    (typeof configPort !== 'number' || configPort === server._configServerPort
       ? server._currentServerPort
       : configPort) ?? DEFAULT_DEV_PORT
   server._configServerPort = configPort


### PR DESCRIPTION
fixes this #7529 bug again
I recently had a use case for assigning `server.port = 0` and read back the assigned port for use
but looks like doing that would cause it trigger `!configPort` and vite would use the default port
fixed by making it explicitly `typeof configPort !== 'number'`

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
