### PR TITLE
fix(config): don't unescape glob characters in Windows input paths

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1249,7 +1249,9 @@ describe('resolveConfig', () => {
     }
   })
 
-  test('support escaped input', async () => {
+  // On Windows, backslash is the path separator, so glob characters cannot
+  // be escaped with a backslash in input paths.
+  test.skipIf(isWindows)('support escaped input', async () => {
     const cases: {
       name: string
       input: UserConfig['input']
@@ -1299,6 +1301,59 @@ describe('resolveConfig', () => {
               name: 'windows path',
               input: 'src\\foo.ts',
               expected: 'src\\foo.ts',
+            },
+          ]
+        : []),
+    ]
+
+    for (const { name, input, expected } of cases) {
+      await expect(
+        resolveConfig({ input }, 'serve'),
+        name,
+      ).resolves.toMatchObject({
+        input: expected,
+      })
+    }
+  })
+
+  // https://github.com/vitejs/vite/issues/23383
+  test('preserves Windows input paths with glob-special segment names', async () => {
+    const cases: {
+      name: string
+      input: UserConfig['input']
+      expected: UserConfig['input']
+    }[] = [
+      ...(isWindows
+        ? [
+            {
+              name: 'segment starting with @',
+              input: 'D:\\desk\\test\\@src\\whatever.html',
+              expected: 'D:\\desk\\test\\@src\\whatever.html',
+            },
+            {
+              name: 'segment starting with !',
+              input: 'D:\\desk\\test\\!notes\\page.html',
+              expected: 'D:\\desk\\test\\!notes\\page.html',
+            },
+            {
+              name: 'segment starting with +',
+              input: 'D:\\desk\\test\\+draft\\page.html',
+              expected: 'D:\\desk\\test\\+draft\\page.html',
+            },
+            {
+              name: 'segment starting with (',
+              input: 'D:\\desk\\test\\(draft)\\page.html',
+              expected: 'D:\\desk\\test\\(draft)\\page.html',
+            },
+            {
+              name: 'segment starting with [',
+              input: 'D:\\desk\\test\\[id]\\page.html',
+              expected: 'D:\\desk\\test\\[id]\\page.html',
+            },
+            {
+              name: 'relative path',
+              input: 'test\\@src\\whatever.html',
+              expected: 'test\\@src\\whatever.html',
             },
           ]
         : []),

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -33,7 +33,7 @@ import {
   createImportMetaResolver,
   importMetaResolveWithCustomHookString,
 } from '../module-runner/importMetaResolver'
-import { withTrailingSlash } from '../shared/utils'
+import { isWindows, withTrailingSlash } from '../shared/utils'
 import type { AnymatchFn } from '../types/anymatch'
 import type { HtmlAssetSource } from './assetSource'
 import { PartialEnvironment } from './baseEnvironment'
@@ -954,6 +954,11 @@ function unescapeGlobCharacters(value: string): string {
       `\`input\` cannot contain glob characters. They are reserved, ` +
         `so the ${JSON.stringify(value)} is not allowed. Please escape them with a backslash (\\)`,
     )
+  }
+  // On Windows, backslash is the path separator, so it must not be treated
+  // as an escape character for glob characters (#23383).
+  if (isWindows) {
+    return value
   }
   // unescape glob characters
   return value.replace(escapedGlobCharactersRE, '$1')


### PR DESCRIPTION
## Description

Fixes #23383.

Top-level `input` paths are normalized through `unescapeGlobCharacters`, which unescapes glob characters reserved for future glob support (`\@` → `@`, `\[` → `[`, …). On Windows, backslash is the path separator, so any path segment starting with one of `*?[]{}()!+@|` was corrupted: `D:\desk\test\@src\whatever.html` became `D:\desk\test@src\whatever.html`, and the dependency scan failed with `failed to resolve rolldownOptions.input value`.

### Root cause

`normalizeInput` ran `value.replace(/\\([*?[\]{}()!+@|])/g, '$1')` unconditionally. On POSIX, `\` only appears as an escape character in `input`, so the unescape is correct. On Windows, every `\` is a path separator, and `\@` (separator + `@`-segment) was wrongly treated as an escaped `@`.

### Change

Skip the unescape on Windows. Backslash is always a path separator there, and the glob characters that are legal in Windows filenames (`[`, `]`, `(`, `)`, `!`, `+`, `@`) no longer need unescaping — `isDynamicPattern` already treats `\[` etc. as escaped, so they pass the glob check and are now preserved as-is.

The `support escaped input` test is now POSIX-only (`test.skipIf(isWindows)`), since escaping glob characters with a backslash is inherently incompatible with Windows path separators.

### Validation

- New Windows-gated regression cases in `config.spec.ts` (segments starting with `@`, `!`, `+`, `(`, `[`, plus a relative path).
- Verified locally against the real `tinyglobby` `isDynamicPattern`: on current `main` all Windows path variants are corrupted (RED); with this fix they are preserved (GREEN), and POSIX escaped-glob behavior (`src/\*.ts` → `src/*.ts`) is unchanged.
- `config.spec.ts`: 109/109 pass. ESLint/oxfmt clean.