### PR TITLE
fix(legacy): emit legacy chunks as strict mode code

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -879,6 +879,45 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         return
       }
 
+      // Legacy chunks contain code that originated from ES modules, which
+      // are always strict-mode code. The SystemJS output instead runs in
+      // sloppy mode, which changes semantics in subtle ways (e.g. Annex B
+      // block-level function hoisting) and combined with names shadowed by
+      // the minifier this can produce runtime TypeErrors in old browsers.
+      // The minifier also strips `use strict` directives, so the directive
+      // is injected here after all transforms have run.
+      for (const name in bundle) {
+        const chunk = bundle[name]
+        if (
+          chunk.type === 'chunk' &&
+          name.endsWith('.js') &&
+          name.includes('-legacy') &&
+          !/^(['"])use strict\1;?/.test(chunk.code)
+        ) {
+          chunk.code = `"use strict";\n${chunk.code}`
+          if (chunk.map) {
+            // The directive occupies a new first line without any mapping,
+            // which is equivalent to shifting all existing mappings down
+            // one line: prepend an empty line to the mappings. The emitted
+            // map is a separate asset in the bundle and mutations on
+            // `chunk.map` alone are not written to disk, so update both.
+            const mapAsset = bundle[`${name}.map`]
+            if (
+              mapAsset?.type === 'asset' &&
+              typeof mapAsset.source === 'string'
+            ) {
+              const map = JSON.parse(mapAsset.source)
+              map.mappings = `;${map.mappings}`
+              mapAsset.source = JSON.stringify(map)
+            }
+            chunk.map = {
+              ...chunk.map,
+              mappings: `;${chunk.map.mappings}`,
+            }
+          }
+        }
+      }
+
       if (isLegacyBundle(bundle) && genModern) {
         const importMapFilename = getImportMapFilename(config)
         // avoid emitting duplicate assets

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -157,6 +157,21 @@ describe.runIf(isBuild)('build', () => {
     expect(mainLegacyChunk).not.toMatch(/\w\?\.\w/)
   })
 
+  test('should emit legacy chunks as strict mode code', () => {
+    // The legacy chunks originate from ES modules, which are always
+    // strict-mode code. The SystemJS output must not silently downgrade them
+    // to sloppy mode: combined with names shadowed by the minifier, Annex B
+    // block-level function hoisting in sloppy mode can cause runtime
+    // TypeErrors in browsers that execute the legacy chunks.
+    for (const pattern of [
+      /index-legacy/,
+      /polyfills-legacy/,
+      /chunk-async-legacy/,
+    ]) {
+      expect(findAssetFile(pattern).startsWith('"use strict";')).toBe(true)
+    }
+  })
+
   test('should emit css file', async () => {
     expect(
       listAssets().some((filename) => filename.endsWith('.css')),


### PR DESCRIPTION
## What is this PR solving?

Fixes #23296.

Legacy chunks originate from ES modules, which are always strict-mode code, but the SystemJS output silently downgrades them to sloppy mode. Combined with names shadowed by the minifier (oxc-project/oxc#25896), Annex B.3.3 block-level function hoisting in sloppy mode then produces runtime TypeErrors — a deterministic white screen at first render for bundles containing the trigger pattern (antd 6 / `@ant-design/cssinjs` `parseStyle` hits it). Browsers executing modern chunks are unaffected, which makes the breakage silent for anyone not testing old browsers.

This PR injects `"use strict";` as the first line of every legacy JS chunk in `generateBundle`:

- restores the strict-mode semantics the code had as ES modules, bringing legacy output to parity with modern output (modern chunks are ESM and therefore always strict)
- independent of the upstream oxc fixes (tracked in oxc-project/oxc#25896 and oxc-project/oxc#25897) — correct regardless of when/how those are fixed

## Alternatives explored

- **Inject the directive at the babel / `renderChunk` stage** (e.g. in `wrapIIFEBabelPlugin`): does not survive — the oxc minifier strips `"use strict"` directives, both program-level and function-level (verified, see oxc-project/oxc#25897). `generateBundle` runs after the minifier and is the only reliable injection point.
- **`build.minify: 'terser'`**: works as a user-level workaround (terser neither creates the collision nor strips directives), but changes unrelated build characteristics and should not be required for correctness.

## Implementation notes

- The directive occupies a new first line without any mapping. For the emitted sourcemaps this is exactly equivalent to shifting all mappings down one line, so an empty line is prepended to the mappings.
- The emitted `.map` is a separate asset in the bundle; mutating `chunk.map` alone is not written to disk, so both are updated.
- Verified by decoding the generated mappings: `fix[1..]` is segment-for-segment identical to the unpatched map, with `sources` / `sourcesContent` unchanged.

## Testing

- Added `should emit legacy chunks as strict mode code` to the legacy playground (fails without the fix, passes with it).
- Verified end-to-end on Chromium 91 (Electron 13) with a minimal repro — https://github.com/liruisen/rolldown-legacy-strict-repro — white screen without the fix, correct rendering with it, sourcemaps byte-verified.

## Parts requiring attention

The `-legacy` filename check mirrors the existing convention in this file (`renderChunk` / asset dedup logic). If there is a more robust way to identify legacy chunks at `generateBundle` time, happy to switch.