### PR TITLE
docs: pin vitepress to 2.0.0-alpha.18 to fix language switcher 

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "feed": "^6.0.0",
     "markdown-it-image-size": "^15.1.0",
     "oxc-minify": "^0.142.0",
-    "vitepress": "^2.0.0-alpha.19",
+    "vitepress": "2.0.0-alpha.18",
     "vitepress-plugin-graphviz": "^0.1.0",
     "vitepress-plugin-group-icons": "^1.7.6",
     "vitepress-plugin-llms": "^1.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,7 @@ importers:
         version: 5.0.6
       '@voidzero-dev/vitepress-theme':
         specifier: ^5.0.4
-        version: 5.0.4(focus-trap@8.2.2)(vite@packages+vite)(vitepress@2.0.0-alpha.19)(vue@3.5.40)
+        version: 5.0.4(focus-trap@8.2.2)(vite@packages+vite)(vitepress@2.0.0-alpha.18)(vue@3.5.40)
       feed:
         specifier: ^6.0.0
         version: 6.0.0
@@ -145,11 +145,11 @@ importers:
         specifier: ^0.142.0
         version: 0.142.0
       vitepress:
-        specifier: ^2.0.0-alpha.19
-        version: 2.0.0-alpha.19(postcss@8.5.25)(typescript@6.0.3)
+        specifier: 2.0.0-alpha.18
+        version: 2.0.0-alpha.18(postcss@8.5.25)(typescript@6.0.3)
       vitepress-plugin-graphviz:
         specifier: ^0.1.0
-        version: 0.1.0(vitepress@2.0.0-alpha.19)
+        version: 0.1.0(vitepress@2.0.0-alpha.18)
       vitepress-plugin-group-icons:
         specifier: ^1.7.6
         version: 1.7.6(vite@packages+vite)
@@ -7995,8 +7995,8 @@ packages:
     resolution: {integrity: sha512-3/L1ceexjpJirWWGlfvqx2hmaDTFGSkSHrn3y2C7RZm6lNa/vmvU49Ayr4GxLYQfOFfo9CP6rsWdD+6rEbnIxA==}
     engines: {node: '>=18'}
 
-  vitepress@2.0.0-alpha.19:
-    resolution: {integrity: sha512-WnBsb0Bwr43kXKyiis+lld/7ri3hnMbthS8N3hpFtjjwsdLO4IRmiAE08D7aud4q6oMDf9uwRowxzNqRFe/amw==}
+  vitepress@2.0.0-alpha.18:
+    resolution: {integrity: sha512-Lk1G2/QqSf+MwNLICl9fmzWOtoCEwjZoWgaQy41QvWTfcGpLE9XwJDbcCyES/9rj6R2g1zFqFvLVkYKLLDALFw==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -10800,7 +10800,7 @@ snapshots:
 
   '@voidzero-dev/vite-task-client@0.2.0': {}
 
-  '@voidzero-dev/vitepress-theme@5.0.4(focus-trap@8.2.2)(vite@packages+vite)(vitepress@2.0.0-alpha.19)(vue@3.5.40)':
+  '@voidzero-dev/vitepress-theme@5.0.4(focus-trap@8.2.2)(vite@packages+vite)(vitepress@2.0.0-alpha.18)(vue@3.5.40)':
     dependencies:
       '@docsearch/css': 4.7.0
       '@docsearch/js': 4.7.0
@@ -10817,7 +10817,7 @@ snapshots:
       minisearch: 7.2.0
       reka-ui: 2.9.0(vue@3.5.40)
       tailwindcss: 4.3.3
-      vitepress: 2.0.0-alpha.19(postcss@8.5.25)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.18(postcss@8.5.25)(typescript@6.0.3)
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -14248,10 +14248,10 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vitepress-plugin-graphviz@0.1.0(vitepress@2.0.0-alpha.19):
+  vitepress-plugin-graphviz@0.1.0(vitepress@2.0.0-alpha.18):
     dependencies:
       '@hpcc-js/wasm-graphviz': 1.21.2
-      vitepress: 2.0.0-alpha.19(postcss@8.5.25)(typescript@6.0.3)
+      vitepress: 2.0.0-alpha.18(postcss@8.5.25)(typescript@6.0.3)
 
   vitepress-plugin-group-icons@1.7.6(vite@packages+vite):
     dependencies:
@@ -14280,7 +14280,7 @@ snapshots:
     transitivePeerDependencies:
       - ms
 
-  vitepress@2.0.0-alpha.19(postcss@8.5.25)(typescript@6.0.3):
+  vitepress@2.0.0-alpha.18(postcss@8.5.25)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 4.7.0
       '@docsearch/js': 4.7.0


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
### What? 
This PR fixes the missing language switcher on the `vite.dev` documentation site.

### Why?
VitePress `2.0.0-alpha.19` removed `useData().hash`, which caused a hydration mismatch and a `TypeError: Cannot read properties of undefined (reading 'value')` within `@voidzero-dev/vitepress-theme`. This PR temporarily pins the `vitepress` version to `2.0.0-alpha.18` until a compatible theme release is available.


fixes #23220


### What alternatives have you tried?
Waiting for an update to `@voidzero-dev/vitepress-theme` to use `useRoute()` instead of `useData()`. However, pinning the version is the fastest way to restore lost functionality on the live documentation site.

### Are there any parts you think require more attention from reviewers?
No.