### PR TITLE
fix(css): clear error when less has no FileManager API (fix #23266)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2907,6 +2907,13 @@ const makeLessWorker = (
         rootFile: string,
       ): Less.Plugin => {
         const { FileManager } = less
+        if (!FileManager) {
+          throw new Error(
+            'The installed version of "less" does not expose the "FileManager" plugin API, ' +
+              'which Vite needs to resolve `@import`s. It was removed in Less 5. ' +
+              'Install "less@^4" to use Less with Vite.',
+          )
+        }
         ViteLessManager ??= class ViteManager extends FileManager {
           rootFile
           constructor(rootFile: string) {


### PR DESCRIPTION
### Description

Fixes #23266.

With `less@5`, any Less file fails to compile with:

```
Error: [less] Class extends value undefined is not a constructor or null
```

Vite builds its `@import` resolver by subclassing `less.FileManager` and registering it via `pluginManager.addFileManager()`. Less 5 is a rewrite (a Less-compatible API backed by the Jess compiler) and drops that architecture entirely. Verified against `less@5.0.0-alpha.1`:

```
resolved version : [ 5, 0, 0 ]
FileManager      : undefined
PluginLoader     : undefined
own keys         : version, render, renderFile, logger, lesscHelper, Compiler
```

So `const { FileManager } = less` is `undefined` and `class ViteManager extends FileManager` throws.

### Why an error rather than Less 5 support

There is no plugin or file-manager API left to hook into, so Vite cannot inject its resolver — supporting Less 5 needs an upstream API first. Vite also already declares `less: ^4.0.0` in `peerDependencies`, so Less 5 is outside the supported range; it should fail with an actionable message rather than an opaque one.

Note `less@5.0.0-alpha.1` is published under the `alpha` dist-tag only (`latest` is `4.9.0`), so this affects users who opt in explicitly.

### Before / after

Before:

```
Error: [less] Class extends value undefined is not a constructor or null
```

After:

```
Error: [less] The installed version of "less" does not expose the "FileManager" plugin API,
which Vite needs to resolve `@import`s. It was removed in Less 5. Install "less@^4" to use Less with Vite.
```

### Testing

Verified end-to-end against a locally built Vite:

- `less@5.0.0-alpha.1` → the new actionable error
- `less@4.9.0` → builds cleanly, emits `h1{color:#333}` (no regression)
- `tsc -p src/node` clean, `oxfmt --check` clean, `eslint` clean
- `vitest run css` → 50 tests pass

No automated test is included: the check lives inside the Less preprocessor worker closure and is not reachable without adding a `less@5` dev dependency, which is currently an alpha-only release. Happy to add coverage if you'd like it done a particular way.