### PR TITLE
fix(build): make client chunkImportMap work with `sharedPlugins: true`

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -723,7 +723,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         // The legacy bundle is built first, and its index.html isn't actually emitted if
         // modern bundle will be generated. Here we simply record its corresponding legacy chunk.
         facadeToLegacyChunkMap.set(chunk.facadeModuleId, chunk.fileName)
-        if (config.build.chunkImportMap) {
+        if (config.environments.client.build.chunkImportMap) {
           facadeToLegacyImportMap.set(
             chunk.facadeModuleId,
             bundle![getImportMapFilename(config)]! as Rollup.OutputAsset,
@@ -773,7 +773,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
 
       // 2. inject importmaps
-      if (config.build.chunkImportMap) {
+      if (config.environments.client.build.chunkImportMap) {
         const importMap = facadeToLegacyImportMap.get(chunk.facadeModuleId)!
         const decoder = new TextDecoder()
         tags.push({

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1096,6 +1096,7 @@ test('chunkImportMap is emitted when emitAssets is false', async () => {
           ssr: true,
           emitAssets: false,
           write: false,
+          chunkImportMap: true,
           rolldownOptions: {
             input: '/entry.js',
             experimental: {

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1020,6 +1020,181 @@ test.for([true, false])(
   },
 )
 
+test('chunkImportMap per environment with shared plugins', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  let client: RolldownOutput | undefined
+  let ssr: RolldownOutput | undefined
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+      ssr: {
+        build: {
+          chunkImportMap: false,
+          ssr: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    builder: {
+      sharedPlugins: true,
+      async buildApp(builder) {
+        client = (await builder.build(
+          builder.environments.client,
+        )) as RolldownOutput
+        ssr = (await builder.build(builder.environments.ssr)) as RolldownOutput
+      },
+    },
+  })
+
+  await builder.buildApp()
+
+  const entry = client!.output.find(
+    (output): output is OutputChunk =>
+      output.type === 'chunk' && output.isEntry,
+  )!
+  const css = client!.output.find(
+    (output) => output.type === 'asset' && output.fileName.endsWith('.css'),
+  )!
+  const importMapAsset = client!.output.find(
+    (output) => output.type === 'asset' && output.fileName === 'importmap.json',
+  )!
+  expect(
+    ssr!.output.some(
+      (output) =>
+        output.type === 'asset' && output.fileName === 'importmap.json',
+    ),
+  ).toBe(false)
+  const importMap = JSON.parse(importMapAsset.source.toString())
+    .imports as Record<string, string>
+  const cssSpecifier = Object.entries(importMap).find(
+    ([, fileName]) => fileName === `/${css.fileName}`,
+  )![0]
+  expect(entry.code).toContain(JSON.stringify(cssSpecifier.slice(1)))
+})
+
+test('chunkImportMap is emitted when emitAssets is false', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    environments: {
+      ssr: {
+        build: {
+          ssr: true,
+          emitAssets: false,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+            experimental: {
+              chunkImportMap: {
+                fileName: 'custom-importmap.json',
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const result = (await builder.build(
+    builder.environments.ssr,
+  )) as RolldownOutput
+
+  expect(result.output).toContainEqual(
+    expect.objectContaining({
+      type: 'asset',
+      fileName: 'custom-importmap.json',
+    }),
+  )
+})
+
+test('chunkImportMap is emitted for SSR when enabled', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    environments: {
+      ssr: {
+        build: {
+          ssr: true,
+          chunkImportMap: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+  })
+
+  const result = (await builder.build(
+    builder.environments.ssr,
+  )) as RolldownOutput
+
+  expect(result.output).toContainEqual(
+    expect.objectContaining({
+      type: 'asset',
+      fileName: 'importmap.json',
+    }),
+  )
+})
+
+test('importmap named asset is not emitted when chunkImportMap is false', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    plugins: [
+      {
+        name: 'emit-importmap-named-asset',
+        buildStart() {
+          this.emitFile({
+            type: 'asset',
+            fileName: 'importmap.json',
+            source: '{}',
+          })
+        },
+      },
+    ],
+    environments: {
+      ssr: {
+        build: {
+          ssr: true,
+          emitAssets: false,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+  })
+
+  const result = (await builder.build(
+    builder.environments.ssr,
+  )) as RolldownOutput
+
+  expect(result.output).not.toContainEqual(
+    expect.objectContaining({
+      type: 'asset',
+      fileName: 'importmap.json',
+    }),
+  )
+})
+
 test('sharedConfigBuild and emitAssets', async () => {
   const root = resolve(dirname, 'fixtures/shared-config-build/emitAssets')
   const builder = await createBuilder({

--- a/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/entry.js
+++ b/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/entry.js
@@ -1,0 +1,1 @@
+import('./lazy.js')

--- a/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/lazy.css
+++ b/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/lazy.css
@@ -1,0 +1,3 @@
+.lazy {
+  color: red;
+}

--- a/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/lazy.js
+++ b/packages/vite/src/node/__tests__/fixtures/shared-plugins/chunk-import-map/lazy.js
@@ -1,0 +1,3 @@
+import './lazy.css'
+
+export const lazy = true

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -685,6 +685,10 @@ export function resolveRolldownOptions(
       viteMode: true,
       chunkImportMap: options.chunkImportMap
         ? {
+            ...(typeof options.rolldownOptions.experimental?.chunkImportMap ===
+            'object'
+              ? options.rolldownOptions.experimental?.chunkImportMap
+              : {}),
             baseUrl: base,
           }
         : options.rolldownOptions.experimental?.chunkImportMap,

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -42,6 +42,7 @@ import {
 } from '../../shared/utils'
 import type { Environment } from '../environment'
 import type { PartialEnvironment } from '../baseEnvironment'
+import { getImportMapFilename } from './html'
 
 // referenceId is base64url but replaces - with $
 export const assetUrlRE: RegExp = /__VITE_ASSET__([\w$]+)__(?:\$_(.*?)__)?/g
@@ -299,11 +300,17 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
         config.command === 'build' &&
         !this.environment.config.build.emitAssets
       ) {
+        const chunkImportMapEnabled =
+          this.environment.config.build.chunkImportMap
         for (const file in bundle) {
           if (
             bundle[file].type === 'asset' &&
             !file.endsWith('ssr-manifest.json') &&
-            !jsSourceMapRE.test(file)
+            !jsSourceMapRE.test(file) &&
+            !(
+              chunkImportMapEnabled &&
+              file === getImportMapFilename(this.environment.config)
+            )
           ) {
             delete bundle[file]
           }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1074,11 +1074,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
       // With `cssCodeSplit: false`, CSS is emitted as a single stylesheet in the HTML,
       // so this per-chunk import map handling is irrelevant.
-      if (config.build.chunkImportMap && chunkCssReferences.size) {
+      if (
+        this.environment.config.build.chunkImportMap &&
+        chunkCssReferences.size
+      ) {
         // The import map hash identifies the JS chunk independently of its content.
         // Since each chunk has at most one extracted CSS sidecar, we can reuse that
         // stable identity with a `.css` extension while mapping it to the CSS content hash.
-        const importMap = getImportMap(bundle, config)!
+        const importMap = getImportMap(bundle, this.environment.config)!
         const importMapReverseMapping = Object.fromEntries(
           Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
         )
@@ -1126,8 +1129,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const pureCssChunkNameSet = new Set(pureCssChunkNames)
 
         let importMapReverseMapping: Record<string, string> | undefined
-        if (config.build.chunkImportMap) {
-          const importMap = getImportMap(bundle, config)!
+        if (this.environment.config.build.chunkImportMap) {
+          const importMap = getImportMap(bundle, this.environment.config)!
           importMapReverseMapping = Object.fromEntries(
             Object.entries(importMap.mapping).map(([k, v]) => [v, k]),
           )

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -33,7 +33,7 @@ import {
   removeLeadingSlash,
   unique,
 } from '../utils'
-import type { ResolvedConfig } from '../config'
+import type { ResolvedConfig, ResolvedEnvironmentOptions } from '../config'
 import { checkPublicFile } from '../publicDir'
 import { BUNDLED_DEV_CLIENT_FILENAME } from '../constants'
 import { toOutputFilePathInHtml } from '../build'
@@ -1233,7 +1233,8 @@ export function postImportMapHook(
   const decoder = new TextDecoder()
   return function (html, { bundle }) {
     const chunkImportMapEnabled =
-      config.command === 'build' && config.build.chunkImportMap
+      config.command === 'build' &&
+      config.environments.client.build.chunkImportMap
 
     if (importMapAppendRE.test(html)) {
       let importMap: string | undefined
@@ -1259,7 +1260,9 @@ export function postImportMapHook(
 
     if (chunkImportMapEnabled) {
       const nonce = config.html?.cspNonce
-      const importMap = bundle![getImportMapFilename(config)] as OutputAsset
+      const importMap = bundle![
+        getImportMapFilename(config.environments.client)
+      ] as OutputAsset
       const importMapHtml = serializeTag({
         tag: 'script',
         attrs: { type: 'importmap', ...(nonce ? { nonce } : {}) },
@@ -1686,13 +1689,24 @@ function incrementIndent(indent: string = '') {
   return `${indent}${indent[0] === '\t' ? '\t' : '  '}`
 }
 
-export function getImportMapFilename(config: ResolvedConfig): string {
+export function getImportMapFilename(
+  options: ResolvedEnvironmentOptions,
+): string {
   const chunkImportMap =
-    config.build.rolldownOptions.experimental?.chunkImportMap
+    options.build.rolldownOptions.experimental?.chunkImportMap
   if (typeof chunkImportMap === 'object' && chunkImportMap.fileName) {
     return chunkImportMap.fileName
   }
   return 'importmap.json'
+}
+
+function getImportMapBaseUrl(options: ResolvedEnvironmentOptions): string {
+  const chunkImportMap =
+    options.build.rolldownOptions.experimental?.chunkImportMap
+  if (typeof chunkImportMap === 'object' && chunkImportMap.baseUrl) {
+    return chunkImportMap.baseUrl
+  }
+  return '/'
 }
 
 /**
@@ -1701,7 +1715,7 @@ export function getImportMapFilename(config: ResolvedConfig): string {
  */
 export function getImportMap(
   bundle: OutputBundle,
-  config: ResolvedConfig,
+  options: ResolvedEnvironmentOptions & ResolvedConfig,
 ):
   | {
       asset: OutputAsset
@@ -1710,7 +1724,7 @@ export function getImportMap(
       mapping: Record<string, string>
     }
   | undefined {
-  const asset = bundle[getImportMapFilename(config)] as OutputAsset | undefined
+  const asset = bundle[getImportMapFilename(options)] as OutputAsset | undefined
   if (!asset) return undefined
 
   const content: { imports: Record<string, string> } = JSON.parse(
@@ -1718,10 +1732,11 @@ export function getImportMap(
       ? asset.source
       : new TextDecoder().decode(asset.source),
   )
+  const baseUrl = getImportMapBaseUrl(options)
   const mapping = Object.fromEntries(
     Object.entries(content.imports).map(([k, v]) => [
-      k.slice(config.base.length),
-      v.slice(config.base.length),
+      k.slice(baseUrl.length),
+      v.slice(baseUrl.length),
     ]),
   )
   return { asset, content, mapping }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -357,8 +357,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
 
       let importMapMapping: Record<string, string> | undefined
       let importMapReverseMapping: Record<string, string> | undefined
-      if (config.build.chunkImportMap) {
-        const importMap = getImportMap(bundle, config)!
+      if (this.environment.config.build.chunkImportMap) {
+        const importMap = getImportMap(bundle, this.environment.config)!
         importMapMapping = importMap.mapping
         importMapReverseMapping = Object.fromEntries(
           Object.entries(importMapMapping).map(([k, v]) => [v, k]),
@@ -370,7 +370,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
             fileName: 'importmap.legacy.json',
             source: importMap.asset.source,
           })
-          delete bundle[getImportMapFilename(config)]
+          delete bundle[getImportMapFilename(this.environment.config)]
         }
       }
 


### PR DESCRIPTION
Changed the chunkImportMap code to be aware of environments.

fixes https://github.com/vitejs/vite/issues/23119
close https://github.com/vitejs/vite/pull/23120  (it is incomplete, currently the htm only makes sense for client environment)
