### PR TITLE
fix(server): skip addWatchFile watcher registration after close

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -373,6 +373,45 @@ describe('plugin container', () => {
     })
   })
 
+  describe('addWatchFile', () => {
+    it('does not register files with the watcher after close', async () => {
+      const root = fileURLToPath(
+        new URL('./fixtures/watcher/nested-root', import.meta.url),
+      )
+      const outside = fileURLToPath(
+        new URL('./fixtures/watcher/config-deps/foo.js', import.meta.url),
+      )
+      const add = vi.fn()
+      const watcher = {
+        add,
+      } as unknown as import('#dep-types/chokidar').FSWatcher
+
+      const plugin: Plugin = {
+        name: 'add-watch-after-close',
+        transform(_code, id) {
+          if (id.endsWith('entry.js')) {
+            this.addWatchFile(outside)
+          }
+        },
+      }
+
+      const environment = await getDevEnvironment(
+        {
+          root,
+          plugins: [plugin],
+        },
+        { watcher },
+      )
+      await environment.pluginContainer.close()
+
+      const entry = '/entry.js'
+      await environment.moduleGraph.ensureEntryFromUrl(entry, false)
+      await environment.pluginContainer.transform('export {}', entry)
+
+      expect(add).not.toHaveBeenCalled()
+    })
+  })
+
   describe('resolveId', () => {
     describe('skipSelf', () => {
       it('should skip the plugin itself when skipSelf is true', async () => {
@@ -481,6 +520,7 @@ describe('plugin container', () => {
 
 async function getDevEnvironment(
   inlineConfig?: UserConfig,
+  initOptions?: { watcher?: import('#dep-types/chokidar').FSWatcher },
 ): Promise<DevEnvironment> {
   const config = await resolveConfig(
     { configFile: false, ...inlineConfig },
@@ -491,7 +531,7 @@ async function getDevEnvironment(
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
   const environment = new DevEnvironment('client', config, { hot: true })
-  await environment.init()
+  await environment.init(initOptions)
 
   return environment
 }

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -387,12 +387,11 @@ describe('plugin container', () => {
         add,
       } as unknown as import('#dep-types/chokidar').FSWatcher
 
+      let addWatch: ((id: string) => void) | undefined
       const plugin: Plugin = {
         name: 'add-watch-after-close',
-        transform(_code, id) {
-          if (id.endsWith('entry.js')) {
-            this.addWatchFile(outside)
-          }
+        buildStart() {
+          addWatch = (id: string) => this.addWatchFile(id)
         },
       }
 
@@ -403,11 +402,9 @@ describe('plugin container', () => {
         },
         { watcher },
       )
+      await environment.pluginContainer.buildStart()
       await environment.pluginContainer.close()
-
-      const entry = '/entry.js'
-      await environment.moduleGraph.ensureEntryFromUrl(entry, false)
-      await environment.pluginContainer.transform('export {}', entry)
+      addWatch!(outside)
 
       expect(add).not.toHaveBeenCalled()
     })

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { stripVTControlCharacters } from 'node:util'
 import MagicString from 'magic-string'
 import { describe, expect, it, vi } from 'vitest'

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -611,14 +611,14 @@ export async function _createServer(
       teardownSIGTERMListener(closeServerAndExit)
     }
 
+    await Promise.allSettled(
+      Object.values(server.environments).map((environment) =>
+        environment.close(),
+      ),
+    )
     await Promise.allSettled([
       watcher.close(),
       ws.close(),
-      Promise.allSettled(
-        Object.values(server.environments).map((environment) =>
-          environment.close(),
-        ),
-      ),
       closeHttpServer(),
       server._ssrCompatModuleRunner?.close(),
     ])

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -195,6 +195,10 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   private _buildStartPromise: Promise<void> | undefined
   private _closed = false
 
+  get closed(): boolean {
+    return this._closed
+  }
+
   /**
    * @internal use `createEnvironmentPluginContainer` instead
    */
@@ -866,7 +870,7 @@ class PluginContext
 
   addWatchFile(id: string): void {
     this._container.watchFiles.add(id)
-    if (this._container.watcher)
+    if (this._container.watcher && !this._container.closed)
       ensureWatchedFile(
         this._container.watcher,
         id,


### PR DESCRIPTION
## Summary

- Skip `ensureWatchedFile` in `PluginContext.addWatchFile` once the environment plugin container is closed, so late transforms (for example `vite:css` during Vitest teardown) cannot call `watcher.add()` after shutdown.
- Close dev environments before the chokidar watcher during `server.close()`, so `_closed` is set while transforms may still finish but before the watcher is torn down.

Fixes #18224.

## Test plan

- [x] Added `pluginContainer` unit test asserting `addWatchFile` does not call `watcher.add` after `pluginContainer.close()`
- [x] `pnpm exec tsc -p src/node --noEmit` in `packages/vite`
- [ ] CI unit tests