### PR TITLE
fix: inject browser hash into node_modules module scripts

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -8,7 +8,7 @@ import type { Connect } from '#dep-types/connect'
 import type { PreviewServer, ResolvedConfig, ViteDevServer } from '../..'
 import { cleanUrl, unwrapId, wrapId } from '../../../shared/utils'
 import { getNodeAssetAttributes } from '../../assetSource'
-import { CLIENT_PUBLIC_PATH, FS_PREFIX } from '../../constants'
+import { CLIENT_PUBLIC_PATH, DEP_VERSION_RE, FS_PREFIX } from '../../constants'
 import { getHmrImplementation } from '../../plugins/clientInjections'
 import type { IndexHtmlTransformHook } from '../../plugins/html'
 import {
@@ -36,8 +36,12 @@ import {
   getHash,
   injectQuery,
   isCSSRequest,
+  isDataUrl,
   isDevServer,
+  isExternalUrl,
+  isInNodeModules,
   isJSRequest,
+  isOptimizable,
   isParentDirectory,
   joinUrlSegments,
   normalizePath,
@@ -161,6 +165,26 @@ const processNodeUrl = (
     }
 
     let preTransformUrl: string | undefined
+
+    if (
+      server &&
+      isClassicScriptLink === false &&
+      !checkPublicFile(url, config) &&
+      isInNodeModules(url) &&
+      !isExternalUrl(url) &&
+      !isDataUrl(url) &&
+      !DEP_VERSION_RE.test(url)
+    ) {
+      const depsOptimizer = server.environments.client.depsOptimizer
+      const versionHash = depsOptimizer?.metadata.browserHash
+      if (
+        versionHash &&
+        depsOptimizer &&
+        isOptimizable(url, depsOptimizer.options)
+      ) {
+        url = injectQuery(url, `v=${versionHash}`)
+      }
+    }
 
     if (!isClassicScriptLink && shouldPreTransform(url, config)) {
       if (url[0] === '/' && url[1] !== '/') {

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -255,6 +255,21 @@ test('non optimized module is not duplicated', async () => {
     .toBe('from-absolute-path, from-relative-path')
 })
 
+test.runIf(isServe)(
+  'node_modules module script is not duplicated',
+  async () => {
+    const testPage = await page.context().newPage()
+    try {
+      await testPage.goto(`${viteTestUrl}/node-modules.html`)
+      await expect
+        .poll(() => testPage.textContent('.non-optimized-module'))
+        .toBe('from-html')
+    } finally {
+      await testPage.close()
+    }
+  },
+)
+
 test.runIf(isServe)('error on builtin modules usage', () => {
   expect(browserLogs).toEqual(
     expect.arrayContaining([

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -258,14 +258,13 @@ test('non optimized module is not duplicated', async () => {
 test.runIf(isServe)(
   'node_modules module script is not duplicated',
   async () => {
-    const testPage = await page.context().newPage()
     try {
-      await testPage.goto(`${viteTestUrl}/node-modules.html`)
+      await page.goto(`${viteTestUrl}/node-modules.html`)
       await expect
-        .poll(() => testPage.textContent('.non-optimized-module'))
+        .poll(() => page.textContent('.non-optimized-module'))
         .toBe('from-html')
     } finally {
-      await testPage.close()
+      await page.goto(viteTestUrl)
     }
   },
 )

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
+  addFile,
   browserErrors,
   browserLogs,
   getColor,
@@ -7,6 +8,7 @@ import {
   isServe,
   page,
   readDepOptimizationMetadata,
+  removeFile,
   serverLogs,
   viteTestUrl,
 } from '~utils'
@@ -258,13 +260,38 @@ test('non optimized module is not duplicated', async () => {
 test.runIf(isServe)(
   'node_modules module script is not duplicated',
   async () => {
+    const packageJson = 'node_modules/test-browserhash-repro/package.json'
+    const packageIndex = 'node_modules/test-browserhash-repro/index.js'
+
     try {
+      addFile(
+        packageJson,
+        JSON.stringify({
+          name: 'test-browserhash-repro',
+          type: 'module',
+          main: 'index.js',
+        }),
+      )
+      addFile(
+        packageIndex,
+        `document.body.insertAdjacentHTML(
+  'beforeend',
+  \`<p class="browserhash-repro-load">\${import.meta.url}</p>\`,
+)`,
+      )
+
       await page.goto(`${viteTestUrl}/node-modules.html`)
-      await expect
-        .poll(() => page.textContent('.non-optimized-module'))
-        .toBe('from-html')
+      const loadedUrls = await page
+        .locator('.browserhash-repro-load')
+        .allTextContents()
+      expect(loadedUrls).toHaveLength(1)
+      expect(loadedUrls[0]).toMatch(
+        /\/node_modules\/test-browserhash-repro\/index\.js\?v=\w+/,
+      )
     } finally {
       await page.goto(viteTestUrl)
+      removeFile(packageIndex)
+      removeFile(packageJson)
     }
   },
 )

--- a/playground/optimize-deps/dep-non-optimized/entry.js
+++ b/playground/optimize-deps/dep-non-optimized/entry.js
@@ -1,3 +1,0 @@
-import { add } from './index.js'
-
-add('from-html')

--- a/playground/optimize-deps/dep-non-optimized/entry.js
+++ b/playground/optimize-deps/dep-non-optimized/entry.js
@@ -1,0 +1,3 @@
+import { add } from './index.js'
+
+add('from-html')

--- a/playground/optimize-deps/node-modules.html
+++ b/playground/optimize-deps/node-modules.html
@@ -1,17 +1,12 @@
 <!doctype html>
 <html>
   <body>
-    <div class="non-optimized-module"></div>
     <script
       type="module"
-      src="/node_modules/@vitejs/test-dep-non-optimized/entry.js"
+      src="/node_modules/test-browserhash-repro/index.js"
     ></script>
     <script type="module">
-      import '/node_modules/@vitejs/test-dep-non-optimized/entry.js'
-      import { get } from '/node_modules/@vitejs/test-dep-non-optimized/index.js'
-
-      document.querySelector('.non-optimized-module').textContent =
-        get().join(', ')
+      import 'test-browserhash-repro'
     </script>
   </body>
 </html>

--- a/playground/optimize-deps/node-modules.html
+++ b/playground/optimize-deps/node-modules.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <body>
+    <div class="non-optimized-module"></div>
+    <script
+      type="module"
+      src="/node_modules/@vitejs/test-dep-non-optimized/entry.js"
+    ></script>
+    <script type="module">
+      import '/node_modules/@vitejs/test-dep-non-optimized/entry.js'
+      import { get } from '/node_modules/@vitejs/test-dep-non-optimized/index.js'
+
+      document.querySelector('.non-optimized-module').textContent =
+        get().join(', ')
+    </script>
+  </body>
+</html>

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
       '@vitejs/test-nested-exclude',
       '@vitejs/test-dep-non-optimized',
       '@vitejs/test-dep-esm-external',
+      'test-browserhash-repro',
       'stream',
     ],
     rolldownOptions: {


### PR DESCRIPTION
### Description

Fixes #9828.

Module scripts that directly reference files in `node_modules` did not receive the dependency optimizer's browser hash, while imports of the same module through JavaScript did.

This caused the browser to see two different module URLs and instantiate the module twice.

This PR injects the current `browserHash` into eligible `node_modules` module script URLs during dev HTML processing, before pre-transform and module graph handling.

Public files, classic scripts, external/data URLs, and existing version queries are left unchanged.

### Tests

Added a regression test that loads the same excluded dependency through both an HTML module script and a JavaScript import and verifies that it is instantiated only once.

Local checks passed:

- TypeScript
- ESLint
- oxfmt
- `indexHtml` unit tests
- `git diff --check`

The targeted optimize-deps browser test could not run locally because the Windows environment could not create the playground junction.