### PR TITLE
fix(config): resolve sourcemap paths against sourcemap location

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -2,6 +2,7 @@ import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs'
+import fsp from 'node:fs/promises'
 import { stripVTControlCharacters } from 'node:util'
 import { afterEach, assert, describe, expect, test, vi } from 'vitest'
 import type { InlineConfig, PluginOption } from '..'
@@ -1957,6 +1958,23 @@ describe('loadConfigFromFile', () => {
 
     const c = config as any
     expect(c.dirname).toContain('shebang-crlf')
+  })
+
+  test('sourcemap of a nested config file points to itself', async () => {
+    const configPath = path.resolve(
+      fixtures,
+      './nested/.nested/vite.config.mts',
+    )
+    const writeFile = vi.spyOn(fsp, 'writeFile')
+    await loadConfigFromFile({} as any, configPath, path.dirname(configPath))
+    const code = writeFile.mock.calls[0][1] as string
+    writeFile.mockRestore()
+
+    const [, base64Map] = code.match(
+      /\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,(.+)/,
+    )!
+    const map = JSON.parse(Buffer.from(base64Map, 'base64').toString())
+    expect(normalizePath(map.sources[0])).toBe(normalizePath(configPath))
   })
 
   describe('loadConfigFromFile with configLoader: native', () => {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -2,12 +2,16 @@ import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs'
-import fsp from 'node:fs/promises'
 import { stripVTControlCharacters } from 'node:util'
 import { afterEach, assert, describe, expect, test, vi } from 'vitest'
 import type { InlineConfig, PluginOption } from '..'
 import type { UserConfig, UserConfigExport } from '../config'
-import { defineConfig, loadConfigFromFile, resolveConfig } from '../config'
+import {
+  bundleConfigFile,
+  defineConfig,
+  loadConfigFromFile,
+  resolveConfig,
+} from '../config'
 import { resolveServerOptions } from '../server'
 import { resolveEnvPrefix } from '../env'
 import {
@@ -1965,16 +1969,14 @@ describe('loadConfigFromFile', () => {
       fixtures,
       './nested/.nested/vite.config.mts',
     )
-    const writeFile = vi.spyOn(fsp, 'writeFile')
-    await loadConfigFromFile({} as any, configPath, path.dirname(configPath))
-    const code = writeFile.mock.calls[0][1] as string
-    writeFile.mockRestore()
-
+    const { code } = await bundleConfigFile(configPath, true)
     const [, base64Map] = code.match(
       /\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,(.+)/,
     )!
     const map = JSON.parse(Buffer.from(base64Map, 'base64').toString())
-    expect(normalizePath(map.sources[0])).toBe(normalizePath(configPath))
+    expect(map.sources.map(normalizePath)).toStrictEqual([
+      normalizePath(configPath),
+    ])
   })
 
   describe('loadConfigFromFile with configLoader: native', () => {

--- a/packages/vite/src/node/__tests__/fixtures/config/nested/.nested/vite.config.mts
+++ b/packages/vite/src/node/__tests__/fixtures/config/nested/.nested/vite.config.mts
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2652,8 +2652,8 @@ async function bundleConfigFile(
   const result = await bundle.generate({
     format: isESM ? 'esm' : 'cjs',
     sourcemap: 'inline',
-    sourcemapPathTransform(relative) {
-      return path.resolve(fileName, relative)
+    sourcemapPathTransform(relative, sourcemapPath) {
+      return path.resolve(path.dirname(sourcemapPath), relative)
     },
     // we want to generate a single chunk like esbuild does with `splitting: false`
     codeSplitting: false,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2504,7 +2504,7 @@ async function bundleAndLoadConfigFile(
   }
 }
 
-async function bundleConfigFile(
+export async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
 ): Promise<{


### PR DESCRIPTION
bundleConfigFile resolves each sourcemap source with path.resolve(fileName, relative), treating the config file path itself as a directory. For configs that don't live at the project root, like a VitePress .vitepress/config.mts, this appends the relative path onto the wrong base and produces a source path with a duplicated directory segment. Debuggers then can't find the real file, so breakpoints set in the config or anything it imports never bind.

rolldown's sourcemapPathTransform also passes the sourcemap's own path as a second argument, and that's the correct base to resolve against. Using it fixes both the nested case and the top-level one, which happened to work before only by coincidence.

Fixes #23238