### PR TITLE
feat: support a native module runner in full bundle mode

### DIFF
--- a/packages/vite/rolldown.config.ts
+++ b/packages/vite/rolldown.config.ts
@@ -154,7 +154,7 @@ const moduleRunnerConfig = defineConfig({
     '@vitejs/devtools/cli-commands',
     ...Object.keys(pkg.dependencies),
   ],
-  plugins: [bundleSizeLimit(55), enableSourceMapsInWatchModePlugin()],
+  plugins: [bundleSizeLimit(67), enableSourceMapsInWatchModePlugin()],
   output: {
     ...sharedNodeOptions.output,
     minify: {

--- a/packages/vite/src/client/bundledDevClient.ts
+++ b/packages/vite/src/client/bundledDevClient.ts
@@ -3,7 +3,7 @@ import { DevRuntime } from 'rolldown/experimental/runtime'
 import {
   BundledDevHMRClient,
   BundledDevHMRContext,
-} from './bundledDevHmrClient'
+} from '../shared/bundledDevHmrClient'
 import {
   base,
   clearOverlayOrReloadOnFirstUpdate,
@@ -51,7 +51,9 @@ if (typeof DevRuntime !== 'undefined') {
     transport,
     runtime,
     {
-      base,
+      loadPatch: async (url) => {
+        await import(/* @vite-ignore */ base + url)
+      },
       beforeApply: clearOverlayOrReloadOnFirstUpdate,
     },
   )

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -8,7 +8,7 @@ import {
 } from '../shared/moduleRunnerTransport'
 import { createHMRHandler } from '../shared/hmrHandler'
 import { setupForwardConsoleHandler } from '../shared/forwardConsole'
-import type { BundledDevHMRClient } from './bundledDevHmrClient'
+import type { BundledDevHMRClient } from '../shared/bundledDevHmrClient'
 import { ErrorOverlay, cspNonce, overlayId } from './overlay'
 // @ts-expect-error internal virtual module
 import '@vite/env'

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -6,6 +6,10 @@ export {
   type EvaluatedModuleNode,
 } from './evaluatedModules'
 export { ModuleRunner } from './runner'
+export {
+  NativeModuleRunner,
+  type NativeModuleRunnerOptions,
+} from './nativeRunner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export {
   createDefaultImportMeta,

--- a/packages/vite/src/module-runner/nativeRunner.ts
+++ b/packages/vite/src/module-runner/nativeRunner.ts
@@ -1,0 +1,149 @@
+import { nanoid } from 'nanoid/non-secure'
+import { DevRuntime } from 'rolldown/experimental/runtime'
+import type { HotPayload } from '#types/hmrPayload'
+import {
+  type ModuleRunnerTransport,
+  type NormalizedModuleRunnerTransport,
+  normalizeModuleRunnerTransport,
+} from '../shared/moduleRunnerTransport'
+import {
+  BundledDevHMRClient,
+  BundledDevHMRContext,
+} from '../shared/bundledDevHmrClient'
+import type { HMRLogger } from '../shared/hmr'
+import { createHMRHandler } from '../shared/hmrHandler'
+
+export interface NativeModuleRunnerOptions {
+  transport: ModuleRunnerTransport
+  hmr?: boolean
+  hmrLogger?: HMRLogger
+}
+
+export class NativeModuleRunner {
+  private closed = false
+  private transport: NormalizedModuleRunnerTransport
+  private hmrEnabled: boolean
+  private hmrLogger: HMRLogger
+  private hmrClient: BundledDevHMRClient | undefined
+  private runtime!: DevRuntime
+  /**
+   * Set when the dev server requests a full reload: we bail out expecting
+   * the user to reload the runtime themselves (workerd or a process).
+   */
+  private fatalError: Error | undefined
+
+  constructor(options: NativeModuleRunnerOptions) {
+    this.hmrEnabled = options.hmr !== false
+    this.hmrLogger = options.hmrLogger ?? {
+      error: (err) => console.error('[vite]', err),
+      debug: () => {},
+    }
+    this.transport = normalizeModuleRunnerTransport(options.transport)
+    this.transport.connect?.(createHMRHandler(this.handlePayload.bind(this)))
+    this.startClientSession()
+  }
+
+  async import<T = Record<string, any>>(url: string): Promise<T> {
+    if (this.closed) {
+      throw new Error('the module runner has been closed')
+    }
+    if (this.fatalError) {
+      throw this.fatalError
+    }
+    const resolved = await this.transport.invoke('resolveBundledModuleUrl', [
+      url,
+    ])
+    if (this.hmrClient && this.runtime.isExecuted(resolved.moduleId)) {
+      return this.runtime.loadExports(resolved.moduleId) as T
+    }
+    return import(resolved.url) as Promise<T>
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+    await this.transport.disconnect?.()
+  }
+
+  isClosed(): boolean {
+    return this.closed
+  }
+
+  private async handlePayload(payload: HotPayload): Promise<void> {
+    if (this.closed) return
+    switch (payload.type) {
+      case 'bundled-dev-update':
+        this.hmrClient?.handlePush(payload)
+        break
+      case 'full-reload':
+        // a full reload cannot be applied in-process: cached modules never
+        // re-execute, so the runner cannot start over the way a browser
+        // page reload does. Treat it as fatal and let the consumer restart
+        // the process/worker.
+        this.fatalError = new Error(
+          'the dev server requested a full reload — the bundled output can ' +
+            'no longer be patched in place. Restart the process (or worker) ' +
+            'running this module runner.',
+        )
+        this.hmrLogger.error(this.fatalError.message)
+        break
+      case 'error':
+        // the build error is also surfaced on the next import
+        this.hmrLogger.error(payload.err.message)
+        break
+      case 'custom':
+        await this.hmrClient?.notifyListeners(payload.event, payload.data)
+        break
+      default:
+        break
+    }
+  }
+
+  private startClientSession(): void {
+    const clientId = nanoid()
+    const runtime = new DevRuntime(clientId)
+    this.runtime = runtime
+    ;(globalThis as any).__rolldown_runtime__ = runtime
+    if (this.hmrEnabled) {
+      const hmrClient = new BundledDevHMRClient(
+        this.hmrLogger,
+        this.transport,
+        runtime,
+        {
+          // the payload's url is already an importable url — the server
+          // knows this client imports patches from disk
+          loadPatch: (url) => import(url),
+          beforeApply: () => 'continue',
+        },
+      )
+      runtime.hooks = {
+        createModuleHotContext: (id) => new BundledDevHMRContext(hmrClient, id),
+        onModuleCacheRemoval: (id) => hmrClient.handleModuleCacheRemoval(id),
+      }
+      this.hmrClient = hmrClient
+      // registers this runner with the dev engine so it gets its own
+      // per-client HMR session and ship map
+      this.transport.send({
+        type: 'custom',
+        event: 'vite:client-connected',
+        data: { clientId },
+      })
+    } else {
+      // HMR is not applied — stale output is rebuilt and re-imported under
+      // fresh urls instead — so the hot context is a stub
+      runtime.hooks = {
+        createModuleHotContext: () => ({
+          data: {},
+          accept: () => {},
+          acceptExports: () => {},
+          dispose: () => {},
+          prune: () => {},
+          invalidate: () => {},
+          on: () => {},
+          off: () => {},
+          send: () => {},
+        }),
+        onModuleCacheRemoval: () => {},
+      }
+    }
+  }
+}

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -330,6 +330,22 @@ export interface SharedEnvironmentOptions {
    * @experimental
    */
   isBundled?: boolean
+  /**
+   * Whether this environment's bundled output is executed with a
+   * `NativeModuleRunner` during dev: the output is written to disk for a
+   * native dynamic `import()` — no module runner transform is involved.
+   * Only applies when `isBundled` is enabled, and only for server
+   * environments.
+   *
+   * This only configures the server side (on-disk output, url resolution,
+   * HMR patch delivery). The environment itself is expected to wire a
+   * `NativeModuleRunner` (from `vite/module-runner`), e.g. via
+   * `createRunnableDevEnvironment`'s `runner` factory.
+   *
+   * @default false
+   * @experimental
+   */
+  nativeModuleRunner?: boolean
 }
 
 export interface EnvironmentOptions extends SharedEnvironmentOptions {
@@ -355,6 +371,7 @@ export type ResolvedEnvironmentOptions = {
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
   isBundled: boolean
+  nativeModuleRunner: boolean
   plugins: readonly Plugin[]
   /** @internal */
   optimizeDepsPluginNames: string[]
@@ -1011,6 +1028,14 @@ function resolveEnvironmentOptions(
   const isBundled =
     options.isBundled ?? (isBuild || (isClientEnvironment && isBundledDev))
 
+  const nativeModuleRunner = !!options.nativeModuleRunner
+  if (nativeModuleRunner && consumer !== 'server') {
+    throw new Error(
+      `\`nativeModuleRunner\` is only available for server environments, ` +
+        `but environment "${environmentName}" has consumer "${consumer}"`,
+    )
+  }
+
   if (options.define?.['process.env']) {
     const processEnvDefine = options.define['process.env']
     if (typeof processEnvDefine === 'object') {
@@ -1069,6 +1094,7 @@ function resolveEnvironmentOptions(
       isSsrTargetWebworkerEnvironment,
     ),
     isBundled,
+    nativeModuleRunner,
     plugins: undefined!, // to be resolved later
     // will be set by `setOptimizeDepsPluginNames` later
     optimizeDepsPluginNames: undefined!,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -108,6 +108,7 @@ export async function resolvePlugins(
             ...config,
             consumer: 'client',
             isBundled: true,
+            nativeModuleRunner: false,
             optimizeDepsPluginNames: [],
           }
         : undefined,

--- a/packages/vite/src/node/server/__tests__/bundledDevSsr.spec.ts
+++ b/packages/vite/src/node/server/__tests__/bundledDevSsr.spec.ts
@@ -1,0 +1,433 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { afterAll, expect, onTestFinished, test } from 'vitest'
+import { NativeModuleRunner } from 'vite/module-runner'
+import type { ModuleRunner } from 'vite/module-runner'
+import type { HotPayload } from '#types/hmrPayload'
+import { createServer } from '../..'
+import { createServerModuleRunnerTransport } from '../../ssr/runtime/serverModuleRunner'
+import type {
+  HotChannel,
+  HotChannelClient,
+  HotChannelListener,
+  NormalizedServerHotChannel,
+} from '../hmr'
+import { DevEnvironment } from '../environment'
+import { createRunnableDevEnvironment } from '../environments/runnableEnvironment'
+import type { RunnableDevEnvironment } from '../environments/runnableEnvironment'
+
+const root = path.resolve(import.meta.dirname, 'fixtures/bundled-dev-ssr')
+
+// every server needs its own url space: the process-wide ESM cache never
+// re-executes an url a previous server's runner already imported
+let serverCount = 0
+
+/** reads a fixture file and restores its content when the test finishes */
+function backupFile(file: string): string {
+  const original = fs.readFileSync(file, 'utf-8')
+  onTestFinished(() => {
+    fs.writeFileSync(file, original)
+  })
+  return original
+}
+
+async function createBundledSsrServer() {
+  const server = await createServer({
+    root,
+    configFile: false,
+    cacheDir: `node_modules/.vite-test/${serverCount++}`,
+    logLevel: 'error',
+    server: {
+      middlewareMode: true,
+      // NOTE: `watch: null` would also disable the dev engine's own watcher
+      // (`convertToDevWatchOptions`), which the HMR tests depend on
+      ws: false,
+    },
+    optimizeDeps: {
+      noDiscovery: true,
+      include: [],
+    },
+    environments: {
+      ssr: {
+        isBundled: true,
+        nativeModuleRunner: true,
+        dev: {
+          createEnvironment: (name, config) =>
+            createRunnableDevEnvironment(name, config, {
+              runner: (environment) =>
+                new NativeModuleRunner({
+                  transport: createServerModuleRunnerTransport({
+                    channel: environment.hot as NormalizedServerHotChannel,
+                  }),
+                }) as unknown as ModuleRunner,
+            }),
+        },
+        build: {
+          rolldownOptions: {
+            input: [
+              path.resolve(root, 'src/app.js'),
+              path.resolve(root, 'src/hot-entry.js'),
+            ],
+          },
+        },
+      },
+    },
+  })
+  onTestFinished(() => server.close())
+  return server
+}
+
+/**
+ * The intended consumer story for `full-reload` with a real runtime boundary:
+ * the runner lives in a worker thread, the consumer provides the server-side
+ * channel, observes `full-reload` there instead of forwarding it to the
+ * runner, and recreates the worker against the same (still running) server.
+ */
+async function createWorkerBundledSsrServer() {
+  const listeners = new Map<string, Set<HotChannelListener>>()
+  const receivedFullReloads: HotPayload[] = []
+  const pendingImports = new Map<
+    number,
+    { resolve: (value: string) => void; reject: (error: Error) => void }
+  >()
+  let nextImportId = 0
+  let worker!: Worker
+  let workerClient!: HotChannelClient
+
+  // the consumer's reload policy: a full reload never reaches the runner —
+  // the consumer restarts the runtime instead (`restartWorker` below)
+  const sendToWorker = (payload: HotPayload) => {
+    if (payload.type === 'full-reload') {
+      receivedFullReloads.push(payload)
+      return
+    }
+    worker.postMessage(payload)
+  }
+
+  const dispatch = (event: string, data: any) => {
+    for (const listener of listeners.get(event) ?? []) {
+      listener(data, workerClient)
+    }
+  }
+
+  const spawnWorker = async () => {
+    workerClient = { send: sendToWorker }
+    worker = new Worker(path.join(root, 'runner-worker.mjs'))
+    worker.on('message', (message: any) => {
+      if (message?.__test === 'import-result') {
+        const pending = pendingImports.get(message.id)
+        pendingImports.delete(message.id)
+        if (message.error != null) pending?.reject(new Error(message.error))
+        else pending?.resolve(message.value)
+      } else if (message?.type === 'custom') {
+        dispatch(message.event, message.data)
+      }
+    })
+    await new Promise<void>((resolve) => worker.once('online', () => resolve()))
+    dispatch('vite:client:connect', null)
+  }
+
+  const stopWorker = async () => {
+    dispatch('vite:client:disconnect', null)
+    await worker.terminate()
+  }
+
+  const channel: HotChannel = {
+    send: sendToWorker,
+    on(event: string, listener: HotChannelListener) {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(listener)
+    },
+    off(event, listener) {
+      listeners.get(event)?.delete(listener as HotChannelListener)
+    },
+    listen: () => {},
+    async close() {
+      await stopWorker()
+    },
+  }
+
+  const server = await createServer({
+    root,
+    configFile: false,
+    cacheDir: `node_modules/.vite-test/${serverCount++}`,
+    logLevel: 'error',
+    server: {
+      middlewareMode: true,
+      ws: false,
+    },
+    optimizeDeps: {
+      noDiscovery: true,
+      include: [],
+    },
+    environments: {
+      ssr: {
+        isBundled: true,
+        nativeModuleRunner: true,
+        dev: {
+          createEnvironment: (name, config) =>
+            new DevEnvironment(name, config, { hot: true, transport: channel }),
+        },
+        build: {
+          rolldownOptions: {
+            input: [path.resolve(root, 'src/app.js')],
+          },
+        },
+      },
+    },
+  })
+  // closing the server also closes the channel, which terminates the worker
+  onTestFinished(() => server.close())
+  await spawnWorker()
+
+  const importInWorker = (url: string) => {
+    const id = nextImportId++
+    return new Promise<string>((resolve, reject) => {
+      pendingImports.set(id, { resolve, reject })
+      worker.postMessage({ __test: 'import', id, url })
+    })
+  }
+
+  return {
+    server,
+    importInWorker,
+    restartWorker: async () => {
+      await stopWorker()
+      await spawnWorker()
+    },
+    receivedFullReloads,
+  }
+}
+
+afterAll(() => {
+  fs.rmSync(path.join(root, 'node_modules'), { recursive: true, force: true })
+})
+
+test('imports a bundled ssr entry natively', async () => {
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  const mod = await ssr.runner.import('/src/app.js')
+  expect(await mod.render()).toBe('hello-dep|hello-lazy')
+
+  // an absolute file path resolves to the same entry (the second import
+  // returns the runtime's live exports object, so compare members)
+  const mod2 = await ssr.runner.import(path.resolve(root, 'src/app.js'))
+  expect(mod2.render).toBe(mod.render)
+})
+
+test('applies an hmr patch in place for a self-accepting module', async () => {
+  const hotFile = path.resolve(root, 'src/hot.js')
+  const originalContent = backupFile(hotFile)
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  const mod = await ssr.runner.import('/src/app.js')
+  expect((globalThis as any).__bundled_dev_ssr_hot).toBe('hot-v1')
+
+  fs.writeFileSync(hotFile, originalContent.replace('hot-v1', 'hot-v2'))
+  // the self-accepting module is re-executed by the patch, in place
+  await expect
+    .poll(() => (globalThis as any).__bundled_dev_ssr_hot, {
+      timeout: 10_000,
+      interval: 50,
+    })
+    .toBe('hot-v2')
+
+  // no full reload happened: the entry still renders from the same graph
+  const mod2 = await ssr.runner.import('/src/app.js')
+  expect(await mod2.render()).toBe('hello-dep|hello-lazy')
+
+  // a second patch continues the same session (seq continuity)
+  fs.writeFileSync(hotFile, originalContent.replace('hot-v1', 'hot-v3'))
+  await expect
+    .poll(() => (globalThis as any).__bundled_dev_ssr_hot, {
+      timeout: 10_000,
+      interval: 50,
+    })
+    .toBe('hot-v3')
+  expect(await mod.render()).toBe('hello-dep|hello-lazy')
+})
+
+test('import() returns the updated module after an hmr patch', async () => {
+  const entryFile = path.resolve(root, 'src/hot-entry.js')
+  const originalContent = backupFile(entryFile)
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  const mod = await ssr.runner.import('/src/hot-entry.js')
+  expect(mod.value).toBe('entry-v1')
+
+  fs.writeFileSync(entryFile, originalContent.replace('entry-v1', 'entry-v2'))
+  // the self-accepting entry is patched in place; import() hands out the
+  // runtime's live module, not the pre-patch ESM namespace
+  await expect
+    .poll(
+      async () => {
+        const mod = await ssr.runner.import('/src/hot-entry.js')
+        return mod.value
+      },
+      { timeout: 10_000, interval: 50 },
+    )
+    .toBe('entry-v2')
+
+  // the originally imported namespace stays what it was — the update is a
+  // different module object owned by the hmr client
+  expect(mod.value).toBe('entry-v1')
+})
+
+// TODO: document how to resolve this
+
+// KNOWN GAP: while an HMR session is active, an edit to a never-executed
+// module is lost: the runner noops the patch (nothing executed to update)
+// and `refreshOutputIfStale` skips the rebuild (active session), so the
+// first import runs the stale on-disk chunk. The next edit of the file
+// heals it. A real fix needs per-entry freshness tracking — a blind
+// rebuild would re-execute the already-patched graph under new hashes.
+test.fails('an edit to a not-yet-imported entry is visible on its first import', async () => {
+  const entryFile = path.resolve(root, 'src/hot-entry.js')
+  const hotFile = path.resolve(root, 'src/hot.js')
+  const originalEntry = backupFile(entryFile)
+  const originalHot = backupFile(hotFile)
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  // executes app.js's graph (including hot.js) but NOT hot-entry.js
+  await ssr.runner.import('/src/app.js')
+
+  // edit the entry that was never imported: the runner receives a patch,
+  // but noops it because nothing of hot-entry's graph is executed
+  fs.writeFileSync(entryFile, originalEntry.replace('entry-v1', 'entry-v2'))
+  // then edit an executed module as a barrier: patches are delivered and
+  // applied in order, so once this one is observable the hot-entry patch
+  // has been processed too
+  fs.writeFileSync(hotFile, originalHot.replace('hot-v1', 'hot-v2'))
+  await expect
+    .poll(() => (globalThis as any).__bundled_dev_ssr_hot, {
+      timeout: 10_000,
+      interval: 50,
+    })
+    .toBe('hot-v2')
+
+  const mod = await ssr.runner.import('/src/hot-entry.js')
+  expect(mod.value).toBe('entry-v2')
+})
+
+test('throws after a change that requires a full reload', async () => {
+  const depFile = path.resolve(root, 'src/dep.js')
+  const originalContent = backupFile(depFile)
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  const mod = await ssr.runner.import('/src/app.js')
+  expect(await mod.render()).toBe('hello-dep|hello-lazy')
+
+  // an unaccepted change cannot be patched in place — the server requests
+  // a full reload, which is fatal for the native runner
+  fs.writeFileSync(depFile, originalContent.replace('hello-dep', 'updated-dep'))
+  await expect
+    .poll(
+      () =>
+        ssr.runner.import('/src/app.js').then(
+          () => 'ok',
+          (e) => (/full reload/.test(e.message) ? 'fatal' : `other: ${e}`),
+        ),
+      { timeout: 10_000, interval: 100 },
+    )
+    .toBe('fatal')
+})
+
+test('concurrent imports during a file change all settle', async () => {
+  const depFile = path.resolve(root, 'src/dep.js')
+  const originalContent = backupFile(depFile)
+  const server = await createBundledSsrServer()
+  const ssr = server.environments.ssr as RunnableDevEnvironment
+  await ssr.runner.import('/src/app.js')
+
+  fs.writeFileSync(depFile, originalContent.replace('hello-dep', 'settled-dep'))
+  // refreshes are serialized — none of these may hang. Each either
+  // observes a bundle version, or the fatal full-reload error once the
+  // unaccepted change escalated
+  const results = await Promise.allSettled(
+    Array.from({ length: 5 }, async () => {
+      const mod = await ssr.runner.import('/src/app.js')
+      return mod.render()
+    }),
+  )
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      expect(['hello-dep|hello-lazy', 'settled-dep|hello-lazy']).toContain(
+        await result.value,
+      )
+    } else {
+      expect(result.reason.message).toMatch(/full reload/)
+    }
+  }
+  await expect
+    .poll(
+      () =>
+        ssr.runner.import('/src/app.js').then(
+          () => 'ok',
+          (e) => (/full reload/.test(e.message) ? 'fatal' : `other: ${e}`),
+        ),
+      { timeout: 10_000, interval: 100 },
+    )
+    .toBe('fatal')
+})
+
+test('surfaces build errors on import', async () => {
+  const depFile = path.resolve(root, 'src/dep.js')
+  const originalContent = backupFile(depFile)
+  let server = await createBundledSsrServer()
+  let ssr = server.environments.ssr as RunnableDevEnvironment
+  await ssr.runner.import('/src/app.js')
+
+  fs.writeFileSync(depFile, 'export const msg = {{{')
+  await expect
+    .poll(
+      () =>
+        ssr.runner.import('/src/app.js').then(
+          () => 'resolved',
+          () => 'rejected',
+        ),
+      { timeout: 10_000, interval: 100 },
+    )
+    .toBe('rejected')
+
+  // fixing the unaccepted module escalates to a full reload — recovery is
+  // a restart, like any other full reload
+  fs.writeFileSync(depFile, originalContent)
+  await server.close()
+  server = await createBundledSsrServer()
+  ssr = server.environments.ssr as RunnableDevEnvironment
+  const mod = await ssr.runner.import('/src/app.js')
+  expect(await mod.render()).toBe('hello-dep|hello-lazy')
+})
+
+test(
+  'a consumer channel intercepts full-reload and restarts the runtime',
+  { timeout: 20_000 },
+  async () => {
+    const depFile = path.resolve(root, 'src/dep.js')
+    const originalContent = backupFile(depFile)
+    const { importInWorker, restartWorker, receivedFullReloads } =
+      await createWorkerBundledSsrServer()
+    expect(await importInWorker('/src/app.js')).toBe('hello-dep|hello-lazy')
+
+    // the unaccepted change escalates to a per-client full reload, which
+    // the consumer-provided channel observes instead of forwarding
+    fs.writeFileSync(
+      depFile,
+      originalContent.replace('hello-dep', 'updated-dep'),
+    )
+    await expect
+      .poll(() => receivedFullReloads.length, {
+        timeout: 10_000,
+        interval: 50,
+      })
+      .toBeGreaterThan(0)
+
+    // the consumer recreates the runtime against the same server: a fresh
+    // worker means a fresh esm cache and a fresh rolldown runtime. The
+    // first import resolves against rebuilt output (the full reload marked
+    // the patched session's output as no longer usable)
+    await restartWorker()
+    expect(await importInWorker('/src/app.js')).toBe('updated-dep|hello-lazy')
+  },
+)

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/runner-worker.mjs
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/runner-worker.mjs
@@ -1,0 +1,37 @@
+// the consumer-controlled "runtime" that a full reload recreates: a worker
+// thread running a NativeModuleRunner over a parentPort message transport
+import { parentPort } from 'node:worker_threads'
+import { NativeModuleRunner } from 'vite/module-runner'
+
+const runner = new NativeModuleRunner({
+  transport: {
+    connect({ onMessage }) {
+      parentPort.on('message', (payload) => {
+        // test driver messages are not transport payloads
+        if (payload && payload.__test) return
+        onMessage(payload)
+      })
+    },
+    send(payload) {
+      parentPort.postMessage(payload)
+    },
+  },
+})
+
+parentPort.on('message', async (message) => {
+  if (!message || message.__test !== 'import') return
+  try {
+    const mod = await runner.import(message.url)
+    parentPort.postMessage({
+      __test: 'import-result',
+      id: message.id,
+      value: await mod.render(),
+    })
+  } catch (error) {
+    parentPort.postMessage({
+      __test: 'import-result',
+      id: message.id,
+      error: String(error && error.message),
+    })
+  }
+})

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/app.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/app.js
@@ -1,0 +1,7 @@
+import { msg } from './dep.js'
+import './hot.js'
+
+export async function render() {
+  const lazy = await import('./lazy.js')
+  return `${msg}|${lazy.value}`
+}

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/dep.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/dep.js
@@ -1,0 +1,1 @@
+export const msg = 'hello-dep'

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/hot-entry.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/hot-entry.js
@@ -1,0 +1,5 @@
+export const value = 'entry-v1'
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/hot.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/hot.js
@@ -1,0 +1,7 @@
+export const hotMsg = 'hot-v1'
+
+globalThis.__bundled_dev_ssr_hot = hotMsg
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/lazy.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/bundled-dev-ssr/src/lazy.js
@@ -1,0 +1,1 @@
+export const value = 'hello-lazy'

--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { setTimeout } from 'node:timers/promises'
 import {
   type BindingClientHmrUpdate,
@@ -11,8 +14,9 @@ import { ChunkMetadataMap, resolveRolldownOptions } from '../build'
 import { convertToDevWatchOptions } from '../watch'
 import { BUNDLED_DEV_CLIENT_FILENAME } from '../constants'
 import { getHmrImplementation } from '../plugins/clientInjections'
-import { createDebugger, formatAndTruncateFileList } from '../utils'
+import { createDebugger, emptyDir, formatAndTruncateFileList } from '../utils'
 import type { DevEnvironment } from './environment'
+import { BundledDevEntryResolver } from './bundledDevEntryResolver'
 import { type NormalizedHotChannelClient, debugHmr, getShortName } from './hmr'
 import { prepareError } from './middlewares/error'
 
@@ -89,11 +93,34 @@ export class BundledDev {
 
   memoryFiles: MemoryFiles = new MemoryFiles()
 
+  private nativeModuleRunner: boolean
+  private serverOutDir: string | undefined
+  private entryResolver: BundledDevEntryResolver | undefined
+
   constructor(private environment: DevEnvironment) {
-    if (environment.name !== 'client') {
+    this.nativeModuleRunner = environment.config.nativeModuleRunner
+    if (environment.name !== 'client' && !this.nativeModuleRunner) {
       throw new Error(
-        'currently full bundle mode is only available for client environment',
+        'currently full bundle mode is only available for the client environment and environments with `nativeModuleRunner` enabled',
       )
+    }
+    if (this.nativeModuleRunner) {
+      // scoped by pid so concurrent dev servers of the same project never
+      // wipe or overwrite each other's output.
+      this.serverOutDir = path.join(
+        environment.getTopLevelConfig().cacheDir,
+        'bundled-dev',
+        `${environment.name}-${process.pid}`,
+      )
+      this.entryResolver = new BundledDevEntryResolver({
+        root: environment.config.root,
+        outDir: this.serverOutDir,
+        getDevEngine: () => this.devEngine,
+        isClosed: () => this._closed,
+        getLastBuildError: () => this.lastBuildError,
+        hasActiveHmrClient: () => this.clients.getAll().length > 0,
+        waitForInitialBuildFinish: () => this.waitForInitialBuildFinish(),
+      })
     }
   }
 
@@ -130,6 +157,17 @@ export class BundledDev {
         ? rolldownOptions.output[0]
         : rolldownOptions.output
     )!
+
+    if (this.nativeModuleRunner) {
+      // native `import()` needs real files: write the bundle to the cache dir
+      // and mark it as ESM regardless of the project's package type
+      fs.mkdirSync(this.serverOutDir!, { recursive: true })
+      emptyDir(this.serverOutDir!)
+      fs.writeFileSync(
+        path.join(this.serverOutDir!, 'package.json'),
+        JSON.stringify({ type: 'module' }),
+      )
+    }
 
     this.environment.hot.on(
       'vite:client-connected',
@@ -183,6 +221,9 @@ export class BundledDev {
               error: result,
             },
           )
+          // the patched runtime can no longer be kept current — the next
+          // import must rebuild (surfacing the error, or picking up a fix)
+          this.entryResolver?.markEntryStale()
           // TODO: send to the specific client
           for (const client of this.clients.getAll()) {
             client.send({
@@ -214,6 +255,7 @@ export class BundledDev {
         }
       },
       onOutput: (result) => {
+        this.entryResolver?.onBuildOutput()
         if (result instanceof Error) {
           this.environment.logger.error(
             colors.red(`✘ Build error: ${result.message}`),
@@ -244,9 +286,19 @@ export class BundledDev {
       },
       onAdditionalAssets: (result) => {
         this.storeOutputFiles(result.output)
+        if (this.nativeModuleRunner) {
+          // assets emitted during HMR compilation don't go through the
+          // engine's watch write — persist them for native imports
+          for (const outputFile of result.output) {
+            this.writeServerFile(
+              outputFile.fileName,
+              outputFile.type === 'chunk' ? outputFile.code : outputFile.source,
+            )
+          }
+        }
       },
       watch: {
-        skipWrite: true,
+        skipWrite: !this.nativeModuleRunner,
         ...convertToDevWatchOptions(this.environment.config.server.watch),
       },
     })
@@ -259,15 +311,17 @@ export class BundledDev {
         debug?.('INITIAL: run error', e)
       },
     )
-    this.viteRuntime = await getHmrImplementation(
-      this.environment.getTopLevelConfig(),
-    )
+    if (!this.nativeModuleRunner) {
+      this.viteRuntime = await getHmrImplementation(
+        this.environment.getTopLevelConfig(),
+      )
+    }
     this.storeOutputFiles([])
     this.waitForInitialBuildFinish().then(() => {
       if (this._closed) return
       debug?.('INITIAL: build done')
       this.initialBuildCompleted = true
-      if (!this.lastBuildError) {
+      if (!this.lastBuildError && !this.nativeModuleRunner) {
         this.environment.hot.send({
           type: 'full-reload',
           path: '*',
@@ -359,10 +413,34 @@ export class BundledDev {
     }
   }
 
+  /**
+   * Resolve a url to the importable file url of its bundled entry chunk,
+   * rebuilding stale output first. Only available with `nativeModuleRunner`.
+   */
+  async resolveEntry(url: string): Promise<{ url: string; moduleId: string }> {
+    if (!this.entryResolver) {
+      throw new Error(
+        'bundledDev.resolveEntry() is only available with `nativeModuleRunner`',
+      )
+    }
+    return this.entryResolver.resolve(url)
+  }
+
+  private writeServerFile(fileName: string, source: string | Uint8Array): void {
+    const filePath = path.join(this.serverOutDir!, fileName)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, source)
+  }
+
   async close(): Promise<void> {
     this._closed = true
+    this.entryResolver?.onClose()
     this.memoryFiles.clear()
     await this._devEngine?.close()
+    if (this.serverOutDir) {
+      // remove after the engine closed so its watcher no longer writes here
+      fs.rmSync(this.serverOutDir, { recursive: true, force: true })
+    }
     this.initialBuildCompleted = false
   }
 
@@ -374,6 +452,7 @@ export class BundledDev {
         etag: getEtag(Buffer.from(this.viteRuntime), { weak: true }),
       })
     }
+    this.entryResolver?.registerChunks(output)
     for (const outputFile of output) {
       this.memoryFiles.set(outputFile.fileName, () => {
         const source =
@@ -425,6 +504,25 @@ export class BundledDev {
       rolldownOptions.output.sourcemap = true
     }
 
+    if (this.nativeModuleRunner) {
+      // lazy compilation emits stubs that fetch `/@vite/lazy` over HTTP with
+      // a browser clientId — dynamic imports must be compiled eagerly to
+      // keep the on-disk graph natively importable
+      rolldownOptions.experimental.devMode.lazy = false
+
+      const outputs = Array.isArray(rolldownOptions.output)
+        ? rolldownOptions.output
+        : [rolldownOptions.output]
+      for (const output of outputs) {
+        // write to a dedicated cache dir instead of the build outDir so dev
+        // output never clobbers a production build
+        output.dir = this.serverOutDir
+        output.sourcemap = 'inline'
+        // to keep builtin ESM cache happy, we also have a hash in the entry name.
+        output.entryFileNames = 'assets/[name]-[hash].js'
+      }
+    }
+
     return rolldownOptions
   }
 
@@ -446,6 +544,16 @@ export class BundledDev {
         colors.green(`trigger page reload `) + colors.dim(shortFile) + reason,
         { clear: true, timestamp: true },
       )
+      if (this.nativeModuleRunner) {
+        // fatal for the native runner: it cannot re-execute cached modules,
+        // so the consumer is expected to restart the process/worker. The
+        // engine rebuilds on its own after a FullReload update — marking the
+        // entry stale makes a resolve that lands before that rebuild's
+        // output wait for it instead of serving the pre-change entry.
+        this.entryResolver?.markEntryStale()
+        client.send({ type: 'full-reload', path: '*' })
+        return
+      }
       // `import.meta.hot.invalidate()` is fully client-side now, so every server-sent
       // reload comes from a file change: defer it until the `onOutput` callback to
       // avoid error overlay flashes.
@@ -459,25 +567,43 @@ export class BundledDev {
     })
 
     this.pendingPayloadFilenames.add(hmrOutput.filename)
-    this.memoryFiles.set(hmrOutput.filename, {
-      // ensure that the generated hmr patch contains ESM syntax
-      // this is to avoid attacks like GHSA-4v9v-hfq4-rm2v
-      // https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-4v9v-hfq4-rm2v
-      // https://green.sapphi.red/blog/local-server-security-best-practices#_2-using-xssi-and-modifying-the-prototype
-      // https://green.sapphi.red/blog/local-server-security-best-practices#properly-check-the-request-origin
-      // we can also use `Cross-Origin Resource Policy` header instead of this
-      // but we cannot use `Sec-Fetch-*` headers as they are only sent to potentially-trustworthy origins
-      source: hmrOutput.code + '\n; export {}',
-    })
-    if (hmrOutput.sourcemapFilename && hmrOutput.sourcemap) {
-      this.memoryFiles.set(hmrOutput.sourcemapFilename, {
-        source: hmrOutput.sourcemap,
-      })
+    // ensure that the generated hmr patch contains ESM syntax
+    // this is to avoid attacks like GHSA-4v9v-hfq4-rm2v
+    // https://github.com/webpack/webpack-dev-server/security/advisories/GHSA-4v9v-hfq4-rm2v
+    // https://green.sapphi.red/blog/local-server-security-best-practices#_2-using-xssi-and-modifying-the-prototype
+    // https://green.sapphi.red/blog/local-server-security-best-practices#properly-check-the-request-origin
+    // we can also use `Cross-Origin Resource Policy` header instead of this
+    // but we cannot use `Sec-Fetch-*` headers as they are only sent to potentially-trustworthy origins
+    const patchSource = hmrOutput.code + '\n; export {}'
+    let patchUrl = hmrOutput.filename
+
+    if (this.nativeModuleRunner) {
+      // the native runner imports patches from disk instead of the dev
+      // server, so the payload carries the importable file url directly.
+      this.writeServerFile(hmrOutput.filename, patchSource)
+      if (hmrOutput.sourcemapFilename && hmrOutput.sourcemap) {
+        this.writeServerFile(hmrOutput.sourcemapFilename, hmrOutput.sourcemap)
+      }
+      patchUrl = pathToFileURL(
+        path.join(this.serverOutDir!, hmrOutput.filename),
+      ).href
+
+      // the patch is imported directly from disk, the server doesn't know when
+      // TODO: should it? we could send an event to the server - why does this exist?
+      this.markPayloadDelivered(hmrOutput.filename)
+    } else {
+      this.memoryFiles.set(hmrOutput.filename, { source: patchSource })
+      if (hmrOutput.sourcemapFilename && hmrOutput.sourcemap) {
+        this.memoryFiles.set(hmrOutput.sourcemapFilename, {
+          source: hmrOutput.sourcemap,
+        })
+      }
     }
+
     client.send({
       type: 'bundled-dev-update',
       changedIds: hmrOutput.changedIds,
-      url: hmrOutput.filename,
+      url: patchUrl,
       seq: hmrOutput.seq,
     })
     const { formatted, truncated } = formatAndTruncateFileList(

--- a/packages/vite/src/node/server/bundledDevEntryResolver.ts
+++ b/packages/vite/src/node/server/bundledDevEntryResolver.ts
@@ -1,0 +1,189 @@
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { DevEngine } from 'rolldown/experimental'
+import type { RolldownOutput } from 'rolldown'
+import { createDebugger, normalizePath } from '../utils'
+import { cleanUrl, promiseWithResolvers } from '../../shared/utils'
+
+const debug = createDebugger('vite:full-bundle-mode')
+
+export interface BundledDevEntryResolverOptions {
+  root: string
+  /** the directory the bundled output is written to for native imports */
+  outDir: string
+  getDevEngine: () => DevEngine
+  isClosed: () => boolean
+  getLastBuildError: () => Error | null
+  hasActiveHmrClient: () => boolean
+  waitForInitialBuildFinish: () => Promise<void>
+}
+
+/**
+ * Resolves urls to the importable file urls of their bundled entry chunks for
+ * `nativeModuleRunner` mode, rebuilding stale output first when needed.
+ * `BundledDev` owns the dev engine and notifies the resolver of build outputs
+ * and of updates that invalidate the executed graph.
+ */
+export class BundledDevEntryResolver {
+  private facadeToChunk = new Map<string, string>()
+  /** set once the first `onOutput` callback (successful or errored) ran */
+  private firstOutputProcessed = false
+  /** resolved and replaced on every processed build output, and on close */
+  private outputProcessedSignal = promiseWithResolvers<void>()
+  /**
+   * Set when the executed graph can no longer be kept current with HMR
+   * patches (a `FullReload` update, or a build error) and the next resolved
+   * import must rebuild and re-execute the bundle. While an HMR client
+   * session is active and this is unset, imports skip the rebuild — patches
+   * already keep the runtime current.
+   */
+  private entryStale = false
+  /**
+   * Serializes refreshes. Rolldown's `onOutput` callback carries no build id,
+   * so an output notification can only be attributed to the rebuild a
+   * refresh triggered when refreshes never overlap. Refreshes are the only
+   * source of rebuilds in native import mode, so under this chain the
+   * notification a refresh observes is effectively a token for its own build
+   * (or a newer one, which is fresher and equally safe to import).
+   */
+  private refreshChain: Promise<void> = Promise.resolve()
+
+  constructor(private options: BundledDevEntryResolverOptions) {}
+
+  /** Called for every processed build output, successful or errored. */
+  onBuildOutput(): void {
+    this.firstOutputProcessed = true
+    const processed = this.outputProcessedSignal
+    this.outputProcessedSignal = promiseWithResolvers<void>()
+    processed.resolve()
+  }
+
+  /**
+   * Unblocks pending output waits so in-flight resolves observe the closed
+   * state instead of waiting for an output that will never come.
+   */
+  onClose(): void {
+    this.outputProcessedSignal.resolve()
+  }
+
+  /**
+   * Called when an update cannot be applied as a patch (a `FullReload`
+   * update, or an HMR-stage build error): the next resolve must rebuild.
+   */
+  markEntryStale(): void {
+    this.entryStale = true
+  }
+
+  registerChunks(output: RolldownOutput['output'][number][]): void {
+    for (const outputFile of output) {
+      if (outputFile.type === 'chunk' && outputFile.facadeModuleId) {
+        this.facadeToChunk.set(
+          normalizePath(outputFile.facadeModuleId),
+          outputFile.fileName,
+        )
+      }
+    }
+  }
+
+  /**
+   * Resolve a url to the importable file url of its bundled entry chunk,
+   * rebuilding stale output first. The url may be a root-relative url
+   * (`/src/entry-server.js`) or an absolute file path of a module that is
+   * part of the environment's rolldown input.
+   */
+  async resolve(url: string): Promise<{ url: string; moduleId: string }> {
+    await this.ensureFreshOutput()
+    if (this.options.isClosed()) {
+      throw new Error(`the environment was closed while resolving "${url}"`)
+    }
+    const lastBuildError = this.options.getLastBuildError()
+    if (lastBuildError) {
+      throw lastBuildError
+    }
+    const { facadeId, chunkFileName } = this.resolveBundledEntry(url)
+    const fileUrl = pathToFileURL(path.join(this.options.outDir, chunkFileName))
+    debug?.(`RESOLVE: ${url} -> ${fileUrl.href}`)
+    return {
+      url: fileUrl.href,
+      // rolldown's runtime registers modules by their cwd-relative id
+      moduleId: normalizePath(path.relative(process.cwd(), facadeId)),
+    }
+  }
+
+  /**
+   * With no browser clients connected, rolldown does not regenerate output on
+   * file changes (`rebuildStrategy` defaults to `'never'`) — the bundle only
+   * goes stale. Rebuild on demand before importing.
+   */
+  private ensureFreshOutput(): Promise<void> {
+    const refresh = this.refreshChain.then(() => this.refreshOutputIfStale())
+    // keep the chain going even when a refresh fails
+    this.refreshChain = refresh.then(
+      () => {},
+      () => {},
+    )
+    return refresh
+  }
+
+  private async refreshOutputIfStale(): Promise<void> {
+    await this.options.waitForInitialBuildFinish()
+    // when the initial build errored, `waitForInitialBuildFinish` may return
+    // before the error passed through `onOutput` — wait for it so imports
+    // observe the build error instead of an empty chunk map
+    if (!this.options.isClosed() && !this.firstOutputProcessed) {
+      await this.outputProcessedSignal.promise
+    }
+    if (this.options.isClosed()) return
+
+    if (!this.entryStale && this.options.hasActiveHmrClient()) {
+      // an active HMR client session keeps the executed graph current by
+      // applying patches — rebuilding here would discard the patched state
+      return
+    }
+    // clear before the awaits below: a `markEntryStale` that arrives while
+    // this refresh waits belongs to a newer change and must survive into
+    // the next refresh
+    this.entryStale = false
+
+    const devEngine = this.options.getDevEngine()
+    // captured before the state check: the rebuild this refresh waits for
+    // may pass through `onOutput` at any point after it
+    const outputProcessed = this.outputProcessedSignal.promise
+    const state = await devEngine.getBundleState()
+    if (state.lastBuildErrored && state.lastErrorStage === 'Hmr') {
+      // HMR-stage failures don't go through `onOutput` — force a full
+      // rebuild to surface the error (or pick up a fix) on import
+      devEngine.triggerFullBuild()
+    } else if (!state.hasStaleOutput) {
+      return
+    }
+    await devEngine.ensureLatestBuildOutput()
+    // `onOutput` may be invoked after `ensureLatestBuildOutput` resolves —
+    // wait until the new output (or its build error) has been processed
+    await outputProcessed
+  }
+
+  private resolveBundledEntry(url: string): {
+    facadeId: string
+    chunkFileName: string
+  } {
+    const cleanedUrl = cleanUrl(url)
+    const candidates = new Set([
+      normalizePath(cleanedUrl),
+      normalizePath(
+        path.resolve(
+          this.options.root,
+          cleanedUrl[0] === '/' ? cleanedUrl.slice(1) : cleanedUrl,
+        ),
+      ),
+    ])
+    for (const candidate of candidates) {
+      const chunk = this.facadeToChunk.get(candidate)
+      if (chunk) return { facadeId: candidate, chunkFileName: chunk }
+    }
+    throw new Error(
+      `no bundled chunk found for "${url}". Bundled modules: ` +
+        `${[...this.facadeToChunk.keys()].join(', ') || '(none)'}`,
+    )
+  }
+}

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -169,6 +169,12 @@ export class DevEnvironment extends BaseEnvironment {
             : { type: 'RegExp', source: builtin.source, flags: builtin.flags },
         )
       },
+      resolveBundledModuleUrl: (url) => {
+        if (!this.bundledDev) {
+          throw new Error('full bundle mode is not enabled in this environment')
+        }
+        return this.bundledDev.resolveEntry(url)
+      },
     })
 
     this.hot.on(

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -89,11 +89,6 @@ export const createServerModuleRunnerTransport = (options: {
 }): ModuleRunnerTransport => {
   const hmrClient: HotChannelClient = {
     send: (payload: HotPayload) => {
-      if (payload.type !== 'custom') {
-        throw new Error(
-          'Cannot send non-custom events from the client to the server.',
-        )
-      }
       options.channel.send(payload)
     },
   }

--- a/packages/vite/src/shared/bundledDevHmrClient.ts
+++ b/packages/vite/src/shared/bundledDevHmrClient.ts
@@ -3,8 +3,8 @@ import type {
   Update,
   UpdatePayload,
 } from '#types/hmrPayload'
-import { HMRClient, HMRContext, type HMRLogger } from '../shared/hmr'
-import type { NormalizedModuleRunnerTransport } from '../shared/moduleRunnerTransport'
+import { HMRClient, HMRContext, type HMRLogger } from './hmr'
+import type { NormalizedModuleRunnerTransport } from './moduleRunnerTransport'
 
 /** the subset of `__rolldown_runtime__` the HMR client uses */
 export interface RolldownRuntimeLike {
@@ -32,7 +32,12 @@ type HmrUpdate =
     }
 
 export interface BundledDevHMRClientOptions {
-  base: string
+  /**
+   * Loads and executes the HMR patch chunk at `url`. The browser imports it
+   * from the dev server, the native module runner imports the patch file
+   * written next to the bundled output.
+   */
+  loadPatch: (url: string) => Promise<void>
   /** returning `'reload'` aborts the apply — the hook reloads the page itself */
   beforeApply: () => 'reload' | 'continue'
 }
@@ -282,7 +287,7 @@ export class BundledDevHMRClient extends HMRClient {
     if (this.options.beforeApply() === 'reload') return
 
     try {
-      await import(/* @vite-ignore */ this.options.base + url)
+      await this.options.loadPatch(url)
     } catch {
       this.requestFullReload(`failed to import hmr patch ${url}`)
       return

--- a/packages/vite/src/shared/invokeMethods.ts
+++ b/packages/vite/src/shared/invokeMethods.ts
@@ -89,4 +89,8 @@ export type InvokeMethods = {
       | { type: 'RegExp'; source: string; flags: string }
     >
   >
+
+  resolveBundledModuleUrl: (
+    url: string,
+  ) => Promise<{ url: string; moduleId: string }>
 }


### PR DESCRIPTION
### Description

This is an experiment to see if we can avoid using the SSR transform on the server in full bundle mode: with `isBundled` + `nativeModuleRunner`, the server environment's bundled output is written to disk and executed with a plain native `import()`.

This mode comes with expectations. The main one is the full reload: HMR patches are applied in place, but an update that cannot be patched (an unaccepted change, or recovery after a build error) escalates to a `full-reload` — and a native runner cannot re-execute modules that the ESM cache already holds, so a full reload is fatal by design. The runner throws from every later `import()`, and the consumer is expected to restart the process/worker that runs the runner (the consumer owns the transport, so it can observe the `full-reload` payload there and restart automatically).