### PR TITLE
fix(utils): handle dot in srcset density descriptor

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -592,6 +592,26 @@ describe('processSrcSetSync', () => {
     ).toBe('"/base/nested/asset.png" 1x, "/base/nested/asset.png" 2x')
   })
 
+  test('keep the url when a density descriptor omits its leading zero', async () => {
+    const devBase = '/base/'
+    expect(
+      processSrcSetSync(
+        './nested/asset.png .5x, ./nested/asset.png 1x',
+        ({ url }) => path.posix.join(devBase, url),
+      ),
+    ).toBe('/base/nested/asset.png .5x, /base/nested/asset.png 1x')
+  })
+
+  test('keep the quoted url when a density descriptor omits its leading zero', async () => {
+    const devBase = '/base/'
+    expect(
+      processSrcSetSync(
+        '"./nested/asset.png" .75x,"./nested/asset.png" 1x',
+        ({ url }) => `"${path.posix.join(devBase, url.slice(1, -1))}"`,
+      ),
+    ).toBe('"/base/nested/asset.png" .75x, "/base/nested/asset.png" 1x')
+  })
+
   test('should not split the comma inside base64 value', async () => {
     const base64 =
       'data:image/avif;base64,aA+/0= 400w, data:image/avif;base64,bB+/9= 800w'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -813,8 +813,12 @@ function joinSrcset(ret: ImageCandidate[]) {
   * URL string (unquoted)
   The `descriptor` is anything after the space and before the comma.
  */
+// The descriptor may start with a dot: a density descriptor is allowed to omit
+// its leading zero (`.5x`). Without the dot in the leading class the descriptor
+// group fails, the alternation then matches the descriptor itself as the url,
+// and the real image url is dropped from the candidate list.
 const imageCandidateRegex =
-  /(?:^|\s|(?<=,))(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>\w[^,]+))?(?:,|$)/g
+  /(?:^|\s|(?<=,))(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>[\w.][^,]+))?(?:,|$)/g
 const escapedSpaceCharacters = /(?: |\\t|\\n|\\f|\\r)+/g
 
 export function parseSrcset(string: string): ImageCandidate[] {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -813,10 +813,6 @@ function joinSrcset(ret: ImageCandidate[]) {
   * URL string (unquoted)
   The `descriptor` is anything after the space and before the comma.
  */
-// The descriptor may start with a dot: a density descriptor is allowed to omit
-// its leading zero (`.5x`). Without the dot in the leading class the descriptor
-// group fails, the alternation then matches the descriptor itself as the url,
-// and the real image url is dropped from the candidate list.
 const imageCandidateRegex =
   /(?:^|\s|(?<=,))(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>[\w.][^,]+))?(?:,|$)/g
 const escapedSpaceCharacters = /(?: |\\t|\\n|\\f|\\r)+/g


### PR DESCRIPTION
### Description

A density descriptor in `srcset` / `image-set()` may be written without its leading zero — `.5x` is as valid as `0.5x`. When one is, `parseSrcset()` **discards the image URL** and returns the descriptor in its place.

```js
parseSrcset('./nested/asset.png .5x, ./nested/asset.png 1x')
// [ { url: '.5x',                descriptor: ''   },   <- url lost
//   { url: './nested/asset.png', descriptor: '1x' } ]
```

Because the URL never reaches the candidate list, base-URL rewriting and asset resolution run on `.5x`, and the first candidate ends up pointing at nothing:

```
processSrcSetSync('./nested/asset.png .5x, ./nested/asset.png 1x', prependBase)
  before  '/base/.5x, /base/nested/asset.png 1x'
  after   '/base/nested/asset.png .5x, /base/nested/asset.png 1x'
```

Quoted URLs are mangled the same way, and worse — the quote handling desynchronises:

```
'"./nested/asset.png" .75x,"./nested/asset.png" 1x'
  before  '"/base/75x,"./nested/asset.png" 1x'
  after   '"/base/nested/asset.png" .75x, "/base/nested/asset.png" 1x'
```

**Why**

The descriptor group starts with `\w`:

```js
(?:\s(?<descriptor>\w[^,]+))?
```

A dot is not `\w`, so the optional group fails to match. The url alternation `[^,]\S*[^,]` then happily consumes `.5x` as the url, and the actual path is left out of the match.

The fix allows a dot as the descriptor's first character. `[^,]+` still requires two or more characters, which every legal descriptor satisfies (`1x`, `.5x`, `400w`, `600dpi`) — that constraint is pre-existing and unchanged.

### Validation

Both new tests fail on `main` and pass with the change:

```
$ npx vitest run .../utils.spec.ts -t "leading zero"     # utils.ts reverted
 FAIL  ... > keep the url when a density descriptor omits its leading zero
   expected '/base/.5x, /base/nested/asset.png 1x' to be '/base/nested/asset.png .5x, …'
 FAIL  ... > keep the quoted url when a density descriptor omits its leading zero
   expected '"/base/75x,"./nested/asset.png" 1x' to be '"/base/nested/asset.png" .75x, …'
  Tests  2 failed | 122 skipped (124)
```

- `npx vitest run packages/vite/src/node/__tests__/utils.spec.ts` — **124 passed (124)**.
- I also ran every distinct source string from the existing `processSrcSetSync` block through the old and the new pattern — base64, comma-in-URL, no-descriptor, `url()`-with-commas, `400w`, `600dpi`, quoted URLs, `1.5x` — and the parsed output is **identical** in all of them. The only inputs whose behaviour changes are the ones that were broken.
- `npx eslint` and `npx oxfmt --check` on both files — clean.

Same code path as the `image-set()` handling in `plugins/css.ts`, so that gets the fix too.