### PR TITLE
build: use JSON import attributes instead of readFIleSync in rolldown configs

### DIFF
--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -1,16 +1,15 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import path from 'node:path'
 import MagicString from 'magic-string'
 import type { Plugin } from 'rolldown'
 import { defineConfig } from 'rolldown'
 import { ImportType, init, parse } from 'es-module-lexer'
 import licensePlugin from './rollupLicensePlugin'
+import pkg from './package.json' with { type: 'json' }
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 const dirname = import.meta.dirname
-const pkg = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url)).toString(),
-)
+
 const disableSourceMap = !!process.env.DEBUG_DISABLE_SOURCE_MAP
 
 const envConfig = defineConfig({

--- a/packages/vite/rolldown.dts.config.ts
+++ b/packages/vite/rolldown.dts.config.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import { builtinModules } from 'node:module'
 import { defineConfig } from 'rolldown'
 import type {
@@ -13,15 +12,12 @@ import { dts } from 'rolldown-plugin-dts'
 import { parse as parseWithBabel } from '@babel/parser'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
+import pkg from './package.json' with { type: 'json' }
 
 type Directive = ESTree.Directive
 type ModuleExportName = ESTree.ModuleExportName
 type Program = ESTree.Program
 type Statement = ESTree.Statement
-
-const pkg = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url)).toString(),
-)
 
 const external = [
   /^node:*/,


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

Replace manual `readFileSync` + `JSON.parse` with native `import pkg from './package.json' with { type: 'json' }` in both      `rolldown.config.ts` and `rolldown.dts.config.ts`.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_non-javascript_modules