### PR TITLE
fix(html): preserve link order in build (fix #8739)

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -62,6 +62,12 @@ const htmlProxyRE =
 const isHtmlProxyRE = /[?&]html-proxy\b/
 
 const inlineCSSRE = /__VITE_INLINE_CSS__([a-z\d]{8}_\d+)__/g
+// Marks where the first bundled stylesheet <link> was removed from the
+// authored HTML so its replacement can be reinserted in the same place
+// instead of always at the end of <head>, preserving relative order against
+// sibling <link> tags that aren't bundled (e.g. ones served from `publicDir`).
+// See #8739.
+const cssLinkInsertionMarker = '\0__VITE_CSS_LINK_INSERT__\0'
 // Do not allow preceding '.', but do allow preceding '...' for spread operations
 const inlineImportRE =
   /(?<!(?<!\.\.)\.)\bimport\s*\(("(?:[^"]|(?<=\\)")*"|'(?:[^']|(?<=\\)')*')\)/dg
@@ -786,6 +792,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             resolved: await this.resolve(styleUrl.url, id),
           })),
         )
+        let cssLinkMarkerInserted = false
         for (const { start, end, url, resolved } of resolvedStyleUrls) {
           if (resolved == null) {
             config.logger.warnOnce(
@@ -794,6 +801,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             const importExpression = `\nimport ${JSON.stringify(url)}`
             js = js.replace(importExpression, '')
           } else {
+            if (!cssLinkMarkerInserted) {
+              s.appendLeft(start, cssLinkInsertionMarker)
+              cssLinkMarkerInserted = true
+            }
             s.remove(start, end)
           }
         }
@@ -936,6 +947,12 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         let result = html
 
+        // stylesheet <link> tags to inject, collected from both the
+        // per-chunk (cssCodeSplit: true) and single-bundle (cssCodeSplit:
+        // false) cases below, then injected together once (see marker
+        // handling further down)
+        const cssTags: HtmlTagDescriptor[] = []
+
         // find corresponding entry chunk
         const chunk = Object.values(bundle).find(
           (chunk) =>
@@ -987,7 +1004,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               )
             }
           }
-          assetTags.push(...getCssTagsForChunk(chunk, toOutputAssetFilePath))
+          cssTags.push(...getCssTagsForChunk(chunk, toOutputAssetFilePath))
 
           result = injectToHead(result, assetTags)
         }
@@ -1026,17 +1043,32 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 chunk.type === 'asset' && chunk.names.includes(cssBundleName),
             ) as OutputAsset | undefined)
           if (cssChunk) {
-            result = injectToHead(result, [
-              {
-                tag: 'link',
-                attrs: {
-                  rel: 'stylesheet',
-                  crossorigin: true,
-                  href: toOutputAssetFilePath(cssChunk.fileName),
-                },
+            cssTags.push({
+              tag: 'link',
+              attrs: {
+                rel: 'stylesheet',
+                crossorigin: true,
+                href: toOutputAssetFilePath(cssChunk.fileName),
               },
-            ])
+            })
           }
+        }
+
+        // Reinsert the bundled stylesheet <link>(s) where the first
+        // authored <link rel="stylesheet"> used to be (see the removal
+        // loop above), instead of always appending to the end of <head>.
+        // This preserves relative order against sibling <link> tags that
+        // weren't bundled (e.g. ones served as-is from `publicDir`), which
+        // matters for CSS cascade order. Falls back to the end of <head>
+        // when no stylesheet <link> was removed from this HTML file (#8739).
+        const cssLinkMarkerIndex = result.indexOf(cssLinkInsertionMarker)
+        if (cssLinkMarkerIndex !== -1) {
+          result =
+            result.slice(0, cssLinkMarkerIndex) +
+            (cssTags.length ? serializeTags(cssTags) : '') +
+            result.slice(cssLinkMarkerIndex + cssLinkInsertionMarker.length)
+        } else if (cssTags.length) {
+          result = injectToHead(result, cssTags)
         }
 
         // no use assets plugin because it will emit file

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -175,6 +175,21 @@ describe.runIf(isBuild)('build', () => {
     })
   })
 
+  describe('link order', () => {
+    beforeAll(async () => {
+      await page.goto(viteTestUrl + '/link-order/')
+    })
+
+    // bundled.css sets color to red, and the publicDir stylesheet (which
+    // isn't bundled and keeps its position) sets it to blue and is authored
+    // after it. Blue should win only if the bundled stylesheet's <link> is
+    // reinserted where it originally was instead of always at the end of
+    // <head> (#8739).
+    test('preserves order against a publicDir stylesheet link', async () => {
+      expect(await getColor('#link-order')).toBe('blue')
+    })
+  })
+
   describe('zeroJS', () => {
     // Ensure that the modulePreload polyfill is discarded in this case
 

--- a/playground/html/link-order/bundled.css
+++ b/playground/html/link-order/bundled.css
@@ -1,0 +1,3 @@
+#link-order {
+  color: red;
+}

--- a/playground/html/link-order/index.html
+++ b/playground/html/link-order/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./bundled.css" />
+    <link rel="stylesheet" href="/link-order-public.css" />
+  </head>
+  <body>
+    <h1 id="link-order">test link order</h1>
+  </body>
+</html>

--- a/playground/html/public/link-order-public.css
+++ b/playground/html/public/link-order-public.css
@@ -1,0 +1,3 @@
+#link-order {
+  color: blue;
+}

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -35,6 +35,7 @@ const input = {
   write: resolve(dirname, 'write.html'),
   'transform-inline-js': resolve(dirname, 'transform-inline-js.html'),
   malformedUrl: resolve(dirname, 'malformed-url.html'),
+  linkOrder: resolve(dirname, 'link-order/index.html'),
   // resolved from `process.cwd()` by Rolldown (resolved from `root` by vite's resolver first)
   relativeInput: relative(
     process.cwd(),


### PR DESCRIPTION
Fixes #8739

### What this solves

In a production build, a `<link rel="stylesheet">` that resolves to a bundleable CSS request is removed from its original position and converted into a JS import; the resulting bundled CSS `<link>` is then always reinjected at the end of `<head>`. A sibling `<link rel="stylesheet">` that isn't bundled (e.g. one served as-is from `publicDir`) keeps its original position. This silently reorders the two links relative to each other in the build output even though `vite dev` preserves the authored order, which breaks the CSS cascade for anyone relying on link order for specificity.

### Approach

`packages/vite/src/node/plugins/html.ts`:
- When the first stylesheet `<link>` is removed from the HTML during the `transform` hook, a marker (`cssLinkInsertionMarker`) is left at that exact position instead of just deleting the text.
- In `generateBundle`, the bundled stylesheet `<link>` tag(s) (from both the `cssCodeSplit: true` per-chunk case and the `cssCodeSplit: false` single-bundle case) are collected into one `cssTags` array and reinserted at the marker's position, restoring the original relative order against links that were never removed.
- Falls back to the previous "inject at end of `<head>`" behavior when no stylesheet link was removed from a given HTML file, so pages without this situation are unaffected.

### Alternatives considered

A full 1:1 restoration of every stylesheet link's original position isn't possible when `cssCodeSplit` merges multiple authored stylesheets into one output chunk/asset — there's no longer a single "correct" position per link. Using the position of the *first* removed link is the smallest change that fixes the reported ordering bug (bundled vs. non-bundled links) without trying to solve the more general "reorder N merged stylesheets against M untouched ones" problem.

### Tests

Added `playground/html/link-order/` — a page with a bundled stylesheet (red) and a `publicDir` stylesheet (blue) authored in that order, asserting the built page shows blue (last rule wins in the CSS cascade only if order is preserved).

I verified this fails without the fix and passes with it via a direct `vite build` on the fixture (before/after diff of the emitted HTML), but could not run the fixture through the full playground harness (`pnpm run test-build html`) on this machine — Windows Developer Mode is unavailable in this environment, and the harness's global setup needs real filesystem symlinks to stage `playground-temp`. The new test follows the same pattern as the existing `scriptAsync`/`scriptMixed`/`zeroJS` build-only tests in `playground/html/__tests__/html.spec.ts`, so it should run normally in CI.

### Parts that may need more reviewer attention

- The reinserted `<link>` tag(s) don't preserve the exact original indentation (the marker's line gets stripped along with the removed link during the `transform` step) — cosmetic only, doesn't affect functionality.
- This only reorders CSS `<link>` tags; `<script type="module">` tags converted from HTML are still always appended at the end of `<head>` as before (unchanged, pre-existing behavior, not part of this bug report).