### PR TITLE
fix: resolve native config compat warning paths relative to cwd

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1663,8 +1663,8 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - \`__dirname\` (vite.config.js:3:29). Use \`import.meta.dirname\` instead
-          - \`__filename\` (vite.config.js:4:30). Use \`import.meta.filename\` instead
+          - \`__dirname\` (./packages/vite/src/node/__tests__/fixtures/config/native-compat/dirname/vite.config.js:3:29). Use \`import.meta.dirname\` instead
+          - \`__filename\` (./packages/vite/src/node/__tests__/fixtures/config/native-compat/dirname/vite.config.js:4:30). Use \`import.meta.filename\` instead
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1679,7 +1679,7 @@ describe('loadConfigFromFile', () => {
         expect(messages).toMatchInlineSnapshot(`
           [
             "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-            - \`__dirname\` (vite.config.ts:10:29). Use \`import.meta.dirname\` instead
+            - \`__dirname\` (./packages/vite/src/node/__tests__/fixtures/config/native-compat/ts-syntax/vite.config.ts:10:29). Use \`import.meta.dirname\` instead
           Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
           ]
         `)
@@ -1691,7 +1691,7 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - import "./helper" without a file extension (vite.config.js:1:23). Add the file extension
+          - import "./helper" without a file extension (./packages/vite/src/node/__tests__/fixtures/config/native-compat/extensionless/vite.config.js:1:23). Add the file extension
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1702,7 +1702,7 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - import "./plugins" resolves to a directory index (vite.config.js:1:25). Import the index file directly
+          - import "./plugins" resolves to a directory index (./packages/vite/src/node/__tests__/fixtures/config/native-compat/directory-index/vite.config.js:1:25). Import the index file directly
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1713,7 +1713,7 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - JSON import "./data.json" without import attributes (vite.config.js:1:18). Add \`with { type: 'json' }\`
+          - JSON import "./data.json" without import attributes (./packages/vite/src/node/__tests__/fixtures/config/native-compat/json/vite.config.js:1:18). Add \`with { type: 'json' }\`
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1728,7 +1728,7 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - import "./foo" resolves to a JSON file (vite.config.js:1:18). Import it with a \`.json\` extension and \`with { type: 'json' }\`
+          - import "./foo" resolves to a JSON file (./packages/vite/src/node/__tests__/fixtures/config/native-compat/json-extensionless/vite.config.js:1:18). Import it with a \`.json\` extension and \`with { type: 'json' }\`
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1750,7 +1750,7 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - \`__dirname\` (esm-helper.mjs:1:35). Use \`import.meta.dirname\` instead
+          - \`__dirname\` (./packages/vite/src/node/__tests__/fixtures/config/native-compat/cjs-imports-esm/esm-helper.mjs:1:35). Use \`import.meta.dirname\` instead
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
@@ -1761,10 +1761,20 @@ describe('loadConfigFromFile', () => {
       expect(messages).toMatchInlineSnapshot(`
         [
           "(!) Your Vite config uses features that are unsupported by \`configLoader: 'native'\`, which is planned to become the default in a future major version of Vite:
-          - ESM syntax in a file loaded as CommonJS (vite.config.js:1:1). Use a \`.mjs\` extension or set \`"type": "module"\` in the closest package.json
+          - ESM syntax in a file loaded as CommonJS (./packages/vite/src/node/__tests__/fixtures/config/native-compat/esm-in-commonjs-pkg/vite.config.js:1:1). Use a \`.mjs\` extension or set \`"type": "module"\` in the closest package.json
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
+    })
+
+    test('warning paths are relative to process.cwd()', async () => {
+      const messages = await loadWithWarnings('dirname')
+      // path should be relative to process.cwd() with ./ prefix,
+      // so it is clickable from the terminal's working directory
+      const expectedPath = normalizePath(
+        `./${path.relative(process.cwd(), path.resolve(compatRoot, 'dirname', 'vite.config.js'))}`,
+      )
+      expect(messages[0]).toContain(`${expectedPath}:3:29`)
     })
   })
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2410,12 +2410,7 @@ export async function loadConfigFromFile(
 
   try {
     const { configExport, dependencies } = await (configLoader === 'bundle'
-      ? bundleAndLoadConfigFile(
-          resolvedPath,
-          configRoot,
-          logLevel,
-          customLogger,
-        )
+      ? bundleAndLoadConfigFile(resolvedPath, logLevel, customLogger)
       : configLoader === 'runner'
         ? runnerImportConfigFile(resolvedPath)
         : nativeImportConfigFile(resolvedPath))
@@ -2474,7 +2469,6 @@ async function runnerImportConfigFile(resolvedPath: string) {
 
 async function bundleAndLoadConfigFile(
   resolvedPath: string,
-  configRoot: string,
   logLevel: LogLevel | undefined,
   customLogger: Logger | undefined,
 ) {
@@ -2491,10 +2485,7 @@ async function bundleAndLoadConfigFile(
   if (bundled.nativeIncompatibilities.length > 0) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
-      formatNativeConfigIncompatWarning(
-        bundled.nativeIncompatibilities,
-        configRoot,
-      ),
+      formatNativeConfigIncompatWarning(bundled.nativeIncompatibilities),
     )
   }
 

--- a/packages/vite/src/node/nativeConfigCompat.ts
+++ b/packages/vite/src/node/nativeConfigCompat.ts
@@ -175,12 +175,17 @@ export function findEsmSyntaxInCjs(
   return undefined
 }
 
-function describeIncompatibility(
-  item: NativeConfigIncompatibility,
-  root: string,
-): string {
-  // 1-based column so terminals can link `file:line:column` to the exact position
-  const loc = `${normalizePath(path.relative(root, item.file))}:${item.line}:${item.column + 1}`
+function describeIncompatibility(item: NativeConfigIncompatibility): string {
+  // 1-based column so terminals can link `file:line:column` to the exact
+  // position. Compute the path relative to `process.cwd()` so the result
+  // is resolvable from the terminal's working directory; fall back to the
+  // absolute path when the file lives outside cwd.
+  const relativePath = normalizePath(path.relative(process.cwd(), item.file))
+  const loc = `${
+    relativePath.startsWith('..')
+      ? normalizePath(item.file)
+      : `./${relativePath}`
+  }:${item.line}:${item.column + 1}`
   switch (item.type) {
     case 'dirname':
       return `\`__dirname\` (${loc}). Use \`import.meta.dirname\` instead`
@@ -201,13 +206,12 @@ function describeIncompatibility(
 
 export function formatNativeConfigIncompatWarning(
   items: NativeConfigIncompatibility[],
-  root: string,
 ): string {
   const header =
     `Your Vite config uses features that are unsupported by ` +
     `\`configLoader: 'native'\`, which is planned to become the default in a ` +
     `future major version of Vite:`
-  const lines = items.map((it) => `  - ${describeIncompatibility(it, root)}`)
+  const lines = items.map((it) => `  - ${describeIncompatibility(it)}`)
   const footer = `Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.`
   return colors.yellow([`(!) ${header}`, ...lines, footer].join('\n'))
 }


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
The file location in native config compat warnings was computed relative to `root`, which can differ from the terminal's working directory when `root` is set to a subdirectory (e.g. `vite packages-private/sfc-playground`).                                            

This made the `./vite.config.ts:line:column` path unresolvable from the terminal. Use `process.cwd()` instead so the path is always clickable.

refs #22850