### PR TITLE
docs: fix grammar in Vite 5.1 blog post

### DIFF
--- a/docs/blog/announcing-vite5-1.md
+++ b/docs/blog/announcing-vite5-1.md
@@ -84,11 +84,11 @@ The preview server now exposes a `close` method, which will properly teardown th
 
 ## Performance improvements
 
-Vite keeps getting faster with each release, and Vite 5.1 is packed with performance improvements. We measured the loading time for 10K modules (25 level deep tree) using [vite-dev-server-perf](https://github.com/yyx990803/vite-dev-server-perf) for all minor versions from Vite 4.0. This is a good benchmark to measure the effect of Vite's bundle-less approach. Each module is a small TypeScript file with a counter and imports to other files in the tree, so this mostly measuring the time it takes to do the requests a separate modules. In Vite 4.0, loading 10K modules took 8 seconds on a M1 MAX. We had a breakthrough in [Vite 4.3 were we focused on performance](./announcing-vite4-3.md), and we were able to load them in 6.35 seconds. In Vite 5.1, we managed to do another performance leap. Vite is now serving the 10K modules in 5.35 seconds.
+Vite keeps getting faster with each release, and Vite 5.1 is packed with performance improvements. We measured the loading time for 10K modules (25 level deep tree) using [vite-dev-server-perf](https://github.com/yyx990803/vite-dev-server-perf) for all minor versions from Vite 4.0. This is a good benchmark to measure the effect of Vite's bundle-less approach. Each module is a small TypeScript file with a counter and imports to other files in the tree, so this mostly measures the time it takes to do the requests as separate modules. In Vite 4.0, loading 10K modules took 8 seconds on a M1 MAX. We had a breakthrough in [Vite 4.3 where we focused on performance](./announcing-vite4-3.md), and we were able to load them in 6.35 seconds. In Vite 5.1, we managed to do another performance leap. Vite is now serving the 10K modules in 5.35 seconds.
 
 ![Vite 10K Modules Loading time progression](../images/vite5-1-10K-modules-loading-time.webp)
 
-The results of this benchmark run on Headless Puppeteer and are a good way to compare versions. They don't represent the time as experienced by users though. When running the same 10K modules in an Incognito window is Chrome, we have:
+The results of this benchmark run on Headless Puppeteer and are a good way to compare versions. They don't represent the time as experienced by users though. When running the same 10K modules in an Incognito window in Chrome, we have:
 
 | 10K Modules           | Vite 5.0 | Vite 5.1 |
 | --------------------- | :------: | :------: |


### PR DESCRIPTION
### Description

Fixes four grammatical errors in the Vite 5.1 announcement post
(`docs/blog/announcing-vite5-1.md`), all within the "Performance improvements" section:

- "so this mostly **measuring** the time" -> "so this mostly **measures** the time"
- "to do the requests **a** separate modules" -> "to do the requests **as** separate modules"
- "[Vite 4.3 **were** we focused on performance]" -> "[Vite 4.3 **where** we focused on performance]"
- "in an Incognito window **is** Chrome" -> "in an Incognito window **in** Chrome"

These are currently live on https://vite.dev/blog/announcing-vite5-1

The diff touches four words across two lines. No links, headings, benchmark numbers
or surrounding wording were changed. I deliberately left the neighbouring sentence
"The results of this benchmark run on Headless Puppeteer..." untouched, since it
reads awkwardly but is not ungrammatical.

### Tests

No tests are included: this is a prose-only change to a Markdown document, with no
behaviour to assert. Verified with `pnpm docs-build` (passes) and by previewing the
page locally with `pnpm docs`.