### PR TITLE
fix(ssr): rewrite computed keys in defaulted destructuring params

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -421,6 +421,42 @@ test('rewrite variables in default value of destructuring params', async () => {
   expect(result?.deps).toEqual(['vue'])
 })
 
+// #23232
+test('rewrite computed key in a defaulted destructuring param', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `import { KEY } from 'vue';function f({ [KEY]: v = null } = {}) { return v }`,
+    ),
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["KEY"]});
+    function f({ [__vite_ssr_import_0__.KEY]: v = null } = {}) { return v }"
+  `)
+})
+
+// #23232
+test('rewrite computed key in nested and array defaulted destructuring params', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `import { KEY } from 'vue';function a({ x: { [KEY]: v } = {} } = {}) { return v };function b([{ [KEY]: v } = {}] = []) { return v }`,
+    ),
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["KEY"]});
+    function a({ x: { [__vite_ssr_import_0__.KEY]: v } = {} } = {}) { return v };function b([{ [__vite_ssr_import_0__.KEY]: v } = {}] = []) { return v }"
+  `)
+})
+
+// #23232
+test('do not rewrite shorthand binding in a defaulted destructuring param', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `import { KEY } from 'vue';function f({ KEY } = {}) { return KEY }`,
+    ),
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("vue", {"importedNames":["KEY"]});
+    function f({ KEY } = {}) { return KEY }"
+  `)
+})
+
 test('do not rewrite when function declaration is in scope', async () => {
   const result = await ssrTransformSimple(
     `import { fn } from 'vue';function A(){ function fn() {}; return { fn }; }`,

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -592,8 +592,16 @@ function walk(
                 return this.skip()
               }
               if (child.type !== 'Identifier') return
-              // do not record as scope variable if is a destructuring keyword
-              if (isStaticPropertyKey(child, parent)) return
+              // do not record as scope variable if this is a property key
+              // rather than the bound value. computed keys are expressions and
+              // must still be rewritten, so they are skipped here too
+              if (
+                parent?.type === 'Property' &&
+                parent.key === child &&
+                parent.value !== child
+              ) {
+                return
+              }
               // do not record if this is a default value
               // assignment of a destructuring variable
               if (


### PR DESCRIPTION
Fixes #23232.

### Problem

In `ssrTransform`'s scope walker, function parameters take two paths. A parameter that is directly an `ObjectPattern`/`ArrayPattern` goes through `handlePattern`, which recurses into each property's **value** and so never scopes a key. A parameter that is an `AssignmentPattern` (has a default) is instead walked generically, where the only property-key guard is `isStaticPropertyKey` — and that matches non-computed keys only.

A computed key therefore falls through to `setScope(...)` and is registered as a locally scoped binding. The rewrite pass then treats it as a local and skips the import rewrite, leaving a bare identifier:

```js
import { KEY } from './data.js'
export function f({ [KEY]: v = null } = {}) { return v }
// emitted:  function f({ [KEY]: v = null } = {}) { ... }
// runtime:  ReferenceError: KEY is not defined
```

The trigger is the default on the **parameter**, not on the property — `f({ [KEY]: v = null })` is fine, `f({ [KEY]: v } = {})` is not. Beyond the plain object case it also affects arrow functions, class methods, nested patterns and array patterns. Non-parameter positions (object literals, in-body destructuring) were never affected.

### Fix

Guard on the key/value relationship instead of on staticness, mirroring what `handlePattern` already does:

```ts
if (parent?.type === 'Property' && parent.key === child && parent.value !== child) {
  return
}
```

Computed keys stop being scoped and fall through to the normal rewrite. Shorthand bindings (`{ x } = {}`) keep their scoping, since `key === value` there and the `parent.value !== child` clause lets them through to `setScope`.

### Alternatives considered

Extending `isStaticPropertyKey` itself would have been smaller, but that helper is also used by `isRefIdentifier`, where "static" genuinely is the property being tested — widening it there would change unrelated behaviour. Keeping the change local to the parameter walker avoids that.

### Tests

Three added to `ssrTransform.spec.ts`:

- computed key in a defaulted destructuring param is rewritten
- same for nested and array patterns
- regression guard: a shorthand binding of the same name is **not** rewritten

The first two fail on `main` and pass with this change. The third passes either way and is there to pin the shadowing behaviour, which is the thing most at risk from this guard.

Full unit suite is green — 936 passed, 3 skipped across 68 files — plus `eslint` and `oxfmt` clean.

### Attention for reviewers

The shadowing side is where I would look hardest. Besides the test above I checked, against a module exporting `KEY`, that a local of the same name still wins in: `f({ KEY } = {})`, `f({ KEY })`, `f({ a: KEY } = {})`, `f(KEY)`, `f({ KEY = 'D' } = {})` and `f([KEY] = [])`, while a plain reference to the import still resolves to the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Smwb1MRyiGRRMEEDVioV88
