### PR TITLE
fix: resolve pending discovered deps on close

### DIFF
--- a/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts
@@ -90,3 +90,54 @@ test('does not crash when a dep is discovered before the server starts listening
   await ssr.depsOptimizer?.scanProcessing
   expect(errors).toStrictEqual([])
 })
+
+// regression test for https://github.com/vitejs/vite/issues/23143
+// If a request for a pre-init discovered dependency is pending when the server
+// closes, the request waits for the dependency's processing promise. Since
+// discovery before listen intentionally doesn't start an optimizer run, close()
+// needs to resolve that promise so shutdown can finish.
+test('does not hang when closing with a pre-init discovered dep request', async () => {
+  server = await createServer({
+    configFile: false,
+    root: path.join(
+      import.meta.dirname,
+      '../fixtures/optimizer-discover-before-listen',
+    ),
+    cacheDir: 'node_modules/.vite',
+    environments: {
+      ssr: {
+        resolve: {
+          noExternal: true,
+        },
+        optimizeDeps: {
+          force: true,
+          noDiscovery: false,
+        },
+      },
+    },
+  })
+
+  const ssr = server.environments.ssr
+  const depsOptimizer = ssr.depsOptimizer!
+
+  await ssr.transformRequest('/entry.js')
+
+  const discovered = depsOptimizer.metadata.discovered.vue!
+  expect(discovered.processing).toBeDefined()
+
+  // Start a request that waits on the discovered dep's unresolved processing
+  // promise. During shutdown, the request may fail because the optimized file
+  // was never written, but it must not keep close() pending forever.
+  const optimizedRequest = ssr
+    .transformRequest(depsOptimizer.getOptimizedDepId(discovered))
+    .catch(() => {})
+
+  const closeFinished = await Promise.race([
+    server.close().then(() => true),
+    setTimeout(300, false),
+  ])
+
+  expect(closeFinished).toBe(true)
+  server = undefined
+  await optimizedRequest
+})

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -147,6 +147,8 @@ export function createDepsOptimizer(
 
   async function close() {
     closed = true
+    depOptimizationProcessing.resolve()
+    resolveEnqueuedProcessingPromises()
     await Promise.allSettled([
       discover?.cancel(),
       depsOptimizer.scanProcessing,


### PR DESCRIPTION
### Description

Fixes #23143.

When a dependency is discovered before `depsOptimizer.init()` runs, Vite intentionally does not start an optimize run yet. If a request for that discovered optimized dep is pending during shutdown, it waits on the dep's `processing` promise while `environment.close()` waits for pending requests to settle. Because no optimize run owns that promise, `server.close()` can hang.

This resolves the active discovered-dep processing promise, plus any queued processing promises, in `depsOptimizer.close()`. Pending optimized-dep requests can then settle during shutdown instead of keeping close pending forever.

This adapts the same shutdown-path idea from the now-closed #23155 to the current optimizer file layout and adds a regression test beside the existing pre-listen discovery coverage.

### Alternatives

Starting an optimize run during close would be more work and would do unnecessary shutdown-time bundling. Resolving the pending processing promises is scoped to teardown and matches the existing closed-path behavior in `runOptimizer()`.

### Validation

- `pnpm run build`
- `pnpm test-unit packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts`
- `pnpm exec oxfmt --check packages/vite/src/node/optimizer/optimizer.ts packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts`
- `pnpm exec eslint packages/vite/src/node/optimizer/optimizer.ts packages/vite/src/node/__tests__/optimizer/discoverBeforeListen.spec.ts --concurrency off`
- `pnpm --filter=./packages/vite exec tsc -p src/node`
- `git diff --check`
