### PR TITLE
docs: correct anchor scroll offset after dismissing top banner

### DIFF
--- a/docs/.vitepress/theme/components/TopBanner.vue
+++ b/docs/.vitepress/theme/components/TopBanner.vue
@@ -176,11 +176,28 @@ function dismiss() {
 
 @media (min-width: 768px) {
   .top-banner {
-    --vp-banner-height: 40px;
+    --vp-banner-height: var(--top-banner-height);
   }
 
   :root:has(.top-banner):not(.banner-dismissed) {
-    --vp-banner-height: 40px;
+    --vp-banner-height: var(--top-banner-height);
+  }
+}
+
+:root:has(.top-banner) {
+  --top-banner-height: 40px;
+}
+
+/* When the banner is dismissed the fixed header moves up by the banner
+   height, so tighten the anchor scroll offset by the same amount to keep
+   the landing position visually identical. .top-banner stays in the DOM
+   (hidden) after dismissal, so :has() still matches. */
+@media (min-width: 1024px) {
+  :root:has(.top-banner).banner-dismissed .vp-doc :is(h1, h2, h3, h4, h5, h6) {
+    scroll-margin-top: calc(
+      var(--vp-nav-height) + var(--vp-layout-top-height, 0px) + 24px -
+        var(--top-banner-height)
+    );
   }
 }
 </style>


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
<img width="545" height="73" alt="image" src="https://github.com/user-attachments/assets/cd288dcf-1790-4f58-aac5-4cf20224a62a" />

After the top banner is closed, clicking the link in the right sidebar redirects back, causing the page title to be slightly misaligned.