### PR TITLE
feat(environment): expose build manifest on build environment

### DIFF
--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -342,6 +342,31 @@ export default defineConfig({
 
 Besides the `builder.buildApp` config option, plugins can define a `buildApp` hook to participate in the app build. The config option and the plugin hooks run in a defined order: hooks with order `'pre'` or `null` run first, then the configured `builder.buildApp`, then hooks with order `'post'`. Within a hook, `environment.isBuilt` tells you whether an environment has already been built, which lets a plugin avoid building it twice.
 
+### Accessing the build manifest with `environment.manifest`
+
+Once an environment has been built, its [build manifest](/config/build-options#build-manifest) is available on `environment.manifest`. This lets a plugin read the manifest of an already built environment directly in the `buildApp` hook, without having to write to and read from the file system. It is a common pattern, for example, to use the manifest to move assets emitted in a server environment to the client bundle.
+
+The manifest is populated regardless of the [`build.manifest`](/config/build-options#build-manifest) option, which only controls whether the manifest file is written to disk. Each environment has its own manifest.
+
+```js [vite.config.js]
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'read-manifest',
+      async buildApp(builder) {
+        const client = builder.environments.client
+        if (!client.isBuilt) {
+          await builder.build(client)
+        }
+        console.log('client manifest', client.manifest)
+      },
+    },
+  ],
+})
+```
+
 ### Building programmatically with `createBuilder`
 
 To trigger an app build from your own code, use `createBuilder` instead of the standalone `build` function. `createBuilder` is the build-time equivalent of `createServer`: it resolves the config and returns a `ViteBuilder`, whose `buildApp` method builds every configured environment. You can also build a single environment with `builder.build(environment)`.

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1517,6 +1517,102 @@ test('watch rebuild manifest', async (ctx) => {
   `)
 })
 
+test('environment.manifest is populated when build.manifest is disabled without emitting a file', async () => {
+  const root = resolve(dirname, 'fixtures/watch-rebuild-manifest')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'error',
+    environments: {
+      client: {
+        build: {
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    build: {
+      write: false,
+      manifest: false,
+    },
+  })
+
+  const environment = builder.environments.client
+  const result = (await builder.build(environment)) as RolldownOutput
+
+  // the manifest file should not be emitted
+  expect(
+    result.output.find((o) => o.fileName === '.vite/manifest.json'),
+  ).toBeUndefined()
+
+  // but the manifest should be available on the environment
+  expect(environment.manifest).toBeDefined()
+  expect(Object.keys(environment.manifest!)).toMatchInlineSnapshot(`
+    [
+      "dep.js",
+      "entry.js",
+    ]
+  `)
+})
+
+test('environment.manifest matches the emitted manifest file when build.manifest is enabled', async () => {
+  const root = resolve(dirname, 'fixtures/watch-rebuild-manifest')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'error',
+    environments: {
+      client: {
+        build: {
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    build: {
+      write: false,
+      manifest: true,
+    },
+  })
+
+  const environment = builder.environments.client
+  const result = (await builder.build(environment)) as RolldownOutput
+
+  const manifestFile = result.output.find(
+    (o) => o.fileName === '.vite/manifest.json',
+  )
+  expect(manifestFile).toBeDefined()
+  expect(environment.manifest).toEqual(JSON.parse((manifestFile as any).source))
+})
+
+test('environment.manifest is populated for the ssr environment', async () => {
+  const root = resolve(dirname, 'fixtures/watch-rebuild-manifest')
+  const builder = await createBuilder({
+    root,
+    logLevel: 'error',
+    environments: {
+      ssr: {
+        build: {
+          ssr: true,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    build: {
+      write: false,
+      manifest: false,
+    },
+  })
+
+  const environment = builder.environments.ssr
+  await builder.build(environment)
+
+  expect(environment.manifest).toBeDefined()
+  expect(Object.keys(environment.manifest!)).toContain('entry.js')
+})
+
 test('copies public directory after building same environment with write false first', async (ctx) => {
   const root = resolve(dirname, 'fixtures/public-dir-write-false')
   ctx.onTestFinished(() =>

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -58,7 +58,7 @@ import { getHookHandler } from './plugins'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { type LicenseOptions, licensePlugin } from './plugins/license'
-import { manifestPlugin } from './plugins/manifest'
+import { type Manifest, manifestPlugin } from './plugins/manifest'
 import { prepareOutDirPlugin } from './plugins/prepareOutDir'
 import { buildReporterPlugin } from './plugins/reporter'
 import { type TerserOptions, terserPlugin } from './plugins/terser'
@@ -1746,6 +1746,16 @@ export class BuildEnvironment extends BaseEnvironment {
   mode = 'build' as const
 
   isBuilt = false
+  /**
+   * The build manifest for this environment. It is populated once the
+   * environment has been built and is available regardless of the
+   * `build.manifest` option, which only controls whether the manifest file is
+   * written to disk. This allows accessing the manifest in the `buildApp` hook
+   * without reading it from the file system.
+   *
+   * @experimental
+   */
+  manifest?: Manifest
   constructor(
     name: string,
     config: ResolvedConfig,

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import type { OutputChunk, RenderedChunk } from 'rolldown'
 import { viteManifestPlugin as nativeManifestPlugin } from 'rolldown/experimental'
 import { type Environment, perEnvironmentPlugin } from '..'
+import type { BuildEnvironment } from '../build'
 import { perEnvironmentState } from '../environment'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
@@ -70,13 +71,11 @@ export function manifestPlugin(): Plugin {
   })
 
   return perEnvironmentPlugin('native:manifest', (environment) => {
-    if (!environment.config.build.manifest) return false
-
     const root = environment.config.root
     const outPath =
-      environment.config.build.manifest === true
-        ? '.vite/manifest.json'
-        : environment.config.build.manifest
+      typeof environment.config.build.manifest === 'string'
+        ? environment.config.build.manifest
+        : '.vite/manifest.json'
 
     const envs: Record<string, Environment> = {}
     function getChunkName(chunk: OutputChunk) {
@@ -149,10 +148,24 @@ export function manifestPlugin(): Plugin {
                 }
               }
             }
+            const environment = this.environment as BuildEnvironment
+            // The manifest is always computed and stored on
+            // `environment.manifest`. The `build.manifest` option only controls
+            // whether the manifest file is written to disk.
+            const emitManifestFile = !!environment.config.build.manifest
+            const finalize = (finalManifest: Manifest) => {
+              environment.manifest = finalManifest
+              if (emitManifestFile) {
+                asset.source = JSON.stringify(finalManifest, undefined, 2)
+              } else {
+                delete bundle[outPath]
+              }
+            }
+
             const output = this.environment.config.build.rolldownOptions.output
             const outputLength = Array.isArray(output) ? output.length : 1
-            if (manifest && outputLength === 1) {
-              asset.source = JSON.stringify(manifest, undefined, 2)
+            if (outputLength === 1) {
+              finalize(manifest ?? JSON.parse(asset.source.toString()))
               return
             }
 
@@ -163,7 +176,7 @@ export function manifestPlugin(): Plugin {
               manifest ?? JSON.parse(asset.source.toString()),
             )
             if (state.outputCount >= outputLength) {
-              asset.source = JSON.stringify(state.manifest, undefined, 2)
+              finalize(state.manifest)
               state.reset()
             } else {
               delete bundle[outPath]


### PR DESCRIPTION
Fixes: https://github.com/vitejs/vite/issues/20052

### Description

Framework integrations often need access to an environment’s build manifest during app build orchestration. Currently, this requires enabling `build.manifest` and reading the emitted file from disk.

This PR exposes the generated manifest as `environment.manifest` after `builder.build(environment)` completes.

- Adds the experimental `BuildEnvironment.manifest` property.
- Generates the in-memory manifest regardless of `build.manifest`.
- Keeps `build.manifest` responsible for whether the manifest is written to disk.
- Documents accessing the manifest from a `buildApp` hook.

### Alternatives considered

#### `environment.bundle`

Storing the full `OutputBundle` would lead to significant increases in memory usage. By contrast, the manifest contains a serialised subset containing the necessary metadata.

#### Capturing the bundle in `generateBundle()` and storing it in a variable for later use

Requires additional logic and has the same memory issues as above.

### Future alternatives

https://github.com/vitejs/vite/discussions/20913