### PR TITLE
ci: use `$/` syntax to reference local action and remove actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,3 @@ jobs:
 
       - name: Test docs
         run: pnpm run test-docs
-
-      # From https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
-      - name: Check workflow files
-        run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color -shellcheck=""

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -13,12 +13,8 @@ jobs:
       issues: write # for actions/issues-helper to update issues
       pull-requests: write # for actions/issues-helper to update PRs
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
       - name: needs reproduction
-        uses: ./.github/actions/issues-helper
+        uses: $/.github/actions/issues-helper
         with:
           actions: "close-issues"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -9,17 +9,12 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-slim
     permissions:
-      contents: read # to check out the repo for local actions
       issues: write # for actions/issues-helper to update issues
       pull-requests: write # for actions/issues-helper to update PRs
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
       - name: contribution welcome
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: ./.github/actions/issues-helper
+        uses: $/.github/actions/issues-helper
         with:
           actions: "remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +23,7 @@ jobs:
 
       - name: remove pending
         if: (github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)') || github.event.label.name == 'needs reproduction') && contains(github.event.issue.labels.*.name, 'pending triage')
-        uses: ./.github/actions/issues-helper
+        uses: $/.github/actions/issues-helper
         with:
           actions: "remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +32,7 @@ jobs:
 
       - name: needs reproduction
         if: github.event.label.name == 'needs reproduction'
-        uses: ./.github/actions/issues-helper
+        uses: $/.github/actions/issues-helper
         with:
           actions: "create-comment"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -5,7 +5,6 @@ on:
     - cron: "0 0 * * *"
 
 permissions:
-  contents: read # to check out the repo for local actions
   issues: write # for actions/issues-helper to update issues
 
 jobs:
@@ -13,11 +12,7 @@ jobs:
     if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
-      - uses: ./.github/actions/issues-helper
+      - uses: $/.github/actions/issues-helper
         with:
           actions: "lock-closed-issues"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/

GitHub supports the `$/` syntax to reference local actions now, so we don't need to checkout and the `contents: read` permission.