### PR TITLE
fix(config): suppress native config incompatibility warning when configLoader is explicitly set

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1649,7 +1649,7 @@ describe('loadConfigFromFile', () => {
         root,
         undefined,
         logger,
-        'bundle',
+        undefined,
       )
       const messages = warn.mock.calls.map((c) =>
         stripVTControlCharacters(c[0]),
@@ -1740,6 +1740,22 @@ describe('loadConfigFromFile', () => {
 
     test('does not warn for a CJS config using __dirname', async () => {
       expect(await loadWithWarnings('cjs', 'vite.config.cjs')).toHaveLength(0)
+    })
+
+    test('does not warn when configLoader is explicitly set to bundle', async () => {
+      const logger = createLogger('info')
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const root = path.resolve(compatRoot, 'dirname')
+      await loadConfigFromFile(
+        {} as any,
+        path.resolve(root, 'vite.config.js'),
+        root,
+        undefined,
+        logger,
+        'bundle',
+      )
+      expect(warn.mock.calls).toHaveLength(0)
+      warn.mockRestore()
     })
 
     test('warns for an ESM file imported by a CJS config', async () => {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2367,16 +2367,17 @@ export async function loadConfigFromFile(
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
-  configLoader: 'bundle' | 'runner' | 'native' = 'bundle',
+  configLoader?: 'bundle' | 'runner' | 'native',
 ): Promise<{
   path: string
   config: UserConfig
   dependencies: string[]
 } | null> {
+  const resolvedLoader = configLoader ?? 'bundle'
   if (
-    configLoader !== 'bundle' &&
-    configLoader !== 'runner' &&
-    configLoader !== 'native'
+    resolvedLoader !== 'bundle' &&
+    resolvedLoader !== 'runner' &&
+    resolvedLoader !== 'native'
   ) {
     throw new Error(
       `Unsupported configLoader: ${configLoader}. Accepted values are 'bundle', 'runner', and 'native'.`,
@@ -2409,14 +2410,15 @@ export async function loadConfigFromFile(
   }
 
   try {
-    const { configExport, dependencies } = await (configLoader === 'bundle'
+    const { configExport, dependencies } = await (resolvedLoader === 'bundle'
       ? bundleAndLoadConfigFile(
           resolvedPath,
           configRoot,
           logLevel,
           customLogger,
+          configLoader === undefined,
         )
-      : configLoader === 'runner'
+      : resolvedLoader === 'runner'
         ? runnerImportConfigFile(resolvedPath)
         : nativeImportConfigFile(resolvedPath))
     debug?.(`config file loaded in ${getTime()}`)
@@ -2477,6 +2479,7 @@ async function bundleAndLoadConfigFile(
   configRoot: string,
   logLevel: LogLevel | undefined,
   customLogger: Logger | undefined,
+  showNativeIncompatWarning: boolean,
 ) {
   const isESM =
     typeof process.versions.deno === 'string' || isFilePathESM(resolvedPath)
@@ -2488,7 +2491,7 @@ async function bundleAndLoadConfigFile(
     isESM,
   )
 
-  if (bundled.nativeIncompatibilities.length > 0) {
+  if (showNativeIncompatWarning && bundled.nativeIncompatibilities.length > 0) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
       formatNativeConfigIncompatWarning(


### PR DESCRIPTION
## Problem

The native config loader incompatibility warning is shown even when the user explicitly sets `--config-loader=bundle` (see #23267). The warning was introduced in #22850 to help users prepare for when the native loader becomes the default in a future major version. When a user has already explicitly chosen the bundle loader, this warning is noise.

To reproduce:
```
echo "import ./helper" > vite.config.js
echo "export default {}" > helper.js
npx vite build --config-loader=bundle
```
The warning about missing file extensions appears even though the user deliberately chose bundle.

## Fix

- Changed `loadConfigFromFile` to accept `configLoader` as optional (no default), resolving to `bundle` when `undefined`.
- Added a `showNativeIncompatWarning` parameter to `bundleAndLoadConfigFile` that is `true` only when `configLoader` was not explicitly set (i.e. the user is relying on the default).
- When `configLoader` is explicitly `bundle` (or `runner`/`native`), the warning is suppressed.
- Updated existing test helper to pass `undefined` to maintain the warning-verification tests.
- Added a new test case confirming no warning is emitted when `configLoader` is explicitly `bundle`.

## Linked issue
Fixes #23267

## Test plan
- `vitest run packages/vite/src/node/__tests__/config.spec.ts` → 106/106 pass
- `pnpm run build` → clean
- `pnpm run lint` → clean (only pre-existing playground warning)