### PR TITLE
chore: upgrade markdown-it-image-size

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "@types/express": "^5.0.6",
     "@voidzero-dev/vitepress-theme": "^5.0.4",
     "feed": "^6.0.0",
-    "markdown-it-image-size": "^15.1.0",
+    "markdown-it-image-size": "^15.2.0",
     "oxc-minify": "^0.142.0",
     "vitepress": "2.0.0-alpha.18",
     "vitepress-plugin-graphviz": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       markdown-it-image-size:
-        specifier: ^15.1.0
-        version: 15.1.0(markdown-it@14.3.0)
+        specifier: ^15.2.0
+        version: 15.2.0(markdown-it@14.3.0)
       oxc-minify:
         specifier: ^0.142.0
         version: 0.142.0
@@ -6440,11 +6440,11 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
-  markdown-it-image-size@15.1.0:
-    resolution: {integrity: sha512-irLIyVV9Mbdqzr71C804b6QGZdtJ+Jv8F2Pypdlm1A8HtgTEJjNCT01HLVM5JlEd/3xJu9iSgAnyPM0aVeQJ2A==}
+  markdown-it-image-size@15.2.0:
+    resolution: {integrity: sha512-AlSkbOdtfKaUk9KbiKC1dJyrVmpVRauxlnDe1RL3NlWQ68bMpjDL4Wpc9uXutFSNhqdJ2LYdcW81tuyDHc4FxA==}
     engines: {node: '>= 20'}
     peerDependencies:
-      markdown-it: '>= 10 < 15'
+      markdown-it: '>= 10 < 16'
     peerDependenciesMeta:
       markdown-it:
         optional: true
@@ -12416,7 +12416,7 @@ snapshots:
 
   mark.js@8.11.1: {}
 
-  markdown-it-image-size@15.1.0(markdown-it@14.3.0):
+  markdown-it-image-size@15.2.0(markdown-it@14.3.0):
     dependencies:
       '@types/markdown-it': 14.1.2
       flat-cache: 6.1.20


### PR DESCRIPTION
This PR upgrades `markdown-it-image-size` from `15.1.0` to `15.2.0`, fixing relative image path resolution when running the Vite documentation on Windows.

The expected fix was missing from the published `15.1.0` package, as described in [markdown-it-image-size#999](https://github.com/boyum/markdown-it-image-size/issues/999). I verified that the issue is still reproducible with `15.1.0` and is resolved after upgrading to `15.2.0`.

With this upstream fix, #23047 is no longer needed and can be closed.

No additional tests or documentation changes are included because this is an upstream dependency fix.