### PR TITLE
fix(resolve): handle optional peer deps under Yarn PnP

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/optional-peer-dep/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/optional-peer-dep/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "optional-peer-dep-app",
+  "private": true,
+  "type": "module"
+}

--- a/packages/vite/src/node/__tests__/optionalPeerDep.spec.ts
+++ b/packages/vite/src/node/__tests__/optionalPeerDep.spec.ts
@@ -1,0 +1,109 @@
+import path from 'node:path'
+import { describe, expect, onTestFinished, test } from 'vitest'
+import { createServer } from '../server'
+import {
+  optionalPeerDepId,
+  tryResolveOptionalPeerDep,
+} from '../plugins/resolve'
+import type { InternalResolveOptions } from '../plugins/resolve'
+
+const appRoot = path.join(import.meta.dirname, 'fixtures/optional-peer-dep')
+const importer = path.join(
+  appRoot,
+  'node_modules/@vitejs/test-optional-peer-importer/index.js',
+)
+
+function baseOptions(
+  overrides: Partial<InternalResolveOptions> = {},
+): InternalResolveOptions {
+  return {
+    root: appRoot,
+    isBuild: false,
+    isProduction: false,
+    asSrc: true,
+    preferRelative: false,
+    scan: false,
+    mainFields: ['module', 'main'],
+    conditions: [],
+    externalConditions: [],
+    extensions: ['.js', '.json'],
+    tryIndex: true,
+    preserveSymlinks: false,
+    tsconfigPaths: false,
+    dedupe: [],
+    optimizeDeps: false,
+    externalize: false,
+    packageCache: new Map(),
+    builtins: [],
+    ...overrides,
+  } as InternalResolveOptions
+}
+
+describe('tryResolveOptionalPeerDep', () => {
+  // regression helper for https://github.com/vitejs/vite/issues/21881
+  test('resolves uninstalled optional peer to optionalPeerDepId', () => {
+    const resolved = tryResolveOptionalPeerDep(
+      'not-installed-optional-peer',
+      importer,
+      baseOptions(),
+    )
+    expect(resolved).toEqual({
+      id: `${optionalPeerDepId}:not-installed-optional-peer:@vitejs/test-optional-peer-importer`,
+    })
+  })
+
+  test('resolves optional peer submodule', () => {
+    const resolved = tryResolveOptionalPeerDep(
+      'not-installed-optional-peer/sub',
+      importer,
+      baseOptions(),
+    )
+    expect(resolved).toEqual({
+      id: `${optionalPeerDepId}:not-installed-optional-peer/sub:@vitejs/test-optional-peer-importer`,
+    })
+  })
+
+  test('returns undefined when disabled', () => {
+    expect(
+      tryResolveOptionalPeerDep('not-installed-optional-peer', importer, {
+        ...baseOptions(),
+        disableOptionalPeerDepHandling: true,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('returns undefined for non-peer imports', () => {
+    expect(
+      tryResolveOptionalPeerDep('totally-missing-pkg', importer, baseOptions()),
+    ).toBeUndefined()
+  })
+})
+
+describe('resolveId optional peer fallback', () => {
+  // Ensures the JS fallback plugin (after native resolve) still maps optional
+  // peers — the path Yarn PnP needs when oxc-resolver skips zip importers.
+  test('plugin container resolves uninstalled optional peer', async () => {
+    const server = await createServer({
+      configFile: false,
+      root: appRoot,
+      logLevel: 'error',
+      optimizeDeps: {
+        noDiscovery: true,
+        include: [],
+      },
+      server: {
+        middlewareMode: true,
+        ws: false,
+      },
+    })
+    onTestFinished(() => server.close())
+
+    const resolved = await server.environments.client.pluginContainer.resolveId(
+      'not-installed-optional-peer',
+      importer,
+    )
+    expect(resolved?.id).toBe(
+      `${optionalPeerDepId}:not-installed-optional-peer:@vitejs/test-optional-peer-importer`,
+    )
+  })
+})

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -382,6 +382,34 @@ export function oxcResolvePlugin(
         return plugin
       },
     ),
+    // Native vite:resolve uses Rust `fs::exists` for importer checks, which
+    // cannot see Yarn PnP zip/virtual paths. Fall back to the JS optional-peer
+    // path (Node's PnP-patched fs) so uninstalled optional peers still resolve
+    // to `__vite-optional-peer-dep` (see #21881).
+    ...perEnvironmentOrWorkerPlugin(
+      'vite:resolve-optional-peer-dep',
+      overrideEnvConfig,
+      (partialEnv) => {
+        const options: InternalResolveOptions = {
+          ...partialEnv.config.resolve,
+          ...resolveOptions,
+        }
+        return {
+          name: 'vite:resolve-optional-peer-dep',
+          resolveId: {
+            filter: { id: bareImportRE },
+            handler(id, importer, resolveOpts) {
+              if (options.disableOptionalPeerDepHandling) return
+              return tryResolveOptionalPeerDep(id, importer, {
+                ...options,
+                isRequire: resolveOpts.kind === 'require-call',
+                scan: resolveOpts.scan ?? options.scan,
+              })
+            },
+          },
+        } satisfies Plugin
+      },
+    ),
   ]
 }
 
@@ -733,28 +761,7 @@ export function tryNodeResolve(
   if (!pkg) {
     // if import can't be found, check if it's an optional peer dep.
     // if so, we can resolve to a special id that errors only when imported.
-    if (
-      !options.disableOptionalPeerDepHandling &&
-      basedir !== root && // root has no peer dep
-      !isModuleBuiltin(id) &&
-      !id.includes('\0') &&
-      bareImportRE.test(id)
-    ) {
-      const mainPkg = findNearestMainPackageData(basedir, packageCache)?.data
-      if (mainPkg) {
-        const pkgName = getNpmPackageName(id)
-        if (
-          pkgName != null &&
-          mainPkg.peerDependencies?.[pkgName] &&
-          mainPkg.peerDependenciesMeta?.[pkgName]?.optional
-        ) {
-          return {
-            id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,
-          }
-        }
-      }
-    }
-    return
+    return tryResolveOptionalPeerDep(id, importer, options, basedir)
   }
 
   const resolveId = deepMatch ? resolveDeepImport : resolvePackageEntry
@@ -1184,6 +1191,67 @@ function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
 function isDirectory(path: string): boolean {
   const stat = tryStatSync(path)
   return stat?.isDirectory() ?? false
+}
+
+/**
+ * Resolve an uninstalled optional peer dependency to `__vite-optional-peer-dep`.
+ * Used by `tryNodeResolve` and as a JS fallback after the native resolve plugin
+ * (which cannot `fs::exists` Yarn PnP zip importers — see #21881).
+ */
+export function tryResolveOptionalPeerDep(
+  id: string,
+  importer: string | null | undefined,
+  options: InternalResolveOptions,
+  basedir?: string,
+): PartialResolvedId | undefined {
+  const { root, packageCache, preserveSymlinks } = options
+
+  if (
+    options.disableOptionalPeerDepHandling ||
+    !importer ||
+    id.includes('\0') ||
+    !bareImportRE.test(id) ||
+    isBuiltin(options.builtins, id)
+  ) {
+    return
+  }
+
+  let resolvedBasedir = basedir
+  if (resolvedBasedir == null) {
+    if (!path.isAbsolute(importer)) return
+    const cleanImporter = cleanUrl(importer)
+    // css processing appends `*` for importer
+    if (!importer.endsWith('*') && !fs.existsSync(cleanImporter)) {
+      return
+    }
+    resolvedBasedir = path.dirname(cleanImporter)
+  }
+
+  // root has no peer dep
+  if (resolvedBasedir === root) return
+
+  const pkgName = getNpmPackageName(id)
+  if (pkgName == null) return
+
+  // Package is installed — not an uninstalled optional peer.
+  if (
+    resolvePackageData(pkgName, resolvedBasedir, preserveSymlinks, packageCache)
+  ) {
+    return
+  }
+
+  const mainPkg = findNearestMainPackageData(
+    resolvedBasedir,
+    packageCache,
+  )?.data
+  if (
+    mainPkg?.peerDependencies?.[pkgName] &&
+    mainPkg.peerDependenciesMeta?.[pkgName]?.optional
+  ) {
+    return {
+      id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,
+    }
+  }
 }
 
 function findNearestPackagePath(


### PR DESCRIPTION
## Summary

- Root cause: Rolldown's native `viteResolvePlugin` uses Rust `fs::exists` for importer checks, which fails on Yarn PnP zip/virtual paths, so the optional-peer fallback never runs.
- Add a JS `vite:resolve-optional-peer-dep` plugin (via Node's PnP-aware fs) that maps uninstalled optional peers to `__vite-optional-peer-dep`.
- Extract `tryResolveOptionalPeerDep` and add regression tests.

Fixes #21881

## Test plan

- [x] `pnpm test-unit packages/vite/src/node/__tests__/optionalPeerDep.spec.ts`
- [x] Manual Yarn PnP repro (optimizer + `optimizeDeps.exclude`) — resolves `foobar` to `__vite-optional-peer-dep:foobar:my-dep`, no hard resolve error
- [ ] CI