### PR TITLE
ci: unpin Windows Node 24 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,7 @@ jobs:
           - os: macos-latest
             node_version: 24
           - os: windows-latest
-            # use older minor to workaround https://github.com/nodejs/node/issues/63638
-            node_version: 24.15.0
+            node_version: 24
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"


### PR DESCRIPTION
## Summary
- unpins the Windows CI test matrix from Node 24.15.0 back to the Node 24 major line
- removes the stale workaround comment for nodejs/node#63638, which is now closed upstream

Closes #22818

## Validation
- `corepack pnpm exec oxfmt --check .github/workflows/ci.yml`
- `git diff --check`