### PR TITLE
test(define): close rolldown bundler after generate

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -55,7 +55,11 @@ async function createDefinePluginTransform(
           attachDebugInfo: 'none',
         },
       })
-      return (await bundler.generate()).output[0].code
+      try {
+        return (await bundler.generate()).output[0].code
+      } finally {
+        await bundler.close()
+      }
     }
   }
 }


### PR DESCRIPTION
Wrap `bundler.generate()` in try/finally so `bundler.close()` is always called, preventing native resource leaks and matching the pattern used in other rolldown bundle call sites.

Refer to #23207
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
