### PR TITLE
chore: replace prettier comment with oxfmt

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -36,7 +36,7 @@ const argv = mri<{
 })
 const cwd = process.cwd()
 
-// prettier-ignore
+// oxfmt-ignore
 const helpMessage = `\
 Usage: create-vite [OPTION]... [DIRECTORY]
 


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

Thank you for contributing to Vite!
-->
https://oxc.rs/docs/guide/usage/formatter/migrate-from-prettier.html#replace-prettierignore-with-ignorepatterns
Although oxfmt also supports prettier format comments, it looks better to stick to oxfmt for all of them.

By the way, are there any incompatibility issues when using oxlint to replace eslint? I noticed that oxlint is also used in project templates created with create-vite. We have already replaced Prettier with oxfmt in our repository, but we haven't replaced ESLint with oxlint.