### PR TITLE
refactor: use JSON import attributes instead of readFileSync in constants

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -1,11 +1,7 @@
 import path, { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { readFileSync } from 'node:fs'
+import { version } from '../../package.json' with { type: 'json' }
 import type { RollupPluginHooks } from './typeUtils'
-
-const { version } = JSON.parse(
-  readFileSync(new URL('../../package.json', import.meta.url)).toString(),
-)
 
 export const ROLLUP_HOOKS: RollupPluginHooks[] = [
   'options',


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
refer to #23251

|main|pr|
|---|---|
|<img width="2324" height="514" alt="image" src="https://github.com/user-attachments/assets/7fb6f551-c8bc-4d5b-8831-8eaaf78314e3" />|<img width="892" height="558" alt="image" src="https://github.com/user-attachments/assets/d7beb6d2-8ddd-4a58-bb60-135453e25270" />|