### PR TITLE
fix(ssr): throw on missing named exports in inlined modules

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -123,13 +123,24 @@ export class ModuleRunner {
     exports: Record<string, any>,
     fetchResult: ResolvedResult,
     metadata?: SSRImportMetadata,
+    isCompleteModule = true,
   ) {
-    if (!('externalize' in fetchResult)) {
+    // Cyclic inlined graphs may return a partial exports object while the
+    // exporter is still evaluating. Named-export checks must wait until the
+    // module finished, matching Node (and avoiding false SyntaxErrors).
+    if (!isCompleteModule) {
       return exports
     }
-    const { url, type } = fetchResult
-    if (type !== 'module' && type !== 'commonjs') return exports
-    analyzeImportedModDifference(exports, url, type, metadata)
+    if ('externalize' in fetchResult) {
+      const { url, type } = fetchResult
+      if (type !== 'module' && type !== 'commonjs') return exports
+      analyzeImportedModDifference(exports, url, type, metadata)
+      return exports
+    }
+    // Vite-transformed modules are ESM. Previously this path skipped
+    // analyzeImportedModDifference entirely, so `import { missing }` from a
+    // local file did not throw (Node throws SyntaxError).
+    analyzeImportedModDifference(exports, fetchResult.url, 'module', metadata)
     return exports
   }
 
@@ -185,7 +196,7 @@ export class ModuleRunner {
         mod.exports &&
         (callstack.includes(moduleId) || this.isCircularRequest(mod, callstack))
       ) {
-        return this.processImport(mod.exports, meta, metadata)
+        return this.processImport(mod.exports, meta, metadata, false)
       }
       return this.processImport(await mod.promise, meta, metadata)
     }

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/esm-internal-existing.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/esm-internal-existing.js
@@ -1,0 +1,3 @@
+import { test } from './simple.js'
+
+export const result = test

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/esm-internal-non-existing.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/esm-internal-non-existing.js
@@ -1,0 +1,3 @@
+import { nonExisting } from './simple.js'
+
+export const result = nonExisting

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -200,6 +200,19 @@ describe('module runner initialization', async () => {
     })
   })
 
+  it('importing inlined esm module checks exports', async ({ runner }) => {
+    await expect(() =>
+      runner.import('/fixtures/esm-internal-non-existing.js'),
+    ).rejects.toThrowError(
+      `[vite] The requested module '/fixtures/simple.js' does not provide an export named 'nonExisting'`,
+    )
+    await expect(
+      runner.import('/fixtures/esm-internal-existing.js'),
+    ).resolves.toMatchObject({
+      result: 'I am initialized',
+    })
+  })
+
   it("dynamic import doesn't produce duplicates", async ({ runner }) => {
     const mod = await runner.import('/fixtures/dynamic-import.js')
     const modules = await mod.initialize()


### PR DESCRIPTION
## Summary

- Local ESM files loaded through the module runner (`ssrLoadModule` / `runner.import`) skipped `analyzeImportedModDifference`. `import { missing } from './file.js'` therefore succeeded, while Node throws `SyntaxError`.
- Externalized ESM/CJS already ran that check. This applies the same ESM check to Vite-transformed modules, using `module` as the type (inlined fetch results have no `type`).
- Circular graphs can observe a partial `exports` object before evaluation finishes. Named-export checks run only after the module is complete, so existing cycle fixtures keep working.

## Test plan

- [x] `vitest run packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts`
- [x] New fixtures: missing named export throws; existing named export still resolves
- [x] CI `test-unit` on this PR