### PR TITLE
fix(css): preserve @layer ordering (fix #23229)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2323,6 +2323,7 @@ async function minifyCSS(
   }
 
   try {
+    const layerOrderStatements = await extractLayerOrderStatements(css)
     const { code, warnings } = (await importLightningCSS()).transform({
       ...config.css.lightningcss,
       targets: convertTargets(config.build.cssTarget),
@@ -2348,7 +2349,10 @@ async function minifyCSS(
     // Deno res.code = Uint8Array
     // For correct decode compiled css need to use TextDecoder
     // LightningCSS output does not return a linebreak at the end
-    return decoder.decode(code) + (inlined ? '' : '\n')
+    return await preserveLayerOrderStatements(
+      decoder.decode(code) + (inlined ? '' : '\n'),
+      layerOrderStatements,
+    )
   } catch (e) {
     e.message = `[lightningcss minify] ${e.message}`
     const friendlyMessage = getLightningCssErrorMessageForIeSyntaxes(css)
@@ -2365,6 +2369,58 @@ async function minifyCSS(
     }
     throw e
   }
+}
+
+const normalizeLayerOrderParams = (params: string) =>
+  params.trim().replace(/\s*,\s*/g, ',')
+
+async function extractLayerOrderStatements(css: string): Promise<string[]> {
+  if (!css.includes('@layer')) return []
+
+  const postcss = (await importPostcss()).default
+  const statements = new Set<string>()
+  for (const node of postcss.parse(css).nodes) {
+    if (node.type === 'atrule' && node.name === 'layer' && !node.nodes) {
+      statements.add(normalizeLayerOrderParams(node.params))
+    }
+  }
+  return [...statements]
+}
+
+async function preserveLayerOrderStatements(
+  css: string,
+  statements: string[],
+): Promise<string> {
+  if (!statements.length) return css
+
+  const postcss = (await importPostcss()).default
+  const root = postcss.parse(css)
+  const existing = new Set<string>()
+  for (const node of root.nodes) {
+    if (node.type === 'atrule' && node.name === 'layer' && !node.nodes) {
+      existing.add(normalizeLayerOrderParams(node.params))
+    }
+  }
+
+  const missing = statements.filter((params) => !existing.has(params))
+  if (!missing.length) return css
+
+  const nodes = missing.map((params) => {
+    const node = postcss.atRule({ name: 'layer', params })
+    node.raws.before = ''
+    return node
+  })
+  const firstNonPrelude = root.nodes.find(
+    (node) =>
+      node.type !== 'atrule' ||
+      !['charset', 'import', 'namespace'].includes(node.name),
+  )
+  if (firstNonPrelude) {
+    root.insertBefore(firstNonPrelude, nodes)
+  } else {
+    root.append(nodes)
+  }
+  return root.toString()
 }
 
 function resolveMinifyCssEsbuildOptions(

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from 'vitest'
-import { getBg, isBundled, page, viteTestUrl } from '~utils'
+import {
+  findAssetFile,
+  getBg,
+  isBuild,
+  isBundled,
+  page,
+  viteTestUrl,
+} from '~utils'
 import './tests'
 
 // not included in tests.ts because the lightningcss variant does not use
@@ -11,4 +18,9 @@ test('postcss plugin that injects url() at OnceExit', async () => {
   expect(await getBg(imported)).toMatch(
     isBundled ? /base64/ : '/injected-source/injected-bg.png',
   )
+})
+
+test.runIf(isBuild)('preserves explicit cascade-layer ordering', () => {
+  const css = findAssetFile(/index-[-\w]+\.css$/)
+  expect(css).toContain('@layer vite-layer-order-reset,vite-layer-order-main;')
 })

--- a/playground/css/layer-order.css
+++ b/playground/css/layer-order.css
@@ -1,0 +1,13 @@
+@layer vite-layer-order-reset, vite-layer-order-main;
+
+@layer vite-layer-order-reset {
+  .vite-layer-order-reset {
+    color: red;
+  }
+}
+
+@layer vite-layer-order-main {
+  .vite-layer-order-main {
+    color: blue;
+  }
+}

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -52,6 +52,7 @@ import charset from './charset.css?inline'
 text('.charset-css', charset)
 
 import './layered/index.css'
+import './layer-order.css'
 import './external.css'
 
 import './dep.css'


### PR DESCRIPTION
## Description

```markdown
## What is this PR solving?

Lightning CSS removes explicit cascade-layer ordering declarations during CSS minification.

For example:

```css
@layer resets, main;
```

can be removed from the generated CSS when using:

```js
build: {
  cssMinify: 'lightningcss',
}
```

This changes the stylesheet's semantics because cascade-layer precedence may then be determined by the order in which the layer blocks appear. This is especially important when CSS is combined from multiple files or packages.

Fixes #23229.

## Where was the issue?

The issue occurred in Vite's final CSS minification path in `packages/vite/src/node/plugins/css.ts`.

Vite delegates CSS minification to Lightning CSS through `minifyCSS()`. Lightning CSS can remove top-level `@layer` ordering statements when it determines that the declaration is redundant within the current input. However, Vite may later combine that CSS with styles from other modules, so the declaration cannot safely be discarded.

## How was it fixed?

Before Lightning CSS minification, Vite now collects top-level explicit `@layer` statements.

After Lightning CSS completes, Vite checks whether those statements are still present. Any statements removed by Lightning CSS are restored using the existing PostCSS parser and inserted after any `@charset`, `@import`, or `@namespace` prelude rules.

The fix:

- Preserves explicit cascade-layer ordering.
- Avoids duplicating statements that Lightning CSS retained.
- Does not add a new user-facing configuration option.
- Reuses the existing CSS finalization and PostCSS infrastructure.
- Preserves the existing Lightning CSS visitor behavior from #23146.
- Does not change asset rewriting, CSS code splitting, or source-map handling.

## Alternatives considered

- Switching the default CSS minifier back to esbuild would avoid this specific behavior, but would regress the current Lightning CSS default.
- Adding a new configuration option would unnecessarily increase Vite's public API surface.
- Changing `hoistAtRules()` to handle `@layer` statements would mix cascade-layer preservation with the existing `@import` and `@charset` hoisting behavior.

Restoring statements within the existing Lightning CSS finalization path keeps the change localized and preserves the current minification architecture.

## Tests

Added a regression fixture to the CSS playground that verifies an explicit cascade-layer ordering declaration survives a production build.

The following checks pass:

- `pnpm run test-build css`
- `pnpm run test-build css-lightningcss`
- `pnpm exec vitest run packages/vite/src/node/__tests__/plugins/css.spec.ts`
- `pnpm --filter vite run typecheck`
- `pnpm --filter vite run build`
- Targeted ESLint checks
- Oxfmt formatting checks

## Documentation

No documentation update is needed because this restores the expected semantics of existing CSS behavior and does not introduce a new option or public API.
```