### PR TITLE
fix(ssr): rewrite imported binding used as computed key in defaulted destructuring param

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -421,6 +421,18 @@ test('rewrite variables in default value of destructuring params', async () => {
   expect(result?.deps).toEqual(['vue'])
 })
 
+// #23232
+test('rewrite imported binding used as a computed key of a defaulted destructuring param', async () => {
+  const result = await ssrTransformSimple(
+    `import { fn } from 'vue';function A({ [fn]: foo } = {}){ return { [fn]: foo }; }`,
+  )
+  expect(result?.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["fn"]});
+    function A({ [__vite_ssr_import_0__.fn]: foo } = {}){ return { [__vite_ssr_import_0__.fn]: foo }; }"
+  `)
+  expect(result?.deps).toEqual(['vue'])
+})
+
 test('do not rewrite when function declaration is in scope', async () => {
   const result = await ssrTransformSimple(
     `import { fn } from 'vue';function A(){ function fn() {}; return { fn }; }`,

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -592,8 +592,17 @@ function walk(
                 return this.skip()
               }
               if (child.type !== 'Identifier') return
-              // do not record as scope variable if is a destructuring keyword
-              if (isStaticPropertyKey(child, parent)) return
+              // do not record as scope variable if it is a destructuring key
+              // (static or computed) rather than the bound value; a computed
+              // key like `{ [IMPORTED]: v } = {}` references an outer binding
+              // and must stay rewritable
+              if (
+                parent?.type === 'Property' &&
+                parent.key === child &&
+                parent.value !== child
+              ) {
+                return
+              }
               // do not record if this is a default value
               // assignment of a destructuring variable
               if (


### PR DESCRIPTION
### Description

Under SSR, an imported binding used as a **computed key** in a **destructured parameter that has a default value** (`function f({ [KEY]: v } = {}) {}`) was not rewritten to the import namespace, throwing `ReferenceError: KEY is not defined` at runtime (via `ssrLoadModule`, vite-node, and Vitest).

Fixes #23232.

### Root cause

A destructured parameter with a default is an `AssignmentPattern`, so it is walked by the generic param walker in `ssrTransform` rather than by `handlePattern`. That walker only skipped **non-computed** property keys (`isStaticPropertyKey`), so a **computed** key referencing an imported binding was registered as a local scope variable via `setScope`. The later rewrite pass then treated it as a local and skipped the import rewrite, leaving a bare identifier.

`handlePattern` (used for non-defaulted `ObjectPattern`/`ArrayPattern` params) already ignores computed keys, which is why the same code without a default value worked.

### Fix

Skip any property key that is not the bound value (both static and computed), mirroring `handlePattern`:

```ts
if (parent?.type === 'Property' && parent.key === child && parent.value !== child) {
  return
}
```

Shorthand bindings (`{ x } = {}`, where `key === value`) remain scoped; computed keys stay rewritable.

### Tests

Added `packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts` case verifying the computed key is rewritten in both the parameter and the function body. The full `ssrTransform` spec passes (76 tests). Also verified end-to-end with a standalone `createServer().ssrLoadModule(...)` repro: throws before this change, returns the expected object after.

<sub>Note: this contribution was prepared with AI assistance; I have verified the reasoning, the fix, and the tests.</sub>
