### PR TITLE
fix(asset): preserve IPv6 brackets in server origin for url imports

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -18,6 +18,7 @@ import {
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
   getServerUrlByHost,
+  encodeURIPath,
   injectQuery,
   isFileReadable,
   isParentDirectory,
@@ -1255,5 +1256,18 @@ describe('resolveServerUrls', () => {
 
     expect(result.network).toStrictEqual(['http://10.0.0.5:3000/'])
     expect(result.networkInterfaceNames).toStrictEqual([undefined])
+  })
+})
+
+
+describe('encodeURIPath', () => {
+  test('encodes path correctly', () => {
+    expect(encodeURIPath('/foo/bar.txt')).toBe('/foo/bar.txt')
+    expect(encodeURIPath('/foo/[bar].txt')).toBe('/foo/%5Bbar%5D.txt')
+  })
+
+  test('does not encode IPv6 brackets in host', () => {
+    expect(encodeURIPath('http://[::1]:5173/foo/bar.txt')).toBe('http://[::1]:5173/foo/bar.txt')
+    expect(encodeURIPath('http://[::1]:5173/foo/[bar].txt')).toBe('http://[::1]:5173/foo/%5Bbar%5D.txt')
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1888,7 +1888,12 @@ export function encodeURIPath(uri: string): string {
   if (uri.startsWith('data:')) return uri
   const filePath = cleanUrl(uri)
   const postfix = filePath !== uri ? uri.slice(filePath.length) : ''
-  return encodeURI(filePath) + postfix
+  const encoded = encodeURI(filePath)
+  return (
+    encoded.replace(/^([a-zA-Z]+:\/\/[^/]+)/, (match) =>
+      match.replace(/%5B/g, '[').replace(/%5D/g, ']'),
+    ) + postfix
+  )
 }
 
 /**


### PR DESCRIPTION
When using an IPv6 address for the server origin (like \http://[::1]\), the \encodeURIPath\ function incorrectly encodes the square brackets into \%5B\ and \%5D\. This causes issues with \?url\ imports that rely on the origin being valid. This PR restores the brackets in the origin host section after encoding.