### PR TITLE
test(hmr): skip virtual module `import.meta.hot.invalidate` test in bundled-dev

### DIFF
--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -303,19 +303,23 @@ if (!isBuild) {
     }
   })
 
-  test('invalidate virtual module propagates to importers', async () => {
-    const el = await page.$('.virtual-invalidation-parent')
-    await expect.poll(() => el.textContent()).toBe('initial')
+  // bundled dev: same missing-importer-factory fallback as `invalidate`
+  test.skipIf(isBundledDev)(
+    'invalidate virtual module propagates to importers',
+    async () => {
+      const el = await page.$('.virtual-invalidation-parent')
+      await expect.poll(() => el.textContent()).toBe('initial')
 
-    // Edit the real dep file — Vite detects the change and sends
-    // js-update to the virtual module.  The virtual module accepts
-    // then invalidates, which should propagate to parent.js.
-    editFile('virtual-invalidation/dep.js', (code) =>
-      code.replace('initial', 'updated2'),
-    )
+      // Edit the real dep file — Vite detects the change and sends
+      // js-update to the virtual module.  The virtual module accepts
+      // then invalidates, which should propagate to parent.js.
+      editFile('virtual-invalidation/dep.js', (code) =>
+        code.replace('initial', 'updated2'),
+      )
 
-    await expect.poll(() => el.textContent()).toBe('updated2')
-  })
+      await expect.poll(() => el.textContent()).toBe('updated2')
+    },
+  )
 
   test('invalidate on root triggers page reload', async () => {
     editFile('invalidation/root.js', (code) => code.replace('Init', 'Updated'))


### PR DESCRIPTION
This test fails in bundled-dev right now.

refs #23171
