### PR TITLE
fix(config): resolve sourcemap sources against the sourcemap directory

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -6,7 +6,12 @@ import { stripVTControlCharacters } from 'node:util'
 import { afterEach, assert, describe, expect, test, vi } from 'vitest'
 import type { InlineConfig, PluginOption } from '..'
 import type { UserConfig, UserConfigExport } from '../config'
-import { defineConfig, loadConfigFromFile, resolveConfig } from '../config'
+import {
+  bundleConfigFile,
+  defineConfig,
+  loadConfigFromFile,
+  resolveConfig,
+} from '../config'
 import { resolveServerOptions } from '../server'
 import { resolveEnvPrefix } from '../env'
 import {
@@ -2014,6 +2019,29 @@ describe('loadConfigFromFile', () => {
         normalizePath(path.resolve(fs.realpathSync.native(tempDir), '.vite')),
       )
     })
+  })
+})
+
+describe('bundleConfigFile', () => {
+  const fixtures = path.resolve(import.meta.dirname, './fixtures/config')
+
+  test('sourcemap sources point to the original files', async () => {
+    const root = path.resolve(fixtures, './bundle-sourcemap')
+    const { code } = await bundleConfigFile(
+      path.resolve(root, './vite.config.ts'),
+      true,
+    )
+
+    const base64 = code.match(
+      /\/\/# sourceMappingURL=data:application\/json[^,]*,([\w+/=]+)/,
+    )?.[1]
+    assert(base64)
+    const map = JSON.parse(Buffer.from(base64, 'base64').toString())
+
+    expect([...map.sources].map(normalizePath).sort()).toStrictEqual([
+      normalizePath(path.resolve(root, './dep.ts')),
+      normalizePath(path.resolve(root, './vite.config.ts')),
+    ])
   })
 })
 

--- a/packages/vite/src/node/__tests__/fixtures/config/bundle-sourcemap/dep.ts
+++ b/packages/vite/src/node/__tests__/fixtures/config/bundle-sourcemap/dep.ts
@@ -1,0 +1,1 @@
+export const value = 1

--- a/packages/vite/src/node/__tests__/fixtures/config/bundle-sourcemap/vite.config.ts
+++ b/packages/vite/src/node/__tests__/fixtures/config/bundle-sourcemap/vite.config.ts
@@ -1,0 +1,3 @@
+import { value } from './dep'
+
+export default { define: { foo: value } }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2504,7 +2504,7 @@ async function bundleAndLoadConfigFile(
   }
 }
 
-async function bundleConfigFile(
+export async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
 ): Promise<{
@@ -2652,8 +2652,10 @@ async function bundleConfigFile(
   const result = await bundle.generate({
     format: isESM ? 'esm' : 'cjs',
     sourcemap: 'inline',
-    sourcemapPathTransform(relative) {
-      return path.resolve(fileName, relative)
+    sourcemapPathTransform(relative, sourcemapPath) {
+      // `relative` is relative to the directory of the sourcemap, not to the
+      // config file, so it has to be resolved against the sourcemap directory
+      return path.resolve(path.dirname(sourcemapPath), relative)
     },
     // we want to generate a single chunk like esbuild does with `splitting: false`
     codeSplitting: false,


### PR DESCRIPTION
### Description

Closes #23238

`bundleConfigFile` generates an inline sourcemap for the bundled config file and maps the sources back to absolute paths in `sourcemapPathTransform`. The hook receives a path relative to the directory of the generated sourcemap, but the path was resolved against `fileName` — the config file itself, not a directory:

```ts
sourcemapPathTransform(relative) {
  return path.resolve(fileName, relative)
},
```

This produces a correct path only when the config file sits directly in the current working directory, where the leading `..` of the relative path happens to cancel out the file name segment. For a config file in any other location the segments get duplicated:

```
/project/docs/.vitepress/docs/.vitepress/config.mts
```

Since that path does not exist, breakpoints set in the config file are never bound and stack traces originating from it point at a non-existent file. This is reproducible with VitePress, whose config lives in `docs/.vitepress/config.mts`.

The relative path is now resolved against the directory of the sourcemap, which is the base it was computed from.

### Tests

Added a unit test that bundles a config file in a nested fixture directory, decodes the inline sourcemap and asserts that `sources` point at the real files. It fails on `main` with the duplicated path shown above:

```
- "…/fixtures/config/bundle-sourcemap/dep.ts"
+ "…/fixtures/config/bundle-sourcemap/src/node/__tests__/fixtures/config/bundle-sourcemap/dep.ts"
```

`bundleConfigFile` is exported so the test can call it directly. It is not re-exported from `packages/vite/src/node/index.ts`, so it stays out of the public API.
