### PR TITLE
fix(dev): apply define constants to worker files in dev mode

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -11,6 +11,9 @@ const nonJsRe = /\.json(?:$|\?)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
 const importMetaEnvMarker = '__vite_import_meta_env__'
 const importMetaEnvKeyReCache = new Map<string, RegExp>()
+// worker files run in a separate global scope, so they can't access the
+// defines injected into the vite client in the main thread during dev
+const workerFileRE = /[?&]worker_file&/
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
@@ -120,7 +123,11 @@ export function definePlugin(config: ResolvedConfig): Plugin {
           // for dev we inject actual global defines in the vite client to
           // avoid the transform cost. see the `clientInjection` and
           // `importAnalysis` plugin.
-          return
+          // workers run in a separate global scope so they can't rely on the
+          // defines injected into the main thread - apply the transform instead
+          if (!workerFileRE.test(id)) {
+            return
+          }
         }
 
         if (


### PR DESCRIPTION
### Description

In dev mode, the `definePlugin` skips transforms for all files when 
consumer is `client`, relying on the vite client's global injection 
for the main thread. However, Web Workers run in a separate global 
scope and cannot access the defines injected into the main thread.

This fix detects worker file requests (identified by the `worker_file` 
query parameter) and applies the define transform even in dev mode, 
ensuring that user-defined constants like 
`define: { __SOME_CONSTANT__: 128 }` are properly replaced in 
worker files.

### Additional context

Fixes #23234

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other