### PR TITLE
fix(server): skip addWatchFile watcher registration after close (fix #18224)

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { stripVTControlCharacters } from 'node:util'
 import MagicString from 'magic-string'
 import { describe, expect, it, vi } from 'vitest'
@@ -373,6 +374,42 @@ describe('plugin container', () => {
     })
   })
 
+  describe('addWatchFile', () => {
+    it('does not register files with the watcher after close', async () => {
+      const root = fileURLToPath(
+        new URL('./fixtures/watcher/nested-root', import.meta.url),
+      )
+      const outside = fileURLToPath(
+        new URL('./fixtures/watcher/config-deps/foo.js', import.meta.url),
+      )
+      const add = vi.fn()
+      const watcher = {
+        add,
+      } as unknown as import('#dep-types/chokidar').FSWatcher
+
+      let addWatch: ((id: string) => void) | undefined
+      const plugin: Plugin = {
+        name: 'add-watch-after-close',
+        buildStart() {
+          addWatch = (id: string) => this.addWatchFile(id)
+        },
+      }
+
+      const environment = await getDevEnvironment(
+        {
+          root,
+          plugins: [plugin],
+        },
+        { watcher },
+      )
+      await environment.pluginContainer.buildStart()
+      await environment.pluginContainer.close()
+      addWatch!(outside)
+
+      expect(add).not.toHaveBeenCalled()
+    })
+  })
+
   describe('resolveId', () => {
     describe('skipSelf', () => {
       it('should skip the plugin itself when skipSelf is true', async () => {
@@ -537,6 +574,7 @@ describe('plugin container', () => {
 
 async function getDevEnvironment(
   inlineConfig?: UserConfig,
+  initOptions?: { watcher?: import('#dep-types/chokidar').FSWatcher },
 ): Promise<DevEnvironment> {
   const config = await resolveConfig(
     { configFile: false, ...inlineConfig },
@@ -547,7 +585,7 @@ async function getDevEnvironment(
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
   const environment = new DevEnvironment('client', config, { hot: true })
-  await environment.init()
+  await environment.init(initOptions)
 
   return environment
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -637,14 +637,14 @@ export async function _createServer(
       teardownSIGTERMListener(closeServerAndExit)
     }
 
+    await Promise.allSettled(
+      Object.values(server.environments).map((environment) =>
+        environment.close(),
+      ),
+    )
     await Promise.allSettled([
       watcher.close(),
       ws.close(),
-      Promise.allSettled(
-        Object.values(server.environments).map((environment) =>
-          environment.close(),
-        ),
-      ),
       closeHttpServer(),
       server._ssrCompatModuleRunner?.close(),
     ])

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -195,6 +195,10 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   private _buildStartPromise: Promise<void> | undefined
   private _closed = false
 
+  get closed(): boolean {
+    return this._closed
+  }
+
   /**
    * @internal use `createEnvironmentPluginContainer` instead
    */
@@ -874,7 +878,7 @@ class PluginContext
 
   addWatchFile(id: string): void {
     this._container.watchFiles.add(id)
-    if (this._container.watcher)
+    if (this._container.watcher && !this._container.closed)
       ensureWatchedFile(
         this._container.watcher,
         id,


### PR DESCRIPTION
### Description

If a plugin calls `this.addWatchFile()` after the Vite dev server has started closing (e.g. `vite:css` is still transforming a CSS file when Vitest teardown runs), the chokidar watcher may be re-armed and the Node.js process never exits.

This PR guards `PluginContext.addWatchFile` so it skips `ensureWatchedFile` once the environment plugin container is closed, and closes the dev environments before tearing down the chokidar watcher in `server.close()` so late transforms cannot re-open file handles.

Fixes #18224.

This supersedes #23316, which I closed while the repo was at PR capacity; it is the same fix rebased onto current `main` with a passing regression test.

### Test plan

- Added a `pluginContainer` unit test that calls `addWatchFile` after `pluginContainer.close()` and asserts `watcher.add` is not called.
- Ran `pnpm vitest run packages/vite/src/node/server/__tests__/pluginContainer.spec.ts` — passes.
- Ran `pnpm -C packages/vite exec tsc -p src/node --noEmit` — no errors.

### AI disclosure

I used an AI coding assistant to explore the issue and recover an earlier attempt. I reviewed the final diff, wrote/verified the regression test, and ran the targeted test and typecheck commands myself.
