### PR TITLE
refactor(config): avoid cyclic evaluation-time reads of build, css and server defaults

### DIFF
--- a/packages/vite/src/node/__tests__/configDefaults.spec.ts
+++ b/packages/vite/src/node/__tests__/configDefaults.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// `../build`, `../plugins/css` and `../server` import `../config` back, so when
+// one of them is the entry of the cycle, `../config` is evaluated while the
+// entry is still parked on its own imports. Reading the defaults it owns at
+// that point yields `undefined`, since the SSR transform swallows the temporal
+// dead zone error. Each case resets the module registry so that the module
+// under test really is the entry of the cycle.
+describe('configDefaults', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  test('keeps the defaults owned by `../build`', async () => {
+    const build = await import('../build')
+    const { cyclicConfigDefaults } = await import('../config')
+
+    expect(cyclicConfigDefaults.build).toBe(
+      build.buildEnvironmentOptionsDefaults,
+    )
+    expect(cyclicConfigDefaults.builder).toBe(build.builderOptionsDefaults)
+  })
+
+  test('keeps the defaults owned by `../plugins/css`', async () => {
+    const css = await import('../plugins/css')
+    const { cyclicConfigDefaults } = await import('../config')
+
+    expect(cyclicConfigDefaults.css).toBe(css.cssConfigDefaults)
+  })
+
+  test('keeps the defaults owned by `../server`', async () => {
+    const server = await import('../server')
+    const { cyclicConfigDefaults } = await import('../config')
+
+    expect(cyclicConfigDefaults.server).toBe(server.serverConfigDefaults)
+  })
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -816,6 +816,10 @@ export async function resolveDevToolsConfig(
 }
 
 // inferred ones are omitted
+// `./build`, `./plugins/css` and `./server` import this module back, so the
+// defaults they own are exposed through getters. Reading them while this object
+// is built hits their temporal dead zone whenever one of them is the entry of
+// the cycle, which the module runner turns into a silent `undefined`.
 const configDefaults = Object.freeze({
   define: {},
   dev: {
@@ -828,7 +832,9 @@ const configDefaults = Object.freeze({
     // recoverable
     // moduleRunnerTransform
   },
-  build: buildEnvironmentOptionsDefaults,
+  get build() {
+    return buildEnvironmentOptionsDefaults
+  },
   resolve: {
     // mainFields
     // conditions
@@ -852,7 +858,9 @@ const configDefaults = Object.freeze({
   html: {
     cspNonce: undefined,
   },
-  css: cssConfigDefaults,
+  get css() {
+    return cssConfigDefaults
+  },
   json: {
     namedExports: true,
     stringify: 'auto',
@@ -860,8 +868,12 @@ const configDefaults = Object.freeze({
   // esbuild
   assetsInclude: undefined,
   /** @experimental */
-  builder: builderOptionsDefaults,
-  server: serverConfigDefaults,
+  get builder() {
+    return builderOptionsDefaults
+  },
+  get server() {
+    return serverConfigDefaults
+  },
   preview: {
     port: DEFAULT_PREVIEW_PORT,
     // strictPort
@@ -924,6 +936,18 @@ const configDefaults = Object.freeze({
   environments: {},
   appType: 'spa',
 } satisfies UserConfig)
+
+/**
+ * The {@link configDefaults} entries owned by modules that import this one
+ * back. Exported for the test that guards them against being read while this
+ * module is evaluated; it is not part of the public API.
+ */
+export const cyclicConfigDefaults: {
+  build: Readonly<Partial<BuildEnvironmentOptions>>
+  builder: Readonly<Partial<BuilderOptions>>
+  css: Readonly<Partial<CSSOptions>>
+  server: Readonly<Partial<ServerOptions>>
+} = configDefaults
 
 function normalizeInput(
   input: InputOption | undefined,


### PR DESCRIPTION
`configDefaults` in `config.ts` reads four values while its own module body runs:

```ts
build: buildEnvironmentOptionsDefaults,   // ./build
builder: builderOptionsDefaults,          // ./build
css: cssConfigDefaults,                   // ./plugins/css
server: serverConfigDefaults,             // ./server
```

All three of those modules import `./config` back. Whenever one of them is the entry of the cycle it is still parked on its own `import` statements at the moment `config.ts` is evaluated, so each read lands in the owner's temporal dead zone. Native ESM throws there. Under the SSR transform every export getter is wrapped in `() => { try { return x } catch {} }`, so instead the entries silently end up `undefined`.

Those four entries happen to be dead today — nothing reads `configDefaults.build`, `.builder`, `.css` or `.server` — which is why this has never been visible. It becomes visible as soon as that `try/catch` is up for removal (#22291): on `main`, dropping the swallow makes 25 of 69 unit test files fail with `Cannot access 'buildEnvironmentOptionsDefaults' before initialization` at `config.ts:831`, plus a cascade of follow-on errors (`clientAlias`, `BasicMinimalPluginContext`, `__vite_ssr_import_N__`) that come from `config.ts` aborting mid-body while the module runner still hands out the half-evaluated namespace. With this change all of those are gone; the only failures left are the `ssrTransform` snapshots that literally contain the `try { return x } catch {}` text.

Reading the four entries through getters defers them past the point where the cycle has settled, whichever module is the entry.

## Alternatives explored

- **Move the defaults into a leaf module.** This only helps if `config.ts` imports the leaf directly; re-exporting through `build.ts` just moves the TDZ from the value binding onto the hoisted import binding. It also works against the existing convention of keeping each defaults object next to the options it documents.
- **Delete the four entries.** They are unread, so removing them also removes the cyclic reads, with a smaller diff and no test-only export. I left them because whether `configDefaults` is meant to be an exhaustive record of the defaults is a call for the maintainers — happy to switch if you prefer it.

## Parts that need reviewer attention

`config.ts` gains a `cyclicConfigDefaults` export used only by the new test. `configDefaults` is module-private and the four entries are read by nothing — precisely why the bug is invisible — so there is no existing observable to assert through. It cannot simply become `export const configDefaults`: the build runs with `--isolatedDeclarations` and `Object.freeze(...)` is a call expression, so that fails `TS9010` without an explicit annotation, which would mean renaming the private binding across its call sites and widening the type internal code relies on. The export is tree-shaken away — it is absent from `dist/node/index.d.ts` and from `dist/node/**/*.js`. If you would rather not carry it, the "delete the entries" alternative above drops both the export and the test.

I deliberately did not touch the other cyclic modules (`server/environment.ts`, `preview.ts`, `plugins/index.ts`, `idResolver.ts`, `ssr/runnerImport.ts`, `nodeResolve.ts`, `server/pluginContainer.ts`, `server/environments/runnableEnvironment.ts`). They all dereference across the cycle inside function bodies only, so they are fine as they are. The cycles remain; only the evaluation-time reads are gone.

## Tests

`packages/vite/src/node/__tests__/configDefaults.spec.ts` resets the module registry before each case and imports `../build`, `../plugins/css` and `../server` first, so each one genuinely becomes the entry of the cycle. All three cases fail without this change (`expected undefined to be {…}`) and pass with it.
