### PR TITLE
fix: avoid inlining optimizer hidden sourcemaps (fix #23287)

### DIFF
--- a/packages/vite/src/node/__tests__/optimizer/hiddenSourcemap.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/hiddenSourcemap.spec.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+import type { ViteDevServer } from '../..'
+import { createServer } from '../..'
+
+let server: ViteDevServer | undefined
+let root: string | undefined
+
+afterEach(async () => {
+  await server?.close()
+  server = undefined
+  if (root) fs.rmSync(root, { recursive: true, force: true })
+  root = undefined
+})
+
+test('does not inline hidden source maps into optimized dependency responses', async () => {
+  root = fs.mkdtempSync(
+    path.join(fs.realpathSync(os.tmpdir()), 'vite-optimizer-hidden-map-'),
+  )
+  const depDir = path.join(root, 'node_modules', 'source-map-dep')
+  fs.mkdirSync(depDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(depDir, 'package.json'),
+    JSON.stringify({
+      name: 'source-map-dep',
+      version: '1.0.0',
+      type: 'module',
+      main: 'index.js',
+    }),
+  )
+  fs.writeFileSync(path.join(depDir, 'index.js'), 'export const value = 1\n')
+
+  server = await createServer({
+    configFile: false,
+    root,
+    cacheDir: 'node_modules/.vite',
+    logLevel: 'silent',
+    optimizeDeps: {
+      force: true,
+      noDiscovery: true,
+      include: ['source-map-dep'],
+    },
+    server: { port: 0 },
+  })
+  await server.listen()
+
+  const depsOptimizer = server.environments.client.depsOptimizer!
+  await depsOptimizer.scanProcessing
+  const depInfo = depsOptimizer.metadata.optimized['source-map-dep']
+  expect(depInfo).toBeDefined()
+
+  const baseUrl = server.resolvedUrls!.local[0]
+  const response = await fetch(
+    new URL(
+      `/node_modules/.vite/deps/source-map-dep.js?v=${depInfo.browserHash}`,
+      baseUrl,
+    ),
+  )
+  expect(response.status).toBe(200)
+  expect(await response.text()).not.toContain('sourceMappingURL=data:')
+
+  const mapResponse = await fetch(
+    new URL('/node_modules/.vite/deps/source-map-dep.js.map', baseUrl),
+  )
+  expect(mapResponse.status).toBe(200)
+  expect((await mapResponse.json()).sources).toHaveLength(1)
+})

--- a/packages/vite/src/node/__tests__/optimizer/hiddenSourcemap.spec.ts
+++ b/packages/vite/src/node/__tests__/optimizer/hiddenSourcemap.spec.ts
@@ -59,7 +59,9 @@ test('does not inline hidden source maps into optimized dependency responses', a
     ),
   )
   expect(response.status).toBe(200)
-  expect(await response.text()).not.toContain('sourceMappingURL=data:')
+  expect(await response.text()).toMatch(
+    /sourceMappingURL=\/node_modules\/\.vite\/deps\/source-map-dep\.js\.map\?v=/,
+  )
 
   const mapResponse = await fetch(
     new URL('/node_modules/.vite/deps/source-map-dep.js.map', baseUrl),

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -166,8 +166,17 @@ export function transformMiddleware(
             return next()
           }
           try {
+            const originalUrl = url.replace(/\.map($|\?)/, '$1')
+            const transformedMap = (
+              await environment.moduleGraph.getModuleByUrl(originalUrl)
+            )?.transformResult?.map
+            if (transformedMap && 'version' in transformedMap) {
+              return send(req, res, JSON.stringify(transformedMap), 'json', {
+                headers: server.config.server.headers,
+              })
+            }
             const map = JSON.parse(
-              await fsp.readFile(sourcemapPath, 'utf-8'),
+              await fsp.readFile(cleanUrl(sourcemapPath), 'utf-8'),
             ) as ExistingRawSourceMap
 
             applySourcemapIgnoreList(
@@ -265,7 +274,10 @@ export function transformMiddleware(
             // allow browser to cache npm deps!
             cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
             headers: server.config.server.headers,
-            map: isOptimizedDep ? { mappings: '' } : result.map,
+            map: result.map,
+            mapUrl: isOptimizedDep
+              ? url.replace(/(\?.*)?$/, '.map$1')
+              : undefined,
           })
         }
       }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -258,14 +258,14 @@ export function transformMiddleware(
         if (result) {
           const depsOptimizer = environment.depsOptimizer
           const type = isDirectCSSRequest(url) ? 'css' : 'js'
-          const isDep =
-            DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
+          const isOptimizedDep = depsOptimizer?.isOptimizedDepUrl(url)
+          const isDep = DEP_VERSION_RE.test(url) || isOptimizedDep
           return send(req, res, result.code, type, {
             etag: result.etag,
             // allow browser to cache npm deps!
             cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
             headers: server.config.server.headers,
-            map: result.map,
+            map: isOptimizedDep ? { mappings: '' } : result.map,
           })
         }
       }

--- a/packages/vite/src/node/server/send.ts
+++ b/packages/vite/src/node/server/send.ts
@@ -27,6 +27,7 @@ export interface SendOptions {
   cacheControl?: string
   headers?: OutgoingHttpHeaders
   map?: SourceMap | { mappings: '' } | null
+  mapUrl?: string
 }
 
 export function send(
@@ -41,6 +42,7 @@ export function send(
     cacheControl = 'no-cache',
     headers,
     map,
+    mapUrl,
   } = options
 
   if (res.writableEnded) {
@@ -64,7 +66,13 @@ export function send(
   }
 
   // inject source map reference
-  if (map && 'version' in map && map.mappings) {
+  if (mapUrl && (type === 'js' || type === 'css')) {
+    const sourceMapComment =
+      type === 'js'
+        ? `\n//# sourceMappingURL=${mapUrl}`
+        : `\n/*# sourceMappingURL=${mapUrl} */`
+    content = `${content.toString()}${sourceMapComment}`
+  } else if (map && 'version' in map && map.mappings) {
     if (type === 'js' || type === 'css') {
       content = getCodeWithSourcemap(type, content.toString(), map)
     }

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -35,14 +35,19 @@ async function getDepJs(entry: string, depIdFragment: string) {
   expect(depUrl).toContain('/deps/')
 
   const depRes = await page.request.get(new URL(depUrl, page.url()).href)
-  return depRes.text()
+  return { js: await depRes.text(), url: depRes.url() }
 }
 
-function expectConsoleLogArgumentMapsToOriginalX(
+async function expectConsoleLogArgumentMapsToOriginalX(
   depJs: string,
+  depUrl: string,
   generatedName: string,
 ) {
-  const map = extractSourcemap(depJs)
+  const map = await extractSourcemap(depJs, async (url) => {
+    const mapRes = await page.request.get(new URL(url, depUrl).href)
+    expect(mapRes.status()).toBe(200)
+    return mapRes.text()
+  })
   const depLines = depJs.split('\n')
   const consoleLogCallRE = new RegExp(
     `console[\\w$]*\\.\\s*log[\\w$]*\\(${escapeRegex(generatedName)}\\)`,
@@ -59,9 +64,7 @@ function expectConsoleLogArgumentMapsToOriginalX(
     column: generatedColumn,
   })
 
-  expect(depJs).toMatch(
-    /^\/\/# sourceMappingURL=data:application\/json;base64,/m,
-  )
+  expect(depJs).toMatch(/^\/\/# sourceMappingURL=\S+\.map(?:\?\S+)?$/m)
   expect(position).toMatchObject({
     line: 6,
     column: 16,
@@ -302,10 +305,11 @@ if (!isBuild) {
       expect(depUrl).toContain('.vite/deps')
       const depRes = await page.request.get(new URL(depUrl, page.url()).href)
       const depJs = await depRes.text()
-      expect(depJs).toMatch(
-        /^\/\/# sourceMappingURL=data:application\/json;base64,/m,
-      )
-      const map = extractSourcemap(depJs)
+      const map = await extractSourcemap(depJs, async (url) => {
+        const mapRes = await page.request.get(new URL(url, depRes.url()).href)
+        expect(mapRes.status()).toBe(200)
+        return mapRes.text()
+      })
       expect(map.sourcesContent).toBeDefined()
       expect(map.sourcesContent).not.toContainEqual(
         expect.stringContaining('defineConfig'),
@@ -318,7 +322,7 @@ if (!isBuild) {
   test.skipIf(isBundledDev)(
     'babel-transformed downleveled optimized dep maps to the correct original name',
     async () => {
-      const depJs = await getDepJs(
+      const { js: depJs, url: depUrl } = await getDepJs(
         './optimized-class-field-import-babel.js',
         'test-dep-class-field-sourcemap-babel',
       )
@@ -326,14 +330,14 @@ if (!isBuild) {
       expect(depJs).toContain('x = () => 1')
       expect(depJs).toContain('constructor(_x)')
       expect(depJs).toContain('console.log(_x)')
-      expectConsoleLogArgumentMapsToOriginalX(depJs, '_x')
+      await expectConsoleLogArgumentMapsToOriginalX(depJs, depUrl, '_x')
     },
   )
 
   test.skipIf(isBundledDev)(
     'oxc-transformed downleveled optimized dep maps to the correct original name',
     async () => {
-      const depJs = await getDepJs(
+      const { js: depJs, url: depUrl } = await getDepJs(
         './optimized-class-field-import-oxc.js',
         'test-dep-class-field-sourcemap-oxc',
       )
@@ -341,7 +345,7 @@ if (!isBuild) {
       expect(depJs).toContain('x$$$ = () => 1')
       expect(depJs).toContain('constructor$$$(_x$$$)')
       expect(depJs).toContain('console$$$.log$$$(_x$$$)')
-      expectConsoleLogArgumentMapsToOriginalX(depJs, '_x$$$')
+      await expectConsoleLogArgumentMapsToOriginalX(depJs, depUrl, '_x$$$')
     },
   )
 }


### PR DESCRIPTION
## Root cause

The dependency optimizer emits hidden source maps, but optimized dependencies were sent through the normal transform response path. `send()` therefore converted the returned map into an inline data URL, making the HTTP response much larger than the optimized file on disk.

## Change

Serve optimized dependencies with an external `sourceMappingURL` that keeps the browser hash query, and return the post-transform map from the dedicated `.map` endpoint. This avoids base64 response bloat while preserving debugger mappings and existing path-traversal sanitization.

## Validation

- Added a RED/GREEN regression proving the optimized response uses an external map and its `.map` endpoint serves the generated map
- `pnpm test-unit packages/vite/src/node/__tests__/optimizer/hiddenSourcemap.spec.ts packages/vite/src/node/__tests__/optimizer/customExtensionBundleClose.spec.ts`
- `pnpm run test-serve js-sourcemap` (9 passed)
- `pnpm exec oxfmt --check ...`
- `pnpm exec eslint ...`
- `pnpm run build`

Fixes #23287
