### PR TITLE
test(bundled-dev): enable hmr playground

### DIFF
--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -471,8 +471,8 @@ if (!isBuild) {
   })
 
   // #2255
-  // bundled dev: the edits cause an unexpected full page reload, which
-  // resets the log the test builds up
+  // bundled dev: the test passes on its own, but its edits queue stray page
+  // reloads that swallow a later hot update (`import.meta.hot?.accept` times out)
   test.skipIf(isBundledDev)('importing reloaded', async () => {
     await page.goto(viteTestUrl)
     const outputEle = page.locator('.importing-reloaded')
@@ -911,8 +911,9 @@ if (!isBuild) {
     await expect.poll(() => btn.textContent()).toBe('Compteur 0')
   })
 
-  // bundled dev: updates that flow through a plugin virtual module do not
-  // reach the page
+  // bundled dev: the update itself applies via HMR, but the edit also queues
+  // stray page reloads that swallow a later hot update
+  // (`import.meta.hot?.accept` times out)
   test.skipIf(isBundledDev)('handle virtual module updates', async () => {
     await page.goto(viteTestUrl)
     const el = page.locator('.virtual')
@@ -931,7 +932,7 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toBe('[wow]1')
   })
 
-  // bundled dev: same virtual-module gap as `handle virtual module updates`
+  // bundled dev: same stray-reload fallout as `handle virtual module updates`
   test.skipIf(isBundledDev)(
     'handle virtual module accept updates',
     async () => {

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -9,6 +9,7 @@ import {
   getBg,
   getColor,
   isBuild,
+  isBundledDev,
   page,
   readFile,
   removeFile,
@@ -25,7 +26,13 @@ test('should render', async () => {
 
 if (!isBuild) {
   test('should connect', async () => {
-    expect(browserLogs.length).toBe(5)
+    if (isBundledDev) {
+      // bundled-dev logs extra `connecting...` and `connected` message (5 + 2)
+      // if the first bundle is not ready and a fallback page is shown when the client connects.
+      expect(browserLogs.length).toBeOneOf([5, 7])
+    } else {
+      expect(browserLogs.length).toBe(5)
+    }
     expect(browserLogs.some((msg) => msg.includes('connected'))).toBe(true)
     browserLogs.length = 0
   })
@@ -38,15 +45,30 @@ if (!isBuild) {
     return res.json()
   }
   test('hot events', async () => {
-    expect(await fetchHotEvents()).toStrictEqual({
-      connectCount: 1,
-      disconnectCount: 0,
-    })
+    if (isBundledDev) {
+      expect(await fetchHotEvents()).toBeOneOf([
+        { connectCount: 1, disconnectCount: 0 },
+        { connectCount: 2, disconnectCount: 1 }, // landed on fallback page first, then reconnected to main page
+      ])
+    } else {
+      expect(await fetchHotEvents()).toStrictEqual({
+        connectCount: 1,
+        disconnectCount: 0,
+      })
+    }
     await untilBrowserLogAfter(() => page.reload(), [/connected/])
-    expect(await fetchHotEvents()).toStrictEqual({
-      connectCount: 2,
-      disconnectCount: 1,
-    })
+
+    if (isBundledDev) {
+      expect(await fetchHotEvents()).toBeOneOf([
+        { connectCount: 2, disconnectCount: 1 },
+        { connectCount: 3, disconnectCount: 2 },
+      ])
+    } else {
+      expect(await fetchHotEvents()).toStrictEqual({
+        connectCount: 2,
+        disconnectCount: 1,
+      })
+    }
   })
 
   test('self accept', async () => {
@@ -61,7 +83,11 @@ if (!isBuild) {
         'foo was: 1',
         '(self-accepting 1) foo is now: 2',
         '(self-accepting 2) foo is now: 2',
-        '[vite] hot updated: /hmr.ts',
+        // bundled dev: the client logs rolldown module ids (cwd-relative, like
+        // `playground-temp/hmr/hmr.ts`). The same `cwd` issue as in hot update log in #23028.
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -78,7 +104,9 @@ if (!isBuild) {
         'foo was: 2',
         '(self-accepting 1) foo is now: 3',
         '(self-accepting 2) foo is now: 3',
-        '[vite] hot updated: /hmr.ts',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -96,7 +124,9 @@ if (!isBuild) {
         '>>> vite:beforeUpdate -- update',
         '(hot data) value from execution: 1',
         '(hot data) value from dispose: 1',
-        '[vite] hot updated: /hotData.js',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hotData.js'
+          : '[vite] hot updated: /hotData.js',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -111,7 +141,9 @@ if (!isBuild) {
         '>>> vite:beforeUpdate -- update',
         '(hot data) value from execution: 2',
         '(hot data) value from dispose: 2',
-        '[vite] hot updated: /hotData.js',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hotData.js'
+          : '[vite] hot updated: /hotData.js',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -133,7 +165,9 @@ if (!isBuild) {
         '(single dep) nested foo is now: 1',
         '(multi deps) foo is now: 2',
         '(multi deps) nested foo is now: 1',
-        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmrDep.js via playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmrDep.js via /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -153,7 +187,9 @@ if (!isBuild) {
         '(single dep) nested foo is now: 1',
         '(multi deps) foo is now: 3',
         '(multi deps) nested foo is now: 1',
-        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmrDep.js via playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmrDep.js via /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -176,7 +212,9 @@ if (!isBuild) {
         '(single dep) nested foo is now: 2',
         '(multi deps) foo is now: 3',
         '(multi deps) nested foo is now: 2',
-        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmrDep.js via playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmrDep.js via /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -196,7 +234,9 @@ if (!isBuild) {
         '(single dep) nested foo is now: 3',
         '(multi deps) foo is now: 3',
         '(multi deps) nested foo is now: 3',
-        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        isBundledDev
+          ? '[vite] hot updated: playground-temp/hmr/hmrDep.js via playground-temp/hmr/hmr.ts'
+          : '[vite] hot updated: /hmrDep.js via /hmr.ts',
         '>>> vite:afterUpdate -- update',
       ],
       true,
@@ -204,7 +244,10 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toMatch('3')
   })
 
-  test('invalidate', async () => {
+  // bundled dev: propagating `import.meta.hot.invalidate()` to the importer
+  // fails with `no factory for module \`...invalidation/parent.js\``, so the
+  // client falls back to a full page reload instead of hot-updating the parent
+  test.skipIf(isBundledDev)('invalidate', async () => {
     const el = await page.$('.invalidation-parent')
     await untilBrowserLogAfter(
       () =>
@@ -227,7 +270,8 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toMatch('child updated')
   })
 
-  test('invalidate works with multiple tabs', async () => {
+  // bundled dev: same missing-importer-factory fallback as `invalidate`
+  test.skipIf(isBundledDev)('invalidate works with multiple tabs', async () => {
     let page2: Page
     try {
       page2 = await browser.newPage()
@@ -307,23 +351,31 @@ if (!isBuild) {
       .toMatch('child updated')
   })
 
-  test('invalidate in circular dep should be hot updated if possible', async () => {
-    const el = await page.$('.invalidation-circular-deps-handled')
-    await expect.poll(() => el.textContent()).toMatch('child')
-    editFile(
-      'invalidation-circular-deps/invalidate-handled-in-circle/child.js',
-      (code) => code.replace('child', 'child updated'),
-    )
-    await expect.poll(() => el.textContent()).toMatch('child updated')
-  })
+  // bundled dev: the invalidate inside the circular import ends in a full
+  // page reload instead of a hot update
+  test.skipIf(isBundledDev)(
+    'invalidate in circular dep should be hot updated if possible',
+    async () => {
+      const el = await page.$('.invalidation-circular-deps-handled')
+      await expect.poll(() => el.textContent()).toMatch('child')
+      editFile(
+        'invalidation-circular-deps/invalidate-handled-in-circle/child.js',
+        (code) => code.replace('child', 'child updated'),
+      )
+      await expect.poll(() => el.textContent()).toMatch('child updated')
+    },
+  )
 
-  test('plugin hmr handler + custom event', async () => {
+  // bundled dev: file changes do not run the `hotUpdate` plugin hook, so the
+  // plugin's custom events never reach the page
+  test.skipIf(isBundledDev)('plugin hmr handler + custom event', async () => {
     const el = await page.$('.custom')
     editFile('customFile.js', (code) => code.replace('custom', 'edited2'))
     await expect.poll(() => el.textContent()).toMatch('edited2')
   })
 
-  test('plugin hmr remove custom events', async () => {
+  // bundled dev: same missing `hotUpdate` plugin hook as the previous case
+  test.skipIf(isBundledDev)('plugin hmr remove custom events', async () => {
     const el = await page.$('.toRemove')
     await expect.poll(() => el.textContent()).toMatch('edited2')
     editFile('customFile.js', (code) => code.replace('edited2', 'custom33'))
@@ -335,7 +387,8 @@ if (!isBuild) {
     await expect.poll(() => el.textContent()).toMatch('3')
   })
 
-  test('full-reload encodeURI path', async () => {
+  // bundled dev: editing an html file does not trigger a page reload
+  test.skipIf(isBundledDev)('full-reload encodeURI path', async () => {
     await page.goto(
       viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
     )
@@ -350,7 +403,9 @@ if (!isBuild) {
       .toBe('title2')
   })
 
-  test('CSS update preserves query params', async () => {
+  // bundled dev: css is a bundle asset, so an edit does not swap the
+  // stylesheet link in place and the query params are lost
+  test.skipIf(isBundledDev)('CSS update preserves query params', async () => {
     await page.goto(viteTestUrl)
 
     editFile('global.css', (code) => code.replace('white', 'tomato'))
@@ -366,7 +421,9 @@ if (!isBuild) {
     expect(textpost).not.toMatch('direct')
   })
 
-  test('it swaps out link tags', async () => {
+  // bundled dev: stylesheet links point at bundle assets and are not swapped
+  // on css edits
+  test.skipIf(isBundledDev)('it swaps out link tags', async () => {
     await page.goto(viteTestUrl)
 
     editFile('global.css', (code) => code.replace('tomato', 'white'))
@@ -380,7 +437,9 @@ if (!isBuild) {
     await expect.poll(async () => (await page.$$('link')).length).toBe(1)
   })
 
-  test('not loaded dynamic import', async () => {
+  // bundled dev: editing a dynamic import that was never loaded triggers a
+  // page reload; plain dev ignores the change (#7561)
+  test.skipIf(isBundledDev)('not loaded dynamic import', async () => {
     await page.goto(viteTestUrl + '/counter/index.html', { waitUntil: 'load' })
 
     let btn = await page.$('button')
@@ -415,7 +474,9 @@ if (!isBuild) {
   })
 
   // #2255
-  test('importing reloaded', async () => {
+  // bundled dev: the edits cause an unexpected full page reload, which
+  // resets the log the test builds up
+  test.skipIf(isBundledDev)('importing reloaded', async () => {
     await page.goto(viteTestUrl)
     const outputEle = await page.$('.importing-reloaded')
     const getOutput = () => {
@@ -442,7 +503,9 @@ if (!isBuild) {
       )
   })
 
-  describe('acceptExports', () => {
+  // bundled dev: partial accept (`import.meta.hot.acceptExports`) is not
+  // supported (rolldown#10061)
+  describe.skipIf(isBundledDev)('acceptExports', () => {
     const HOT_UPDATED = /hot updated/
     const CONNECTED = /connected/
 
@@ -823,7 +886,9 @@ if (!isBuild) {
     })
   })
 
-  test('css in html hmr', async () => {
+  // bundled dev: the icon is inlined as a data URI (build-style inlining),
+  // and editing index.html does not trigger a page reload
+  test.skipIf(isBundledDev)('css in html hmr', async () => {
     await page.goto(viteTestUrl)
     expect(await getBg('.import-image')).toMatch('icon')
     await page.goto(viteTestUrl + '/foo/', { waitUntil: 'load' })
@@ -835,7 +900,8 @@ if (!isBuild) {
     expect(await getBg('.import-image')).toMatch('')
   })
 
-  test('HTML', async () => {
+  // bundled dev: editing an html file does not trigger a page reload
+  test.skipIf(isBundledDev)('HTML', async () => {
     await page.goto(viteTestUrl + '/counter/index.html')
     let btn = await page.$('button')
     expect(await btn.textContent()).toBe('Counter 0')
@@ -849,7 +915,9 @@ if (!isBuild) {
     expect(await btn.textContent()).toBe('Compteur 0')
   })
 
-  test('handle virtual module updates', async () => {
+  // bundled dev: updates that flow through a plugin virtual module do not
+  // reach the page
+  test.skipIf(isBundledDev)('handle virtual module updates', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[success]0')
@@ -862,7 +930,9 @@ if (!isBuild) {
       .toBe('[wow]0')
   })
 
-  test('invalidate virtual module', async () => {
+  // bundled dev: `server.moduleGraph` is empty, so the plugin's
+  // `reloadModule(virtual module)` call finds nothing to reload
+  test.skipIf(isBundledDev)('invalidate virtual module', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[wow]0')
@@ -876,111 +946,131 @@ if (!isBuild) {
       .toBe('[wow]1')
   })
 
-  test('handle virtual module accept updates', async () => {
-    await page.goto(viteTestUrl)
-    const el = await page.$('.virtual-dep')
-    expect(await el.textContent()).toBe('0')
-    editFile('importedVirtual.js', (code) => code.replace('[wow]', '[wow2]'))
-    await expect
-      .poll(async () => {
-        const el = await page.$('.virtual-dep')
-        return await el.textContent()
-      })
-      .toBe('[wow2]0')
-  })
+  // bundled dev: same virtual-module gap as `handle virtual module updates`
+  test.skipIf(isBundledDev)(
+    'handle virtual module accept updates',
+    async () => {
+      await page.goto(viteTestUrl)
+      const el = await page.$('.virtual-dep')
+      expect(await el.textContent()).toBe('0')
+      editFile('importedVirtual.js', (code) => code.replace('[wow]', '[wow2]'))
+      await expect
+        .poll(async () => {
+          const el = await page.$('.virtual-dep')
+          return await el.textContent()
+        })
+        .toBe('[wow2]0')
+    },
+  )
 
-  test('invalidate virtual module and accept', async () => {
-    await page.goto(viteTestUrl)
-    const el = await page.$('.virtual-dep')
-    expect(await el.textContent()).toBe('0')
-    const btn = await page.$('.virtual-update-dep')
-    btn.click()
-    await expect
-      .poll(async () => {
-        const el = await page.$('.virtual-dep')
-        return await el.textContent()
-      })
-      .toBe('[wow2]2')
-  })
+  // bundled dev: same empty-module-graph gap as `invalidate virtual module`
+  test.skipIf(isBundledDev)(
+    'invalidate virtual module and accept',
+    async () => {
+      await page.goto(viteTestUrl)
+      const el = await page.$('.virtual-dep')
+      expect(await el.textContent()).toBe('0')
+      const btn = await page.$('.virtual-update-dep')
+      btn.click()
+      await expect
+        .poll(async () => {
+          const el = await page.$('.virtual-dep')
+          return await el.textContent()
+        })
+        .toBe('[wow2]2')
+    },
+  )
 
-  test('keep hmr reload after missing import on server startup', async () => {
-    const file = 'missing-import/a.js'
-    const importCode = "import 'missing-modules'"
-    const unImportCode = `// ${importCode}`
+  // bundled dev: recovery after a startup build error (missing import) does
+  // not rebuild and reload the page
+  test.skipIf(isBundledDev)(
+    'keep hmr reload after missing import on server startup',
+    async () => {
+      const file = 'missing-import/a.js'
+      const importCode = "import 'missing-modules'"
+      const unImportCode = `// ${importCode}`
 
-    await untilBrowserLogAfter(
-      () =>
-        page.goto(viteTestUrl + '/missing-import/index.html', {
-          waitUntil: 'load',
-        }),
-      /connected/, // wait for HMR connection
-    )
+      await untilBrowserLogAfter(
+        () =>
+          page.goto(viteTestUrl + '/missing-import/index.html', {
+            waitUntil: 'load',
+          }),
+        /connected/, // wait for HMR connection
+      )
 
-    await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load')
-      editFile(file, (code) => code.replace(importCode, unImportCode))
-      await loadPromise
-    }, ['missing test', /connected/])
+      await untilBrowserLogAfter(async () => {
+        const loadPromise = page.waitForEvent('load')
+        editFile(file, (code) => code.replace(importCode, unImportCode))
+        await loadPromise
+      }, ['missing test', /connected/])
 
-    await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load')
-      editFile(file, (code) => code.replace(unImportCode, importCode))
-      await loadPromise
-    }, [/500/, /connected/])
-  })
+      await untilBrowserLogAfter(async () => {
+        const loadPromise = page.waitForEvent('load')
+        editFile(file, (code) => code.replace(unImportCode, importCode))
+        await loadPromise
+      }, [/500/, /connected/])
+    },
+  )
 
-  test('should hmr when file is deleted and restored', async () => {
-    await page.goto(viteTestUrl)
+  // bundled dev: deleting and re-adding files is not handled — no dispose
+  // events, no rebuild, no reload
+  test.skipIf(isBundledDev)(
+    'should hmr when file is deleted and restored',
+    async () => {
+      await page.goto(viteTestUrl)
 
-    const parentFile = 'file-delete-restore/parent.js'
-    const childFile = 'file-delete-restore/child.js'
+      const parentFile = 'file-delete-restore/parent.js'
+      const childFile = 'file-delete-restore/child.js'
 
-    await expect
-      .poll(() => page.textContent('.file-delete-restore'))
-      .toMatch('parent:child')
-
-    editFile(childFile, (code) =>
-      code.replace("value = 'child'", "value = 'child1'"),
-    )
-    await expect
-      .poll(() => page.textContent('.file-delete-restore'))
-      .toMatch('parent:child1')
-
-    // delete the file
-    editFile(parentFile, (code) =>
-      code.replace(
-        "export { value as childValue } from './child'",
-        "export const childValue = 'not-child'",
-      ),
-    )
-    const originalChildFileCode = readFile(childFile)
-    await Promise.all([
-      untilBrowserLogAfter(
-        () => removeFile(childFile),
-        `${childFile} is disposed`,
-      ),
-      expect
+      await expect
         .poll(() => page.textContent('.file-delete-restore'))
-        .toMatch('parent:not-child'),
-    ])
+        .toMatch('parent:child')
 
-    await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load')
-      addFile(childFile, originalChildFileCode)
+      editFile(childFile, (code) =>
+        code.replace("value = 'child'", "value = 'child1'"),
+      )
+      await expect
+        .poll(() => page.textContent('.file-delete-restore'))
+        .toMatch('parent:child1')
+
+      // delete the file
       editFile(parentFile, (code) =>
         code.replace(
-          "export const childValue = 'not-child'",
           "export { value as childValue } from './child'",
+          "export const childValue = 'not-child'",
         ),
       )
-      await loadPromise
-    }, [/connected/])
-    await expect
-      .poll(() => page.textContent('.file-delete-restore'))
-      .toMatch('parent:child')
-  })
+      const originalChildFileCode = readFile(childFile)
+      await Promise.all([
+        untilBrowserLogAfter(
+          () => removeFile(childFile),
+          `${childFile} is disposed`,
+        ),
+        expect
+          .poll(() => page.textContent('.file-delete-restore'))
+          .toMatch('parent:not-child'),
+      ])
 
-  test('delete file should not break hmr', async () => {
+      await untilBrowserLogAfter(async () => {
+        const loadPromise = page.waitForEvent('load')
+        addFile(childFile, originalChildFileCode)
+        editFile(parentFile, (code) =>
+          code.replace(
+            "export const childValue = 'not-child'",
+            "export { value as childValue } from './child'",
+          ),
+        )
+        await loadPromise
+      }, [/connected/])
+      await expect
+        .poll(() => page.textContent('.file-delete-restore'))
+        .toMatch('parent:child')
+    },
+  )
+
+  // bundled dev: same file-delete gap as
+  // `should hmr when file is deleted and restored`
+  test.skipIf(isBundledDev)('delete file should not break hmr', async () => {
     await page.goto(viteTestUrl)
 
     await expect
@@ -1025,69 +1115,81 @@ if (!isBuild) {
       .toMatch('count is 2')
   })
 
-  test('deleted file should trigger dispose and prune callbacks', async () => {
-    await page.goto(viteTestUrl)
+  // bundled dev: dispose and prune events for deleted files are not sent
+  test.skipIf(isBundledDev)(
+    'deleted file should trigger dispose and prune callbacks',
+    async () => {
+      await page.goto(viteTestUrl)
 
-    const parentFile = 'file-delete-restore/parent.js'
-    const childFile = 'file-delete-restore/child.js'
-    const originalChildFileCode = readFile(childFile)
+      const parentFile = 'file-delete-restore/parent.js'
+      const childFile = 'file-delete-restore/child.js'
+      const originalChildFileCode = readFile(childFile)
 
-    await untilBrowserLogAfter(
-      () => {
-        // delete the file
+      await untilBrowserLogAfter(
+        () => {
+          // delete the file
+          editFile(parentFile, (code) =>
+            code.replace(
+              "export { value as childValue } from './child'",
+              "export const childValue = 'not-child'",
+            ),
+          )
+          removeFile(childFile)
+        },
+        [
+          'file-delete-restore/child.js is disposed',
+          'file-delete-restore/child.js is pruned',
+        ],
+        false,
+      )
+      await expect
+        .poll(() => page.textContent('.file-delete-restore'))
+        .toMatch('parent:not-child')
+
+      // restore the file
+      await untilBrowserLogAfter(() => {
+        addFile(childFile, originalChildFileCode)
         editFile(parentFile, (code) =>
           code.replace(
-            "export { value as childValue } from './child'",
             "export const childValue = 'not-child'",
+            "export { value as childValue } from './child'",
           ),
         )
-        removeFile(childFile)
-      },
-      [
-        'file-delete-restore/child.js is disposed',
-        'file-delete-restore/child.js is pruned',
-      ],
-      false,
-    )
-    await expect
-      .poll(() => page.textContent('.file-delete-restore'))
-      .toMatch('parent:not-child')
+      }, 'file-delete-restore/child.js hot data after prune: undefined')
+      await expect
+        .poll(() => page.textContent('.file-delete-restore'))
+        .toMatch('parent:child')
+    },
+  )
 
-    // restore the file
-    await untilBrowserLogAfter(() => {
-      addFile(childFile, originalChildFileCode)
-      editFile(parentFile, (code) =>
-        code.replace(
-          "export const childValue = 'not-child'",
-          "export { value as childValue } from './child'",
-        ),
+  // bundled dev: prune events are not sent when an import is removed
+  test.skipIf(isBundledDev)(
+    'deleting import from non-self-accepting module can trigger prune event',
+    async () => {
+      await page.goto(viteTestUrl)
+      await expect.poll(() => page.textContent('.prune')).toMatch('prune-init')
+      editFile('prune/dep1.js', (code) =>
+        code.replace(`import './dep2.js'`, `// import './dep2.js'`),
       )
-    }, 'file-delete-restore/child.js hot data after prune: undefined')
-    await expect
-      .poll(() => page.textContent('.file-delete-restore'))
-      .toMatch('parent:child')
-  })
+      // Prune is triggered when there are other dependencies.
+      await expect
+        .poll(() => page.textContent('.prune'))
+        .toMatch('prune-init|dep2-disposed|dep2-pruned')
+      editFile('prune/dep1.js', (code) =>
+        code.replace(`import './dep3.js'`, `// import './dep3.js'`),
+      )
+      // Prune is triggered when there are no more dependencies.
+      await expect
+        .poll(() => page.textContent('.prune'))
+        .toMatch(
+          'prune-init|dep2-disposed|dep2-pruned|dep3-disposed|dep3-pruned',
+        )
+    },
+  )
 
-  test('deleting import from non-self-accepting module can trigger prune event', async () => {
-    await page.goto(viteTestUrl)
-    await expect.poll(() => page.textContent('.prune')).toMatch('prune-init')
-    editFile('prune/dep1.js', (code) =>
-      code.replace(`import './dep2.js'`, `// import './dep2.js'`),
-    )
-    // Prune is triggered when there are other dependencies.
-    await expect
-      .poll(() => page.textContent('.prune'))
-      .toMatch('prune-init|dep2-disposed|dep2-pruned')
-    editFile('prune/dep1.js', (code) =>
-      code.replace(`import './dep3.js'`, `// import './dep3.js'`),
-    )
-    // Prune is triggered when there are no more dependencies.
-    await expect
-      .poll(() => page.textContent('.prune'))
-      .toMatch('prune-init|dep2-disposed|dep2-pruned|dep3-disposed|dep3-pruned')
-  })
-
-  test('import.meta.hot?.accept', async () => {
+  // bundled dev: `import.meta.hot?.accept` (optional chaining) is not picked
+  // up as an accept call, so the update never applies
+  test.skipIf(isBundledDev)('import.meta.hot?.accept', async () => {
     await page.goto(viteTestUrl)
 
     const el = await page.$('.optional-chaining')
@@ -1116,24 +1218,39 @@ if (!isBuild) {
     // Should still keep hmr update, but it'll error on the browser-side and will refresh itself.
     expect(
       serverLogs.slice(lastServerLogIndex).map(stripVTControlCharacters),
-    ).toContain('hmr update /self-accept-within-circular/c.js')
+    ).toContain(
+      isBundledDev
+        ? 'hmr update playground-temp/hmr/self-accept-within-circular/c.js'
+        : 'hmr update /self-accept-within-circular/c.js',
+    )
   })
 
-  test('hmr should not reload if no accepted within circular imported files', async () => {
-    await page.goto(viteTestUrl + '/circular/index.html')
-    const el = await page.$('.circular')
-    expect(await el.textContent()).toBe(
-      'mod-a -> mod-b -> mod-c -> mod-a (expected error)',
-    )
-    editFile('circular/mod-b.js', (code) =>
-      code.replace(`mod-b ->`, `mod-b (edited) ->`),
-    )
-    await expect
-      .poll(() => el.textContent())
-      .toBe('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
-  })
+  // bundled dev:
+  // 1. `unexpected no error` is shown instead of `expected error`,
+  //    `_value` in `mod-c` is initialzed with `var` and is hoisted to the top of the module,
+  //    whereas in unbundled dev, `_value` is still in TDZ, which causes a `ReferenceError`.
+  //
+  // 2. an edit inside the circular import chain triggers a full
+  //    page reload instead of a hot update
+  test.skipIf(isBundledDev)(
+    'hmr should not reload if no accepted within circular imported files',
+    async () => {
+      await page.goto(viteTestUrl + '/circular/index.html')
+      const el = await page.$('.circular')
+      expect(await el.textContent()).toBe(
+        'mod-a -> mod-b -> mod-c -> mod-a (expected error)',
+      )
+      editFile('circular/mod-b.js', (code) =>
+        code.replace(`mod-b ->`, `mod-b (edited) ->`),
+      )
+      await expect
+        .poll(() => el.textContent())
+        .toBe('mod-a -> mod-b (edited) -> mod-c -> mod-a (expected error)')
+    },
+  )
 
-  test('not inlined assets HMR', async () => {
+  // bundled dev: editing an asset file does not push an update to the page
+  test.skipIf(isBundledDev)('not inlined assets HMR', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('#logo-no-inline')
     await untilBrowserLogAfter(
@@ -1148,7 +1265,8 @@ if (!isBuild) {
       .toMatch('40')
   })
 
-  test('inlined assets HMR', async () => {
+  // bundled dev: same asset-edit gap as `not inlined assets HMR`
+  test.skipIf(isBundledDev)('inlined assets HMR', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('#logo')
     await untilBrowserLogAfter(
@@ -1165,50 +1283,61 @@ if (!isBuild) {
 
   test('CSS HMR with this.addWatchFile', async () => {
     await page.goto(viteTestUrl + '/css-deps/index.html')
-    expect(await getColor('.css-deps')).toBe('red')
+    // poll: under bundled dev the previous test's error recovery can still be
+    // reloading the page when this test starts
+    await expect.poll(() => getColor('.css-deps')).toBe('red')
     editFile('css-deps/dep.js', (code) => code.replace(`red`, `green`))
     await expect.poll(() => getColor('.css-deps')).toBe('green')
   })
 
-  test('hmr should happen after missing file is created', async () => {
-    const file = 'missing-file/a.js'
-    const code = 'console.log("a.js")'
+  // bundled dev: adding the missing file does not rebuild and reload the page
+  test.skipIf(isBundledDev)(
+    'hmr should happen after missing file is created',
+    async () => {
+      const file = 'missing-file/a.js'
+      const code = 'console.log("a.js")'
 
-    await untilBrowserLogAfter(
-      () =>
-        page.goto(viteTestUrl + '/missing-file/index.html', {
-          waitUntil: 'load',
-        }),
-      /connected/, // wait for HMR connection
-    )
+      await untilBrowserLogAfter(
+        () =>
+          page.goto(viteTestUrl + '/missing-file/index.html', {
+            waitUntil: 'load',
+          }),
+        /connected/, // wait for HMR connection
+      )
 
-    await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load')
-      addFile(file, code)
-      await loadPromise
-    }, [/connected/, 'a.js'])
-  })
+      await untilBrowserLogAfter(async () => {
+        const loadPromise = page.waitForEvent('load')
+        addFile(file, code)
+        await loadPromise
+      }, [/connected/, 'a.js'])
+    },
+  )
 
-  test('deduplicate server rendered link stylesheet', async () => {
-    await page.goto(viteTestUrl + '/css-link/index.html')
-    await expect.poll(() => getColor('.test-css-link')).toBe('orange')
+  // bundled dev: /css-link/index.html is not a bundle input, so the page is
+  // never served and the styled element never appears
+  test.skipIf(isBundledDev)(
+    'deduplicate server rendered link stylesheet',
+    async () => {
+      await page.goto(viteTestUrl + '/css-link/index.html')
+      await expect.poll(() => getColor('.test-css-link')).toBe('orange')
 
-    // remove color
-    editFile('css-link/styles.css', (code) =>
-      code.replace('color: orange;', '/* removed */'),
-    )
-    await expect.poll(() => getColor('.test-css-link')).toBe('black')
+      // remove color
+      editFile('css-link/styles.css', (code) =>
+        code.replace('color: orange;', '/* removed */'),
+      )
+      await expect.poll(() => getColor('.test-css-link')).toBe('black')
 
-    // add color
-    editFile('css-link/styles.css', (code) =>
-      code.replace('/* removed */', 'color: blue;'),
-    )
-    await expect.poll(() => getColor('.test-css-link')).toBe('blue')
+      // add color
+      editFile('css-link/styles.css', (code) =>
+        code.replace('/* removed */', 'color: blue;'),
+      )
+      await expect.poll(() => getColor('.test-css-link')).toBe('blue')
 
-    // // remove css import from js
-    editFile('css-link/main.js', (code) =>
-      code.replace(`import './styles.css'`, ``),
-    )
-    await expect.poll(() => getColor('.test-css-link')).toBe('black')
-  })
+      // // remove css import from js
+      editFile('css-link/main.js', (code) =>
+        code.replace(`import './styles.css'`, ``),
+      )
+      await expect.poll(() => getColor('.test-css-link')).toBe('black')
+    },
+  )
 }

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -19,9 +19,9 @@ import {
 } from '~utils'
 
 test('should render', async () => {
-  expect(await page.textContent('.app')).toBe('1')
-  expect(await page.textContent('.dep')).toBe('1')
-  expect(await page.textContent('.nested')).toBe('1')
+  await expect.poll(() => page.textContent('.app')).toBe('1')
+  await expect.poll(() => page.textContent('.dep')).toBe('1')
+  await expect.poll(() => page.textContent('.nested')).toBe('1')
 })
 
 if (!isBuild) {
@@ -72,7 +72,7 @@ if (!isBuild) {
   })
 
   test('self accept', async () => {
-    const el = await page.$('.app')
+    const el = page.locator('.app')
     await untilBrowserLogAfter(
       () =>
         editFile('hmr.ts', (code) =>
@@ -151,7 +151,7 @@ if (!isBuild) {
   })
 
   test('accept dep', async () => {
-    const el = await page.$('.dep')
+    const el = page.locator('.dep')
     await untilBrowserLogAfter(
       () =>
         editFile('hmrDep.js', (code) =>
@@ -198,7 +198,7 @@ if (!isBuild) {
   })
 
   test('nested dep propagation', async () => {
-    const el = await page.$('.nested')
+    const el = page.locator('.nested')
     await untilBrowserLogAfter(
       () =>
         editFile('hmrNestedDep.js', (code) =>
@@ -248,7 +248,7 @@ if (!isBuild) {
   // fails with `no factory for module \`...invalidation/parent.js\``, so the
   // client falls back to a full page reload instead of hot-updating the parent
   test.skipIf(isBundledDev)('invalidate', async () => {
-    const el = await page.$('.invalidation-parent')
+    const el = page.locator('.invalidation-parent')
     await untilBrowserLogAfter(
       () =>
         editFile('invalidation/child.js', (code) =>
@@ -277,7 +277,7 @@ if (!isBuild) {
       page2 = await browser.newPage()
       await page2.goto(viteTestUrl)
 
-      const el = await page.$('.invalidation-parent')
+      const el = page.locator('.invalidation-parent')
       await untilBrowserLogAfter(
         () =>
           editFile('invalidation/child.js', (code) =>
@@ -307,15 +307,15 @@ if (!isBuild) {
     editFile('invalidation/root.js', (code) => code.replace('Init', 'Updated'))
     await page.waitForEvent('load')
     await expect
-      .poll(async () => (await page.$('.invalidation-root')).textContent())
+      .poll(() => page.textContent('.invalidation-root'))
       .toMatch('Updated')
   })
 
   test('soft invalidate', async () => {
-    const el = await page.$('.soft-invalidation')
-    expect(await el.textContent()).toBe(
-      'soft-invalidation/index.js is transformed 1 times. child is bar',
-    )
+    const el = page.locator('.soft-invalidation')
+    await expect
+      .poll(() => el.textContent())
+      .toBe('soft-invalidation/index.js is transformed 1 times. child is bar')
     editFile('soft-invalidation/child.js', (code) =>
       code.replace('bar', 'updated'),
     )
@@ -339,7 +339,7 @@ if (!isBuild) {
   })
 
   test('invalidate in circular dep should not trigger infinite HMR', async () => {
-    const el = await page.$('.invalidation-circular-deps')
+    const el = page.locator('.invalidation-circular-deps')
     await expect.poll(() => el.textContent()).toMatch('child')
     editFile(
       'invalidation-circular-deps/circular-invalidate/child.js',
@@ -356,7 +356,7 @@ if (!isBuild) {
   test.skipIf(isBundledDev)(
     'invalidate in circular dep should be hot updated if possible',
     async () => {
-      const el = await page.$('.invalidation-circular-deps-handled')
+      const el = page.locator('.invalidation-circular-deps-handled')
       await expect.poll(() => el.textContent()).toMatch('child')
       editFile(
         'invalidation-circular-deps/invalidate-handled-in-circle/child.js',
@@ -369,21 +369,21 @@ if (!isBuild) {
   // bundled dev: file changes do not run the `hotUpdate` plugin hook, so the
   // plugin's custom events never reach the page
   test.skipIf(isBundledDev)('plugin hmr handler + custom event', async () => {
-    const el = await page.$('.custom')
+    const el = page.locator('.custom')
     editFile('customFile.js', (code) => code.replace('custom', 'edited2'))
     await expect.poll(() => el.textContent()).toMatch('edited2')
   })
 
   // bundled dev: same missing `hotUpdate` plugin hook as the previous case
   test.skipIf(isBundledDev)('plugin hmr remove custom events', async () => {
-    const el = await page.$('.toRemove')
+    const el = page.locator('.toRemove')
     await expect.poll(() => el.textContent()).toMatch('edited2')
     editFile('customFile.js', (code) => code.replace('edited2', 'custom33'))
     await expect.poll(() => el.textContent()).toMatch('edited2')
   })
 
   test('plugin client-server communication', async () => {
-    const el = await page.$('.custom-communication')
+    const el = page.locator('.custom-communication')
     await expect.poll(() => el.textContent()).toMatch('3')
   })
 
@@ -392,15 +392,13 @@ if (!isBuild) {
     await page.goto(
       viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
     )
-    const el = await page.$('#app')
-    expect(await el.textContent()).toBe('title')
+    const el = page.locator('#app')
+    await expect.poll(() => el.textContent()).toBe('title')
     editFile('unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html', (code) =>
       code.replace('title', 'title2'),
     )
     await page.waitForEvent('load')
-    await expect
-      .poll(async () => (await page.$('#app')).textContent())
-      .toBe('title2')
+    await expect.poll(() => el.textContent()).toBe('title2')
   })
 
   // bundled dev: css is a bundle asset, so an edit does not swap the
@@ -410,8 +408,8 @@ if (!isBuild) {
 
     editFile('global.css', (code) => code.replace('white', 'tomato'))
 
-    const elprev = await page.$('.css-prev')
-    const elpost = await page.$('.css-post')
+    const elprev = page.locator('.css-prev')
+    const elpost = page.locator('.css-post')
     await expect.poll(() => elprev.textContent()).toMatch('param=required')
     await expect.poll(() => elpost.textContent()).toMatch('param=required')
     const textprev = await elprev.textContent()
@@ -428,13 +426,14 @@ if (!isBuild) {
 
     editFile('global.css', (code) => code.replace('tomato', 'white'))
 
-    let el = await page.$('.link-tag-added')
-    await expect.poll(() => el.textContent()).toMatch('yes')
+    await expect
+      .poll(() => page.locator('.link-tag-added').textContent())
+      .toMatch('yes')
+    await expect
+      .poll(() => page.locator('.link-tag-removed').textContent())
+      .toMatch('yes')
 
-    el = await page.$('.link-tag-removed')
-    await expect.poll(() => el.textContent()).toMatch('yes')
-
-    await expect.poll(async () => (await page.$$('link')).length).toBe(1)
+    await expect.poll(() => page.locator('link').count()).toBe(1)
   })
 
   // bundled dev: editing a dynamic import that was never loaded triggers a
@@ -442,20 +441,19 @@ if (!isBuild) {
   test.skipIf(isBundledDev)('not loaded dynamic import', async () => {
     await page.goto(viteTestUrl + '/counter/index.html', { waitUntil: 'load' })
 
-    let btn = await page.$('button')
-    expect(await btn.textContent()).toBe('Counter 0')
+    const btn = page.locator('button')
+    await expect.poll(() => btn.textContent()).toBe('Counter 0')
     await btn.click()
-    expect(await btn.textContent()).toBe('Counter 1')
+    await expect.poll(() => btn.textContent()).toBe('Counter 1')
 
     // Modifying `index.ts` triggers a page reload, as expected
     const indexTsLoadPromise = page.waitForEvent('load')
     editFile('counter/index.ts', (code) => code + '\n')
     await indexTsLoadPromise
-    btn = await page.$('button')
-    expect(await btn.textContent()).toBe('Counter 0')
+    await expect.poll(() => btn.textContent()).toBe('Counter 0')
 
     await btn.click()
-    expect(await btn.textContent()).toBe('Counter 1')
+    await expect.poll(() => btn.textContent()).toBe('Counter 1')
 
     // #7561
     // `dep.ts` defines `import.module.hot.accept` and has not been loaded.
@@ -469,8 +467,7 @@ if (!isBuild) {
       /page\.waitForEvent: Timeout \d+ms exceeded while waiting for event "load"/,
     )
 
-    btn = await page.$('button')
-    expect(await btn.textContent()).toBe('Counter 1')
+    await expect.poll(() => btn.textContent()).toBe('Counter 1')
   })
 
   // #2255
@@ -478,7 +475,7 @@ if (!isBuild) {
   // resets the log the test builds up
   test.skipIf(isBundledDev)('importing reloaded', async () => {
     await page.goto(viteTestUrl)
-    const outputEle = await page.$('.importing-reloaded')
+    const outputEle = page.locator('.importing-reloaded')
     const getOutput = () => {
       return outputEle.innerHTML()
     }
@@ -890,60 +887,48 @@ if (!isBuild) {
   // and editing index.html does not trigger a page reload
   test.skipIf(isBundledDev)('css in html hmr', async () => {
     await page.goto(viteTestUrl)
-    expect(await getBg('.import-image')).toMatch('icon')
+    await expect.poll(() => getBg('.import-image')).toMatch('icon')
     await page.goto(viteTestUrl + '/foo/', { waitUntil: 'load' })
-    expect(await getBg('.import-image')).toMatch('icon')
+    await expect.poll(() => getBg('.import-image')).toMatch('icon')
 
     const loadPromise = page.waitForEvent('load')
     editFile('index.html', (code) => code.replace("url('./icon.png')", ''))
     await loadPromise
-    expect(await getBg('.import-image')).toMatch('')
+    await expect.poll(() => getBg('.import-image')).toMatch('')
   })
 
   // bundled dev: editing an html file does not trigger a page reload
   test.skipIf(isBundledDev)('HTML', async () => {
     await page.goto(viteTestUrl + '/counter/index.html')
-    let btn = await page.$('button')
-    expect(await btn.textContent()).toBe('Counter 0')
+    const btn = page.locator('button')
+    await expect.poll(() => btn.textContent()).toBe('Counter 0')
 
     const loadPromise = page.waitForEvent('load')
     editFile('counter/index.html', (code) =>
       code.replace('Counter', 'Compteur'),
     )
     await loadPromise
-    btn = await page.$('button')
-    expect(await btn.textContent()).toBe('Compteur 0')
+    await expect.poll(() => btn.textContent()).toBe('Compteur 0')
   })
 
   // bundled dev: updates that flow through a plugin virtual module do not
   // reach the page
   test.skipIf(isBundledDev)('handle virtual module updates', async () => {
     await page.goto(viteTestUrl)
-    const el = await page.$('.virtual')
-    expect(await el.textContent()).toBe('[success]0')
+    const el = page.locator('.virtual')
+    await expect.poll(() => el.textContent()).toBe('[success]0')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await expect
-      .poll(async () => {
-        const el = await page.$('.virtual')
-        return await el.textContent()
-      })
-      .toBe('[wow]0')
+    await expect.poll(() => el.textContent()).toBe('[wow]0')
   })
 
   // bundled dev: `server.moduleGraph` is empty, so the plugin's
   // `reloadModule(virtual module)` call finds nothing to reload
   test.skipIf(isBundledDev)('invalidate virtual module', async () => {
     await page.goto(viteTestUrl)
-    const el = await page.$('.virtual')
-    expect(await el.textContent()).toBe('[wow]0')
-    const btn = await page.$('.virtual-update')
-    btn.click()
-    await expect
-      .poll(async () => {
-        const el = await page.$('.virtual')
-        return await el.textContent()
-      })
-      .toBe('[wow]1')
+    const el = page.locator('.virtual')
+    await expect.poll(() => el.textContent()).toBe('[wow]0')
+    await page.locator('.virtual-update').click()
+    await expect.poll(() => el.textContent()).toBe('[wow]1')
   })
 
   // bundled dev: same virtual-module gap as `handle virtual module updates`
@@ -951,15 +936,10 @@ if (!isBuild) {
     'handle virtual module accept updates',
     async () => {
       await page.goto(viteTestUrl)
-      const el = await page.$('.virtual-dep')
-      expect(await el.textContent()).toBe('0')
+      const el = page.locator('.virtual-dep')
+      await expect.poll(() => el.textContent()).toBe('0')
       editFile('importedVirtual.js', (code) => code.replace('[wow]', '[wow2]'))
-      await expect
-        .poll(async () => {
-          const el = await page.$('.virtual-dep')
-          return await el.textContent()
-        })
-        .toBe('[wow2]0')
+      await expect.poll(() => el.textContent()).toBe('[wow2]0')
     },
   )
 
@@ -968,16 +948,10 @@ if (!isBuild) {
     'invalidate virtual module and accept',
     async () => {
       await page.goto(viteTestUrl)
-      const el = await page.$('.virtual-dep')
-      expect(await el.textContent()).toBe('0')
-      const btn = await page.$('.virtual-update-dep')
-      btn.click()
-      await expect
-        .poll(async () => {
-          const el = await page.$('.virtual-dep')
-          return await el.textContent()
-        })
-        .toBe('[wow2]2')
+      const el = page.locator('.virtual-dep')
+      await expect.poll(() => el.textContent()).toBe('0')
+      await page.locator('.virtual-update-dep').click()
+      await expect.poll(() => el.textContent()).toBe('[wow2]2')
     },
   )
 
@@ -1187,12 +1161,10 @@ if (!isBuild) {
     },
   )
 
-  // bundled dev: `import.meta.hot?.accept` (optional chaining) is not picked
-  // up as an accept call, so the update never applies
-  test.skipIf(isBundledDev)('import.meta.hot?.accept', async () => {
+  test('import.meta.hot?.accept', async () => {
     await page.goto(viteTestUrl)
 
-    const el = await page.$('.optional-chaining')
+    const el = page.locator('.optional-chaining')
     await untilBrowserLogAfter(
       () =>
         editFile(
@@ -1206,15 +1178,13 @@ if (!isBuild) {
 
   test('hmr works for self-accepted module within circular imported files', async () => {
     await page.goto(viteTestUrl + '/self-accept-within-circular/index.html')
-    const el = await page.$('.self-accept-within-circular')
-    expect(await el.textContent()).toBe('c')
+    const el = page.locator('.self-accept-within-circular')
+    await expect.poll(() => el.textContent()).toBe('c')
     const lastServerLogIndex = serverLogs.length
     editFile('self-accept-within-circular/c.js', (code) =>
       code.replace(`export const c = 'c'`, `export const c = 'cc'`),
     )
-    await expect
-      .poll(() => page.textContent('.self-accept-within-circular'))
-      .toBe('cc')
+    await expect.poll(() => el.textContent()).toBe('cc')
     // Should still keep hmr update, but it'll error on the browser-side and will refresh itself.
     expect(
       serverLogs.slice(lastServerLogIndex).map(stripVTControlCharacters),
@@ -1236,10 +1206,10 @@ if (!isBuild) {
     'hmr should not reload if no accepted within circular imported files',
     async () => {
       await page.goto(viteTestUrl + '/circular/index.html')
-      const el = await page.$('.circular')
-      expect(await el.textContent()).toBe(
-        'mod-a -> mod-b -> mod-c -> mod-a (expected error)',
-      )
+      const el = page.locator('.circular')
+      await expect
+        .poll(() => el.textContent())
+        .toBe('mod-a -> mod-b -> mod-c -> mod-a (expected error)')
       editFile('circular/mod-b.js', (code) =>
         code.replace(`mod-b ->`, `mod-b (edited) ->`),
       )
@@ -1252,7 +1222,7 @@ if (!isBuild) {
   // bundled dev: editing an asset file does not push an update to the page
   test.skipIf(isBundledDev)('not inlined assets HMR', async () => {
     await page.goto(viteTestUrl)
-    const el = await page.$('#logo-no-inline')
+    const el = page.locator('#logo-no-inline')
     await untilBrowserLogAfter(
       () =>
         editFile('logo-no-inline.svg', (code) =>
@@ -1268,7 +1238,7 @@ if (!isBuild) {
   // bundled dev: same asset-edit gap as `not inlined assets HMR`
   test.skipIf(isBundledDev)('inlined assets HMR', async () => {
     await page.goto(viteTestUrl)
-    const el = await page.$('#logo')
+    const el = page.locator('#logo')
     await untilBrowserLogAfter(
       () =>
         editFile('logo.svg', (code) =>
@@ -1283,8 +1253,6 @@ if (!isBuild) {
 
   test('CSS HMR with this.addWatchFile', async () => {
     await page.goto(viteTestUrl + '/css-deps/index.html')
-    // poll: under bundled dev the previous test's error recovery can still be
-    // reloading the page when this test starts
     await expect.poll(() => getColor('.css-deps')).toBe('red')
     editFile('css-deps/dep.js', (code) => code.replace(`red`, `green`))
     await expect.poll(() => getColor('.css-deps')).toBe('green')

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -19,7 +19,6 @@ const bundledDevExclude = [
   './playground/fs-serve/__tests__/base/fs-serve-base.spec.ts',
   './playground/fs-serve/__tests__/deny/fs-serve-deny.spec.ts',
   './playground/fs-serve/__tests__/fs-serve.spec.ts',
-  './playground/hmr/__tests__/hmr.spec.ts',
   './playground/legacy/__tests__/chunk-importmap/legacy-chunk-importmap.spec.ts',
   './playground/object-hooks/__tests__/object-hooks.spec.ts',
   './playground/optimize-deps/__tests__/optimize-deps.spec.ts',


### PR DESCRIPTION
Enable HMR playground in bundled-dev. 
Check out the comments for the tests that are not able to enable.

Updated checklist in https://github.com/vitejs/vite/issues/23028