### PR TITLE
chore(config): add @deprecated tags to plugin hook utilities

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1091,9 +1091,15 @@ export function getDefaultEnvironmentOptions(
 }
 
 export interface PluginHookUtils {
+  /**
+   * @deprecated Use `config.environments` instead
+   */
   getSortedPlugins: <K extends keyof Plugin>(
     hookName: K,
   ) => PluginWithRequiredHook<K>[]
+  /**
+   * @deprecated Use `config.environments` instead
+   */
   getSortedPluginHooks: <K extends keyof Plugin>(
     hookName: K,
   ) => NonNullable<HookHandler<Plugin[K]>>[]
@@ -2178,7 +2184,6 @@ export async function resolveConfig(
   patchPlugins?.(resolvedPlugins)
   ;(resolved.plugins as Plugin[]) = resolvedPlugins
 
-  // TODO: Deprecate config.getSortedPlugins and config.getSortedPluginHooks
   Object.assign(resolved, createPluginHookUtils(resolved.plugins))
 
   // call configResolved hooks


### PR DESCRIPTION
- **What is this PR solving?**
  This PR fulfills an outstanding `TODO` in `config.ts` by adding `@deprecated` JSDoc annotations to `getSortedPlugins` and `getSortedPluginHooks` on the `PluginHookUtils` interface (which is exposed via `ResolvedConfig`). This ensures that downstream plugin authors receive proper IDE warnings, pointing them toward the newer `config.environments` API.

- **Reference the issues it solves**
  N/A (resolves an internal codebase TODO)

- **What other alternatives have you explored?**
  N/A - this is a direct implementation of a planned deprecation comment left by the core team.

- **Are there any parts you think require more attention from reviewers?**
  No, this is a straightforward types-only change that doesn't alter any runtime behavior.

- **Tests**
  Tests are not included because this is strictly a TypeScript JSDoc annotation update and does not change any runtime logic.
