### PR TITLE
docs: remove outdated locale links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,10 +107,8 @@ const config = defineConfig({
     zh: { label: '简体中文', link: 'https://cn.vite.dev' },
     ja: { label: '日本語', link: 'https://ja.vite.dev' },
     es: { label: 'Español', link: 'https://es.vite.dev' },
-    pt: { label: 'Português', link: 'https://pt.vite.dev' },
     ko: { label: '한국어', link: 'https://ko.vite.dev' },
     de: { label: 'Deutsch', link: 'https://de.vite.dev' },
-    fa: { label: 'فارسی', link: 'https://fa.vite.dev' },
   },
 
   themeConfig: {


### PR DESCRIPTION
We've redirected `pt.vite.dev` and `fa.vite.dev` back to `vite.dev` as they haven't been updated a while. This PR removes their links.

I've kept the links in the blog post as I _think_ it's worth knowing the translations we had when we published the blog post? 