### PR TITLE
fix(bundled-dev): handle lazy request error

### DIFF
--- a/packages/vite/src/node/server/middlewares/triggerLazyBundling.ts
+++ b/packages/vite/src/node/server/middlewares/triggerLazyBundling.ts
@@ -26,7 +26,17 @@ export function triggerLazyBundlingMiddleware(
 
     const moduleId = params.get('id')
     const clientId = params.get('clientId')
-    const result = await bundledDev.triggerLazyBundling(moduleId, clientId)
+    let result: { code: string; filename: string } | undefined
+    try {
+      result = await bundledDev.triggerLazyBundling(moduleId, clientId)
+    } catch (e) {
+      server.config.logger.error(
+        `Failed to trigger lazy bundling for ${moduleId} (clientId: ${clientId}):` +
+          e,
+        { error: e },
+      )
+      return next(new Error(`Failed to trigger lazy bundling`))
+    }
     if (result == null) {
       return next()
     }

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -448,6 +448,13 @@ if (isBuild) {
       .toBe('worker-plain-updated')
   })
 
+  test('lazy bundling errors return 500', async () => {
+    const response = await page.request.get(
+      new URL('/@vite/lazy?id=%2Ffoo%2Fbar&clientId=x', page.url()).href,
+    )
+    expect(response.status()).toBe(500)
+  })
+
   // Blocked by https://github.com/rolldown/rolldown/issues/10340
   test.skip('chained invalidate in an import cycle settles', async () => {
     const original = readFile('cycle-a.js')


### PR DESCRIPTION
Sending lazy request with invalid args caused the process to exit. This PR adds error handling for that.