### PR TITLE
fix(server): queue follow-up restart if requested during in-flight restart (fix #23392)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/hooks.spec.ts
@@ -581,6 +581,33 @@ describe('closeServer hook', () => {
 
     await server.close()
   })
+
+  test('queues and runs follow-up restart if requested while restart is in flight', async () => {
+    let restartCount = 0
+    const server = await createServerWithPlugin({
+      name: 'test-restart-race',
+      async config() {
+        restartCount++
+        // simulate slow plugin startup to ensure race window
+        await new Promise((r) => setTimeout(r, 50))
+      },
+    })
+
+    // restartCount is 1 from initial createServer
+    expect(restartCount).toBe(1)
+
+    // Trigger restart 1
+    const p1 = server.restart()
+    // Trigger restart 2 while restart 1 is in flight
+    const p2 = server.restart()
+
+    await Promise.all([p1, p2])
+
+    // restartCount should be 3: 1 (init) + 1 (first restart) + 1 (follow-up restart)
+    expect(restartCount).toBe(3)
+
+    await server.close()
+  })
 })
 
 describe('closePreviewServer hook', () => {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -476,6 +476,10 @@ export interface ViteDevServer {
   /**
    * @internal
    */
+  _pendingRestart?: boolean
+  /**
+   * @internal
+   */
   _shortcutsState?: ShortcutsState<ViteDevServer>
   /**
    * @internal
@@ -517,6 +521,7 @@ export async function _createServer(
     previousShortcutsState?: ShortcutsState<ViteDevServer>
     previousRestartPromise?: Promise<void> | null
     previousForceOptimizeOnRestart?: boolean
+    previousPendingRestart?: boolean
   },
 ): Promise<ViteDevServer> {
   // The dev server is a long-running, interactive process whose outputs
@@ -840,12 +845,26 @@ export async function _createServer(
       bindCLIShortcuts(server, options)
     },
     async restart(forceOptimize?: boolean) {
+      if (forceOptimize) {
+        server._forceOptimizeOnRestart = true
+      }
       if (!server._restartPromise) {
         server._forceOptimizeOnRestart = !!forceOptimize
-        server._restartPromise = restartServer(server).finally(() => {
+        server._restartPromise = (async () => {
+          while (true) {
+            server._pendingRestart = false
+            await restartServer(server)
+            if (!server._pendingRestart) {
+              break
+            }
+          }
+        })().finally(() => {
           server._restartPromise = null
           server._forceOptimizeOnRestart = false
+          server._pendingRestart = false
         })
+      } else {
+        server._pendingRestart = true
       }
       return server._restartPromise
     },
@@ -867,6 +886,7 @@ export async function _createServer(
     },
     _restartPromise: options.previousRestartPromise ?? null,
     _forceOptimizeOnRestart: options.previousForceOptimizeOnRestart ?? false,
+    _pendingRestart: options.previousPendingRestart ?? false,
     _shortcutsState: options.previousShortcutsState,
   }
 
@@ -1408,6 +1428,7 @@ async function restartServer(server: ViteDevServer) {
         previousShortcutsState: server._shortcutsState,
         previousRestartPromise: server._restartPromise,
         previousForceOptimizeOnRestart: server._forceOptimizeOnRestart,
+        previousPendingRestart: server._pendingRestart,
       })
     } catch (err: any) {
       server.config.logger.error(err.message, {
@@ -1428,7 +1449,13 @@ async function restartServer(server: ViteDevServer) {
     const middlewares = server.middlewares
     newServer._configServerPort = server._configServerPort
     newServer._currentServerPort = server._currentServerPort
+    const restartPromise = server._restartPromise
+    const pendingRestart = server._pendingRestart
+    const forceOptimizeOnRestart = server._forceOptimizeOnRestart
     Object.assign(server, newServer)
+    server._restartPromise = restartPromise
+    server._pendingRestart = pendingRestart
+    server._forceOptimizeOnRestart = forceOptimizeOnRestart
 
     // Keep the same connect instance so app.use(vite.middlewares) works
     // after a restart in middlewareMode (.route is always '/')


### PR DESCRIPTION
### Description

fixes #23392

When a config/env change lands while `restartServer` is in flight (e.g. fast consecutive edits or switching branches with `git checkout`), `server.restart()` returns the active `_restartPromise` directly without scheduling a follow-up restart once the current one completes. As a result, the server stays running the previous config snapshot.

This PR adds an internal `_pendingRestart` flag to `server.restart()` so that if another restart request arrives while a restart is in flight, `restartServer` loops until no pending requests remain before resolving the promise.

Added a test case in `hooks.spec.ts` covering concurrent `server.restart()` calls.