### PR TITLE
fix(docs): open language switcher links in the current tab

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -556,6 +556,28 @@ const config = defineConfig({
           import.meta.dirname,
           'theme/components/TopBanner.vue',
         ),
+        // Keep language subdomain links in the current tab (vitejs/vite#21112).
+        // Mirrors vuejs/vitepress#5158; VoidZero theme still vendors pre-fix VPLink.
+        '@vp-default/VPLink.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/VPLink.vue',
+        ),
+        '@vp-default/VPMenuLink.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/VPMenuLink.vue',
+        ),
+        '@vp-default/VPNavBarTranslations.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/VPNavBarTranslations.vue',
+        ),
+        '@vp-default/VPNavBarExtra.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/VPNavBarExtra.vue',
+        ),
+        '@vp-default/VPNavScreenTranslations.vue': path.resolve(
+          import.meta.dirname,
+          'theme/components/VPNavScreenTranslations.vue',
+        ),
       },
     },
     plugins: [

--- a/docs/.vitepress/theme/components/VPLink.vue
+++ b/docs/.vitepress/theme/components/VPLink.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { normalizeLink } from '@vp-support/utils'
+import { EXTERNAL_URL_RE } from '@vp-support/shared-utils'
+
+const props = withDefaults(
+  defineProps<{
+    tag?: string
+    href?: string
+    noIcon?: boolean
+    external?: boolean
+    target?: string
+    rel?: string
+  }>(),
+  {
+    external: undefined,
+  },
+)
+
+const tag = computed(() => props.tag ?? (props.href ? 'a' : 'span'))
+const isExternal = computed(() => {
+  if (props.external !== undefined) {
+    return props.external
+  }
+  return (
+    (!!props.href && EXTERNAL_URL_RE.test(props.href)) ||
+    props.target === '_blank'
+  )
+})
+</script>
+
+<template>
+  <component
+    :is="tag"
+    class="VPLink"
+    :class="{
+      link: href,
+      'vp-external-link-icon': isExternal,
+      'no-icon': noIcon,
+    }"
+    :href="href ? normalizeLink(href) : undefined"
+    :target="target ?? (isExternal ? '_blank' : undefined)"
+    :rel="rel ?? (isExternal ? 'noreferrer' : undefined)"
+  >
+    <slot />
+  </component>
+</template>

--- a/docs/.vitepress/theme/components/VPMenuLink.vue
+++ b/docs/.vitepress/theme/components/VPMenuLink.vue
@@ -1,0 +1,66 @@
+<script lang="ts" setup generic="T extends DefaultTheme.NavItemWithLink">
+import type { DefaultTheme } from 'vitepress/theme'
+import { computed } from 'vue'
+import { useData } from '@vp-composables/data'
+import { useIcon } from '@vp-composables/icon'
+import { isActive } from '@vp-support/shared-utils'
+import { Icon } from '@iconify/vue'
+import VPLink from './VPLink.vue'
+
+const props = defineProps<{
+  item: T
+  rel?: string
+}>()
+
+const { page } = useData()
+
+const icon = useIcon(() => props.item.icon)
+
+const href = computed(() =>
+  typeof props.item.link === 'function'
+    ? props.item.link(page.value)
+    : props.item.link,
+)
+
+defineOptions({ inheritAttrs: false })
+</script>
+
+<template>
+  <div class="VPMenuLink">
+    <VPLink
+      v-bind="$attrs"
+      class="flex items-center justify-between rounded-md px-3 py-2 text-sm font-heading text-primary dark:text-white text-left whitespace-nowrap hover:opacity-70 transition-opacity"
+      :class="{
+        active: isActive(
+          page.relativePath,
+          item.activeMatch || href,
+          !!item.activeMatch,
+        ),
+      }"
+      :href
+      :target="item.target"
+      :rel="props.rel ?? item.rel"
+      :no-icon="item.noIcon"
+    >
+      <Icon v-if="icon" :icon="icon" class="shrink-0 mr-0.5" />
+      <span v-html="item.text"></span>
+    </VPLink>
+  </div>
+</template>
+
+<style scoped>
+.VPMenuGroup + .VPMenuLink {
+  margin: 12px -12px 0;
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 12px 12px 0;
+}
+
+.link:hover {
+  color: var(--vp-c-brand-1);
+  background-color: var(--vp-c-default-soft);
+}
+
+.link.active {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/VPNavBarExtra.vue
+++ b/docs/.vitepress/theme/components/VPNavBarExtra.vue
@@ -1,0 +1,118 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import VPFlyout from '@vp-default/VPFlyout.vue'
+import VPMenuLink from './VPMenuLink.vue'
+import VPSwitchAppearance from '@vp-default/VPSwitchAppearance.vue'
+import VPSocialLinks from '@vp-default/VPSocialLinks.vue'
+import { useData } from '@vp-composables/data'
+import { useLangs } from '@vp-composables/langs'
+
+const { site, theme, frontmatter } = useData()
+const { localeLinks, currentLang } = useLangs({ correspondingLink: true })
+
+const isForcedTheme = computed(() => !!frontmatter.value.theme)
+
+const hasExtraContent = computed(
+  () =>
+    (localeLinks.value.length && currentLang.value.label) ||
+    (site.value.appearance && !isForcedTheme.value) ||
+    theme.value.socialLinks,
+)
+</script>
+
+<template>
+  <VPFlyout
+    v-if="hasExtraContent"
+    class="VPNavBarExtra"
+    label="extra navigation"
+  >
+    <div
+      v-if="localeLinks.length && currentLang.label"
+      class="group translations"
+    >
+      <p class="trans-title">{{ currentLang.label }}</p>
+
+      <template v-for="locale in localeLinks" :key="locale.link">
+        <VPMenuLink
+          :item="locale"
+          :external="false"
+          :lang="locale.lang"
+          :hreflang="locale.lang"
+          rel="alternate"
+          :dir="locale.dir"
+        />
+      </template>
+    </div>
+
+    <div
+      v-if="
+        site.appearance &&
+        site.appearance !== 'force-dark' &&
+        site.appearance !== 'force-auto' &&
+        !isForcedTheme
+      "
+      class="group"
+    >
+      <div class="item appearance">
+        <p class="label">
+          {{ theme.darkModeSwitchLabel || 'Appearance' }}
+        </p>
+        <div class="appearance-action">
+          <VPSwitchAppearance />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="theme.socialLinks" class="group">
+      <div class="item social-links">
+        <VPSocialLinks class="social-links-list" :links="theme.socialLinks" />
+      </div>
+    </div>
+  </VPFlyout>
+</template>
+
+<style scoped>
+.VPNavBarExtra {
+  display: none;
+  margin-right: -12px;
+}
+
+@media (min-width: 768px) {
+  .VPNavBarExtra {
+    display: block;
+  }
+}
+
+@media (min-width: 1280px) {
+  .VPNavBarExtra {
+    display: none;
+  }
+}
+
+.trans-title {
+  padding: 0 24px 0 12px;
+  line-height: 32px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+}
+
+.item.appearance,
+.item.social-links {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+}
+
+.item.appearance {
+  min-width: 176px;
+}
+
+.appearance-action {
+  margin-right: -2px;
+}
+
+.social-links-list {
+  margin: -4px -8px;
+}
+</style>

--- a/docs/.vitepress/theme/components/VPNavBarTranslations.vue
+++ b/docs/.vitepress/theme/components/VPNavBarTranslations.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import VPFlyout from '@vp-default/VPFlyout.vue'
+import VPMenuLink from './VPMenuLink.vue'
+import { useData } from '@vp-composables/data'
+import { useLangs } from '@vp-composables/langs'
+
+const { theme } = useData()
+const { localeLinks, currentLang } = useLangs({ correspondingLink: true })
+</script>
+
+<template>
+  <VPFlyout
+    v-if="localeLinks.length && currentLang.label"
+    class="VPNavBarTranslations"
+    icon="lucide:languages"
+    :label="theme.langMenuLabel || 'Change language'"
+  >
+    <div class="items">
+      <p class="title">{{ currentLang.label }}</p>
+
+      <template v-for="locale in localeLinks" :key="locale.link">
+        <VPMenuLink
+          :item="locale"
+          :external="false"
+          :lang="locale.lang"
+          :hreflang="locale.lang"
+          rel="alternate"
+          :dir="locale.dir"
+        />
+      </template>
+    </div>
+  </VPFlyout>
+</template>
+
+<style scoped>
+.VPNavBarTranslations {
+  display: none;
+}
+
+@media (min-width: 1280px) {
+  .VPNavBarTranslations {
+    display: flex;
+    align-items: center;
+  }
+}
+
+.title {
+  padding: 0 24px 0 12px;
+  line-height: 32px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+}
+</style>

--- a/docs/.vitepress/theme/components/VPNavScreenTranslations.vue
+++ b/docs/.vitepress/theme/components/VPNavScreenTranslations.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useLangs } from '@vp-composables/langs'
+import VPLink from './VPLink.vue'
+
+const { localeLinks, currentLang } = useLangs({ correspondingLink: true })
+const isOpen = ref(false)
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+</script>
+
+<template>
+  <div
+    v-if="localeLinks.length && currentLang.label"
+    class="VPNavScreenTranslations"
+    :class="{ open: isOpen }"
+  >
+    <button class="title" @click="toggle">
+      <span class="vpi-languages icon lang" />
+      {{ currentLang.label }}
+      <span class="vpi-chevron-down icon chevron" />
+    </button>
+
+    <ul class="list">
+      <li v-for="locale in localeLinks" :key="locale.link" class="item">
+        <VPLink
+          class="link"
+          :href="locale.link"
+          :external="false"
+          :lang="locale.lang"
+          :hreflang="locale.lang"
+          rel="alternate"
+          :dir="locale.dir"
+        >
+          {{ locale.text }}
+        </VPLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.VPNavScreenTranslations {
+  height: 24px;
+  overflow: hidden;
+}
+
+.VPNavScreenTranslations.open {
+  height: auto;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vp-c-text-1);
+}
+
+.icon {
+  font-size: 16px;
+}
+
+.icon.lang {
+  margin-right: 8px;
+}
+
+.icon.chevron {
+  margin-left: 4px;
+}
+
+.list {
+  padding: 4px 0 0 24px;
+}
+
+.link {
+  line-height: 32px;
+  font-size: 13px;
+  color: var(--vp-c-text-1);
+}
+</style>


### PR DESCRIPTION
## Summary

- Language switcher links to `*.vite.dev` locale subdomains were treated as external by the VoidZero theme’s vendored `VPLink`, which forced `target="_blank"`.
- Ports the VitePress approach from [vuejs/vitepress#5158](https://github.com/vuejs/vitepress/pull/5158): allow `VPLink` to accept `external={false}`, and pass that from the translation menu components.
- Overrides are wired the same way as the existing `TopBanner` theme alias in the docs Vite config.

Fixes #21112

## Test plan

- [ ] Open the docs navbar language menu and click a locale link (e.g. 简体中文 / 日本語).
- [ ] Confirm navigation happens in the **same** tab (no forced new tab).
- [ ] Confirm true external nav links (GitHub, social, etc.) still open in a new tab with the external-link treatment.
- [ ] Check the mid-width “extra” flyout language list and mobile language list behave the same.