### PR TITLE
fix: skip native config warnings for explicit loader

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1639,6 +1639,7 @@ describe('loadConfigFromFile', () => {
     const loadWithWarnings = async (
       dir: string,
       configFile = 'vite.config.js',
+      configLoader?: 'bundle' | 'runner' | 'native',
     ) => {
       const logger = createLogger('info')
       const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
@@ -1649,7 +1650,7 @@ describe('loadConfigFromFile', () => {
         root,
         undefined,
         logger,
-        'bundle',
+        configLoader,
       )
       const messages = warn.mock.calls.map((c) =>
         stripVTControlCharacters(c[0]),
@@ -1668,6 +1669,12 @@ describe('loadConfigFromFile', () => {
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
+    })
+
+    test('does not warn when the bundle config loader is explicit', async () => {
+      expect(
+        await loadWithWarnings('dirname', 'vite.config.js', 'bundle'),
+      ).toHaveLength(0)
     })
 
     // uses a `.ts` config with TypeScript-only syntax; skipped on Node

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2491,10 +2491,7 @@ async function bundleAndLoadConfigFile(
     isESM,
   )
 
-  if (
-    warnNativeIncompatibilities &&
-    bundled.nativeIncompatibilities.length > 0
-  ) {
+  if (bundled.nativeIncompatibilities.length > 0) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
       formatNativeConfigIncompatWarning(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2367,19 +2367,16 @@ export async function loadConfigFromFile(
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
-  configLoader: 'bundle' | 'runner' | 'native' = 'bundle',
+  configLoader?: 'bundle' | 'runner' | 'native',
 ): Promise<{
   path: string
   config: UserConfig
   dependencies: string[]
 } | null> {
-  if (
-    configLoader !== 'bundle' &&
-    configLoader !== 'runner' &&
-    configLoader !== 'native'
-  ) {
+  const loader = configLoader ?? 'bundle'
+  if (loader !== 'bundle' && loader !== 'runner' && loader !== 'native') {
     throw new Error(
-      `Unsupported configLoader: ${configLoader}. Accepted values are 'bundle', 'runner', and 'native'.`,
+      `Unsupported configLoader: ${loader}. Accepted values are 'bundle', 'runner', and 'native'.`,
     )
   }
 
@@ -2409,14 +2406,15 @@ export async function loadConfigFromFile(
   }
 
   try {
-    const { configExport, dependencies } = await (configLoader === 'bundle'
+    const { configExport, dependencies } = await (loader === 'bundle'
       ? bundleAndLoadConfigFile(
           resolvedPath,
           configRoot,
           logLevel,
           customLogger,
+          configLoader == null,
         )
-      : configLoader === 'runner'
+      : loader === 'runner'
         ? runnerImportConfigFile(resolvedPath)
         : nativeImportConfigFile(resolvedPath))
     debug?.(`config file loaded in ${getTime()}`)
@@ -2477,18 +2475,26 @@ async function bundleAndLoadConfigFile(
   configRoot: string,
   logLevel: LogLevel | undefined,
   customLogger: Logger | undefined,
+  warnNativeIncompatibilities: boolean,
 ) {
   const isESM =
     typeof process.versions.deno === 'string' || isFilePathESM(resolvedPath)
 
-  const bundled = await bundleConfigFile(resolvedPath, isESM)
+  const bundled = await bundleConfigFile(
+    resolvedPath,
+    isESM,
+    warnNativeIncompatibilities,
+  )
   const userConfig = await loadConfigFromBundledFile(
     resolvedPath,
     bundled.code,
     isESM,
   )
 
-  if (bundled.nativeIncompatibilities.length > 0) {
+  if (
+    warnNativeIncompatibilities &&
+    bundled.nativeIncompatibilities.length > 0
+  ) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
       formatNativeConfigIncompatWarning(
@@ -2507,6 +2513,7 @@ async function bundleAndLoadConfigFile(
 async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
+  warnNativeIncompatibilities: boolean,
 ): Promise<{
   code: string
   dependencies: string[]
@@ -2549,6 +2556,7 @@ async function bundleConfigFile(
     tsconfig: false,
     plugins: [
       !process.env.VITE_CONFIG_NATIVE_IGNORE_WARNING &&
+        warnNativeIncompatibilities &&
         createNativeConfigCompatPlugin(nativeIncompatibilities),
       {
         name: 'externalize-deps',


### PR DESCRIPTION
## Summary

- keep native config incompatibility warnings on the default config loader path
- skip those warnings when callers explicitly choose `configLoader: 'bundle'`
- add a regression test for the explicit bundle loader case

Fixes #23267.

## Validation

- `pnpm exec vitest run packages/vite/src/node/__tests__/config.spec.ts -t "native-incompatibility warnings"`
- `pnpm exec oxfmt --check packages/vite/src/node/config.ts packages/vite/src/node/__tests__/config.spec.ts`
- `pnpm exec eslint packages/vite/src/node/config.ts packages/vite/src/node/__tests__/config.spec.ts`
- `pnpm --filter vite build-types-check`
- `git diff --check`
