### PR TITLE
chore: fix ts-check comment ordering

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,8 +6,7 @@
   "sortImports": {
     "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
     "partitionByNewline": true,
-    "newlinesBetween": false,
-    "partitionByComment": true
+    "newlinesBetween": false
   },
   "overrides": [
     {

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,7 +6,8 @@
   "sortImports": {
     "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
     "partitionByNewline": true,
-    "newlinesBetween": false
+    "newlinesBetween": false,
+    "partitionByComment": true
   },
   "overrides": [
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 // @ts-check
+
 import eslint from '@eslint/js'
 import pluginImportX from 'eslint-plugin-import-x'
 import pluginN from 'eslint-plugin-n'


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
https://oxc.rs/docs/guide/usage/formatter/config-file-reference.html#sortimports-partitionbycomment

https://github.com/vitejs/vite/blob/ee644014aab61e546742b862a7d7b0d6c7d67a7b/eslint.config.js#L2-L3
After swapping the second and third lines and running `pnpm format`, the third line becomes the first line, before the comment `// @ts-check`.