### PR TITLE
fix(config): close bundles when generation fails

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -20,6 +20,7 @@ import {
   type OutputChunk,
   type PluginContextMeta,
   type RolldownOptions,
+  type RolldownOutput,
   rolldown,
 } from 'rolldown'
 import { isDynamicPattern } from 'tinyglobby'
@@ -2652,16 +2653,20 @@ export async function bundleConfigFile(
       },
     ],
   })
-  const result = await bundle.generate({
-    format: isESM ? 'esm' : 'cjs',
-    sourcemap: 'inline',
-    sourcemapPathTransform(relative, sourcemapPath) {
-      return path.resolve(path.dirname(sourcemapPath), relative)
-    },
-    // we want to generate a single chunk like esbuild does with `splitting: false`
-    codeSplitting: false,
-  })
-  await bundle.close()
+  let result: RolldownOutput
+  try {
+    result = await bundle.generate({
+      format: isESM ? 'esm' : 'cjs',
+      sourcemap: 'inline',
+      sourcemapPathTransform(relative, sourcemapPath) {
+        return path.resolve(path.dirname(sourcemapPath), relative)
+      },
+      // we want to generate a single chunk like esbuild does with `splitting: false`
+      codeSplitting: false,
+    })
+  } finally {
+    await bundle.close()
+  }
 
   const entryChunk = result.output.find(
     (chunk): chunk is OutputChunk => chunk.type === 'chunk' && chunk.isEntry,


### PR DESCRIPTION
### Description

`bundleConfigFile` closed its Rolldown bundle only after a successful `generate()` call. If config generation failed, the bundle remained open and its plugin/native resources were not finalized.

Close the config bundle in a `finally` block so both the successful and the failing generation path release it.

### Validation

- `pnpm --filter vite typecheck`
- `pnpm exec eslint packages/vite/src/node/config.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/config.ts`

The regression test that was here originally has been dropped at review request — it needed mocking to force `generate()` to reject, and the fix is small enough not to warrant it.