### PR TITLE
test(node): add unit tests for setupRollupOptionCompat proxy logic

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -29,6 +29,7 @@ import {
   removeTimestampQuery,
   resolveHostname,
   resolveServerUrls,
+  setupRollupOptionCompat,
 } from '../utils'
 
 // Test certificate for SAN parsing (localhost, foo.localhost, *.vite.localhost)
@@ -1283,5 +1284,30 @@ describe('resolveServerUrls', () => {
 
     expect(result.network).toStrictEqual(['http://10.0.0.5:3000/'])
     expect(result.networkInterfaceNames).toStrictEqual([undefined])
+  })
+})
+
+describe('setupRollupOptionCompat', () => {
+  test('proxies rollupOptions to rolldownOptions', () => {
+    const config = { rollupOptions: { input: 'index.html' } }
+    setupRollupOptionCompat(config as any, 'optimizeDeps')
+    expect((config as any).rolldownOptions).toBeDefined()
+    expect((config as any).rolldownOptions.input).toBe('index.html')
+
+    // accessing rollupOptions should return rolldownOptions
+    const opts = (config as any).rollupOptions
+    expect(opts.input).toBe('index.html')
+  })
+
+  test('prioritizes rolldownOptions if both are present', () => {
+    const config = {
+      rollupOptions: { input: 'index.html' },
+      rolldownOptions: { input: 'main.html' },
+    }
+    setupRollupOptionCompat(config as any, 'optimizeDeps')
+    expect((config as any).rolldownOptions.input).toBe('main.html')
+
+    const opts = (config as any).rollupOptions
+    expect(opts.input).toBe('main.html')
   })
 })


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
### What is this PR solving? 
This PR adds a previously missing unit test for the `setupRollupOptionCompat` utility function, introduced for the `rollupOptions` migration in Vite 8. This ensures that the backward-compatibility proxy logic correctly switches to `rolldownOptions` and prioritizes `rolldownOptions` when both are available, preventing future regressions.

###  What other alternatives have you explored?
N/A

###  Are there any parts you think require more attention from reviewers?
It is not necessary, as the test proceeded smoothly without any side effects.