### PR TITLE
docs(build): fix incomplete `@default` for build.minify

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -177,7 +177,7 @@ export interface BuildEnvironmentOptions {
   /**
    * Set to `false` to disable minification, or specify the minifier to use.
    * Available options are 'oxc' or 'terser' or 'esbuild'.
-   * @default 'oxc'
+   * @default 'oxc' for client build, false for SSR build
    */
   minify?: boolean | 'oxc' | 'terser' | 'esbuild'
   /**


### PR DESCRIPTION
The `@default 'oxc'` for `build.minify` omits the SSR exception: for a server environment the resolved default is `false`.

```ts
minify: consumer === 'server' || isBundledDev ? false : 'oxc',
```

Updated the `@default` to match the published docs (`build-options.md`): "'oxc' for client build, false for SSR build".