### PR TITLE
docs(build): note cssTarget precedence

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -123,6 +123,8 @@ If you specify `build.lib`, `build.cssCodeSplit` will be `false` as default.
 
 This option allows users to set a different browser target for CSS minification from the one used for JavaScript transpilation.
 
+When `build.cssMinify` is `'lightningcss'` (the default), this option takes precedence over [`css.lightningcss.targets`](./shared-options.md#css-lightningcss) for the minification step.
+
 It should only be used when you are targeting a non-mainstream browser.
 One example is Android WeChat WebView, which supports most modern JavaScript features but not the [`#RGBA` hexadecimal color notation in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors).
 In this case, you need to set `build.cssTarget` to `chrome61` to prevent vite from transforming `rgba()` colors into `#RGBA` hexadecimal notations.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -281,7 +281,7 @@ Vite is pre-configured to support CSS `@import` inlining via `postcss-import`. V
 
 If the project contains valid PostCSS config (any format supported by [postcss-load-config](https://github.com/postcss/postcss-load-config), e.g. `postcss.config.js`), it will be automatically applied to all imported CSS.
 
-Note that CSS minification will run after PostCSS and will use [`build.cssTarget`](/config/build-options.md#build-csstarget) option.
+Note that CSS minification will run after PostCSS and will use the [`build.cssTarget`](/config/build-options.md#build-csstarget) option. When `build.cssMinify` is `'lightningcss'` (the default), it takes precedence over [`css.lightningcss.targets`](/config/shared-options.md#css-lightningcss) for the minification step.
 
 ### CSS Modules
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -281,7 +281,7 @@ Vite is pre-configured to support CSS `@import` inlining via `postcss-import`. V
 
 If the project contains valid PostCSS config (any format supported by [postcss-load-config](https://github.com/postcss/postcss-load-config), e.g. `postcss.config.js`), it will be automatically applied to all imported CSS.
 
-Note that CSS minification will run after PostCSS and will use the [`build.cssTarget`](/config/build-options.md#build-csstarget) option. When `build.cssMinify` is `'lightningcss'` (the default), it takes precedence over [`css.lightningcss.targets`](/config/shared-options.md#css-lightningcss) for the minification step.
+Note that CSS minification will run after PostCSS and will use the [`build.cssTarget`](/config/build-options.md#build-csstarget) option.
 
 ### CSS Modules
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -157,6 +157,9 @@ export interface BuildEnvironmentOptions {
    * a niche browser that comes with most modern JavaScript features
    * but has poor CSS support, e.g. Android WeChat WebView, which
    * doesn't support the #RGBA syntax.
+   * When `build.cssMinify` is `lightningcss` (the default), this
+   * option takes precedence over `css.lightningcss.targets` for the
+   * minification step.
    * @default target
    */
   cssTarget?: EsbuildTarget | false


### PR DESCRIPTION
## Problem

`build.cssTarget` takes precedence over `css.lightningcss.targets` during the lightningcss minification step, but this was not documented (see #17900).

## Fix

- `docs/config/build-options.md`: note that `build.cssTarget` takes precedence over `css.lightningcss.targets` when `build.cssMinify` is `lightningcss` (the default).
- `docs/guide/features.md`: same note for the CSS minification section.
- `packages/vite/src/node/build.ts`: update the `BuildEnvironmentOptions.cssTarget` JSDoc.

## Linked issue

Fixes #17900

## Verification

- `npx oxfmt --write docs/config/build-options.md docs/guide/features.md packages/vite/src/node/build.ts` pass
- `pnpm run lint` pass (one pre-existing `eqeqeq` warning in `playground/test-utils.ts`)
- `pnpm run docs-build` pass