### PR TITLE
fix(create-vite): update moved eslint-react plugin links in generated README

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -1013,7 +1013,7 @@ If you are developing a production application, we recommend updating the config
 ${eslintTypeAwareConfig}
 \`\`\`
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 \`\`\`js
 ${eslintReactConfig}

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -1013,7 +1013,7 @@ If you are developing a production application, we recommend updating the config
 ${eslintTypeAwareConfig}
 \`\`\`
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://npmx.dev/package/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://npmx.dev/package/eslint-plugin-react-dom) for React-specific lint rules:
 
 \`\`\`js
 ${eslintReactConfig}


### PR DESCRIPTION
## Problem

In `packages/create-vite/src/index.ts`, the generated README for React templates links to the eslint-react plugin directories at the old `packages/plugins/` location:

- `https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x`
- `https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom`

Both URLs now return 404. The eslint-react repository restructured and the plugins now live under `plugins/`, which can be confirmed in the repository tree:

- `https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x`
- `https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-dom`

This affects every newly scaffolded React project that reads its generated README.

## Solution

Update both links to the current `plugins/` paths in the template text used to generate the README.

## Verification

- `curl -L -o /dev/null -w "%{http_code}"` on the old URLs returns `404`
- The same check on the new URLs returns `200`
- `git diff --check` passes; only the single template line changes
