### PR TITLE
fix(bundled-dev): bind environment in hotUpdate plugin hook

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -26,8 +26,8 @@ import {
 } from '../build'
 import type { Logger } from '../logger'
 import { createLogger } from '../logger'
-import { getHookHandler } from '../plugins'
 import type { Plugin } from '../plugin'
+import { getHookHandler } from '../plugins'
 
 const dirname = import.meta.dirname
 

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -18,6 +18,7 @@ import {
   ChunkMetadataMap,
   build,
   createBuilder,
+  injectEnvironmentToHooks,
   onRollupLog,
   resolveBuildOutputs,
   resolveLibFilename,
@@ -25,6 +26,8 @@ import {
 } from '../build'
 import type { Logger } from '../logger'
 import { createLogger } from '../logger'
+import { getHookHandler } from '../plugins'
+import type { Plugin } from '../plugin'
 
 const dirname = import.meta.dirname
 
@@ -1577,6 +1580,34 @@ async function buildProjectWithRenderBuiltUrl(
     ],
   })) as RolldownOutput
 }
+
+describe('injectEnvironmentToHooks', () => {
+  test('binds environment to hotUpdate hook', async () => {
+    const config = await resolveConfig(
+      { configFile: false, logLevel: 'error' },
+      'serve',
+    )
+    const environment = new BuildEnvironment('client', config)
+    const chunkMetadataMap = new ChunkMetadataMap()
+    let name: string | undefined
+    const plugin: Plugin = {
+      name: 'test-hot-update-env',
+      hotUpdate() {
+        name = this.environment.name
+      },
+    }
+
+    const wrapped = injectEnvironmentToHooks(
+      environment,
+      chunkMetadataMap,
+      plugin,
+    )
+    const context = { meta: {} } as import('rolldown').PluginContext
+
+    await getHookHandler(wrapped.hotUpdate!).call(context, {} as any)
+    expect(name).toBe('client')
+  })
+})
 
 /**
  * for each chunks in output1, if there's a chunk in output2 with the same fileName,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1326,6 +1326,14 @@ export function injectEnvironmentToHooks(
           plugin.name,
         )
         break
+      case 'hotUpdate':
+        clone[hook] = wrapEnvironmentHook(
+          environment,
+          chunkMetadataMap,
+          plugin,
+          hook,
+        )
+        break
       default:
         if (ROLLUP_HOOKS.includes(hook)) {
           ;(clone as any)[hook] = wrapEnvironmentHook(

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1326,14 +1326,6 @@ export function injectEnvironmentToHooks(
           plugin.name,
         )
         break
-      case 'hotUpdate':
-        clone[hook] = wrapEnvironmentHook(
-          environment,
-          chunkMetadataMap,
-          plugin,
-          hook,
-        )
-        break
       default:
         if (ROLLUP_HOOKS.includes(hook)) {
           ;(clone as any)[hook] = wrapEnvironmentHook(
@@ -1345,6 +1337,15 @@ export function injectEnvironmentToHooks(
         }
         break
     }
+  }
+
+  if (plugin.hotUpdate) {
+    clone.hotUpdate = wrapEnvironmentHook(
+      environment,
+      chunkMetadataMap,
+      plugin,
+      'hotUpdate',
+    )
   }
 
   return clone


### PR DESCRIPTION
## Summary

- Wrap the Vite-specific `hotUpdate` hook in `injectEnvironmentToHooks`, matching how `resolveId` / `load` / `transform` and Rollup hooks get `this.environment`.
- Add a unit test that asserts `this.environment.name` is available inside wrapped `hotUpdate`.

Fixes #23314.

## Context

Under `experimental.bundledDev`, plugins are cloned through `injectEnvironmentToHooks` before being passed to the rolldown dev engine. That helper only wrapped hooks listed in `ROLLUP_HOOKS` (plus the three special-cased transform hooks). `hotUpdate` is Vite-specific and was skipped, so plugins following the documented Environment API (e.g. `@tanstack/start-plugin-core` reading `this.environment.name`) threw on every edit and left stale output until restart.

This is intentionally narrow: it only fixes the missing `this.environment` binding. It does not overlap with #22956, which adds the broader bundled-dev `hotUpdate` adapter.

## Test plan

- [x] Added `injectEnvironmentToHooks` unit test in `packages/vite/src/node/__tests__/build.spec.ts`
- [ ] CI `test-unit` (local run blocked by missing vite build artifact in this environment; upstream CI should cover)