### PR TITLE
fix(utils): strip timestamp query when followed by a hash

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -221,6 +221,15 @@ describe('removeTimestampQuery', () => {
       '/foo.js#t=1712345678901',
     )
   })
+
+  test('removes timestamp query parameter followed by a hash', () => {
+    expect(removeTimestampQuery('/icon.svg?t=1712345678901#shape')).toBe(
+      '/icon.svg#shape',
+    )
+    expect(removeTimestampQuery('/icon.svg?import&t=1712345678901#shape')).toBe(
+      '/icon.svg?import#shape',
+    )
+  })
 })
 
 describe('resolveHostname', () => {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -338,7 +338,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   return `${normalizedFile}?${queryToInject}${postfix[0] === '?' ? `&${postfix.slice(1)}` : /* hash only */ postfix}`
 }
 
-const timestampRE = /(\?|&)t=\d{13}(?:&|$)/
+const timestampRE = /(\?|&)t=\d{13}&|[?&]t=\d{13}(?=#|$)/
 export function removeTimestampQuery(url: string): string {
   return url.replace(timestampRE, '$1').replace(trailingSeparatorRE, '')
 }


### PR DESCRIPTION
`removeTimestampQuery()` stops stripping the `?t=<13-digit>` HMR query when the URL also has a hash fragment, so the timestamp leaks into the module graph.

`utils.ts:341`'s terminator `(?:&|$)` accepts `&` or end-of-string but never `#`. This is a regression from #23364: the previous `/\bt=\d{13}&?\b/` matched before a `#` because of the word boundary.

It is the inverse of `injectQuery()`, which has a dedicated hash-only branch and emits exactly `file?t=<ms>#frag`, so the round trip no longer round-trips.

Against a dev server with `import iconUrl from './icon.svg#shape'`, the module-graph URL after an asset update is `/icon.svg?t=1787868494725#shape` instead of `/icon.svg#shape`. A new module-graph node is created on every HMR update of that asset, and `transformRequest.ts:502`'s `importedMod.url !== moduleUrl` check never matches. Fragment URLs are a normal shape here - SVG sprites and `#iefix` fonts - and the playgrounds use them.

The fix only changes the terminator; `\d{13}` preceded by `?` or `&` still defines a timestamp. A differential over old and new across query shapes differs on exactly one class, a 13-digit `t=` followed by a hash: `current-t=`, `my-t=`, 12- and 14-digit values, `#t=`, duplicate timestamps and `?raw&import` are all untouched.

Worth noting #22343 was closed as expected behaviour for widening `\d{13}` to `\w+`; this does not widen what counts as a timestamp.

Test added to the existing `removeTimestampQuery` block. The `utils` suite goes 124 to 125 passing.
