### PR TITLE
feat(deps): widen `@vitejs/devtools` peer range to v0.5.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -135,7 +135,7 @@
   },
   "peerDependencies": {
     "@types/node": "^20.19.0 || >=22.12.0",
-    "@vitejs/devtools": "^0.4.0",
+    "@vitejs/devtools": "^0.4.0 || ^0.5.0",
     "esbuild": "^0.27.0 || ^0.28.0",
     "jiti": ">=1.21.0",
     "less": "^4.0.0",


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->

The changes in v0.5.0 do not affect the Vite side integration. Widen the peer deps range. I didn't bump the dev deps because of the `minimumReleaseAge` limitation at this momenet and I don't want to create too much noise to `minimumReleaseAgeExclude`
