### PR TITLE
ci: narrow semantic-pull-request triggers

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -7,10 +7,7 @@ on:
   # - Only PR title is read
   # - No PR-supplied code is executed
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+    types: [opened, reopened, edited]
 
 jobs:
   main:


### PR DESCRIPTION
We don't really need the `synchronize` trigger for semantic-pull-request, since we only need to detect changes to the PR title, which is based on the `edited` event. So all these years the `synchronize` trigger (which triggers on every PR commit) has been running unnecessarily 😬 

The trigger is also suggested by https://github.com/amannn/action-semantic-pull-request#installation