### PR TITLE
docs: document server.preTransformRequests

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -299,6 +299,25 @@ export default defineConfig({
 })
 ```
 
+## server.preTransformRequests
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Pre-transform known direct imports. When Vite transforms a module, it also warms up the modules that module imports statically, so they are already transformed by the time the browser asks for them instead of arriving as a request waterfall. Dynamic imports are not pre-transformed.
+
+Vite also relies on this to start crawling static imports earlier when [`server.open`](#server-open) is enabled, by requesting the entry URL while the browser is still opening.
+
+Set it to `false` to only transform modules when they are requested.
+
+```js
+export default defineConfig({
+  server: {
+    preTransformRequests: false,
+  },
+})
+```
+
 ## server.watch
 
 - **Type:** `object | null`


### PR DESCRIPTION
### What

`server.preTransformRequests` is part of the public `ServerOptions` type and carries its own JSDoc and `@default`, but `grep -rn "preTransformRequests" docs/` returns nothing. The only way to discover it today is reading `packages/vite/src/node/server/index.ts`.

It is also the odd one out next to `server.warmup`, which sits in the same interface, controls closely related behaviour, and is documented.

### Changes

Adds a `## server.preTransformRequests` section to `docs/config/server-options.md`, placed between `server.warmup` and `server.watch`. It covers:

- the type and default, taken from the existing JSDoc on `ServerOptions.preTransformRequests`
- what it does: `importAnalysis` calls `environment.warmupRequest()` for every static local import of a module it transforms, so those modules are ready before the browser asks for them
- that dynamic imports are not pre-transformed
- that `server.open`'s early-crawl optimisation depends on it (`server/index.ts` guards that path with `if (server.config.server.preTransformRequests)`)

### What I checked

The one internal link I used, `#server-open`, already resolves: `## server.open` exists in the same file and `docs/config/preview-options.md` links to it the same way. The code sample matches the formatting of the `server.warmup` sample directly above it.

I did not run `pnpm run test-docs` locally, since it needs a full monorepo install and build to be meaningful. The change is markdown only, with no new anchors and no new external links.
