### PR TITLE
fix(css): resolve `cssMinify` from the environment config

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1087,6 +1087,55 @@ test('chunkImportMap per environment with shared plugins', async () => {
   expect(entry.code).toContain(JSON.stringify(cssSpecifier.slice(1)))
 })
 
+test('cssMinify per environment with shared plugins', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/css-minify')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          cssMinify: false,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+      custom: {
+        consumer: 'client',
+        build: {
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    builder: {
+      sharedPlugins: true,
+    },
+  })
+
+  const findCss = (output: RolldownOutput) =>
+    (
+      output.output.find(
+        (o): o is OutputAsset =>
+          o.type === 'asset' && o.fileName.endsWith('.css'),
+      )!.source as string
+    ).trim()
+
+  const client = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+  const custom = (await builder.build(
+    builder.environments.custom,
+  )) as RolldownOutput
+
+  expect(findCss(client)).toContain('\n')
+  expect(findCss(custom)).not.toContain('\n')
+})
+
 test('chunkImportMap is emitted when emitAssets is false', async () => {
   const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
   const builder = await createBuilder({

--- a/packages/vite/src/node/__tests__/fixtures/shared-plugins/css-minify/entry.js
+++ b/packages/vite/src/node/__tests__/fixtures/shared-plugins/css-minify/entry.js
@@ -1,0 +1,3 @@
+import './style.css'
+
+console.log('test')

--- a/packages/vite/src/node/__tests__/fixtures/shared-plugins/css-minify/style.css
+++ b/packages/vite/src/node/__tests__/fixtures/shared-plugins/css-minify/style.css
@@ -1,0 +1,7 @@
+.foo {
+  color: red;
+}
+
+.bar {
+  color: blue;
+}

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -644,8 +644,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           code = modulesCode
         } else if (inlined) {
           let content = css
-          if (config.build.cssMinify) {
-            content = await minifyCSS(content, config, true, id)
+          if (this.environment.config.build.cssMinify) {
+            content = await minifyCSS(
+              content,
+              this.environment.config,
+              true,
+              id,
+            )
           }
           code = `export default ${JSON.stringify(content)}`
         } else {
@@ -839,7 +844,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             await urlEmitQueue.run(async () =>
               Promise.all(
                 urlEmitTasks.map(async (info) => {
-                  info.content = await finalizeCss(info.content, config)
+                  info.content = await finalizeCss(
+                    info.content,
+                    this.environment.config,
+                  )
                 }),
               ),
             )
@@ -924,7 +932,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
                   // wait for previous tasks as well
                   chunkCSS = await codeSplitEmitQueue.run(async () => {
-                    return finalizeCss(chunkCSS!, config)
+                    return finalizeCss(chunkCSS!, this.environment.config)
                   })
 
                   // emit corresponding css file
@@ -952,7 +960,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                   // But because entry chunk can be imported by dynamic import,
                   // we shouldn't remove the inlined CSS. (#10285)
 
-                  chunkCSS = await finalizeCss(chunkCSS, config)
+                  chunkCSS = await finalizeCss(
+                    chunkCSS,
+                    this.environment.config,
+                  )
                   let cssString = JSON.stringify(chunkCSS)
                   cssString =
                     renderAssetUrlInJS(
@@ -1060,7 +1071,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         // Finally, if there's any extracted CSS, we emit the asset
         if (extractedCss) {
           hasEmitted = true
-          extractedCss = await finalizeCss(extractedCss, config)
+          extractedCss = await finalizeCss(
+            extractedCss,
+            this.environment.config,
+          )
           this.emitFile({
             name: getCssBundleName(),
             type: 'asset',


### PR DESCRIPTION
### Description

`cssPostPlugin` captures the root `ResolvedConfig` at plugin creation time and reads `build.cssMinify` from it. With `builder.sharedPlugins: true` a single plugin instance is reused across every environment, so a per-environment `build.cssMinify` was ignored and the root value was applied everywhere — the config in #20789 produces minified CSS for both the client and the ssr build.

This reads the option from `this.environment.config` instead, which is what the surrounding code in the same plugin already does for `build.cssCodeSplit`, `build.emitAssets` and `build.chunkImportMap`. `compileLightningCSS` resolves it per environment too, so this only aligns the remaining call sites.

Changed call sites, all in `cssPostPlugin`:

- the `?inline` branch in `transform`
- `finalizeCss` for `__VITE_CSS_URL__` emit tasks
- `finalizeCss` for code-split chunk CSS
- `finalizeCss` for inlined chunk CSS
- `finalizeCss` for the extracted single stylesheet

Since `minifyCSS` receives the same config object, `build.cssTarget`, `css.lightningcss` and `esbuild` options used during minification now resolve per environment as well.

fixes #20789

### Tests

Added `cssMinify per environment with shared plugins` next to the existing `minify per environment` and `chunkImportMap per environment with shared plugins` tests, using a new `fixtures/shared-plugins/css-minify` fixture. It builds two client-consumer environments with `sharedPlugins: true` — one with `cssMinify: false`, one with the default — and asserts the first emits unminified CSS while the second stays minified.

Without the fix the test fails with `expected '.foo{color:red}.bar{color:#00f}' to contain '\n'`.
