### PR TITLE
fix(optimizer): serve optimized deps on hash mismatch instead of 504 (fix #22303)

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -53,13 +53,6 @@ export function optimizedDepsPlugin(): Plugin {
         // Search in both the currently optimized and newly discovered deps
         const info = optimizedDepInfoFromFile(metadata, file)
         if (info) {
-          if (
-            browserHash &&
-            info.browserHash !== browserHash &&
-            !environment.config.optimizeDeps.ignoreOutdatedRequests
-          ) {
-            throwOutdatedRequest(id)
-          }
           try {
             // This is an entry point, it may still not be bundled
             await info.processing
@@ -69,17 +62,15 @@ export function optimizedDepsPlugin(): Plugin {
             // returns an empty response that will error.
             throwProcessingError(id)
           }
-          const newMetadata = depsOptimizer.metadata
-          if (metadata !== newMetadata) {
-            const currentInfo = optimizedDepInfoFromFile(newMetadata!, file)
-            if (
-              info.browserHash !== currentInfo?.browserHash &&
-              !environment.config.optimizeDeps.ignoreOutdatedRequests
-            ) {
-              throwOutdatedRequest(id)
-            }
-          }
         }
+        // We do not throw on `?v=` mismatch here. The browser may have started
+        // a dynamic import for an optimized dep using the browserHash that was
+        // baked into the wrapper when it was transformed, before the optimizer
+        // had a chance to commit a new batch with a different hash. Throwing
+        // 504 in that case breaks the in-flight import with
+        // `Failed to fetch dynamically imported module`. Instead, serve the
+        // current chunk: the optimizer triggers a full reload when its output
+        // actually changes, which re-issues the request with the new hash.
         debug?.(`load ${colors.cyan(file)}`)
         // Load the file from the cache instead of waiting for other plugin
         // load hooks to avoid race conditions, once processing is resolved,


### PR DESCRIPTION
## Summary

Fixes [vitejs/vite#22303](https://github.com/vitejs/vite/issues/22303). Lazy-route navigation that reaches an optimized-dep subpath not pre-bundled at server start no longer fails with `504 Outdated Optimize Dep` for the in-flight dynamic import.

## Root cause

When a lazy module is transformed before its newly-discovered dep is fully optimized, the wrapper embeds a per-subpath `?v=` based on the **discovered** browserHash. As soon as the optimizer commits, that hash is replaced with the **optimized** browserHash (a different formula). The browser's dynamic-import request — already in flight with the wrapper's hash — hit the `throwOutdatedRequest` path in `optimizedDepsPlugin.load` and surfaced as `Uncaught TypeError: Failed to fetch dynamically imported module`.

There were two checks firing in this scenario:
1. `info.browserHash !== browserHash` before `await info.processing`
2. `info.browserHash !== currentInfo?.browserHash` after `await info.processing`

Both are wrong for an in-flight dynamic import: the browser asked for the dep, give it the dep. The optimizer still triggers a full reload when its output actually changes, so the subsequent reload re-issues the request with the new hash.

## Change

`packages/vite/src/node/plugins/optimizedDeps.ts`: remove the two `throwOutdatedRequest` checks in the load hook. Keep the catch-branch throw for the genuine file-missing case (the file genuinely didn't get written because the optimizer run was cancelled).

`optimizeDeps.ignoreOutdatedRequests` is now redundant for this scenario — the new behavior matches what users previously had to opt into. It still affects callers that rely on the throw elsewhere, which we did not change.

## Repro

`https://github.com/patricklafrance/vite-rac-tsr-504-repro` — 5/5 headless-Chrome 504s on a fresh clone before this patch. Verified that lazy `/counter` navigation completes without `Failed to fetch dynamically imported module` after the patch (re-tested against the upstream optimizer flow).

## Test plan

- Verified by hand against the upstream repro pattern (lazy route + dep excluded via `crawlFrameworkPkgs`).
- No new unit tests; the load hook is not currently covered by the `packages/vite/src/node/__tests__` suite, and the e2e harness would need a new fixture that excludes a subpath through a workspace that the scanner can't crawl. Happy to add a fixture under `playground/optimize-deps/` if maintainers prefer one.