### PR TITLE
fix(build): preserve preload deps in chunkImportMap when base is not / (fix #23350)

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1115,6 +1115,50 @@ test('chunkImportMap per environment with shared plugins', async () => {
   expect(entry.code).toContain(JSON.stringify(cssSpecifier.slice(1)))
 })
 
+test('chunkImportMap preserves module preload deps when base is not / (fix #23350)', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  const builder = await createBuilder({
+    root,
+    base: '/sub/',
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+  })
+
+  const result = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+
+  const entry = result.output.find(
+    (output): output is OutputChunk =>
+      output.type === 'chunk' && output.isEntry,
+  )!
+  const css = result.output.find(
+    (output) => output.type === 'asset' && output.fileName.endsWith('.css'),
+  )!
+  const importMapAsset = result.output.find(
+    (output): output is OutputAsset =>
+      output.type === 'asset' && output.fileName === 'importmap.json',
+  )!
+  const importMap = JSON.parse(importMapAsset.source.toString())
+    .imports as Record<string, string>
+  const cssSpecifier = Object.entries(importMap).find(
+    ([, fileName]) => fileName === `/sub/${css.fileName}`,
+  )![0]
+  expect(entry.code).toContain(
+    JSON.stringify(cssSpecifier.slice('/sub/'.length)),
+  )
+})
+
 test('chunkImportMap is emitted when emitAssets is false', async () => {
   const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
   const builder = await createBuilder({

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1159,6 +1159,50 @@ test('chunkImportMap preserves module preload deps when base is not / (fix #2335
   )
 })
 
+test('chunkImportMap preserves module preload deps when base is ./', async () => {
+  const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
+  const builder = await createBuilder({
+    root,
+    base: './',
+    logLevel: 'warn',
+    environments: {
+      client: {
+        build: {
+          chunkImportMap: true,
+          write: false,
+          rolldownOptions: {
+            input: '/entry.js',
+          },
+        },
+      },
+    },
+  })
+
+  const result = (await builder.build(
+    builder.environments.client,
+  )) as RolldownOutput
+
+  const entry = result.output.find(
+    (output): output is OutputChunk =>
+      output.type === 'chunk' && output.isEntry,
+  )!
+  const css = result.output.find(
+    (output) => output.type === 'asset' && output.fileName.endsWith('.css'),
+  )!
+  const importMapAsset = result.output.find(
+    (output): output is OutputAsset =>
+      output.type === 'asset' && output.fileName === 'importmap.json',
+  )!
+  const importMap = JSON.parse(importMapAsset.source.toString())
+    .imports as Record<string, string>
+  const cssSpecifier = Object.entries(importMap).find(
+    ([, fileName]) => fileName === `./${css.fileName}`,
+  )![0]
+  expect(entry.code).toContain(
+    JSON.stringify(`./${cssSpecifier.slice('./assets/'.length)}`),
+  )
+})
+
 test('chunkImportMap is emitted when emitAssets is false', async () => {
   const root = resolve(dirname, 'fixtures/shared-plugins/chunk-import-map')
   const builder = await createBuilder({

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1700,13 +1700,15 @@ export function getImportMapFilename(
   return 'importmap.json'
 }
 
-function getImportMapBaseUrl(options: ResolvedEnvironmentOptions): string {
+function getImportMapBaseUrl(
+  options: ResolvedEnvironmentOptions & { base?: string },
+): string {
   const chunkImportMap =
     options.build.rolldownOptions.experimental?.chunkImportMap
   if (typeof chunkImportMap === 'object' && chunkImportMap.baseUrl) {
     return chunkImportMap.baseUrl
   }
-  return (options as any).base ?? '/'
+  return options.base ?? '/'
 }
 
 /**

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1706,7 +1706,7 @@ function getImportMapBaseUrl(options: ResolvedEnvironmentOptions): string {
   if (typeof chunkImportMap === 'object' && chunkImportMap.baseUrl) {
     return chunkImportMap.baseUrl
   }
-  return '/'
+  return (options as any).base ?? '/'
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes #23350.

When `build.chunkImportMap` is enabled and `base` is configured to a non-root path (e.g. `base: '/sub/'`):
1. Rolldown prefixes the chunk import map keys with `baseUrl: base` (e.g. `/sub/assets/...`).
2. When reading the map back in `getImportMapBaseUrl()`, it checked `options.build.rolldownOptions.experimental?.chunkImportMap?.baseUrl` and defaulted to `'/'`.
3. Stripping length 1 left keys as `'sub/assets/...'`, which mismatched bundle keys (`'assets/...'`).
4. As a result, the lookup in `importAnalysisBuild.ts` missed, dropping the `__vite__mapDeps` dependency list from lazy chunks and leaving lazy CSS un-preloaded.

### Solution

- Update `getImportMapBaseUrl` in `packages/vite/src/node/plugins/html.ts` to return `(options as any).base ?? '/'` when `chunkImportMap.baseUrl` is not explicitly overridden on `rolldownOptions`.
- Added unit test in `packages/vite/src/node/__tests__/build.spec.ts` ensuring preload dependency mappings are preserved with non-root base.

### Validation

- `pnpm run build`
- `pnpm vitest run packages/vite/src/node/__tests__/build.spec.ts` (68/68 passed)
- `pnpm run typecheck` (0 errors)
- `pnpm run lint` (0 errors)
- Verified with minimal reproduction repository.