### PR TITLE
fix(css): rewrite root-relative dev CSS sourcemap sources (fixes #23195)

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -394,7 +394,8 @@ async function loadAndTransform(
     )
 
     if (path.isAbsolute(mod.file)) {
-      let modDirname
+      const modDirname = path.dirname(mod.file)
+      const projectRoot = config.root
       for (
         let sourcesIndex = 0;
         sourcesIndex < normalizedMap.sources.length;
@@ -405,13 +406,15 @@ async function loadAndTransform(
           // Rewrite sources to relative paths to give debuggers the chance
           // to resolve and display them in a meaningful way (rather than
           // with absolute paths).
-          if (path.isAbsolute(sourcePath)) {
-            modDirname ??= path.dirname(mod.file)
-            normalizedMap.sources[sourcesIndex] = path.relative(
-              modDirname,
-              sourcePath,
-            )
-          }
+          const absoluteSourcePath = resolveSourcemapSourcePath(
+            modDirname,
+            projectRoot,
+            sourcePath,
+          )
+          normalizedMap.sources[sourcesIndex] = path.relative(
+            modDirname,
+            absoluteSourcePath,
+          )
         }
       }
     }
@@ -535,6 +538,33 @@ async function handleModuleSoftInvalidation(
     environment.moduleGraph.updateModuleTransformResult(mod, result)
 
   return result
+}
+
+function resolveSourcemapSourcePath(
+  modDirname: string,
+  projectRoot: string,
+  sourcePath: string,
+): string {
+  if (path.isAbsolute(sourcePath)) {
+    return sourcePath
+  }
+
+  const fromMod = path.resolve(modDirname, sourcePath)
+  const fromRoot = path.resolve(projectRoot, sourcePath)
+  if (fromMod === fromRoot) {
+    return fromMod
+  }
+
+  const relFromMod = path.relative(modDirname, fromMod)
+  const relFromRoot = path.relative(modDirname, fromRoot)
+  const escapesModDir = (rel: string) =>
+    rel === '' || rel.startsWith('..') || path.isAbsolute(rel)
+  const modEscapes = escapesModDir(relFromMod)
+  const rootEscapes = escapesModDir(relFromRoot)
+  if (modEscapes !== rootEscapes) {
+    return modEscapes ? fromRoot : fromMod
+  }
+  return relFromMod.length <= relFromRoot.length ? fromMod : fromRoot
 }
 
 // https://github.com/rolldown/rolldown/blob/cc66f4b7189dfb3a248608d02f5962edb09b11f8/crates/rolldown/src/utils/normalize_options.rs#L95-L111

--- a/playground/css-sourcemap/__tests__/lightningcss/sources-resolution.spec.ts
+++ b/playground/css-sourcemap/__tests__/lightningcss/sources-resolution.spec.ts
@@ -1,0 +1,35 @@
+import { URL } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import {
+  extractSourcemap,
+  isBundledDev,
+  isServe,
+  page,
+  viteTestUrl,
+} from '~utils'
+
+// Shape 3 (#23195): lightningcss URL-served maps keep root-relative `sources`
+// unless transformRequest rewrites them relative to the css file URL.
+describe.runIf(isServe)('css sourcemap sources', () => {
+  const fetchResolved = async (source: string, base: string) => {
+    const res = await page.request.get(new URL(source, base).href)
+    return res.text()
+  }
+
+  test.skipIf(isBundledDev)(
+    'URL-served css: sources resolve against the css URL',
+    async () => {
+      const cssUrl = new URL('./nested/dir/from-js.css', viteTestUrl + '/').href
+      const res = await page.request.get(cssUrl, {
+        headers: { accept: 'text/css' },
+      })
+      const map = extractSourcemap(await res.text())
+
+      const resolved = await Promise.all(
+        map.sources.map((source: string) => fetchResolved(source, cssUrl)),
+      )
+      expect(resolved.join('\n')).toContain('.from-js {')
+      expect(resolved.join('\n')).toContain('.dep {')
+    },
+  )
+})

--- a/playground/css-sourcemap/__tests__/sources-resolution.spec.ts
+++ b/playground/css-sourcemap/__tests__/sources-resolution.spec.ts
@@ -1,0 +1,35 @@
+import { URL } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import {
+  extractSourcemap,
+  isBundledDev,
+  isServe,
+  page,
+  viteTestUrl,
+} from '~utils'
+
+// Regression guard for Shape 3 (#23195): postcss URL-served maps were already
+// correct; keep them passing while lightningcss maps are rewritten.
+describe.runIf(isServe)('css sourcemap sources', () => {
+  const fetchResolved = async (source: string, base: string) => {
+    const res = await page.request.get(new URL(source, base).href)
+    return res.text()
+  }
+
+  test.skipIf(isBundledDev)(
+    'URL-served css: sources resolve against the css URL',
+    async () => {
+      const cssUrl = new URL('./nested/dir/from-js.css', viteTestUrl + '/').href
+      const res = await page.request.get(cssUrl, {
+        headers: { accept: 'text/css' },
+      })
+      const map = extractSourcemap(await res.text())
+
+      const resolved = await Promise.all(
+        map.sources.map((source: string) => fetchResolved(source, cssUrl)),
+      )
+      expect(resolved.join('\n')).toContain('.from-js {')
+      expect(resolved.join('\n')).toContain('.dep {')
+    },
+  )
+})

--- a/playground/css-sourcemap/admin/index.html
+++ b/playground/css-sourcemap/admin/index.html
@@ -1,0 +1,2 @@
+<script type="module" src="/nested-entry.js"></script>
+<p class="from-js">nested page importing the same css module</p>

--- a/playground/css-sourcemap/index.html
+++ b/playground/css-sourcemap/index.html
@@ -30,6 +30,8 @@
   <p class="input-map">&lt;input source-map&gt;</p>
 </div>
 
+<script type="module" src="./nested-entry.js"></script>
+
 <script type="module">
   import './imported.css'
   import './imported-with-import.css'

--- a/playground/css-sourcemap/nested-entry.js
+++ b/playground/css-sourcemap/nested-entry.js
@@ -1,0 +1,1 @@
+import './nested/dir/from-js.css'

--- a/playground/css-sourcemap/nested/dir/dep.css
+++ b/playground/css-sourcemap/nested/dir/dep.css
@@ -1,0 +1,3 @@
+.dep {
+  color: green;
+}

--- a/playground/css-sourcemap/nested/dir/from-js.css
+++ b/playground/css-sourcemap/nested/dir/from-js.css
@@ -1,0 +1,5 @@
+@import './dep.css';
+
+.from-js {
+  color: red;
+}

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -7,6 +7,9 @@ export default defineConfig({
       '@': import.meta.dirname,
     },
   },
+  dev: {
+    sourcemap: true,
+  },
   css: {
     devSourcemap: true,
     preprocessorOptions: {


### PR DESCRIPTION
## Problem

With `css.devSourcemap: true`, URL-served CSS sourcemaps can keep project-root-relative `sources` entries (Shape 3 in #23195). `transformRequest` only rebased absolute paths to be relative to the served module, so browsers resolve those entries against the CSS URL incorrectly and devtools fail to load the underlying files.

## Triage

- Re-verified on current `main` (2026-08-17): bug still present in `packages/vite/src/node/server/transformRequest.ts`.
- Prior attempt #23205 was closed by author after upstream restructuring invalidated the branch; this is a clean rebase onto current `main`, not a duplicate approach.

## Fix

When rewriting sourcemap `sources`, resolve non-absolute paths against the module directory or project root (whichever keeps the path inside the project), then emit paths relative to the served CSS file URL.

## Verification

```bash
pnpm run build
pnpm exec vitest run -c vitest.config.e2e.ts \
  playground/css-sourcemap/__tests__/sources-resolution.spec.ts \
  playground/css-sourcemap/__tests__/lightningcss/sources-resolution.spec.ts
```

Result: 2 files, 2 tests passed.

## Risks

Low — scoped to dev sourcemap path rewriting in `transformRequest`; no build output changes.

fixes #23195