### PR TITLE
fix(css): don't pass empty targets to lightningcss

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -285,6 +285,9 @@ describe('convertTargets', () => {
     expect(convertTargets('esnext')).toBeUndefined()
     expect(convertTargets(['esnext'])).toBeUndefined()
     expect(convertTargets(false)).toBeUndefined()
+    expect(convertTargets(['esnext', 'chrome148'])).toStrictEqual({
+      chrome: 0x94_00_00,
+    })
   })
 })
 

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -280,6 +280,12 @@ describe('convertTargets', () => {
   test('supports es6 as an alias of es2015', () => {
     expect(convertTargets('es6')).toStrictEqual(convertTargets('es2015'))
   })
+
+  test('returns undefined when there is no constraint', () => {
+    expect(convertTargets('esnext')).toBeUndefined()
+    expect(convertTargets(['esnext'])).toBeUndefined()
+    expect(convertTargets(false)).toBeUndefined()
+  })
 })
 
 describe('getEmptyChunkReplacer', () => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3616,9 +3616,10 @@ const convertTargetsCache = new Map<
 export const convertTargets = (
   esbuildTarget: string | string[] | false,
 ): LightningCSSOptions['targets'] => {
-  if (!esbuildTarget) return {}
-  const cached = convertTargetsCache.get(esbuildTarget)
-  if (cached) return cached
+  if (!esbuildTarget) return undefined
+  if (convertTargetsCache.has(esbuildTarget)) {
+    return convertTargetsCache.get(esbuildTarget)
+  }
   const targets: LightningCSSOptions['targets'] = {}
 
   const entriesWithoutES = arraify(esbuildTarget).flatMap((e) => {
@@ -3652,8 +3653,10 @@ export const convertTargets = (
     throw new Error(`Unsupported target "${entry}"`)
   }
 
-  convertTargetsCache.set(esbuildTarget, targets)
-  return targets
+  // an empty object means "no browser supports anything" to lightningcss
+  const result = Object.keys(targets).length > 0 ? targets : undefined
+  convertTargetsCache.set(esbuildTarget, result)
+  return result
 }
 
 export function resolveLibCssFilename(


### PR DESCRIPTION
`convertTargets` returns an empty object when every entry is `esnext` (or when `build.cssTarget` is `false`), and `minifyCSS` passes that straight to Lightning CSS. Lightning CSS reads `targets: {}` as "no browser supports anything" and runs compatibility lowering, while `undefined` means no constraints. So `esnext` currently gets the transforms it opted out of, and in the reported case that silently dropped a `:open` rule from the minified output.

Return `undefined` instead of an empty object, so `esnext` means the same for CSS as it does for JS. Added a `convertTargets` unit test that fails on `main` and passes with this change.

fixes #23294
