### PR TITLE
fix(bundledDev): include default-order HTML virtual module injections

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -352,6 +352,8 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
   By default `order` is `undefined`, with this hook applied after the HTML has been transformed. In order to inject a script that should go through the Vite plugins pipeline, `order: 'pre'` will apply the hook before processing the HTML. `order: 'post'` applies the hook after all hooks with `order` undefined are applied.
 
+  Under [`experimental.bundledDev`](/blog/announcing-vite8-1#experimental-bundled-dev-mode), Vite also collects module script / stylesheet tags from default-order hooks before the HTML is turned into JS imports, so injected virtual modules (for example `/@id/virtual:…`) are included in the Rolldown graph. Prefer setting `order: 'pre'` explicitly when injecting pipeline tags so build and bundledDev stay aligned.
+
   **Basic Example:**
 
   ```js

--- a/packages/vite/src/node/__tests__/plugins/htmlPipelineTags.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/htmlPipelineTags.spec.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { Plugin, ViteDevServer } from '../..'
+import { createServer } from '../..'
+import {
+  injectModulePipelineTagsFromHtmlTransforms,
+  stripUnservableDevModuleScripts,
+} from '../../plugins/html'
+
+const tempDirs: string[] = []
+let server: ViteDevServer | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function createTempRoot(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-html-pipeline-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+describe('stripUnservableDevModuleScripts', () => {
+  test('removes /@id/ and /@fs/ module scripts', () => {
+    const html = `<!doctype html><head>
+<script type="module" src="/@id/virtual:overlay.js"></script>
+<script type="module" src="/@fs/Users/x/inject.js"></script>
+<script type="module" src="/assets/index.js"></script>
+</head>`
+    const stripped = stripUnservableDevModuleScripts(html)
+    expect(stripped).not.toContain('/@id/')
+    expect(stripped).not.toContain('/@fs/')
+    expect(stripped).toContain('/assets/index.js')
+  })
+})
+
+describe('injectModulePipelineTagsFromHtmlTransforms', () => {
+  test('injects only module pipeline tags from default-order hooks', async () => {
+    const html = '<!doctype html><html><head></head><body></body></html>'
+    const result = await injectModulePipelineTagsFromHtmlTransforms(
+      html,
+      [
+        () => [
+          {
+            tag: 'script',
+            attrs: { type: 'module', src: '/@id/virtual:overlay.js' },
+            injectTo: 'head-prepend',
+          },
+          {
+            tag: 'meta',
+            attrs: { name: 'description', content: 'nope' },
+          },
+        ],
+      ],
+      {} as any,
+      { path: '/', filename: 'index.html' },
+    )
+    expect(result).toContain('src="/@id/virtual:overlay.js"')
+    expect(result).not.toContain('description')
+  })
+})
+
+describe('bundledDev virtual module HTML injection', () => {
+  // regression test for https://github.com/vitejs/vite/issues/22864
+  test('includes default-order injected virtual modules in the bundle', async () => {
+    const root = createTempRoot()
+    fs.writeFileSync(
+      path.join(root, 'index.html'),
+      `<!doctype html>
+<html>
+  <head><title>t</title></head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>`,
+    )
+    fs.mkdirSync(path.join(root, 'src'))
+    fs.writeFileSync(
+      path.join(root, 'src/main.js'),
+      `document.getElementById('app').textContent = 'ok'\n`,
+    )
+
+    const virtualId = 'virtual:injected-overlay.js'
+    const resolvedVirtualId = `\0${virtualId}`
+    const injectPlugin: Plugin = {
+      name: 'test-virtual-inject',
+      resolveId(id) {
+        // Match the decoded virtual id only (not the `/@id/` browser URL),
+        // same as typical ecosystem plugins such as Vue DevTools.
+        if (id === virtualId) return resolvedVirtualId
+      },
+      load(id) {
+        if (id === resolvedVirtualId) {
+          return 'window.__VIRTUAL_INJECTED__ = true'
+        }
+      },
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'script',
+            attrs: { type: 'module', src: `/@id/${virtualId}` },
+            injectTo: 'head-prepend',
+          },
+        ]
+      },
+    }
+
+    server = await createServer({
+      configFile: false,
+      root,
+      logLevel: 'error',
+      experimental: { bundledDev: true },
+      plugins: [injectPlugin],
+    })
+    await server.listen()
+
+    const bundledDev = server.environments.client.bundledDev
+    expect(bundledDev).toBeTruthy()
+    await vi.waitFor(() => {
+      expect(bundledDev!.hasBuildOutput).toBe(true)
+    })
+
+    const htmlRes = await fetch(server.resolvedUrls!.local[0])
+    const html = await htmlRes.text()
+    expect(html).not.toContain('Bundling in progress')
+    expect(html).not.toContain(`/@id/${virtualId}`)
+    expect(html).toMatch(/\/assets\/[^"]+\.js/)
+
+    const assetPath = html.match(/src="(\/assets\/[^"]+\.js)"/)?.[1]
+    expect(assetPath).toBeTruthy()
+    const jsRes = await fetch(
+      new URL(assetPath!, server.resolvedUrls!.local[0]),
+    )
+    const js = await jsRes.text()
+    expect(js).toContain('__VIRTUAL_INJECTED__')
+    expect(js).toContain('virtual:injected-overlay.js')
+  })
+})

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -31,14 +31,16 @@ import {
   partialEncodeURIPath,
   processSrcSet,
   removeLeadingSlash,
+  stripBase,
   unique,
 } from '../utils'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from '../config'
 import { checkPublicFile } from '../publicDir'
-import { BUNDLED_DEV_CLIENT_FILENAME } from '../constants'
+import { BUNDLED_DEV_CLIENT_FILENAME, FS_PREFIX } from '../constants'
 import { toOutputFilePathInHtml } from '../build'
 import { resolveEnvPrefix } from '../env'
-import { cleanUrl } from '../../shared/utils'
+import { cleanUrl, unwrapId } from '../../shared/utils'
+import { VALID_ID_PREFIX } from '../../shared/constants'
 import { perEnvironmentState } from '../environment'
 import { getNodeAssetAttributes } from '../assetSource'
 import type { Logger } from '../logger'
@@ -494,6 +496,22 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           path: publicPath,
           filename: id,
         })
+        // In bundledDev, default-order `transformIndexHtml` hooks run after the
+        // HTML→JS scan — too late for injected module scripts/links to enter the
+        // graph, so `/@id/...` URLs 404 (see #22864). Collect only pipeline tags
+        // from those hooks here; the hooks still run fully after generateBundle
+        // for `ctx.bundle` / final HTML transforms.
+        if (config.command === 'serve') {
+          html = await injectModulePipelineTagsFromHtmlTransforms(
+            html,
+            normalHooks,
+            this,
+            {
+              path: publicPath,
+              filename: id,
+            },
+          )
+        }
 
         let js = ''
         const s = new MagicString(html)
@@ -560,11 +578,19 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               if (isModule) {
                 inlineModuleIndex++
                 if (url && !isExcludedUrl(url) && !isPublicFile) {
+                  // Plugins often inject browser URLs like `/@id/virtual:…`.
+                  // Decode those before resolve/import so bundledDev matches
+                  // transform-middleware behavior (see #22864).
+                  const resolvedUrl = unwrapId(
+                    stripBase(url, config.decodedBase || config.base || '/'),
+                  )
                   setModuleSideEffectPromises.push(
-                    this.resolve(url, id).then((resolved) => {
+                    this.resolve(resolvedUrl, id).then((resolved) => {
                       if (!resolved) {
                         return Promise.reject(
-                          new Error(`Failed to resolve ${url} from ${id}`),
+                          new Error(
+                            `Failed to resolve ${resolvedUrl} from ${id}`,
+                          ),
                         )
                       }
                       // set moduleSideEffects to keep the module even if `treeshake.moduleSideEffects=false` is set
@@ -581,7 +607,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   )
                   // <script type="module" src="..."/>
                   // add it as an import
-                  js += `\nimport ${JSON.stringify(url)}`
+                  js += `\nimport ${JSON.stringify(resolvedUrl)}`
                   shouldRemove = true
                 } else if (node.childNodes.length) {
                   const scriptNode =
@@ -1063,6 +1089,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             chunk,
           },
         )
+        // Default-order hooks may re-inject `/@id/` or `/@fs/` module scripts
+        // after the bundle; those URLs are not served in bundledDev.
+        if (config.command === 'serve') {
+          result = stripUnservableDevModuleScripts(result)
+        }
         // resolve asset url references
         result = result.replace(assetUrlRE, (_, fileHash, postfix = '') => {
           const file = this.getFileName(fileHash)
@@ -1468,6 +1499,108 @@ function headTagInsertCheck(
   }
 }
 
+function isHtmlModulePipelineTag(tag: HtmlTagDescriptor): boolean {
+  if (tag.tag === 'script') {
+    const src = tag.attrs?.src
+    return (
+      typeof src === 'string' &&
+      src.length > 0 &&
+      tag.attrs?.type === 'module' &&
+      !isExternalUrl(src) &&
+      !isDataUrl(src)
+    )
+  }
+  if (tag.tag === 'link') {
+    const href = tag.attrs?.href
+    const rel = tag.attrs?.rel
+    return (
+      typeof href === 'string' &&
+      href.length > 0 &&
+      (rel === 'stylesheet' || rel === 'modulepreload') &&
+      !isExternalUrl(href) &&
+      !isDataUrl(href)
+    )
+  }
+  return false
+}
+
+function injectHtmlTags(
+  html: string,
+  tags: HtmlTagDescriptor[],
+  ctx: IndexHtmlTransformContext,
+): string {
+  let headTags: HtmlTagDescriptor[] | undefined
+  let headPrependTags: HtmlTagDescriptor[] | undefined
+  let bodyTags: HtmlTagDescriptor[] | undefined
+  let bodyPrependTags: HtmlTagDescriptor[] | undefined
+
+  for (const tag of tags) {
+    switch (tag.injectTo) {
+      case 'body':
+        ;(bodyTags ??= []).push(tag)
+        break
+      case 'body-prepend':
+        ;(bodyPrependTags ??= []).push(tag)
+        break
+      case 'head':
+        ;(headTags ??= []).push(tag)
+        break
+      default:
+        ;(headPrependTags ??= []).push(tag)
+    }
+  }
+  headTagInsertCheck([...(headTags || []), ...(headPrependTags || [])], ctx)
+  if (headPrependTags) html = injectToHead(html, headPrependTags, true)
+  if (headTags) html = injectToHead(html, headTags)
+  if (bodyPrependTags) html = injectToBody(html, bodyPrependTags, true)
+  if (bodyTags) html = injectToBody(html, bodyTags)
+  return html
+}
+
+/**
+ * Runs default-order `transformIndexHtml` hooks and injects only tags that must
+ * enter the HTML→JS module graph (module scripts / stylesheets). Used by
+ * bundledDev before scanning.
+ */
+export async function injectModulePipelineTagsFromHtmlTransforms(
+  html: string,
+  hooks: IndexHtmlTransformHook[],
+  pluginContext: MinimalPluginContextWithoutEnvironment,
+  ctx: IndexHtmlTransformContext,
+): Promise<string> {
+  const pipelineTags: HtmlTagDescriptor[] = []
+  for (const hook of hooks) {
+    const res = await hook.call(pluginContext, html, ctx)
+    if (!res || typeof res === 'string') continue
+    const tags = Array.isArray(res) ? res : res.tags
+    if (!tags) continue
+    for (const tag of tags) {
+      if (isHtmlModulePipelineTag(tag)) {
+        pipelineTags.push(tag)
+      }
+    }
+  }
+  if (!pipelineTags.length) return html
+  return injectHtmlTags(html, pipelineTags, ctx)
+}
+
+/**
+ * Removes module scripts pointing at `/@id/` or `/@fs/` — these are not served
+ * under bundledDev (only Rolldown memory outputs are).
+ */
+export function stripUnservableDevModuleScripts(html: string): string {
+  return html.replace(/<script\b[^>]*>\s*<\/script>/gi, (scriptTag) => {
+    // Quoted values cannot use a trailing `\b` (end is a non-word `"`).
+    if (
+      /\btype\s*=\s*(?:"module"|'module'|module[\s>/])/i.test(scriptTag) &&
+      (scriptTag.includes(VALID_ID_PREFIX) || scriptTag.includes(FS_PREFIX))
+    ) {
+      return ''
+    }
+    return scriptTag
+  })
+}
+
 export async function applyHtmlTransforms(
   html: string,
   hooks: IndexHtmlTransformHook[],
@@ -1489,32 +1622,7 @@ export async function applyHtmlTransforms(
         html = res.html || html
         tags = res.tags
       }
-
-      let headTags: HtmlTagDescriptor[] | undefined
-      let headPrependTags: HtmlTagDescriptor[] | undefined
-      let bodyTags: HtmlTagDescriptor[] | undefined
-      let bodyPrependTags: HtmlTagDescriptor[] | undefined
-
-      for (const tag of tags) {
-        switch (tag.injectTo) {
-          case 'body':
-            ;(bodyTags ??= []).push(tag)
-            break
-          case 'body-prepend':
-            ;(bodyPrependTags ??= []).push(tag)
-            break
-          case 'head':
-            ;(headTags ??= []).push(tag)
-            break
-          default:
-            ;(headPrependTags ??= []).push(tag)
-        }
-      }
-      headTagInsertCheck([...(headTags || []), ...(headPrependTags || [])], ctx)
-      if (headPrependTags) html = injectToHead(html, headPrependTags, true)
-      if (headTags) html = injectToHead(html, headTags)
-      if (bodyPrependTags) html = injectToBody(html, bodyPrependTags, true)
-      if (bodyTags) html = injectToBody(html, bodyTags)
+      html = injectHtmlTags(html, tags, ctx)
     }
   }
 

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs'
 import type { Connect } from '#dep-types/connect'
 import { createDebugger, joinUrlSegments } from '../../utils'
 import { cleanUrl } from '../../../shared/utils'
+import { VALID_ID_PREFIX } from '../../../shared/constants'
+import { FS_PREFIX } from '../../constants'
 import type { DevEnvironment } from '../environment'
 
 const debug = createDebugger('vite:html-fallback')
@@ -77,7 +79,14 @@ export function htmlFallbackMiddleware(
       }
     }
 
-    if (spaFallback) {
+    // `/@id/` and `/@fs/` are not served from disk/memory in bundledDev. Do not
+    // SPA-fallback them to index.html — that masks missing virtual modules as a
+    // 200 HTML response (see #22864).
+    if (
+      spaFallback &&
+      !pathname.startsWith(VALID_ID_PREFIX) &&
+      !pathname.startsWith(FS_PREFIX)
+    ) {
       debug?.(`Rewriting ${req.method} ${req.url} to /index.html`)
       req.url = '/index.html'
     }


### PR DESCRIPTION
## Summary

- In `experimental.bundledDev`, collect module script / stylesheet tags from default-order `transformIndexHtml` hooks **before** the HTML→JS scan so injected virtual modules (e.g. Vue DevTools `/@id/virtual:…`) enter the Rolldown graph.
- Unwrap `/@id/` browser URLs when resolving HTML module scripts.
- Strip re-injected unservable `/@id/` and `/@fs/` module scripts from the final HTML, and skip SPA fallback for those paths.
- Document the bundledDev behavior and add regression tests.

Fixes #22864

## Test plan

- [x] `pnpm --filter vite run build-bundle`
- [x] `pnpm test-unit packages/vite/src/node/__tests__/plugins/htmlPipelineTags.spec.ts`
- [x] Manual check with `vite-plugin-vue-devtools` + `experimental.bundledDev: true` (overlay/inspector modules present in the client bundle; no `/@id/` tags left in HTML)
- [ ] CI unit / e2e checks