### PR TITLE
fix(build): watch publicDir files in build watch mode

### DIFF
--- a/packages/vite/src/node/plugins/prepareOutDir.ts
+++ b/packages/vite/src/node/plugins/prepareOutDir.ts
@@ -5,13 +5,44 @@ import colors from 'picocolors'
 import type { Plugin } from '../plugin'
 import { getResolvedOutDirs, resolveEmptyOutDir } from '../watch'
 import type { Environment } from '../environment'
-import { copyDir, emptyDir, normalizePath } from '../utils'
+import {
+  ERR_SYMLINK_IN_RECURSIVE_READDIR,
+  copyDir,
+  emptyDir,
+  normalizePath,
+  recursiveReaddir,
+} from '../utils'
 import { withTrailingSlash } from '../../shared/utils'
 
 export function prepareOutDirPlugin(): Plugin {
   const rendered = new Set<Environment>()
   return {
     name: 'vite:prepare-out-dir',
+    async buildStart() {
+      const { build: options, publicDir } = this.environment.config
+      if (
+        !options.watch ||
+        !options.write ||
+        !options.copyPublicDir ||
+        !publicDir
+      ) {
+        return
+      }
+      // Public files bypass the bundler, so nothing else adds them to the
+      // watch set. A rebuild re-copies them in `renderStart` below.
+      let publicFiles: string[]
+      try {
+        publicFiles = await recursiveReaddir(publicDir)
+      } catch (e) {
+        if (e.code === ERR_SYMLINK_IN_RECURSIVE_READDIR) {
+          return
+        }
+        throw e
+      }
+      for (const file of publicFiles) {
+        this.addWatchFile(file)
+      }
+    },
     watchChange() {
       rendered.delete(this.environment)
     },

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
@@ -15,7 +16,9 @@ import {
   page,
   readFile,
   readManifest,
+  removeFile,
   serverLogs,
+  testDir,
   viteTestUrl,
   watcher,
 } from '~utils'
@@ -810,6 +813,21 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
     await notifyRebuildComplete(watcher)
     await page.reload()
     expect(await page.textContent('.raw-query')).toBe('zoo2')
+  })
+
+  // `static/bar` is not imported anywhere, so it only reaches outDir if
+  // publicDir itself is watched
+  test('editing a file in publicDir updates outDir', async () => {
+    expect(readFile('dist/foo/bar')).toBe('bar\n')
+    editFile('static/bar', (code) => code.replace('bar', 'bar2'))
+    await notifyRebuildComplete(watcher)
+    expect(readFile('dist/foo/bar')).toBe('bar2\n')
+  })
+
+  test('removing a file from publicDir updates outDir', async () => {
+    removeFile('static/bar')
+    await notifyRebuildComplete(watcher)
+    expect(existsSync(path.resolve(testDir, 'dist/foo/bar'))).toBe(false)
   })
 })
 


### PR DESCRIPTION
### What this solves

`vite build --watch` doesn't rebuild when you change a file in `publicDir`. Rolldown watches the module graph plus whatever plugins register via `addWatchFile()`, and public assets are in neither — they're just copied once in `renderStart`.

The fix is small, because `prepareOutDirPlugin` already re-copies `publicDir` on every rebuild (`watchChange()` clears the `rendered` guard). All that was missing was making a change under `publicDir` trigger a rebuild at all, so `buildStart` now registers each public file with `this.addWatchFile()`. No copying logic added.

Closes #18655

Why this slipped past the existing tests: `playground/assets` does edit `static/foo.txt` under build watch and passes — but that file is imported as `?raw` from `index.html`, so it's in the module graph, and the assertion reads the bundle rather than `outDir`.

### Alternatives

#22667 (closed by its author) synced files straight into `outDir` without rebuilding. Faster, but in build `checkPublicFile` falls back to `tryStatSync`, so whether a public file exists changes the bundle itself — `<img src="/icon.png">`, `@import '/foo.css'`. A plain copy can't re-resolve those, and `outDir` drifts from a real build. Rebuilding keeps them identical for free.

I also tried registering the directory instead of each file. rolldown accepts it and then fires nothing, not even `change`:

```
addWatchFile(DIR .../public)
  change existing.txt : no rebuild (5s timeout)
  add    added.txt    : no rebuild (5s timeout)
  unlink existing.txt : no rebuild (5s timeout)
  change main.js      : rebuild triggered   <- control
```

### One thing I'd like your call on

**A newly added public file doesn't rebuild immediately.** It didn't exist at `buildStart`, and `Watcher` has no `invalidate()`, so there's nothing to hook into. It does land on the next rebuild, since `buildStart` re-reads `publicDir` each time. Covering it eagerly would mean a chokidar watcher copying files directly — two different consistency guarantees in one feature, which is why I left it out. Glad to add it if you'd rather.

The other trade-off: every public edit now costs a full rebuild, `emptyDir(outDir)` included.

### Tests

Two tests in the existing build-watch block in `playground/assets`, using `static/bar` — a public file nothing imports — asserting on `dist/foo/bar` on disk rather than through the page. Without the patch both time out after 30s, waiting on a rebuild that never comes; with it they pass in 1.5s. No test for the added-file case, since it's knowingly not covered.
