### PR TITLE
docs(config): fix wording and terminology

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -86,7 +86,7 @@ Specify the output directory (relative to [project root](/guide/#index-html-and-
 - **Type:** `string`
 - **Default:** `assets`
 
-Specify the directory to nest generated assets under (relative to `build.outDir`. This is not used in [Library Mode](/guide/build#library-mode)).
+Specify the directory to nest generated assets under (relative to `build.outDir`). This is not used in [Library Mode](/guide/build#library-mode).
 
 ## build.assetsInlineLimit
 
@@ -127,7 +127,7 @@ When `build.cssMinify` is `'lightningcss'` (the default), this option takes prec
 
 It should only be used when you are targeting a non-mainstream browser.
 One example is Android WeChat WebView, which supports most modern JavaScript features but not the [`#RGBA` hexadecimal color notation in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors).
-In this case, you need to set `build.cssTarget` to `chrome61` to prevent vite from transforming `rgba()` colors into `#RGBA` hexadecimal notations.
+In this case, you need to set `build.cssTarget` to `chrome61` to prevent Vite from transforming `rgba()` colors into `#RGBA` hexadecimal notations.
 
 ## build.cssMinify
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -30,7 +30,7 @@ By default, Vite uses [Rolldown](https://rolldown.rs/) to bundle the config into
 
 ## Config Intellisense
 
-Since Vite ships with TypeScript typings, you can leverage your IDE's intellisense with jsdoc type hints:
+Since Vite ships with TypeScript typings, you can leverage your IDE's intellisense with JSDoc type hints:
 
 ```js
 /** @type {import('vite').UserConfig} */
@@ -39,7 +39,7 @@ export default {
 }
 ```
 
-Alternatively, you can use the `defineConfig` helper which should provide intellisense without the need for jsdoc annotations:
+Alternatively, you can use the `defineConfig` helper which should provide intellisense without the need for JSDoc annotations:
 
 ```js
 import { defineConfig } from 'vite'


### PR DESCRIPTION
- Corrects a missing closing parenthesis in `build.assetsDir`.
- Uses the proper `Vite` product name.
- Uses the standard `JSDoc` capitalization.