### PR TITLE
docs: document keepProcessEnv in the environment options

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -80,10 +80,13 @@ interface EnvironmentOptions {
   resolve?: EnvironmentResolveOptions
   optimizeDeps: DepOptimizationOptions
   consumer?: 'client' | 'server'
+  keepProcessEnv?: boolean
   dev: DevOptions
   build: BuildOptions
 }
 ```
+
+`keepProcessEnv` declares whether the environment's runtime provides a real `process.env`. It defaults to `true` for server environments and `false` for the client one, so a new environment only needs to set it when its runtime does not match that assumption. When it is `false`, Vite statically replaces `process.env` with `{}` and `process.env.NODE_ENV` with the current mode.
 
 The `UserConfig` interface extends from the `EnvironmentOptions` interface, allowing to configure the client and defaults for other environments, configured through the `environments` option. The `client` and a server environment named `ssr` are always present during dev. This allows backward compatibility with `server.ssrLoadModule(url)` and `server.moduleGraph`. During build, the `client` environment is always present, and the `ssr` environment is only present if it is explicitly configured (using `environments.ssr` or for backward compatibility `build.ssr`). An app doesn't need to use the `ssr` name for its SSR environment, it could name it `server` for example.
 


### PR DESCRIPTION
### What

`keepProcessEnv` is part of `EnvironmentOptions`, but it is missing from the interface listing in the Environment API guide, and `grep -rn "keepProcessEnv" docs/` returns nothing. So a custom environment has no documented way to declare how its runtime treats `process.env`.

### Changes

Adds `keepProcessEnv?: boolean` to the `EnvironmentOptions` listing in `docs/guide/api-environment.md`, plus one paragraph describing it.

The default comes from `config.ts`, which resolves it as `options.keepProcessEnv ?? (isSsrTargetWebworkerEnvironment ? false : consumer === 'server')`, so `true` for server environments and `false` for the client. What happens when it is `false` comes from `plugins/define.ts`, which maps `process.env` to `{}` and `process.env.NODE_ENV` to `process.env.NODE_ENV || config.mode`.

### Note

An earlier version of this PR documented this on the shared options page as a top-level option. That was wrong: `DefaultEnvironmentOptions` omits `keepProcessEnv`, so it cannot be set at the top level, and the example I had written would not type-check. Thanks to @bluwy for catching it and pointing at the right place.