### PR TITLE
fix(build): use resolved base for chunk import map keys

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1115,6 +1115,58 @@ test('chunkImportMap per environment with shared plugins', async () => {
   expect(entry.code).toContain(JSON.stringify(cssSpecifier.slice(1)))
 })
 
+test('chunkImportMap import map keys match when base is not "/"', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  let client: RolldownOutput | undefined
+  const builder = await createBuilder({
+    root,
+    base: '/sub/',
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+    builder: {
+      sharedPlugins: true,
+      async buildApp(builder) {
+        client = (await builder.build(
+          builder.environments.client,
+        )) as RolldownOutput
+      },
+    },
+  })
+
+  await builder.buildApp()
+
+  const entry = client!.output.find(
+    (output): output is OutputChunk =>
+      output.type === 'chunk' && output.isEntry,
+  )!
+  const css = client!.output.find(
+    (output) => output.type === 'asset' && output.fileName.endsWith('.css'),
+  )!
+  const importMapAsset = client!.output.find(
+    (output): output is OutputAsset =>
+      output.type === 'asset' && output.fileName === 'importmap.json',
+  )!
+  const importMap = JSON.parse(importMapAsset.source.toString())
+    .imports as Record<string, string>
+  const cssSpecifier = Object.entries(importMap).find(
+    ([, fileName]) => fileName === `/sub/${css.fileName}`,
+  )![0]
+  expect(cssSpecifier.startsWith('/sub/')).toBe(true)
+  expect(entry.code).toContain(
+    JSON.stringify(cssSpecifier.slice('/sub/'.length)),
+  )
+})
+
 test('chunkImportMap is emitted when emitAssets is false', async () => {
   const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
   const builder = await createBuilder({

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1700,13 +1700,10 @@ export function getImportMapFilename(
   return 'importmap.json'
 }
 
-function getImportMapBaseUrl(options: ResolvedEnvironmentOptions): string {
-  const chunkImportMap =
-    options.build.rolldownOptions.experimental?.chunkImportMap
-  if (typeof chunkImportMap === 'object' && chunkImportMap.baseUrl) {
-    return chunkImportMap.baseUrl
-  }
-  return '/'
+function getImportMapBaseUrl(
+  options: ResolvedEnvironmentOptions & ResolvedConfig,
+): string {
+  return options.base ?? '/'
 }
 
 /**


### PR DESCRIPTION
When `build.chunkImportMap` is enabled, the baseUrl handed to rolldown is always the resolved `base`, overwriting anything set in `rolldownOptions.experimental.chunkImportMap.baseUrl`. `getImportMapBaseUrl` still read that user value back instead, which is either unset or already overwritten, so it fell back to `/` whenever `base` wasn't `/`. That mismatch made the import map keys and the mapping lookup diverge, dropping `__vite__mapDeps` and modulepreload/CSS references for lazy chunks.

`getImportMapBaseUrl` is only ever reached behind that same `chunkImportMap` flag, so it can just return the resolved `base` directly.

fixes #23350