### PR TITLE
revert: narrow semantic-pull-request triggers

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -7,7 +7,7 @@ on:
   # - Only PR title is read
   # - No PR-supplied code is executed
   pull_request_target:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   main:


### PR DESCRIPTION
reverts #23335

Apparently since this is a required status check, it needs to run on the latest commit, so it needs the `synchronize` trigger. Don't think there's a way to make it required based on the last check. So reverting for now.

I kept the `reopened` trigger as the PR title could be changed before re-opening.

ref: https://github.com/vitejs/vite/pull/23356 the required check is stucked pending