### PR TITLE
fix(hmr): preserve explicit 0 websocket timeout and port

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -82,7 +82,7 @@ async function createClientConfigValueReplacer(
   const wsConfig = isObject(config.server.ws) ? config.server.ws : undefined
   const host = wsConfig?.host || null
   const protocol = wsConfig?.protocol || null
-  const timeout = wsConfig?.timeout || 30000
+  const timeout = wsConfig?.timeout ?? 30000
   const isWsServerSpecified = !!wsConfig?.server
   const hmrConfigName = path.basename(config.configFile || 'vite.config.js')
 

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -159,7 +159,7 @@ export function createWebSocketServer(
   ) => void
   const customListeners = new Map<string, Set<WebSocketCustomListener<any>>>()
   const clientsMap = new WeakMap<WebSocketRaw, WebSocketClient>()
-  const port = wsPort || 24678
+  const port = wsPort ?? 24678
   const host = wsOptions?.host || undefined
   const allowedHosts =
     config.server.allowedHosts === true

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -317,11 +317,14 @@ export const createWebSocketModuleRunnerTransport = (options: {
 
       // proxy(nginx, docker) hmr ws maybe caused timeout,
       // so send ping package let ws keep alive.
-      pingIntervalId = setInterval(() => {
-        if (socket.readyState === socket.OPEN) {
-          socket.send(JSON.stringify({ type: 'ping' }))
-        }
-      }, pingInterval)
+      // pingInterval 0 disables keep-alive pings (timeout: 0 is a valid config).
+      if (pingInterval > 0) {
+        pingIntervalId = setInterval(() => {
+          if (socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify({ type: 'ping' }))
+          }
+        }, pingInterval)
+      }
     },
     disconnect() {
       clearInterval(pingIntervalId)


### PR DESCRIPTION
### Description

`server.ws.timeout` and `server.ws.port` are typed as `number`, but both defaults used `||`, so an explicit `0` was treated as missing.

- `timeout || 30000` made `server.ws.timeout: 0` inject `30000` into the client as `__HMR_TIMEOUT__` (the HMR keep-alive ping interval).
- `wsPort || 24678` made `listen(0)` (OS-assigned port) in middleware mode become `listen(24678)`.

This switches those defaults to `??`. `createWebSocketModuleRunnerTransport` already uses `pingInterval ?? 30000`; with `timeout: 0` now reaching the transport, it also skips `setInterval` when the interval is `0` so keep-alive pings can be disabled without a `setInterval(..., 0)` busy loop. That matches the invoke path in the same file (`if (timeout > 0)`).

### Tests

No new unit test. The timeout/port values are string-replaced into the client bundle, and the ping-interval guard needs a live `WebSocket`. Happy to add a playground or mock-based test if you want one.

### How this was found

While benchmarking an OSS AST checker that flags `||` defaults on numeric config (explicit `0` discarded), these two sites were the leftover hits in Vite. Same family as [goreleaser#6813](https://github.com/goreleaser/goreleaser/pull/6813).

Made with [Cursor](https://cursor.com)