### PR TITLE
docs: patch langs.ts to use useRoute instead of removed `useData().hash`

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -556,6 +556,10 @@ const config = defineConfig({
           import.meta.dirname,
           'theme/components/TopBanner.vue',
         ),
+        '@vp-composables/langs': path.resolve(
+          import.meta.dirname,
+          'theme/langs.ts',
+        ),
       },
     },
     plugins: [

--- a/docs/.vitepress/theme/langs.ts
+++ b/docs/.vitepress/theme/langs.ts
@@ -1,0 +1,62 @@
+// FIXME: remove this file and the corresponding alias in config.ts once
+// @voidzero-dev/vitepress-theme is updated to use `useRoute()` instead of the
+// removed `useData().hash` (removed in vitepress dcb7a755).
+// Tracked: https://github.com/vuejs/vitepress/commit/dcb7a75532c5472060ec379d25a5fafbc7932637
+import { computed } from 'vue'
+import { useData, useRoute } from 'vitepress'
+
+export function useLangs({ correspondingLink = false } = {}) {
+  const { site, localeIndex, theme } = useData()
+  const route = useRoute()
+  const currentLang = computed(() => ({
+    label: site.value.locales[localeIndex.value]?.label,
+    link:
+      site.value.locales[localeIndex.value]?.link ||
+      (localeIndex.value === 'root' ? '/' : `/${localeIndex.value}/`),
+  }))
+
+  const localeLinks = computed(() =>
+    Object.entries(site.value.locales).flatMap(([key, value]) =>
+      currentLang.value.label === value.label
+        ? []
+        : {
+            text: value.label,
+            link:
+              normalizeLink(
+                value.link || (key === 'root' ? '/' : `/${key}/`),
+                theme.value.i18nRouting !== false && correspondingLink,
+                route.data.relativePath.slice(
+                  currentLang.value.link.length - 1,
+                ),
+                !site.value.cleanUrls,
+              ) +
+              route.query +
+              route.hash,
+            lang: value.lang,
+            dir: value.dir,
+          },
+    ),
+  )
+
+  return { localeLinks, currentLang }
+}
+
+function normalizeLink(
+  link: string,
+  addPath: boolean,
+  path: string,
+  addExt: boolean,
+) {
+  return addPath
+    ? link.replace(/\/$/, '') +
+        ensureStartingSlash(
+          path
+            .replace(/(^|\/)index\.md$/, '$1')
+            .replace(/\.md$/, addExt ? '.html' : ''),
+        )
+    : link
+}
+
+function ensureStartingSlash(path: string): string {
+  return path.startsWith('/') ? path : `/${path}`
+}


### PR DESCRIPTION
vitepress 2.0.0-alpha.19 removed `useData().hash` in favor of useRoute() (commit dcb7a755). @voidzero-dev/vitepress-theme@5.0.4 still references the removed API, causing a runtime TypeError in the browser console.

Add a patched langs.ts and alias @vp-composables/langs to it until the upstream theme is updated.

The most reasonable solution would be to fix the `@voidzero-dev/vitepress-theme` package and then release a new version. However, it seems that the source code for this package is not publicly available, and the latest version on our official website currently lacks a lang switching option. I think we can fix it temporarily first and then revert it back after `@voidzero-dev/vitepress-theme` is fixed.

https://npmx.dev/package-code/@voidzero-dev/vitepress-theme/v/5.0.4/src%2Fcomposables%2Fvitepress-default%2Flangs.ts

|v8.2.1|v7|
|---|---|
|<img width="458" height="99" alt="image" src="https://github.com/user-attachments/assets/b0b4e3c1-2911-4c41-8286-21325db895cf" />|<img width="451" height="75" alt="image" src="https://github.com/user-attachments/assets/f387b204-20b8-4a6f-8961-51b306dbbfb3" />|
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
