### PR TITLE
fix(bundled-dev): recover when HMR messages are dropped (fix #23162)

### DIFF
--- a/packages/vite/src/client/__tests__/bundledDevHmrClient.spec.ts
+++ b/packages/vite/src/client/__tests__/bundledDevHmrClient.spec.ts
@@ -20,6 +20,7 @@ function createClient(options?: {
       sent.push(payload)
       options?.send?.(payload)
     },
+    invoke: async () => undefined as never,
   }
   const runtime: RolldownRuntimeLike = {
     getImporters: () => [],

--- a/packages/vite/src/client/__tests__/bundledDevHmrClient.spec.ts
+++ b/packages/vite/src/client/__tests__/bundledDevHmrClient.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { BundledDevUpdatePayload } from '#types/hmrPayload'
+import {
+  BundledDevHMRClient,
+  type RolldownRuntimeLike,
+} from '../bundledDevHmrClient'
+import type { NormalizedModuleRunnerTransport } from '../../shared/moduleRunnerTransport'
+
+function createClient(options?: {
+  reloadAckTimeoutMs?: number
+  reloadPage?: () => void
+  send?: (payload: unknown) => void
+}) {
+  const sent: unknown[] = []
+  const reloadPage = options?.reloadPage ?? vi.fn()
+  const transport: NormalizedModuleRunnerTransport = {
+    connect: async () => {},
+    disconnect: async () => {},
+    send: async (payload) => {
+      sent.push(payload)
+      options?.send?.(payload)
+    },
+  }
+  const runtime: RolldownRuntimeLike = {
+    getImporters: () => [],
+    isExecuted: () => false,
+    hasFactory: () => false,
+    removeModuleCache: () => {},
+    initModule: () => {},
+    loadExports: () => ({}),
+  }
+  const client = new BundledDevHMRClient(
+    { error: () => {}, debug: () => {} },
+    transport,
+    runtime,
+    {
+      base: '/',
+      beforeApply: () => 'continue',
+      reloadAckTimeoutMs: options?.reloadAckTimeoutMs ?? 50,
+      reloadPage,
+    },
+  )
+  return { client, sent, reloadPage }
+}
+
+function push(
+  client: BundledDevHMRClient,
+  seq: number,
+  url = `hmr_patch_${seq}.js`,
+): Promise<void> {
+  const payload: BundledDevUpdatePayload = {
+    type: 'bundled-dev-update',
+    changedIds: [],
+    url,
+    seq,
+  }
+  client.handlePush(payload)
+  // flush the internal apply queue
+  return (client as any).applyQueue as Promise<void>
+}
+
+describe('BundledDevHMRClient reload recovery', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('falls back to page reload if full-reload reply times out', async () => {
+    vi.useFakeTimers()
+    const { client, sent, reloadPage } = createClient({
+      reloadAckTimeoutMs: 50,
+    })
+
+    await push(client, 1)
+    await push(client, 3) // sequence gap → requestFullReload
+
+    expect(sent).toContainEqual({
+      type: 'custom',
+      event: 'vite:bundled-dev:reload-needed',
+      data: {
+        reason: 'hmr update sequence gap (expected 2, got 3)',
+      },
+    })
+    expect(reloadPage).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(reloadPage).toHaveBeenCalledTimes(1)
+  })
+
+  test('acknowledgeFullReload cancels the timeout', async () => {
+    vi.useFakeTimers()
+    const { client, reloadPage } = createClient({ reloadAckTimeoutMs: 50 })
+
+    await push(client, 1)
+    await push(client, 3)
+    client.acknowledgeFullReload()
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(reloadPage).not.toHaveBeenCalled()
+  })
+
+  test('a later update while reload is pending re-requests a full reload', async () => {
+    vi.useFakeTimers()
+    const { client, sent, reloadPage } = createClient({
+      reloadAckTimeoutMs: 5_000,
+    })
+
+    await push(client, 1)
+    await push(client, 3) // pending reload
+    expect(reloadPage).not.toHaveBeenCalled()
+    const sentAfterFirstRequest = sent.length
+
+    await push(client, 4) // later update while sticky flag is set
+    expect(reloadPage).not.toHaveBeenCalled()
+    expect(sent.length).toBeGreaterThan(sentAfterFirstRequest)
+    expect(sent.at(-1)).toMatchObject({
+      type: 'custom',
+      event: 'vite:bundled-dev:reload-needed',
+    })
+  })
+})

--- a/packages/vite/src/client/bundledDevHmrClient.ts
+++ b/packages/vite/src/client/bundledDevHmrClient.ts
@@ -30,12 +30,23 @@ export interface BundledDevHMRClientOptions {
   base: string
   /** returning `'reload'` aborts the apply — the hook reloads the page itself */
   beforeApply: () => 'reload' | 'continue'
+  /**
+   * How long to wait for a `full-reload` after requesting one before falling
+   * back to `location.reload()`. Override in tests.
+   */
+  reloadAckTimeoutMs?: number
+  /** Invoked when the client falls back to reloading the page itself. */
+  reloadPage?: () => void
 }
+
+/** default wait for the server's `full-reload` reply after `reload-needed` */
+export const DEFAULT_RELOAD_ACK_TIMEOUT_MS = 8_000
 
 export class BundledDevHMRClient extends HMRClient {
   private applyQueue = Promise.resolve()
   private lastSeq = 0
   private reloadPending = false
+  private reloadAckTimeout: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     logger: HMRLogger,
@@ -173,7 +184,15 @@ export class BundledDevHMRClient extends HMRClient {
     url,
     seq,
   }: BundledDevUpdatePayload): Promise<void> {
-    if (this.reloadPending) return
+    // A later update while waiting for `full-reload` means the reply was lost.
+    // Re-request a server-driven reload instead of navigating blindly (the
+    // in-memory bundle may still be stale until `ensureLatestBuildOutput`).
+    if (this.reloadPending) {
+      this.rerequestFullReload(
+        'received hmr update while full reload was pending (reply likely lost)',
+      )
+      return
+    }
     if (seq !== this.lastSeq + 1) {
       this.requestFullReload(
         `hmr update sequence gap (expected ${this.lastSeq + 1}, got ${seq})`,
@@ -205,7 +224,12 @@ export class BundledDevHMRClient extends HMRClient {
   }
 
   private async applyInvalidate(id: string): Promise<void> {
-    if (this.reloadPending) return
+    if (this.reloadPending) {
+      this.rerequestFullReload(
+        'received invalidate while full reload was pending (reply likely lost)',
+      )
+      return
+    }
     const firstInvalidatedBy = this.currentFirstInvalidatedBy ?? id
     const importers = this.runtime
       .getImporters(id)
@@ -300,12 +324,46 @@ export class BundledDevHMRClient extends HMRClient {
   private requestFullReload(reason: string): void {
     if (this.reloadPending) return
     this.reloadPending = true
+    // Visible at Chrome's default console level (unlike `debug`).
+    console.info(`[vite] full reload needed: ${reason}`)
     this.logger.debug(`full reload needed: ${reason}`)
     this.send({
       type: 'custom',
       event: 'vite:bundled-dev:reload-needed',
       data: { reason },
     })
+    const timeoutMs =
+      this.options.reloadAckTimeoutMs ?? DEFAULT_RELOAD_ACK_TIMEOUT_MS
+    this.reloadAckTimeout = setTimeout(() => {
+      this.reloadAckTimeout = null
+      this.fallbackReload(
+        `full reload reply timed out after ${timeoutMs}ms (${reason})`,
+      )
+    }, timeoutMs)
+  }
+
+  /**
+   * Called when the server's `full-reload` message arrives so the client stops
+   * waiting and does not fall back to a second navigation.
+   */
+  acknowledgeFullReload(): void {
+    if (this.reloadAckTimeout != null) {
+      clearTimeout(this.reloadAckTimeout)
+      this.reloadAckTimeout = null
+    }
+  }
+
+  private rerequestFullReload(reason: string): void {
+    this.acknowledgeFullReload()
+    this.reloadPending = false
+    console.warn(`[vite] ${reason}; re-requesting full reload`)
+    this.requestFullReload(reason)
+  }
+
+  private fallbackReload(reason: string): void {
+    this.acknowledgeFullReload()
+    console.warn(`[vite] ${reason}; reloading page`)
+    ;(this.options.reloadPage ?? (() => location.reload()))()
   }
 }
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -287,6 +287,8 @@ async function handleMessage(payload: HotPayload) {
       ) {
         break
       }
+      // Cancel the client's reload-needed timeout so we don't navigate twice.
+      bundledDevClient?.acknowledgeFullReload()
       await activeHmrClient.notifyListeners('vite:beforeFullReload', payload)
       if (hasDocument) {
         if (payload.path && payload.path.endsWith('.html')) {

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -105,6 +105,15 @@ export class BundledDev {
   }
 
   private pendingPayloadFilenames = new Set<string>()
+  /** client that was sent each still-pending HMR patch (for delivery timeout) */
+  private pendingPayloadClients = new Map<string, NormalizedHotChannelClient>()
+  private pendingPayloadTimers = new Map<
+    string,
+    ReturnType<typeof globalThis.setTimeout>
+  >()
+
+  /** How long an HMR patch may remain unfetched before we force a full reload. */
+  static payloadDeliveryTimeoutMs = 3_000
 
   get hasBuildOutput(): boolean {
     return (
@@ -150,6 +159,7 @@ export class BundledDev {
       }
     })
     this.environment.hot.on('vite:client:disconnect', (_payload, client) => {
+      this.clearPendingPayloadsForClient(client)
       const clientId = this.clients.delete(client)
       if (clientId) {
         this.devEngine.removeClient(clientId)
@@ -160,7 +170,29 @@ export class BundledDev {
       'vite:bundled-dev:reload-needed',
       (payload, client) => {
         const clientId = this.clients.getId(client)
-        if (!clientId) return
+        // Registration happens on `vite:client-connected`. A client that asks
+        // during reconnect may not be in the map yet — still honor the request
+        // via the socket we already have instead of silently dropping it.
+        if (!clientId) {
+          debug?.(
+            `TRIGGER: unregistered client requested a page reload (${payload.reason}); responding via socket`,
+          )
+          this.environment.logger.info(
+            colors.green(`bundling for page reload `) +
+              colors.dim(payload.reason),
+            { clear: true, timestamp: true },
+          )
+          this.devEngine.ensureLatestBuildOutput().then(
+            () => {
+              client.send({ type: 'full-reload', path: '*' })
+              this.environment.logger.info(colors.green(`page reload`), {
+                timestamp: true,
+              })
+            },
+            () => {},
+          )
+          return
+        }
         debug?.(
           `TRIGGER: client ${clientId} requested a page reload (${payload.reason})`,
         )
@@ -353,6 +385,8 @@ export class BundledDev {
    * Note: the payload filename is unique across all clients.
    */
   markPayloadDelivered(filename: string): void {
+    this.clearPayloadDeliveryTimer(filename)
+    this.pendingPayloadClients.delete(filename)
     if (this.pendingPayloadFilenames.delete(filename)) {
       this.devEngine.notifyPayloadDelivered(filename)
     }
@@ -360,9 +394,75 @@ export class BundledDev {
 
   async close(): Promise<void> {
     this._closed = true
+    for (const timer of this.pendingPayloadTimers.values()) {
+      globalThis.clearTimeout(timer)
+    }
+    this.pendingPayloadTimers.clear()
+    this.pendingPayloadClients.clear()
+    this.pendingPayloadFilenames.clear()
     this.memoryFiles.clear()
     await this._devEngine?.close()
     this.initialBuildCompleted = false
+  }
+
+  private trackPendingHmrPayload(
+    filename: string,
+    client: NormalizedHotChannelClient,
+  ): void {
+    this.pendingPayloadFilenames.add(filename)
+    this.clearPayloadDeliveryTimer(filename)
+    this.pendingPayloadClients.set(filename, client)
+    this.pendingPayloadTimers.set(
+      filename,
+      globalThis.setTimeout(() => {
+        this.pendingPayloadTimers.delete(filename)
+        this.pendingPayloadClients.delete(filename)
+        if (!this.pendingPayloadFilenames.has(filename) || this._closed) {
+          return
+        }
+        // Abandon the undelivered patch: the client will load a fresh bundle.
+        this.pendingPayloadFilenames.delete(filename)
+        this.devEngine.notifyPayloadDelivered(filename)
+        debug?.(
+          `payload ${filename} was not delivered within ${BundledDev.payloadDeliveryTimeoutMs}ms; forcing full reload`,
+        )
+        this.devEngine.ensureLatestBuildOutput().then(
+          () => {
+            if (this._closed) return
+            client.send({ type: 'full-reload', path: '*' })
+            this.environment.logger.info(
+              colors.green(`page reload `) +
+                colors.dim(`(hmr patch not delivered: ${filename})`),
+              { timestamp: true },
+            )
+          },
+          () => {},
+        )
+      }, BundledDev.payloadDeliveryTimeoutMs),
+    )
+  }
+
+  private clearPayloadDeliveryTimer(filename: string): void {
+    const timer = this.pendingPayloadTimers.get(filename)
+    if (timer != null) {
+      globalThis.clearTimeout(timer)
+      this.pendingPayloadTimers.delete(filename)
+    }
+  }
+
+  private clearPendingPayloadsForClient(
+    client: NormalizedHotChannelClient,
+  ): void {
+    for (const [filename, pendingClient] of this.pendingPayloadClients) {
+      if (pendingClient !== client) continue
+      this.clearPayloadDeliveryTimer(filename)
+      this.pendingPayloadClients.delete(filename)
+      // Client is gone (reload or disconnect). Abandon the patch so a stale
+      // undelivered payload does not force another reload on the next session.
+      if (this.pendingPayloadFilenames.delete(filename)) {
+        this.devEngine.notifyPayloadDelivered(filename)
+      }
+    }
   }
 
   private storeOutputFiles(output: RolldownOutput['output'][number][]): void {
@@ -464,7 +564,7 @@ export class BundledDev {
       code: typeof hmrOutput.code === 'string' ? '[code]' : hmrOutput.code,
     })
 
-    this.pendingPayloadFilenames.add(hmrOutput.filename)
+    this.trackPendingHmrPayload(hmrOutput.filename, client)
     this.memoryFiles.set(hmrOutput.filename, {
       // ensure that the generated hmr patch contains ESM syntax
       // this is to avoid attacks like GHSA-4v9v-hfq4-rm2v


### PR DESCRIPTION
## Summary

- Fixes [#23162](https://github.com/vitejs/vite/issues/23162): in `experimental.bundledDev`, a dropped HMR patch or `full-reload` reply could leave the page silently stale with no recovery path.
- **Lost patch:** the server tracks pending HMR payload delivery and forces a full reload if the patch is not fetched within 3s.
- **Lost reload reply:** the client times out waiting for `full-reload` (8s) and falls back to `location.reload()`; a later update while reload is pending re-requests a server-driven reload instead of staying stuck behind the sticky `reloadPending` flag.
- **Unregistered client:** `vite:bundled-dev:reload-needed` is no longer silently dropped when the client is not yet in the registry — the server responds via the existing socket.
- Raises the "full reload needed" client log above `debug` so it is visible at Chrome's default console level.

## Test plan

- [x] Reproduced both failure modes from https://github.com/jamie-retool/vite-bundleddev-hmr-repro against local Vite before the fix (`VERSION-1` stuck).
- [x] Confirmed both modes recover to `VERSION-2` after the fix (single navigation).
- [x] `pnpm run test-unit bundledDevHmrClient`
- [x] `pnpm run test-serve hmr-full-bundle-mode`