### PR TITLE
fix(asset): escape glob characters in dynamic `new URL` paths

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/assetImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/assetImportMetaUrl.spec.ts
@@ -57,6 +57,24 @@ describe('assetImportMetaUrlPlugin', async () => {
     )
   })
 
+  test('escape glob characters in the static parts', async () => {
+    expect(
+      await transform('new URL(`./foo(1)/${file}.js`, import.meta.url)'),
+    ).toMatchInlineSnapshot(
+      `"new URL((import.meta.glob("./foo\\\\(1\\\\)/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo(1)/\${file}.js\`], import.meta.url)"`,
+    )
+    expect(
+      await transform('new URL(`./foo/bar[1].${ext}`, import.meta.url)'),
+    ).toMatchInlineSnapshot(
+      `"new URL((import.meta.glob("./foo/bar\\\\[1\\\\].*", {"eager":true,"import":"default","query":"?url"}))[\`./foo/bar[1].\${ext}\`], import.meta.url)"`,
+    )
+    expect(
+      await transform('new URL(`./foo/{a,b}/${file}.js`, import.meta.url)'),
+    ).toMatchInlineSnapshot(
+      `"new URL((import.meta.glob("./foo/\\\\{a,b\\\\}/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/{a,b}/\${file}.js\`], import.meta.url)"`,
+    )
+  })
+
   test('ignore starting with a variable', async () => {
     expect(
       await transform('new URL(`${file}.js`, import.meta.url)'),

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import MagicString from 'magic-string'
 import { exactRegex } from 'rolldown/filter'
 import { stripLiteral } from 'strip-literal'
+import { escapePath } from 'tinyglobby'
 import { slash } from '../../shared/utils'
 import type { ResolvedConfig } from '../config'
 import { CLIENT_ENTRY } from '../constants'
@@ -185,7 +186,9 @@ function buildGlobPattern(ast: any) {
   for (let i = 0; i < ast.quasis.length; i++) {
     const str = ast.quasis[i].value.raw
     if (str) {
-      pattern += str
+      // the static parts are plain paths, so glob characters in them
+      // (e.g. a `foo(1)` directory) have to be escaped
+      pattern += escapePath(str)
       lastIsGlob = false
     }
 


### PR DESCRIPTION
### Problem

`buildGlobPattern` in `assetImportMetaUrl.ts` builds the `import.meta.glob` pattern for a dynamic `new URL()` by concatenating the template's static parts verbatim and replacing each `${...}` with `*`. The static parts are plain paths, so any glob character in a directory or file name is interpreted as pattern syntax. The glob then matches nothing, and the emitted code indexes an empty object, so the browser gets `new URL(undefined, import.meta.url)`.

Repro — a project with `src/icons(v2)/a.svg` and:

```js
const url = new URL(`./icons(v2)/${name}.svg`, import.meta.url)
```

`vite dev`, request `/src/main.js`:

```js
const url = new URL((/* #__PURE__ */ Object.assign({}))[`./icons(v2)/${name}.svg`], import.meta.url)
```

`url.href` ends up as `http://localhost:5201/src/undefined`, so the asset 404s and nothing warns. Renaming the directory to `icons` makes the same code emit `Object.assign({"./icons/a.svg": __vite_glob_0_0})`, which works, so the only difference is the parentheses. Build mode goes through the same function and emits the same empty object.

The `import()` equivalent in the same project is already correct — `import(`./icons(v2)/${name}.svg?url`)` emits both files — because `dynamicImportVars` goes through `@rollup/plugin-dynamic-import-vars`, which runs every static part through `escapePath` before concatenating. `buildGlobPattern` is a hand-rolled copy of that loop and skips the escaping step.

### Fix

Run the static parts through tinyglobby's `escapePath`, matching what `@rollup/plugin-dynamic-import-vars` does and what `globSafePath` in `importMetaGlob.ts` already does elsewhere in Vite. The `*` we insert ourselves for each expression is unaffected, and the glob's result keys are still real file paths, so the runtime lookup key is unchanged.

After the fix, the same request returns:

```js
import { default as __vite_glob_0_0 } from "/src/icons(v2)/a.svg?import&url";
const url = new URL((/* #__PURE__ */ Object.assign({"./icons(v2)/a.svg": __vite_glob_0_0, ...}))[`./icons(v2)/${name}.svg`], import.meta.url)
```

`vite build` on the same project emits the asset at `dist/assets/icons(v2)/a.svg` and references it correctly.

### Tests

Added a case to `assetImportMetaUrl.spec.ts` covering `()`, `[]` and `{}`. It fails on `main` (`"./foo(1)/*.js"` vs the expected `"./foo\(1\)/*.js"`) and passes with the fix. Those three characters are escaped identically by `escapePath` on POSIX and win32, so the snapshots are platform-stable.

I did not add a playground case. My first attempt reused the existing `nested/asset[small].png` fixture, but that one passes with and without the fix — tinyglobby tolerates the unescaped brackets — so it was not covering anything. Covering it properly needs a new fixture with parentheses in the name, which I left out to keep the diff small; happy to add one if you'd prefer the e2e coverage.

`pnpm test-unit` and `pnpm typecheck` pass. Two pre-existing failures on my machine are unrelated to this change and also occur on a clean `main` checkout: `config.spec.ts > resolves a symlinked root to its real path`, and `eslint` parse errors on `playground/preserve-symlinks/module-a/linked.js` and `playground/ssr-wasm/src/imports.js` (symlinks checked out as text stubs on Windows).

### AI disclosure

I used an AI assistant while investigating. It helped me search the plugin directory and pointed at `buildGlobPattern` as a place where a path is spliced into a glob. I verified the claim myself before writing any code: I built the repro project above, reproduced the empty `Object.assign({})` against an unmodified build, confirmed the `import()` control case works in the same project, read `@rollup/plugin-dynamic-import-vars`' `sanitizeString` to confirm escaping is the established fix, and then re-ran the repro and the unit tests against the patched build. I also discarded the playground test described above once I measured that it passed without the fix. The wording here is mine.
