### PR TITLE
test(module-runner): add TLA circular import case

### DIFF
--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/a.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/a.js
@@ -1,0 +1,6 @@
+import { b } from './b.js'
+
+await Promise.resolve()
+
+export const a = 'a'
+export const getB = () => b

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/b.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/b.js
@@ -1,0 +1,6 @@
+import { a } from './a.js'
+
+await Promise.resolve()
+
+export const b = 'b'
+export const getA = () => a

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/index.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/tla-circular/index.js
@@ -1,0 +1,4 @@
+import { a, getB } from './a.js'
+import { b, getA } from './b.js'
+
+export { a, b, getA, getB }

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -272,6 +272,17 @@ describe('module runner initialization', async () => {
     expect(action).toBeDefined()
   })
 
+  it('resolves circular imports between modules with top-level await', async ({
+    runner,
+  }) => {
+    const mod = await runner.import('/fixtures/tla-circular/index.js')
+
+    expect(mod.a).toBe('a')
+    expect(mod.b).toBe('b')
+    expect(mod.getA()).toBe('a')
+    expect(mod.getB()).toBe('b')
+  })
+
   it('this of the exported function should be undefined', async ({
     runner,
   }) => {


### PR DESCRIPTION
Add a test case I came up while reviewing https://github.com/vitejs/vite/pull/23009 but a bit unrelated to that PR itself.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>