### PR TITLE
fix(config): skip native-loader compat warning when loader is explicit

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1654,7 +1654,6 @@ describe('loadConfigFromFile', () => {
         root,
         undefined,
         logger,
-        'bundle',
       )
       const messages = warn.mock.calls.map((c) =>
         stripVTControlCharacters(c[0]),
@@ -1673,6 +1672,24 @@ describe('loadConfigFromFile', () => {
         Set \`VITE_CONFIG_NATIVE_IGNORE_WARNING=true\` to suppress this warning.",
         ]
       `)
+    })
+
+    test('does not warn when an explicit non-native loader is used', async () => {
+      const logger = createLogger('info')
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const root = path.resolve(compatRoot, 'dirname')
+      await loadConfigFromFile(
+        {} as any,
+        path.resolve(root, 'vite.config.js'),
+        root,
+        undefined,
+        logger,
+        'bundle',
+      )
+      const messages = warn.mock.calls.map((c) =>
+        stripVTControlCharacters(c[0]),
+      )
+      expect(messages).toEqual([])
     })
 
     // uses a `.ts` config with TypeScript-only syntax; skipped on Node

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -2370,21 +2370,27 @@ export async function loadConfigFromFile(
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
-  configLoader: 'bundle' | 'runner' | 'native' = 'bundle',
+  configLoader?: 'bundle' | 'runner' | 'native',
 ): Promise<{
   path: string
   config: UserConfig
   dependencies: string[]
 } | null> {
+  // Only surface native-loader compatibility warnings when the loader was not
+  // chosen explicitly: users who deliberately picked a bundler have already
+  // opted out of the native loader.
+  const resolvedConfigLoader = configLoader ?? 'bundle'
+
   if (
-    configLoader !== 'bundle' &&
-    configLoader !== 'runner' &&
-    configLoader !== 'native'
+    resolvedConfigLoader !== 'bundle' &&
+    resolvedConfigLoader !== 'runner' &&
+    resolvedConfigLoader !== 'native'
   ) {
     throw new Error(
-      `Unsupported configLoader: ${configLoader}. Accepted values are 'bundle', 'runner', and 'native'.`,
+      `Unsupported configLoader: ${resolvedConfigLoader}. Accepted values are 'bundle', 'runner', and 'native'.`,
     )
   }
+  const warnNativeCompat = configLoader === undefined
 
   const start = performance.now()
   const getTime = () => `${(performance.now() - start).toFixed(2)}ms`
@@ -2412,14 +2418,16 @@ export async function loadConfigFromFile(
   }
 
   try {
-    const { configExport, dependencies } = await (configLoader === 'bundle'
+    const { configExport, dependencies } = await (resolvedConfigLoader ===
+    'bundle'
       ? bundleAndLoadConfigFile(
           resolvedPath,
           configRoot,
           logLevel,
           customLogger,
+          warnNativeCompat,
         )
-      : configLoader === 'runner'
+      : resolvedConfigLoader === 'runner'
         ? runnerImportConfigFile(resolvedPath)
         : nativeImportConfigFile(resolvedPath))
     debug?.(`config file loaded in ${getTime()}`)
@@ -2480,6 +2488,7 @@ async function bundleAndLoadConfigFile(
   configRoot: string,
   logLevel: LogLevel | undefined,
   customLogger: Logger | undefined,
+  warnNativeCompat: boolean,
 ) {
   const isESM =
     typeof process.versions.deno === 'string' || isFilePathESM(resolvedPath)
@@ -2491,7 +2500,7 @@ async function bundleAndLoadConfigFile(
     isESM,
   )
 
-  if (bundled.nativeIncompatibilities.length > 0) {
+  if (warnNativeCompat && bundled.nativeIncompatibilities.length > 0) {
     const logger = createLogger(logLevel, { customLogger })
     logger.warn(
       formatNativeConfigIncompatWarning(


### PR DESCRIPTION
Fixes #23267

## Summary

The `(!) Your Vite config uses features that are unsupported by configLoader: 'native'` warning fired even when the user explicitly set `--config-loader=bundle` (or a bundler loader via API). Since an explicit choice means the native loader will never be used, the warning is noise in that case.

## Fix

Make `configLoader` optional in `loadConfigFromFile` so an unset value can be distinguished from an explicit `'bundle'`, and only emit the compat warning on the default path:

- unset → defaults to `'bundle'`, warning fires (migration heads-up preserved)
- explicit `'bundle'` / `'runner'` → no warning
- explicit `'native'` → bundler path not taken, no change

## Test

- Existing 8 native-incompatibility warning tests updated to call through the default path
- Added regression test: explicit `configLoader: 'bundle'` produces no warnings
- All 109 tests in `config.spec.ts` pass; `tsc --noEmit` passes