### PR TITLE
fix(bundled-dev): respect base for lazy imports (fix #23216)

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -340,6 +340,7 @@ export class BundledDev {
       `TRIGGER-LAZY: trigger lazy bundling for module ${moduleId} for client ${clientId}`,
     )
     const result = await this.devEngine.compileEntry(moduleId, clientId)
+    result.code = this.withBaseForLazyBundlingUrl(result.code)
     this.pendingPayloadFilenames.add(result.filename)
     return result
   }
@@ -375,7 +376,9 @@ export class BundledDev {
     for (const outputFile of output) {
       this.memoryFiles.set(outputFile.fileName, () => {
         const source =
-          outputFile.type === 'chunk' ? outputFile.code : outputFile.source
+          outputFile.type === 'chunk'
+            ? this.withBaseForLazyBundlingUrl(outputFile.code)
+            : outputFile.source
         return {
           source,
           etag: getEtag(Buffer.from(source), { weak: true }),
@@ -465,7 +468,7 @@ export class BundledDev {
       // https://green.sapphi.red/blog/local-server-security-best-practices#properly-check-the-request-origin
       // we can also use `Cross-Origin Resource Policy` header instead of this
       // but we cannot use `Sec-Fetch-*` headers as they are only sent to potentially-trustworthy origins
-      source: hmrOutput.code + '\n; export {}',
+      source: this.withBaseForLazyBundlingUrl(hmrOutput.code) + '\n; export {}',
     })
     if (hmrOutput.sourcemapFilename && hmrOutput.sourcemap) {
       this.memoryFiles.set(hmrOutput.sourcemapFilename, {
@@ -489,6 +492,12 @@ export class BundledDev {
         timestamp: true,
       },
     )
+  }
+
+  private withBaseForLazyBundlingUrl(code: string): string {
+    const { base } = this.environment.config
+    if (base === '/') return code
+    return code.replace(/([`"'])\/@vite\/lazy\?/g, `$1${base}@vite/lazy?`)
   }
 }
 

--- a/playground/hmr-full-bundle-mode/__tests__/base/hmr-full-bundle-mode-base.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/base/hmr-full-bundle-mode-base.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { isServe, page } from '~utils'
+
+test.runIf(isServe)('lazy bundling respects configured base', async () => {
+  await expect.poll(() => page.textContent('h1')).toBe('HMR Full Bundle Mode')
+
+  const lazyResponsePromise = page.waitForResponse((response) => {
+    return new URL(response.url()).pathname.endsWith('/@vite/lazy')
+  })
+  await page.click('#load-dynamic')
+
+  const lazyResponse = await lazyResponsePromise
+  expect(new URL(lazyResponse.url()).pathname).toBe('/nested-base/@vite/lazy')
+  expect(lazyResponse.status()).toBe(200)
+  await expect.poll(() => page.textContent('.dynamic')).toBe('loaded')
+})

--- a/playground/hmr-full-bundle-mode/vite.config-base.js
+++ b/playground/hmr-full-bundle-mode/vite.config-base.js
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vite'
+import baseConfig from './vite.config.ts'
+
+export default defineConfig(
+  mergeConfig(baseConfig, {
+    base: '/nested-base/',
+  }),
+)


### PR DESCRIPTION
## What
Fixes #23216. Bundled dev lazy imports ignored non-root `base` and hit `/@vite/lazy`.

## Fix
Add `withBaseForLazyBundlingUrl()` to prefix generated lazy URLs before middleware handling.

## Test
Added non-root `base` lazy import regression coverage.
