### PR TITLE
feat: partial support for CSS sourcemaps in build

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -1,16 +1,18 @@
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import type { InternalModuleFormat } from 'rolldown'
+import { TraceMap, decodedMappings } from '@jridgewell/trace-mapping'
 import MagicString from 'magic-string'
 import { resolveConfig } from '../../config'
 import type { InlineConfig } from '../../config'
 import {
   convertTargets,
+  concatWithSourcemaps,
   createCSSResolvers,
   cssPlugin,
   cssUrlRE,
   getEmptyChunkReplacer,
-  hoistAtRules,
+  hoistAtRules as hoistAtRulesMagicString,
   injectInlinedCSS,
   preprocessCSS,
   resolveLibCssFilename,
@@ -19,6 +21,10 @@ import { PartialEnvironment } from '../../baseEnvironment'
 import { normalizePath } from '../../utils'
 
 const dirname = import.meta.dirname
+
+function hoistAtRules(css: string): string {
+  return hoistAtRulesMagicString(css).toString()
+}
 
 describe('search css url function', () => {
   test('some spaces before it', () => {
@@ -394,6 +400,20 @@ describe('preprocessCSS', () => {
         background: url(./foo.png);
       }"
     `)
+  })
+
+  test('returns null map when sourcemaps are enabled and no transform happened', async () => {
+    const resolvedConfig = await resolveConfig(
+      { configFile: false, build: { sourcemap: true } },
+      'build',
+    )
+    const result = await preprocessCSS(
+      '.foo { color: red; }',
+      'foo.css',
+      resolvedConfig,
+    )
+
+    expect(result.map).toBeNull()
   })
 
   test('works with lightningcss', async () => {
@@ -870,4 +890,131 @@ console.log("foo");`,
       injectCSS();"
     `)
   })
+})
+
+test('concatenates code and offsets sourcemaps', () => {
+  const result = concatWithSourcemaps([
+    {
+      code: 'a{}',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['a.css'],
+        sourcesContent: ['a{}'],
+        mappings: 'AAAA',
+      },
+    },
+    {
+      code: 'b{}\n',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['b.css', 'unused.css'],
+        sourcesContent: ['b{}'],
+        mappings: 'AAAA',
+      },
+    },
+    {
+      code: 'c{}',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['c.css'],
+        sourcesContent: ['c{}'],
+        mappings: 'AAAA',
+      },
+    },
+  ])
+
+  expect(result.code).toBe('a{}b{}\nc{}')
+  expect(result.map!.sources).toStrictEqual([
+    'a.css',
+    'b.css',
+    'unused.css',
+    'c.css',
+  ])
+  expect(result.map!.sourcesContent).toStrictEqual(['a{}', 'b{}', null, 'c{}'])
+  expect(decodedMappings(new TraceMap(result.map! as any))).toStrictEqual([
+    [
+      [0, 0, 0, 0],
+      [3, 1, 0, 0],
+    ],
+    [[0, 3, 0, 0]],
+  ])
+})
+
+test('concatenates code with optional sourcemaps', () => {
+  const result = concatWithSourcemaps([
+    { code: 'a{}' },
+    {
+      code: 'b{}',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['b.css'],
+        sourcesContent: ['b{}'],
+        mappings: 'AAAA',
+      },
+    },
+  ])
+
+  expect(result.code).toBe('a{}b{}')
+  expect(decodedMappings(new TraceMap(result.map! as any))).toStrictEqual([
+    [[3, 0, 0, 0]],
+  ])
+  expect(concatWithSourcemaps([{ code: 'a{}' }]).map).toBeUndefined()
+})
+
+test('handles sources shared by multiple input maps', () => {
+  const result = concatWithSourcemaps([
+    {
+      code: 'a{}\n',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['shared.css'],
+        sourcesContent: ['a{}\nb{}'],
+        mappings: 'AAAA',
+      },
+    },
+    {
+      code: 'b{}',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['shared.css'],
+        sourcesContent: ['a{}\nb{}'],
+        mappings: 'AACA',
+      },
+    },
+  ])
+
+  expect(result.map!.sources).toStrictEqual(['shared.css', 'shared.css'])
+  expect(result.map!.sourcesContent).toStrictEqual(['a{}\nb{}', 'a{}\nb{}'])
+  expect(decodedMappings(new TraceMap(result.map! as any))).toStrictEqual([
+    [[0, 0, 0, 0]],
+    [[0, 1, 1, 0]],
+  ])
+})
+
+test('offsets a sourcemap after unmapped multiline code', () => {
+  const result = concatWithSourcemaps([
+    { code: 'a\nbc' },
+    {
+      code: 'd{}',
+      map: {
+        version: 3,
+        names: [],
+        sources: ['d.css'],
+        sourcesContent: ['d{}'],
+        mappings: 'AAAA',
+      },
+    },
+  ])
+
+  expect(result.code).toBe('a\nbcd{}')
+  expect(decodedMappings(new TraceMap(result.map! as any))).toStrictEqual([
+    [],
+    [[2, 0, 0, 0]],
+  ])
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -12,8 +12,10 @@ import type {
   RenderedChunk,
   RenderedModule,
   RollupError,
+  SourceMap,
   SourceMapInput,
 } from 'rolldown'
+import { FlattenMap, encodedMap, type Section } from '@jridgewell/trace-mapping'
 import { dataToEsm } from '@rollup/pluginutils'
 import colors from 'picocolors'
 import MagicString from 'magic-string'
@@ -21,7 +23,7 @@ import type * as PostCSS from 'postcss'
 import type Sass from 'sass'
 import type Stylus from 'stylus'
 import type Less from 'less'
-import type { RawSourceMap } from '@jridgewell/remapping'
+import type { EncodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
 import { WorkerWithFallback } from 'artichokie'
 import { globSync } from 'tinyglobby'
 import type {
@@ -477,12 +479,13 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
  */
 export function cssPostPlugin(config: ResolvedConfig): Plugin {
   // styles initialization in buildStart causes a styling loss in watch
-  const styles = new Map<string, string>()
+  const styles = new Map<string, { code: string; map?: ExistingRawSourceMap }>()
   // queue to emit css serially to guarantee the files are emitted in a deterministic order
-  let codeSplitEmitQueue = createSerialPromiseQueue<string>()
+  let codeSplitEmitQueue = createSerialPromiseQueue<FinalizeCssResult>()
   const urlEmitQueue = createSerialPromiseQueue<unknown>()
   let pureCssChunks: Set<RenderedChunk>
   let chunkCssReferences: Map<string, string>
+  let chunkCssMaps: Map<string, ExistingRawSourceMap>
 
   // when there are multiple rollup outputs and extracting CSS, only emit once,
   // since output formats have no effect on the generated CSS.
@@ -540,6 +543,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       // Ensure new caches for every build (i.e. rebuilding in watch mode)
       pureCssChunks = new Set<RenderedChunk>()
       chunkCssReferences = new Map<string, string>()
+      chunkCssMaps = new Map<string, ExistingRawSourceMap>()
       hasEmitted = false
       chunkCSSMap = new Map()
       codeSplitEmitQueue = createSerialPromiseQueue()
@@ -636,7 +640,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         // record css
         if (!inlined) {
-          styles.set(id, css)
+          let sourcemap: ExistingRawSourceMap | undefined
+          if (this.environment.config.build.sourcemap) {
+            sourcemap = this.getCombinedSourcemap() as ExistingRawSourceMap
+          }
+          styles.set(id, {
+            code: css,
+            map: sourcemap,
+          })
         }
 
         let code: string
@@ -645,7 +656,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else if (inlined) {
           let content = css
           if (config.build.cssMinify) {
-            content = await minifyCSS(content, config, true, id)
+            content = (await minifyCSS(content, config, true, id)).code
           }
           code = `export default ${JSON.stringify(content)}`
         } else {
@@ -668,6 +679,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       ? {
           async renderChunk(code, chunk, opts, meta) {
             let chunkCSS: string | undefined
+            let chunkSourcemap: ExistingRawSourceMap | undefined
+            const chunkSources: Array<{
+              code: string
+              map?: ExistingRawSourceMap
+            }> = []
             const renderedModules = new Proxy(
               {} as Record<string, RenderedModule | undefined>,
               {
@@ -709,7 +725,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   isPureCssChunk = false
                 }
 
-                chunkCSS = (chunkCSS || '') + styles.get(id)
+                chunkSources.push(styles.get(id)!)
               } else if (!isJsChunkEmpty) {
                 // if the module does not have a style, then it's not a pure css chunk.
                 // this is true because in the `transform` hook above, only modules
@@ -725,7 +741,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               chunkCSS: string,
               cssAssetName: string,
               originalFileName?: string,
-            ) => {
+            ): { code: string; map?: ExistingRawSourceMap } => {
+              const s = new MagicString(chunkCSS)
               const encodedPublicUrls = encodePublicUrlsInCSS(config)
 
               const relative = config.base === './' || config.base === ''
@@ -745,29 +762,26 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               }
 
               // replace asset url references with resolved url.
-              chunkCSS = chunkCSS.replace(
-                assetUrlRE,
-                (_, fileHash, postfix = '') => {
-                  const filename = this.getFileName(fileHash) + postfix
-                  chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
-                  return encodeURIPath(
-                    toOutputFilePathInCss(
-                      filename,
-                      'asset',
-                      cssAssetName,
-                      'css',
-                      config,
-                      toRelative,
-                    ),
-                  )
-                },
-              )
+              s.replace(assetUrlRE, (_, fileHash, postfix = '') => {
+                const filename = this.getFileName(fileHash) + postfix
+                chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
+                return encodeURIPath(
+                  toOutputFilePathInCss(
+                    filename,
+                    'asset',
+                    cssAssetName,
+                    'css',
+                    config,
+                    toRelative,
+                  ),
+                )
+              })
               // resolve public URL from CSS paths
               if (encodedPublicUrls) {
                 const relativePathToPublicFromCSS = normalizePath(
                   path.relative(cssAssetDirname!, ''),
                 )
-                chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
+                s.replace(publicAssetUrlRE, (_, hash) => {
                   const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)
                   return encodeURIPath(
                     toOutputFilePathInCss(
@@ -781,7 +795,16 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   )
                 })
               }
-              return chunkCSS
+              const code = s.toString()
+              const map =
+                this.environment.config.build.sourcemap && s.hasChanged()
+                  ? (s.generateMap({
+                      source: cssAssetName,
+                      includeContent: true,
+                      hires: 'boundary',
+                    }) as ExistingRawSourceMap)
+                  : undefined
+              return { code, map }
             }
 
             function ensureFileExt(name: string, ext: string) {
@@ -816,13 +839,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   )
                 }
 
-                let cssContent = styles.get(id)!
+                let cssContent = styles.get(id)!.code
 
                 cssContent = resolveAssetUrlsInCss(
                   cssContent,
                   cssAssetName,
                   originalFileName,
-                )
+                ).code
 
                 urlEmitTasks.push({
                   cssAssetName,
@@ -839,7 +862,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             await urlEmitQueue.run(async () =>
               Promise.all(
                 urlEmitTasks.map(async (info) => {
-                  info.content = await finalizeCss(info.content, config)
+                  info.content = (await finalizeCss(info.content, config)).code
                 }),
               ),
             )
@@ -883,6 +906,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               }
             }
 
+            if (chunkSources.length) {
+              const concatenated = concatWithSourcemaps(chunkSources)
+              chunkCSS = concatenated.code
+              chunkSourcemap = concatenated.map
+            }
             if (chunkCSS !== undefined) {
               if (
                 isPureCssChunk &&
@@ -916,16 +944,41 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                     ) ?? false,
                   )
 
-                  chunkCSS = resolveAssetUrlsInCss(
+                  const resolved = resolveAssetUrlsInCss(
                     chunkCSS,
                     cssAssetName,
                     originalFileName,
                   )
+                  chunkCSS = resolved.code
+                  if (resolved.map) {
+                    chunkSourcemap = chunkSourcemap
+                      ? (combineSourcemaps(cssAssetName, [
+                          resolved.map as RawSourceMap,
+                          chunkSourcemap as RawSourceMap,
+                        ]) as ExistingRawSourceMap)
+                      : resolved.map
+                  }
 
                   // wait for previous tasks as well
-                  chunkCSS = await codeSplitEmitQueue.run(async () => {
-                    return finalizeCss(chunkCSS!, config)
-                  })
+                  const finalizedCss = await codeSplitEmitQueue.run(
+                    async () => {
+                      return finalizeCss(
+                        chunkCSS!,
+                        config,
+                        cssAssetName,
+                        !!chunkSourcemap,
+                      )
+                    },
+                  )
+                  chunkCSS = finalizedCss.code
+                  if (finalizedCss.map) {
+                    chunkSourcemap = chunkSourcemap
+                      ? (combineSourcemaps(cssAssetName, [
+                          finalizedCss.map as RawSourceMap,
+                          chunkSourcemap as RawSourceMap,
+                        ]) as ExistingRawSourceMap)
+                      : finalizedCss.map
+                  }
 
                   // emit corresponding css file
                   const referenceId = this.emitFile({
@@ -934,6 +987,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                     originalFileName,
                     source: chunkCSS,
                   })
+                  // Rolldown preserves the first emitted asset when
+                  // deduplicating identical CSS, so preserve its sourcemap too.
+                  if (chunkSourcemap && !chunkCssMaps.has(referenceId)) {
+                    chunkCssMaps.set(referenceId, chunkSourcemap)
+                  }
                   chunkCssReferences.set(chunk.fileName, referenceId)
                   if (isEntry) {
                     cssEntriesMap
@@ -952,7 +1010,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   // But because entry chunk can be imported by dynamic import,
                   // we shouldn't remove the inlined CSS. (#10285)
 
-                  chunkCSS = await finalizeCss(chunkCSS, config)
+                  chunkCSS = (await finalizeCss(chunkCSS, config)).code
                   let cssString = JSON.stringify(chunkCSS)
                   cssString =
                     renderAssetUrlInJS(
@@ -976,9 +1034,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   chunkCSS,
                   getCssBundleName(),
                   defaultCssBundleName,
-                )
+                ).code
                 // finalizeCss is called for the aggregated chunk in generateBundle
-
                 chunkCSSMap.set(chunk.fileName, chunkCSS)
               }
             }
@@ -1060,7 +1117,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         // Finally, if there's any extracted CSS, we emit the asset
         if (extractedCss) {
           hasEmitted = true
-          extractedCss = await finalizeCss(extractedCss, config)
+          extractedCss = (await finalizeCss(extractedCss, config)).code
           this.emitFile({
             name: getCssBundleName(),
             type: 'asset',
@@ -1196,6 +1253,53 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           delete bundle[fileName]
           delete bundle[`${fileName}.map`]
         })
+      }
+
+      const environmentBuild = this.environment.config.build
+      if (environmentBuild.sourcemap && chunkCssMaps.size) {
+        const mapsByCssFileName = new Map<string, ExistingRawSourceMap>()
+        for (const [referenceId, map] of chunkCssMaps) {
+          const cssFileName = this.getFileName(referenceId)
+          mapsByCssFileName.set(cssFileName, map)
+        }
+
+        for (const [cssFileName, map] of mapsByCssFileName) {
+          const cssAsset = bundle[cssFileName]
+          if (!cssAsset || cssAsset.type !== 'asset') continue
+
+          const cssFilePath = path.resolve(
+            config.root,
+            environmentBuild.outDir,
+            cssFileName,
+          )
+          map.file = path.basename(cssFileName)
+          map.sources =
+            map.sources?.map((source) =>
+              source && path.isAbsolute(source)
+                ? normalizePath(
+                    path.relative(path.dirname(cssFilePath), source),
+                  )
+                : source,
+            ) ?? []
+
+          if (environmentBuild.sourcemap === 'inline') {
+            cssAsset.source = getCodeWithSourcemap(
+              'css',
+              cssAsset.source.toString(),
+              map as SourceMap,
+            )
+          } else {
+            const mapFileName = `${cssFileName}.map`
+            this.emitFile({
+              type: 'asset',
+              fileName: mapFileName,
+              source: JSON.stringify(map),
+            })
+            if (environmentBuild.sourcemap === true) {
+              cssAsset.source = `${cssAsset.source}\n/*# sourceMappingURL=${path.basename(mapFileName)} */`
+            }
+          }
+        }
       }
 
       const cssAssets = Object.values(bundle).filter(
@@ -1437,7 +1541,10 @@ async function compileCSSPreprocessors(
   deps?: Set<string>
 }> {
   const { config } = environment
-  const { preprocessorOptions, devSourcemap } = config.css
+  const { preprocessorOptions } = config.css
+  const enableSourcemap =
+    config.css.devSourcemap ||
+    (config.command === 'build' && !!config.build.sourcemap)
   const atImportResolvers = getAtImportResolvers(
     environment.getTopLevelConfig(),
   )
@@ -1445,7 +1552,7 @@ async function compileCSSPreprocessors(
     ...((preprocessorOptions && preprocessorOptions[lang]) || {}),
     // important: set this for relative import resolving
     filename: cleanUrl(id),
-    enableSourcemap: devSourcemap ?? false,
+    enableSourcemap,
   }
 
   const preProcessor = workerController[lang]
@@ -1510,6 +1617,9 @@ async function compileCSS(
   const { config } = environment
   const lang = CSS_LANGS_RE.exec(id)?.[1] as CssLang | undefined
   const deps = new Set<string>()
+  const enableSourcemap =
+    config.css.devSourcemap ||
+    (config.command === 'build' && !!config.build.sourcemap)
 
   // pre-processors: sass etc.
   let preprocessorMap: ExistingRawSourceMap | { mappings: '' } | undefined
@@ -1552,14 +1662,14 @@ async function compileCSS(
   if (!transformResult) {
     return {
       code,
-      map: config.css.devSourcemap ? preprocessorMap : { mappings: '' },
+      map: enableSourcemap ? (preprocessorMap ?? null) : { mappings: '' },
       deps,
     }
   }
 
   return {
     ...transformResult,
-    map: config.css.devSourcemap
+    map: enableSourcemap
       ? combineSourcemapsIfExists(
           cleanUrl(id),
           typeof transformResult.map === 'string'
@@ -1590,6 +1700,8 @@ async function compilePostCSS(
 > {
   const { config } = environment
   const { modules: modulesOptions, devSourcemap } = config.css
+  const enableSourcemap =
+    devSourcemap || (config.command === 'build' && !!config.build.sourcemap)
   const isModule = modulesOptions !== false && cssModuleRE.test(id)
   // although at serve time it can work without processing, we do need to
   // crawl them in order to register watch dependencies.
@@ -1745,7 +1857,7 @@ async function compilePostCSS(
     { ...postcssOptions, parser: postcssParser },
     deps,
     environment.logger,
-    devSourcemap,
+    enableSourcemap,
   )
   return { ...result, modules }
 }
@@ -1756,7 +1868,9 @@ async function transformSugarSS(
   code: string,
 ) {
   const { config } = environment
-  const { devSourcemap } = config.css
+  const enableSourcemap =
+    config.css.devSourcemap ||
+    (config.command === 'build' && !!config.build.sourcemap)
 
   const sssParser = await loadSss(config.root)
   const result = await runPostCSS(
@@ -1766,7 +1880,7 @@ async function transformSugarSS(
     { parser: sssParser },
     undefined,
     environment.logger,
-    devSourcemap,
+    enableSourcemap,
   )
   return result
 }
@@ -1981,16 +2095,100 @@ function combineSourcemapsIfExists(
   ]) as ExistingRawSourceMap
 }
 
+/** Concatenates generated code and offsets each of its existing sourcemaps. */
+export function concatWithSourcemaps(
+  sources: readonly {
+    code: string
+    map?: ExistingRawSourceMap
+  }[],
+): { code: string; map?: ExistingRawSourceMap } {
+  let code = ''
+  let line = 0
+  let column = 0
+  const sections: Section[] = []
+
+  for (const source of sources) {
+    const sourceMap = source.map
+    if (sourceMap) {
+      const mapSources = sourceMap.sources ?? []
+      sections.push({
+        offset: { line, column },
+        map: {
+          ...sourceMap,
+          names: sourceMap.names ?? [],
+          sources: mapSources,
+          sourcesContent: mapSources.map(
+            (_, index) => sourceMap.sourcesContent?.[index] ?? null,
+          ),
+        } as EncodedSourceMap,
+      })
+    }
+    code += source.code
+
+    let lastLineStart = -1
+    for (let i = 0; i < source.code.length; i++) {
+      if (source.code[i] === '\n') {
+        line++
+        lastLineStart = i + 1
+      }
+    }
+    if (lastLineStart === -1) {
+      column += source.code.length
+    } else {
+      column = source.code.length - lastLineStart
+    }
+  }
+
+  const map = sections.length
+    ? encodedMap(new FlattenMap({ version: 3, sections }))
+    : undefined
+  return { code, map }
+}
+
 const viteHashUpdateMarker = '/*$vite$:1*/'
 const viteHashUpdateMarkerRE = /\/\*\$vite\$:\d+\*\//
 
-async function finalizeCss(css: string, config: ResolvedConfig) {
+interface FinalizeCssResult {
+  code: string
+  map?: ExistingRawSourceMap
+}
+
+async function finalizeCss(
+  css: string,
+  config: ResolvedConfig,
+  filename: string = defaultCssBundleName,
+  enableSourcemap: boolean = false,
+): Promise<FinalizeCssResult> {
+  let map: ExistingRawSourceMap | undefined
   // hoist external @imports and @charset to the top of the CSS chunk per spec (#1845 and #6333)
   if (css.includes('@import') || css.includes('@charset')) {
-    css = hoistAtRules(css)
+    const s = hoistAtRules(css)
+    css = s.toString()
+    if (enableSourcemap) {
+      map = s.generateMap({
+        source: filename,
+        includeContent: true,
+        hires: 'boundary',
+      }) as ExistingRawSourceMap
+    }
   }
   if (config.build.cssMinify) {
-    css = await minifyCSS(css, config, false)
+    const minified = await minifyCSS(
+      css,
+      config,
+      false,
+      filename,
+      enableSourcemap,
+    )
+    css = minified.code
+    if (minified.map) {
+      map = map
+        ? (combineSourcemaps(filename, [
+            minified.map as RawSourceMap,
+            map as RawSourceMap,
+          ]) as ExistingRawSourceMap)
+        : minified.map
+    }
   }
   // inject an additional string to generate a different hash for https://github.com/vitejs/vite/issues/18038
   //
@@ -2002,7 +2200,7 @@ async function finalizeCss(css: string, config: ResolvedConfig) {
   // to avoid that happening, we inject an additional string so that a different hash is generated
   // for the same CSS content
   css += viteHashUpdateMarker
-  return css
+  return { code: css, map }
 }
 
 interface PostCSSConfigResult {
@@ -2281,12 +2479,18 @@ async function doImportCSSReplace(
   return `@import ${prefix}${wrap}${newUrl}${wrap}`
 }
 
+interface MinifiedCssResult {
+  code: string
+  map?: ExistingRawSourceMap
+}
+
 async function minifyCSS(
   css: string,
   config: ResolvedConfig,
   inlined: boolean,
   filename: string = defaultCssBundleName,
-) {
+  enableSourcemap: boolean = false,
+): Promise<MinifiedCssResult> {
   // We want inlined CSS to not end with a linebreak, while ensuring that
   // regular CSS assets do end with a linebreak.
   // See https://github.com/vitejs/vite/pull/13893#issuecomment-1678628198
@@ -2294,11 +2498,12 @@ async function minifyCSS(
   if (config.build.cssMinify === 'esbuild') {
     const { transform, formatMessages } = await importEsbuild()
     try {
-      const { code, warnings } = await transform(css, {
+      const { code, map, warnings } = await transform(css, {
         loader: 'css',
         target: config.build.cssTarget || undefined,
         sourcefile: filename,
         ...resolveMinifyCssEsbuildOptions(config.esbuild || {}),
+        sourcemap: enableSourcemap ? 'external' : false,
       })
       if (warnings.length) {
         const msgs = await formatMessages(warnings, { kind: 'warning' })
@@ -2307,7 +2512,11 @@ async function minifyCSS(
         )
       }
       // esbuild output does return a linebreak at the end
-      return inlined ? code.trimEnd() : code
+      const minifiedCode = inlined ? code.trimEnd() : code
+      return {
+        code: minifiedCode,
+        map: map ? (JSON.parse(map) as ExistingRawSourceMap) : undefined,
+      }
     } catch (e) {
       if (e.errors) {
         e.message = '[esbuild css minify] ' + e.message
@@ -2320,13 +2529,14 @@ async function minifyCSS(
   }
 
   try {
-    const { code, warnings } = (await importLightningCSS()).transform({
+    const { code, map, warnings } = (await importLightningCSS()).transform({
       ...config.css.lightningcss,
       targets: convertTargets(config.build.cssTarget),
       cssModules: undefined,
       filename,
       code: Buffer.from(css),
       minify: true,
+      sourceMap: enableSourcemap,
     })
 
     for (const warning of warnings) {
@@ -2342,7 +2552,13 @@ async function minifyCSS(
     // Deno res.code = Uint8Array
     // For correct decode compiled css need to use TextDecoder
     // LightningCSS output does not return a linebreak at the end
-    return decoder.decode(code) + (inlined ? '' : '\n')
+    const minifiedCode = decoder.decode(code) + (inlined ? '' : '\n')
+    return {
+      code: minifiedCode,
+      map: map
+        ? (JSON.parse(decoder.decode(map)) as ExistingRawSourceMap)
+        : undefined,
+    }
   } catch (e) {
     e.message = `[lightningcss minify] ${e.message}`
     const friendlyMessage = getLightningCssErrorMessageForIeSyntaxes(css)
@@ -2393,10 +2609,23 @@ const atImportRE =
 const atCharsetRE =
   /@charset(?:\s*(?:"(?:[^"]|(?<=\\)")*"|'(?:[^']|(?<=\\)')*').*?|[^;]*);/g
 
-export function hoistAtRules(css: string): string {
+export function hoistAtRules(css: string): MagicString {
   const s = new MagicString(css)
   const cleanCss = emptyCssComments(css)
   let match: RegExpExecArray | null
+
+  // #6333
+  // CSS @charset must be the top-first in the file, hoist the first to top
+  atCharsetRE.lastIndex = 0
+  let foundCharset = false
+  while ((match = atCharsetRE.exec(cleanCss))) {
+    if (!foundCharset) {
+      s.move(match.index, match.index + match[0].length, 0)
+      foundCharset = true
+    } else {
+      s.remove(match.index, match.index + match[0].length)
+    }
+  }
 
   // #1845
   // CSS @import can only appear at top of the file. We need to hoist all @import
@@ -2404,24 +2633,10 @@ export function hoistAtRules(css: string): string {
   // match until semicolon that's not in quotes
   atImportRE.lastIndex = 0
   while ((match = atImportRE.exec(cleanCss))) {
-    s.remove(match.index, match.index + match[0].length)
-    // Use `appendLeft` instead of `prepend` to preserve original @import order
-    s.appendLeft(0, match[0])
+    s.move(match.index, match.index + match[0].length, 0)
   }
 
-  // #6333
-  // CSS @charset must be the top-first in the file, hoist the first to top
-  atCharsetRE.lastIndex = 0
-  let foundCharset = false
-  while ((match = atCharsetRE.exec(cleanCss))) {
-    s.remove(match.index, match.index + match[0].length)
-    if (!foundCharset) {
-      s.prepend(match[0])
-      foundCharset = true
-    }
-  }
-
-  return s.toString()
+  return s
 }
 
 // Preprocessor support. This logic is largely replicated from @vue/compiler-sfc
@@ -3386,7 +3601,7 @@ async function compileLightningCSS(
               return id
             },
           },
-          minify: config.isProduction && !!config.build.cssMinify,
+          minify: false,
           sourceMap:
             config.command === 'build'
               ? !!config.build.sourcemap

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -1,7 +1,9 @@
 import { URL } from 'node:url'
 import { describe, expect, test } from 'vitest'
+import { removeSourceMappingURL } from './utils'
 import {
   extractSourcemap,
+  findAssetFile,
   formatSourcemapForSnapshot,
   isBuild,
   isServe,
@@ -13,6 +15,47 @@ test.runIf(isBuild)('should not output sourcemap warning (#4939)', () => {
   serverLogs.forEach((log) => {
     expect(log).not.toMatch('Sourcemap is likely to be incorrect')
   })
+})
+
+test.runIf(isBuild)('emit css sourcemap', () => {
+  const css = findAssetFile(/index-[-\w]+\.css$/, 'default')!
+  const map = JSON.parse(findAssetFile(/index-[-\w]+\.css\.map$/, 'default')!)
+
+  expect(formatSourcemapForSnapshot(removeSourceMappingURL(map), css))
+    .toMatchInlineSnapshot(`
+    SourceMap {
+      content: {
+        "ignoreList": [],
+        "mappings": "AAAA,6JCCE,8BCDF,4BCAA",
+        "sources": [
+          "../../../linked.css",
+          "../../../imported.styl",
+          "../../../imported.sss",
+          "../../../input-map.css",
+        ],
+        "sourcesContent": [
+          ".linked {
+      color: red;
+    }
+    ",
+          ".imported
+      &-stylus
+        color blue-red-mixed
+    ",
+          ".imported-sugarss
+      color: red
+    ",
+          ".input-map {
+      color: #00f;
+    }
+    ",
+        ],
+        "version": 3,
+      },
+      visualization: "https://evanw.github.io/source-map-visualization/#Mjg1AC5saW5rZWQsLmJlLWltcG9ydGVkLC5saW5rZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLC5iZS1pbXBvcnRlZCwuaW1wb3J0ZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLXNhc3MsLl9pbXBvcnRlZC1zYXNzLW1vZHVsZV9yMXFjcF8xLC5pbXBvcnRlZC1sZXNze2NvbG9yOnJlZH0uaW1wb3J0ZWQtc3R5bHVze2NvbG9yOnB1cnBsZX0uaW1wb3J0ZWQtc3VnYXJzc3tjb2xvcjpyZWR9LmlucHV0LW1hcHtjb2xvcjojMDBmfQoKLyojIHNvdXJjZU1hcHBpbmdVUkw9aW5kZXgtRGtTREZEeEsuY3NzLm1hcCAqLzM0OAB7InZlcnNpb24iOjMsIm1hcHBpbmdzIjoiQUFBQSw2SkNDRSw4QkNERiw0QkNBQSIsImlnbm9yZUxpc3QiOltdLCJzb3VyY2VzIjpbIi4uLy4uLy4uL2xpbmtlZC5jc3MiLCIuLi8uLi8uLi9pbXBvcnRlZC5zdHlsIiwiLi4vLi4vLi4vaW1wb3J0ZWQuc3NzIiwiLi4vLi4vLi4vaW5wdXQtbWFwLmNzcyJdLCJzb3VyY2VzQ29udGVudCI6WyIubGlua2VkIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsIi5pbXBvcnRlZFxuICAmLXN0eWx1c1xuICAgIGNvbG9yIGJsdWUtcmVkLW1peGVkXG4iLCIuaW1wb3J0ZWQtc3VnYXJzc1xuICBjb2xvcjogcmVkXG4iLCIuaW5wdXQtbWFwIHtcbiAgY29sb3I6ICMwMGY7XG59XG4iXX0="
+    }
+  `)
+  expect(css).toMatch(/\/\*# sourceMappingURL=index-[-\w]+\.css\.map \*\/\s*$/)
 })
 
 describe.runIf(isServe)('serve', () => {

--- a/playground/css-sourcemap/__tests__/esbuild/css-sourcemap-esbuild.spec.ts
+++ b/playground/css-sourcemap/__tests__/esbuild/css-sourcemap-esbuild.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'vitest'
+import { removeSourceMappingURL } from '../utils'
+import { findAssetFile, formatSourcemapForSnapshot, isBuild } from '~utils'
+
+describe.runIf(isBuild)('css with esbuild minification', () => {
+  test('remap minified css to compiled module sources', () => {
+    const css = findAssetFile(/index-[-\w]+\.css$/, 'esbuild')!
+    const map = JSON.parse(findAssetFile(/index-[-\w]+\.css\.map$/, 'esbuild')!)
+
+    expect(formatSourcemapForSnapshot(removeSourceMappingURL(map), css))
+      .toMatchInlineSnapshot(`
+      SourceMap {
+        content: {
+          "ignoreList": [],
+          "mappings": "AAAA,CAAC,OCAD,aCEA,oBCFA,CAAC,SCED,sBCCE,eCFA,+BCAA,ePAA,MAAO,GACT,CQDE,iBACE,MAAM,OCFV,kBACE,SADe,CCAjB,CAAC,UACC,MAAO,IACT",
+          "sources": [
+            "../../../linked.css",
+            "../../../be-imported.css",
+            "../../../linked-with-import.css",
+            "../../../imported.css",
+            "../../../imported-with-import.css",
+            "../../../imported.sass",
+            "../../../imported.module.sass",
+            "../../../imported.less",
+            "../../../imported.styl",
+            "../../../imported.sss",
+            "../../../input-map.css",
+          ],
+          "sourcesContent": [
+            ".linked {
+        color: red;
+      }
+      ",
+            ".be-imported {
+        color: red;
+      }
+      ",
+            "@import '@/be-imported.css';
+
+      .linked-with-import {
+        color: red;
+      }
+      ",
+            ".imported {
+        color: red;
+      }
+      ",
+            "@import '@/be-imported.css';
+
+      .imported-with-import {
+        color: red;
+      }
+      ",
+            "@use "/imported-nested.sass"
+
+      .imported
+        &-sass
+          color: imported-nested.$primary
+      ",
+            ".imported
+        &-sass-module
+          color: red
+      ",
+            ".imported {
+        &-less {
+          color: @color;
+        }
+      }
+      ",
+            ".imported
+        &-stylus
+          color blue-red-mixed
+      ",
+            ".imported-sugarss
+        color: red
+      ",
+            ".input-map {
+        color: #00f;
+      }
+      ",
+          ],
+          "version": 3,
+        },
+        visualization: "https://evanw.github.io/source-map-visualization/#MjcyAC5saW5rZWQsLmJlLWltcG9ydGVkLC5saW5rZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLC5pbXBvcnRlZC13aXRoLWltcG9ydCwuaW1wb3J0ZWQtc2FzcywuX2ltcG9ydGVkLXNhc3MtbW9kdWxlX3IxcWNwXzEsLmltcG9ydGVkLWxlc3N7Y29sb3I6cmVkfS5pbXBvcnRlZC1zdHlsdXN7Y29sb3I6cHVycGxlfS5pbXBvcnRlZC1zdWdhcnNze2NvbG9yOnJlZH0uaW5wdXQtbWFwe2NvbG9yOiMwMGZ9CgovKiMgc291cmNlTWFwcGluZ1VSTD1pbmRleC1CYWhUTjdNaS5jc3MubWFwICovMTA3NwB7InZlcnNpb24iOjMsIm1hcHBpbmdzIjoiQUFBQSxDQUFDLE9DQUQsYUNFQSxvQkNGQSxDQUFDLFNDRUQsc0JDQ0UsZUNGQSwrQkNBQSxlUEFBLE1BQU8sR0FDVCxDUURFLGlCQUNFLE1BQU0sT0NGVixrQkFDRSxTQURlLENDQWpCLENBQUMsVUFDQyxNQUFPLElBQ1QiLCJpZ25vcmVMaXN0IjpbXSwic291cmNlcyI6WyIuLi8uLi8uLi9saW5rZWQuY3NzIiwiLi4vLi4vLi4vYmUtaW1wb3J0ZWQuY3NzIiwiLi4vLi4vLi4vbGlua2VkLXdpdGgtaW1wb3J0LmNzcyIsIi4uLy4uLy4uL2ltcG9ydGVkLmNzcyIsIi4uLy4uLy4uL2ltcG9ydGVkLXdpdGgtaW1wb3J0LmNzcyIsIi4uLy4uLy4uL2ltcG9ydGVkLnNhc3MiLCIuLi8uLi8uLi9pbXBvcnRlZC5tb2R1bGUuc2FzcyIsIi4uLy4uLy4uL2ltcG9ydGVkLmxlc3MiLCIuLi8uLi8uLi9pbXBvcnRlZC5zdHlsIiwiLi4vLi4vLi4vaW1wb3J0ZWQuc3NzIiwiLi4vLi4vLi4vaW5wdXQtbWFwLmNzcyJdLCJzb3VyY2VzQ29udGVudCI6WyIubGlua2VkIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsIi5iZS1pbXBvcnRlZCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCJAaW1wb3J0ICdAL2JlLWltcG9ydGVkLmNzcyc7XG5cbi5saW5rZWQtd2l0aC1pbXBvcnQge1xuICBjb2xvcjogcmVkO1xufVxuIiwiLmltcG9ydGVkIHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsIkBpbXBvcnQgJ0AvYmUtaW1wb3J0ZWQuY3NzJztcblxuLmltcG9ydGVkLXdpdGgtaW1wb3J0IHtcbiAgY29sb3I6IHJlZDtcbn1cbiIsIkB1c2UgXCIvaW1wb3J0ZWQtbmVzdGVkLnNhc3NcIlxuXG4uaW1wb3J0ZWRcbiAgJi1zYXNzXG4gICAgY29sb3I6IGltcG9ydGVkLW5lc3RlZC4kcHJpbWFyeVxuIiwiLmltcG9ydGVkXG4gICYtc2Fzcy1tb2R1bGVcbiAgICBjb2xvcjogcmVkXG4iLCIuaW1wb3J0ZWQge1xuICAmLWxlc3Mge1xuICAgIGNvbG9yOiBAY29sb3I7XG4gIH1cbn1cbiIsIi5pbXBvcnRlZFxuICAmLXN0eWx1c1xuICAgIGNvbG9yIGJsdWUtcmVkLW1peGVkXG4iLCIuaW1wb3J0ZWQtc3VnYXJzc1xuICBjb2xvcjogcmVkXG4iLCIuaW5wdXQtbWFwIHtcbiAgY29sb3I6ICMwMGY7XG59XG4iXX0="
+      }
+    `)
+  })
+})

--- a/playground/css-sourcemap/__tests__/hidden/css-sourcemap-hidden.spec.ts
+++ b/playground/css-sourcemap/__tests__/hidden/css-sourcemap-hidden.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+import { removeSourceMappingURL } from '../utils'
+import { findAssetFile, formatSourcemapForSnapshot, isBuild } from '~utils'
+
+describe.runIf(isBuild)('css with hidden sourcemap', () => {
+  test('emit css sourcemap without a comment', () => {
+    const css = findAssetFile(/index-[-\w]+\.css$/, 'hidden')
+    expect(css).not.toContain('sourceMappingURL')
+
+    const map = JSON.parse(findAssetFile(/index-[-\w]+\.css\.map$/, 'hidden')!)
+    expect(formatSourcemapForSnapshot(removeSourceMappingURL(map), css!))
+      .toMatchInlineSnapshot(`
+      SourceMap {
+        content: {
+          "ignoreList": [],
+          "mappings": "AAAA,6JCCE,8BCDF,4BCAA",
+          "sources": [
+            "../../../linked.css",
+            "../../../imported.styl",
+            "../../../imported.sss",
+            "../../../input-map.css",
+          ],
+          "sourcesContent": [
+            ".linked {
+        color: red;
+      }
+      ",
+            ".imported
+        &-stylus
+          color blue-red-mixed
+      ",
+            ".imported-sugarss
+        color: red
+      ",
+            ".input-map {
+        color: #00f;
+      }
+      ",
+          ],
+          "version": 3,
+        },
+        visualization: "https://evanw.github.io/source-map-visualization/#MjM4AC5saW5rZWQsLmJlLWltcG9ydGVkLC5saW5rZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLC5iZS1pbXBvcnRlZCwuaW1wb3J0ZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLXNhc3MsLl9pbXBvcnRlZC1zYXNzLW1vZHVsZV9yMXFjcF8xLC5pbXBvcnRlZC1sZXNze2NvbG9yOnJlZH0uaW1wb3J0ZWQtc3R5bHVze2NvbG9yOnB1cnBsZX0uaW1wb3J0ZWQtc3VnYXJzc3tjb2xvcjpyZWR9LmlucHV0LW1hcHtjb2xvcjojMDBmfQozNDgAeyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUEsNkpDQ0UsOEJDREYsNEJDQUEiLCJpZ25vcmVMaXN0IjpbXSwic291cmNlcyI6WyIuLi8uLi8uLi9saW5rZWQuY3NzIiwiLi4vLi4vLi4vaW1wb3J0ZWQuc3R5bCIsIi4uLy4uLy4uL2ltcG9ydGVkLnNzcyIsIi4uLy4uLy4uL2lucHV0LW1hcC5jc3MiXSwic291cmNlc0NvbnRlbnQiOlsiLmxpbmtlZCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuaW1wb3J0ZWRcbiAgJi1zdHlsdXNcbiAgICBjb2xvciBibHVlLXJlZC1taXhlZFxuIiwiLmltcG9ydGVkLXN1Z2Fyc3NcbiAgY29sb3I6IHJlZFxuIiwiLmlucHV0LW1hcCB7XG4gIGNvbG9yOiAjMDBmO1xufVxuIl19"
+      }
+    `)
+  })
+})

--- a/playground/css-sourcemap/__tests__/inline/css-sourcemap-inline.spec.ts
+++ b/playground/css-sourcemap/__tests__/inline/css-sourcemap-inline.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+import { removeSourceMappingURL } from '../utils'
+import {
+  extractSourcemap,
+  findAssetFile,
+  formatSourcemapForSnapshot,
+  isBuild,
+} from '~utils'
+
+describe.runIf(isBuild)('css with inline sourcemap', () => {
+  test('inline css sourcemap without emitting a map asset', () => {
+    const css = findAssetFile(/index-[-\w]+\.css$/, 'inline')!
+    expect(css).toMatch(
+      /\/\*# sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,/,
+    )
+    expect(findAssetFile(/\.css\.map$/, 'inline')).toBeUndefined()
+
+    expect(
+      formatSourcemapForSnapshot(
+        removeSourceMappingURL(extractSourcemap(css)),
+        css,
+      ),
+    ).toMatchInlineSnapshot(`
+      SourceMap {
+        content: {
+          "ignoreList": [],
+          "mappings": "AAAA,6JCCE,8BCDF,4BCAA",
+          "sources": [
+            "../../../linked.css",
+            "../../../imported.styl",
+            "../../../imported.sss",
+            "../../../input-map.css",
+          ],
+          "sourcesContent": [
+            ".linked {
+        color: red;
+      }
+      ",
+            ".imported
+        &-stylus
+          color blue-red-mixed
+      ",
+            ".imported-sugarss
+        color: red
+      ",
+            ".input-map {
+        color: #00f;
+      }
+      ",
+          ],
+          "version": 3,
+        },
+        visualization: "https://evanw.github.io/source-map-visualization/#MjM4AC5saW5rZWQsLmJlLWltcG9ydGVkLC5saW5rZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLC5iZS1pbXBvcnRlZCwuaW1wb3J0ZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLXNhc3MsLl9pbXBvcnRlZC1zYXNzLW1vZHVsZV9yMXFjcF8xLC5pbXBvcnRlZC1sZXNze2NvbG9yOnJlZH0uaW1wb3J0ZWQtc3R5bHVze2NvbG9yOnB1cnBsZX0uaW1wb3J0ZWQtc3VnYXJzc3tjb2xvcjpyZWR9LmlucHV0LW1hcHtjb2xvcjojMDBmfQozNDgAeyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUEsNkpDQ0UsOEJDREYsNEJDQUEiLCJpZ25vcmVMaXN0IjpbXSwic291cmNlcyI6WyIuLi8uLi8uLi9saW5rZWQuY3NzIiwiLi4vLi4vLi4vaW1wb3J0ZWQuc3R5bCIsIi4uLy4uLy4uL2ltcG9ydGVkLnNzcyIsIi4uLy4uLy4uL2lucHV0LW1hcC5jc3MiXSwic291cmNlc0NvbnRlbnQiOlsiLmxpbmtlZCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuaW1wb3J0ZWRcbiAgJi1zdHlsdXNcbiAgICBjb2xvciBibHVlLXJlZC1taXhlZFxuIiwiLmltcG9ydGVkLXN1Z2Fyc3NcbiAgY29sb3I6IHJlZFxuIiwiLmlucHV0LW1hcCB7XG4gIGNvbG9yOiAjMDBmO1xufVxuIl19"
+      }
+    `)
+  })
+})

--- a/playground/css-sourcemap/__tests__/lightningcss/lightningcss.spec.ts
+++ b/playground/css-sourcemap/__tests__/lightningcss/lightningcss.spec.ts
@@ -1,7 +1,9 @@
 import { URL } from 'node:url'
 import { describe, expect, test } from 'vitest'
+import { removeSourceMappingURL } from '../utils'
 import {
   extractSourcemap,
+  findAssetFile,
   formatSourcemapForSnapshot,
   isBuild,
   isServe,
@@ -13,6 +15,52 @@ test.runIf(isBuild)('should not output sourcemap warning (#4939)', () => {
   serverLogs.forEach((log) => {
     expect(log).not.toMatch('Sourcemap is likely to be incorrect')
   })
+})
+
+test.runIf(isBuild)('emit css sourcemap', () => {
+  const css = findAssetFile(/index-[-\w]+\.css$/, 'lightningcss')!
+  const map = JSON.parse(
+    findAssetFile(/index-[-\w]+\.css\.map$/, 'lightningcss')!,
+  )
+  expect(map.sourcesContent).toContain(`.linked {
+  color: red;
+}
+`)
+
+  expect(formatSourcemapForSnapshot(removeSourceMappingURL(map), css))
+    .toMatchInlineSnapshot(`
+    SourceMap {
+      content: {
+        "ignoreList": [],
+        "mappings": "AAAA,2JCCE,8BCDF,4BCAA",
+        "sources": [
+          "../../../linked.css",
+          "../../../imported.styl",
+          "../../../imported.sss",
+          "../../../input-map.css",
+        ],
+        "sourcesContent": [
+          ".linked {
+      color: red;
+    }
+    ",
+          ".imported
+      &-stylus
+        color blue-red-mixed
+    ",
+          ".imported-sugarss
+      color: red
+    ",
+          ".input-map {
+      color: #00f;
+    }
+    ",
+        ],
+        "version": 3,
+      },
+      visualization: "https://evanw.github.io/source-map-visualization/#MjgzAC5saW5rZWQsLmJlLWltcG9ydGVkLC5saW5rZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLC5iZS1pbXBvcnRlZCwuaW1wb3J0ZWQtd2l0aC1pbXBvcnQsLmltcG9ydGVkLXNhc3MsLmhvUU10V19pbXBvcnRlZC1zYXNzLW1vZHVsZSwuaW1wb3J0ZWQtbGVzc3tjb2xvcjpyZWR9LmltcG9ydGVkLXN0eWx1c3tjb2xvcjpwdXJwbGV9LmltcG9ydGVkLXN1Z2Fyc3N7Y29sb3I6cmVkfS5pbnB1dC1tYXB7Y29sb3I6IzAwZn0KCi8qIyBzb3VyY2VNYXBwaW5nVVJMPWluZGV4LUNoc2RmUkJwLmNzcy5tYXAgKi8zNDgAeyJ2ZXJzaW9uIjozLCJtYXBwaW5ncyI6IkFBQUEsMkpDQ0UsOEJDREYsNEJDQUEiLCJpZ25vcmVMaXN0IjpbXSwic291cmNlcyI6WyIuLi8uLi8uLi9saW5rZWQuY3NzIiwiLi4vLi4vLi4vaW1wb3J0ZWQuc3R5bCIsIi4uLy4uLy4uL2ltcG9ydGVkLnNzcyIsIi4uLy4uLy4uL2lucHV0LW1hcC5jc3MiXSwic291cmNlc0NvbnRlbnQiOlsiLmxpbmtlZCB7XG4gIGNvbG9yOiByZWQ7XG59XG4iLCIuaW1wb3J0ZWRcbiAgJi1zdHlsdXNcbiAgICBjb2xvciBibHVlLXJlZC1taXhlZFxuIiwiLmltcG9ydGVkLXN1Z2Fyc3NcbiAgY29sb3I6IHJlZFxuIiwiLmlucHV0LW1hcCB7XG4gIGNvbG9yOiAjMDBmO1xufVxuIl19"
+    }
+  `)
 })
 
 describe.runIf(isServe)('serve', () => {

--- a/playground/css-sourcemap/__tests__/utils.ts
+++ b/playground/css-sourcemap/__tests__/utils.ts
@@ -1,0 +1,16 @@
+interface SourcemapWithSourcesContent {
+  sourcesContent?: (string | null)[]
+}
+
+export function removeSourceMappingURL<T extends SourcemapWithSourcesContent>(
+  sourcemap: T,
+): T {
+  // The sourceMappingURL comment is detected by Vitest and it tries to load the file
+  // causing false warnings
+  return {
+    ...sourcemap,
+    sourcesContent: sourcemap.sourcesContent?.map((source) =>
+      source?.replace(/\n?\/\*# sourceMappingURL=.*?\*\//g, ''),
+    ),
+  }
+}

--- a/playground/css-sourcemap/vite.config-esbuild.js
+++ b/playground/css-sourcemap/vite.config-esbuild.js
@@ -1,0 +1,9 @@
+import { mergeConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default mergeConfig(baseConfig, {
+  build: {
+    cssMinify: 'esbuild',
+    outDir: 'dist/esbuild',
+  },
+})

--- a/playground/css-sourcemap/vite.config-hidden.js
+++ b/playground/css-sourcemap/vite.config-hidden.js
@@ -1,0 +1,9 @@
+import { mergeConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default mergeConfig(baseConfig, {
+  build: {
+    sourcemap: 'hidden',
+    outDir: 'dist/hidden',
+  },
+})

--- a/playground/css-sourcemap/vite.config-inline.js
+++ b/playground/css-sourcemap/vite.config-inline.js
@@ -1,0 +1,9 @@
+import { mergeConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default mergeConfig(baseConfig, {
+  build: {
+    sourcemap: 'inline',
+    outDir: 'dist/inline',
+  },
+})

--- a/playground/css-sourcemap/vite.config-lightningcss.js
+++ b/playground/css-sourcemap/vite.config-lightningcss.js
@@ -7,5 +7,8 @@ export default mergeConfig(
     css: {
       transformer: 'lightningcss',
     },
+    build: {
+      outDir: 'dist/lightningcss',
+    },
   }),
 )

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -34,6 +34,7 @@ export default defineConfig({
     },
   },
   build: {
+    outDir: 'dist/default',
     sourcemap: true,
   },
   plugins: [


### PR DESCRIPTION
Add basic support for CSS sourcemaps in build.

The remaining parts that is needed are:
- support for `cssCodeSplit: false`
- support for `.css?url`
- URL replacement by lightningcss does not change the sourcemap
- combination of preprocessor + lightningcss

Need to decide on which option enabled this. Currently, this PR enables it when `build.sourcemap` is truthy.

refs #2830