### PR TITLE
feat: add warning for unsupported hooks in plugin returned from `applyToEnvironment` hook

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -242,6 +242,8 @@ export default defineConfig({
 })
 ```
 
+Note that the plugin returned from `applyToEnvironment` or `perEnvironmentPlugin` should not use Vite-specific hooks.
+
 The `applyToEnvironment` hook is called at config time, currently after `configResolved` due to projects in the ecosystem modifying the plugins in it. Environment plugins resolution may be moved before `configResolved` in the future.
 
 ## Application-Plugin Communication

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1162,6 +1162,43 @@ describe('resolveConfig', () => {
     await resolveConfig({ root: './inc?ud#s*', customLogger: logger }, 'build')
   })
 
+  test('warns about ignored hooks returned from applyToEnvironment', async () => {
+    const warn = vi.fn()
+    const logger = createLogger('info', {
+      console: { warn } as unknown as Console,
+    })
+
+    await resolveConfig(
+      {
+        configFile: false,
+        customLogger: logger,
+        plugins: [
+          {
+            name: 'parent-plugin',
+            applyToEnvironment() {
+              return {
+                name: 'environment-plugin',
+                config: () => undefined,
+                configEnvironment: () => undefined,
+                configureServer: () => undefined,
+                configResolved: () => undefined,
+                resolveId: () => undefined,
+              }
+            },
+          },
+        ],
+      },
+      'serve',
+    )
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Plugin "environment-plugin" defines Vite-specific hooks (config, configEnvironment, configureServer, configResolved) in a plugin returned from applyToEnvironment. These hooks will be ignored.',
+      ),
+    )
+  })
+
   test('syncs `build.rollupOptions` and `build.rolldownOptions`', async () => {
     const resolved = await resolveConfig({}, 'build')
     expect(resolved.build!.rollupOptions).toStrictEqual(

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -387,6 +387,13 @@ export type PluginOption = Thenable<
   | PluginOption[]
 >
 
+const ignoredEnvironmentPluginHooks = [
+  'config',
+  'configEnvironment',
+  'configureServer',
+  'configResolved',
+] as const
+
 export async function resolveEnvironmentPlugins(
   environment: PartialEnvironment,
 ): Promise<Plugin[]> {
@@ -398,11 +405,20 @@ export async function resolveEnvironmentPlugins(
         continue
       }
       if (applied !== true) {
-        environmentPlugins.push(
-          ...((await asyncFlatten(arraify(applied))).filter(
-            Boolean,
-          ) as Plugin[]),
-        )
+        const appliedPlugins = (await asyncFlatten(arraify(applied))).filter(
+          Boolean,
+        ) as Plugin[]
+        for (const appliedPlugin of appliedPlugins) {
+          const ignoredHooks = ignoredEnvironmentPluginHooks.filter(
+            (hook) => appliedPlugin[hook],
+          )
+          if (ignoredHooks.length > 0) {
+            environment.logger.warnOnce(
+              `Plugin "${appliedPlugin.name}" defines Vite-specific hooks (${ignoredHooks.join(', ')}) in a plugin returned from applyToEnvironment. These hooks will be ignored.`,
+            )
+          }
+        }
+        environmentPlugins.push(...appliedPlugins)
         continue
       }
     }


### PR DESCRIPTION
Some hooks do not for plugins returned by `applyToEnvironment` hook. This PR clarifies that in the docs and adds warning if those hooks are declared.

refs https://github.com/vitejs/vite/pull/18544
refs https://discord.com/channels/804011606160703521/1534597514987176086/1535141249030430750
