### PR TITLE
fix(utils): match timestamp query parameter with proper delimiters

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -26,6 +26,7 @@ import {
   numberToPos,
   posToNumber,
   processSrcSetSync,
+  removeTimestampQuery,
   resolveHostname,
   resolveServerUrls,
 } from '../utils'
@@ -192,6 +193,33 @@ describe('injectQuery', () => {
     const src = '/src/module.ts?url=https%3A%2F%2Fusr.vite%2F'
     const expected = '/src/module.ts?t=1234&url=https%3A%2F%2Fusr.vite%2F'
     expect(injectQuery(src, 't=1234')).toEqual(expected)
+  })
+})
+
+describe('removeTimestampQuery', () => {
+  test('removes timestamp query parameter', () => {
+    expect(removeTimestampQuery('/foo.js?t=1712345678901')).toBe('/foo.js')
+    expect(removeTimestampQuery('/foo.js?t=1712345678901&bar=1')).toBe(
+      '/foo.js?bar=1',
+    )
+    expect(removeTimestampQuery('/foo.js?bar=1&t=1712345678901')).toBe(
+      '/foo.js?bar=1',
+    )
+    expect(removeTimestampQuery('/foo.js?bar=1&t=1712345678901&baz=2')).toBe(
+      '/foo.js?bar=1&baz=2',
+    )
+  })
+
+  test('does not strip params with names ending in hyphen-t', () => {
+    expect(removeTimestampQuery('/foo.js?current-t=1712345678901')).toBe(
+      '/foo.js?current-t=1712345678901',
+    )
+    expect(removeTimestampQuery('/foo.js?my-t=1712345678901&other=1')).toBe(
+      '/foo.js?my-t=1712345678901&other=1',
+    )
+    expect(removeTimestampQuery('/foo.js#t=1712345678901')).toBe(
+      '/foo.js#t=1712345678901',
+    )
   })
 })
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -338,9 +338,9 @@ export function injectQuery(url: string, queryToInject: string): string {
   return `${normalizedFile}?${queryToInject}${postfix[0] === '?' ? `&${postfix.slice(1)}` : /* hash only */ postfix}`
 }
 
-const timestampRE = /\bt=\d{13}&?\b/
+const timestampRE = /(\?|&)t=\d{13}(?:&|$)/
 export function removeTimestampQuery(url: string): string {
-  return url.replace(timestampRE, '').replace(trailingSeparatorRE, '')
+  return url.replace(timestampRE, '$1').replace(trailingSeparatorRE, '')
 }
 
 export async function asyncReplace(


### PR DESCRIPTION
## Summary

Matches the `t=\d{13}` timestamp query parameter using explicit query delimiters (`?` / `&`) rather than generic `\b` word boundaries in `removeTimestampQuery()`, preventing accidental corruption of user query parameters whose names end in a hyphen (e.g. `request-t=1712345678901`, `event-t=...`).

## Motivation & Root Cause

`removeTimestampQuery()` previously defined `timestampRE` as:
```ts
const timestampRE = /\bt=\d{13}&?\b/
```
In JavaScript RegExp, the hyphen `-` is a non-word character (`\W`), which means a word boundary `\b` exists between `-` and `t`. If an application or plugin passes URLs with query parameters like `?request-t=1712345678901&foo=1`, `removeTimestampQuery()` stripped `t=1712345678901&`, corrupting the URL into `?request-foo=1`.

This function is used across `moduleGraph.ts`, `transformRequest.ts`, `server/send.ts`, and middleware when resolving and normalizing module IDs and URLs.

## Changes

- Update `timestampRE` in `packages/vite/src/node/utils.ts` to `/(\?|&)t=\d{13}(?:&|$)/`, aligning with the delimiter matching pattern used by `rawRE` and `urlRE`.
- Replace with `$1` followed by trailing separator cleanup.
- Add regression test suite in `packages/vite/src/node/__tests__/utils.spec.ts`.

## Verification

- `pnpm test-unit`: **67/67 test files pass (967 tests passed)**.
- `pnpm build`: Clean.
- `pnpm lint`: Clean.
