### PR TITLE
docs(migration): import swc in the decorator workaround

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -179,6 +179,7 @@ $ deno add -D npm:@rollup/plugin-swc npm:@swc/core
 
 ```js
 import { defineConfig, withFilter } from 'vite'
+import swc from '@rollup/plugin-swc'
 
 export default defineConfig({
   // ...


### PR DESCRIPTION
Fix the missing `@rollup/plugin-swc` import in the SWC example in `docs/guide/migration.md`.