### PR TITLE
fix(config): resolve bundled config sourcemap sources against the sourcemap location

### DIFF
--- a/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
+++ b/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
@@ -1,0 +1,59 @@
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test, vi } from 'vitest'
+import { loadConfigFromFile } from '../config'
+
+describe('bundleConfigFile', () => {
+  const fixtures = path.resolve(import.meta.dirname, './fixtures/config')
+
+  test('resolves the inline sourcemap source to the absolute config path for a nested config', async () => {
+    // VitePress-style layout: the config lives in a nested `.vitepress` dir.
+    const configFile = path.resolve(
+      fixtures,
+      './sourcemap/nested/.vitepress/config.mts',
+    )
+    const configRoot = path.dirname(path.dirname(configFile))
+
+    // `loadConfigFromBundledFile` writes the bundled code (which embeds the
+    // inline sourcemap) to a temp file before importing it. Intercept that
+    // write so we can inspect the emitted sourcemap.
+    const originalWriteFile = fsp.writeFile
+    let bundledCode = ''
+    const writeSpy = vi.spyOn(fsp, 'writeFile').mockImplementation(
+      ((file: unknown, data: unknown) => {
+        if (typeof data === 'string') {
+          bundledCode = data
+        }
+        return originalWriteFile.call(fsp, file, data)
+      }) as any,
+    )
+
+    try {
+      const result = await loadConfigFromFile(
+        {} as any,
+        configFile,
+        configRoot,
+        undefined,
+        undefined,
+        'bundle',
+      )
+      expect(result).not.toBeNull()
+    } finally {
+      writeSpy.mockRestore()
+    }
+
+    const sourceMapMatch = bundledCode.match(
+      /base64,([A-Za-z0-9+/=]+)/,
+    )
+    expect(
+      sourceMapMatch,
+      'the bundled config should embed an inline sourcemap',
+    ).toBeTruthy()
+    const sourceMap = JSON.parse(
+      Buffer.from(sourceMapMatch![1], 'base64').toString('utf-8'),
+    )
+    // The source path must point at the actual config file, not a path
+    // nested under it (e.g. `.../.vitepress/.vitepress/config.mts`).
+    expect(sourceMap.sources[0]).toBe(configFile)
+  })
+})

--- a/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
+++ b/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
@@ -55,6 +55,8 @@ describe('bundleConfigFile', () => {
     // nested under it (e.g. `.../.vitepress/.vitepress/config.mts`).
     // `sourceMap.sources` uses `/` separators even on Windows; normalize both
     // sides so the comparison is platform-independent.
-    expect(path.normalize(sourceMap.sources[0])).toBe(path.normalize(configFile))
+    expect(path.normalize(sourceMap.sources[0])).toBe(
+      path.normalize(configFile),
+    )
   })
 })

--- a/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
+++ b/packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts
@@ -19,14 +19,15 @@ describe('bundleConfigFile', () => {
     // write so we can inspect the emitted sourcemap.
     const originalWriteFile = fsp.writeFile
     let bundledCode = ''
-    const writeSpy = vi.spyOn(fsp, 'writeFile').mockImplementation(
-      ((file: unknown, data: unknown) => {
-        if (typeof data === 'string') {
-          bundledCode = data
-        }
-        return originalWriteFile.call(fsp, file, data)
-      }) as any,
-    )
+    const writeSpy = vi.spyOn(fsp, 'writeFile').mockImplementation(((
+      file: unknown,
+      data: unknown,
+    ) => {
+      if (typeof data === 'string') {
+        bundledCode = data
+      }
+      return originalWriteFile.call(fsp, file, data)
+    }) as any)
 
     try {
       const result = await loadConfigFromFile(
@@ -42,9 +43,7 @@ describe('bundleConfigFile', () => {
       writeSpy.mockRestore()
     }
 
-    const sourceMapMatch = bundledCode.match(
-      /base64,([A-Za-z0-9+/=]+)/,
-    )
+    const sourceMapMatch = bundledCode.match(/base64,([A-Za-z0-9+/=]+)/)
     expect(
       sourceMapMatch,
       'the bundled config should embed an inline sourcemap',
@@ -54,6 +53,8 @@ describe('bundleConfigFile', () => {
     )
     // The source path must point at the actual config file, not a path
     // nested under it (e.g. `.../.vitepress/.vitepress/config.mts`).
-    expect(sourceMap.sources[0]).toBe(configFile)
+    // `sourceMap.sources` uses `/` separators even on Windows; normalize both
+    // sides so the comparison is platform-independent.
+    expect(path.normalize(sourceMap.sources[0])).toBe(path.normalize(configFile))
   })
 })

--- a/packages/vite/src/node/__tests__/fixtures/config/sourcemap/nested/.vitepress/config.mts
+++ b/packages/vite/src/node/__tests__/fixtures/config/sourcemap/nested/.vitepress/config.mts
@@ -1,0 +1,3 @@
+export default {
+  plugins: [],
+}

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2652,8 +2652,8 @@ async function bundleConfigFile(
   const result = await bundle.generate({
     format: isESM ? 'esm' : 'cjs',
     sourcemap: 'inline',
-    sourcemapPathTransform(relative) {
-      return path.resolve(fileName, relative)
+    sourcemapPathTransform(relative, sourcemapPath) {
+      return path.resolve(path.dirname(sourcemapPath), relative)
     },
     // we want to generate a single chunk like esbuild does with `splitting: false`
     codeSplitting: false,


### PR DESCRIPTION
Fixes #23238

## Problem

In `bundleConfigFile`, the `sourcemapPathTransform` callback resolved each source path against `fileName` (the path of the config *file*), treating that file path as a directory:

```js
sourcemapPathTransform(relative) {
  return path.resolve(fileName, relative)
}
```

For a config nested in a directory (e.g. a VitePress `docs/.vitepress/config.mts`), `relative` is the source path relative to the generated sourcemap's directory. Resolving it against the config file path nests the path segments, producing doubled segments such as `.../.vitepress/.vitepress/config.mts` in the inline sourcemap's `sources`. This breaks debugger source-map resolution and any tooling that reads the config's inline sourcemap.

## Fix

Rollup/Rolldown pass the generated sourcemap's path as the second argument to `sourcemapPathTransform`. The source paths are relative to that map's directory, so resolve against it:

```js
sourcemapPathTransform(relative, sourcemapPath) {
  return path.resolve(path.dirname(sourcemapPath), relative)
}
```

This yields the correct absolute source path regardless of where the config file lives (verified for both a root-level `vite.config.ts` and a nested `.vitepress/config.mts`).

## Verification

Added a unit test (`packages/vite/src/node/__tests__/config-bundle-sourcemap.spec.ts`) that loads a nested config fixture with `loadConfigFromFile(..., 'bundle')`, decodes the inline sourcemap from the emitted bundle, and asserts `sources[0]` points at the actual config file.

- Before this change the test fails: the sourcemap source resolves to `.../.vitepress/.vitepress/config.mts`.
- After this change the test passes: the sourcemap source resolves to `.../.vitepress/config.mts`.

Reproduction project: a vanilla VitePress project with a TypeScript config (per the issue) exhibits the doubled `.vitepress/.vitepress` source path.