### PR TITLE
test: use `server.fs.allow: []`

### DIFF
--- a/playground/js-sourcemap/index.html
+++ b/playground/js-sourcemap/index.html
@@ -4,6 +4,7 @@
 </div>
 
 <script type="module" src="./foo.js"></script>
+<script type="module" src="./foo-with-sourcemap.js"></script>
 <script type="module" src="./bar.ts"></script>
 <script type="module" src="./after-preload-dynamic.js"></script>
 <script type="module" src="./after-preload-dynamic-hashbang.js"></script>

--- a/playground/optimize-missing-deps/server.js
+++ b/playground/optimize-missing-deps/server.js
@@ -23,6 +23,10 @@ export async function createServer(root = process.cwd(), hmrPort) {
       hmr: {
         port: hmrPort,
       },
+      fs: {
+        // TODO: expose `config.safeModulePaths.add` and use it
+        allow: [resolve('main.js')],
+      },
     },
     appType: 'custom',
   })

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -79,6 +79,34 @@ export const viteBinPath = path.posix.join(
   'packages/vite/bin/vite.js',
 )
 
+// skip for now until it's compatible
+const playgroundsUsingDefaultFsAllow = new Set([
+  'alias',
+  'assets',
+  'build-old',
+  'chunk-importmap',
+  'csp',
+  'css',
+  'css-codesplit',
+  'css-lightningcss',
+  'css-no-codesplit',
+  'css-sourcemap',
+  'dynamic-import',
+  'glob-import',
+  'hmr',
+  'html',
+  'json',
+  'legacy',
+  'multiple-entrypoints',
+  'optimize-deps',
+  'resolve',
+  'tailwind',
+  'tailwind-v3',
+  'tsconfig-json-load-error',
+  'wasm',
+  'worker',
+])
+
 // #endregion
 
 // #region context
@@ -262,6 +290,9 @@ async function loadConfig(configEnv: ConfigEnv) {
     logLevel: 'silent',
     configFile: false,
     server: {
+      ...(playgroundsUsingDefaultFsAllow.has(testName)
+        ? {}
+        : { fs: { allow: [] } }),
       watch: {
         // During tests we edit the files too fast and sometimes chokidar
         // misses change events, so enforce polling for consistency


### PR DESCRIPTION
Use `server.fs.allow: []` in the playground to find out modules that are not included in `safeModulePaths` even if it's included in the module graph.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>