### PR TITLE
fix(define): fix match escaped dots to support $-prefixed define keys

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -90,6 +90,15 @@ describe('definePlugin (SSR dev)', () => {
     ).toBe(undefined)
   })
 
+  test('replaces define keys containing `$`', async () => {
+    const transform = await createJsDefinePluginTransform({
+      $FOO: JSON.stringify('bar'),
+    })
+    expect(await transform('export const x = $FOO;')).toBe(
+      'export const x = "bar";\n',
+    )
+  })
+
   test('replace import.meta.env when it is a invalid json', async () => {
     const transform = await createJsDefinePluginTransform({
       'import.meta.env.LEGACY': '__VITE_IS_LEGACY__',

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -7,7 +7,7 @@ import { isHTMLRequest } from './html'
 
 const nonJsRe = /\.json(?:$|\?)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
-const escapedDotRE = /(?<!\\)\\./g
+const escapedDotRE = /(?<!\\)\\\./g
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'


### PR DESCRIPTION
## Description

The `define` plugin silently drops define keys that contain a `$` (e.g. `define: { $FOO: '"bar"' }`) — the transform leaves the source unchanged instead of replacing `$FOO`.

**Root cause:** `escapedDotRE = /(?<!\\)\\./g` is meant to rewrite an escaped dot (`\.`) inside an already-`escapeRegex`-escaped key into `\??\.` (so it also matches optional chaining, `?.`). But the `.` in that regex is unescaped, so it actually matches a backslash followed by *any* character. `escapeRegex('$FOO')` produces `\$FOO`; the `replaceAll` then rewrites `\$` → `\??\.`, producing the pattern `\??\.FOO`, which never matches `$FOO`. The `pattern.test(code)` pre-check is then false and the replacement is skipped.

**Fix:** escape the dot (`/(?<!\\)\\\./g`) so only an escaped literal dot is rewritten. Dotted keys like `import.meta.env` are unaffected (both regexes yield `foo\??\.bar`), while escaped metacharacters such as `\$` are left intact.

Added a regression test (`replaces define keys containing $`) that fails on `main` (the transform returns `undefined`) and passes with this change.
