### PR TITLE
fix(deps): watch asset files in linked optimized dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -272,6 +272,10 @@ export interface DepOptimizationMetadata {
    * OptimizedDepInfo list
    */
   depInfoList: OptimizedDepInfo[]
+  /**
+   * Directories and files to watch for changes
+   */
+  watchFiles?: string[]
 }
 
 /**
@@ -728,6 +732,29 @@ export function runOptimizeDeps(
           }
         }
 
+        // Gather directories of linked monorepo packages to watch for changes
+        metadata.watchFiles ??= []
+        for (const depInfo of Object.values(metadata.optimized)) {
+          if (depInfo.src) {
+            try {
+              const realPath = fs.realpathSync(depInfo.src)
+              if (!realPath.includes('node_modules')) {
+                const pkgPath = lookupFile(path.dirname(realPath), [
+                  'package.json',
+                ])
+                if (pkgPath) {
+                  const pkgDir = path.dirname(pkgPath)
+                  if (!metadata.watchFiles.includes(pkgDir)) {
+                    metadata.watchFiles.push(pkgDir)
+                  }
+                }
+              }
+            } catch (_e) {
+              // Ignore
+            }
+          }
+        }
+
         clearTimeout(bundleTimer)
 
         debug?.(
@@ -1014,15 +1041,22 @@ function parseDepsOptimizerMetadata(
   jsonMetadata: string,
   depsCacheDir: string,
 ): DepOptimizationMetadata | undefined {
-  const { hash, lockfileHash, configHash, browserHash, optimized, chunks } =
-    JSON.parse(jsonMetadata, (key: string, value: string) => {
-      // Paths can be absolute or relative to the deps cache dir where
-      // the _metadata.json is located
-      if (key === 'file' || key === 'src') {
-        return normalizePath(path.resolve(depsCacheDir, value))
-      }
-      return value
-    })
+  const {
+    hash,
+    lockfileHash,
+    configHash,
+    browserHash,
+    optimized,
+    chunks,
+    watchFiles,
+  } = JSON.parse(jsonMetadata, (key: string, value: string) => {
+    // Paths can be absolute or relative to the deps cache dir where
+    // the _metadata.json is located
+    if (key === 'file' || key === 'src') {
+      return normalizePath(path.resolve(depsCacheDir, value))
+    }
+    return value
+  })
   if (
     !chunks ||
     Object.values(optimized).some((depInfo: any) => !depInfo.fileHash)
@@ -1039,6 +1073,7 @@ function parseDepsOptimizerMetadata(
     discovered: {},
     chunks: {},
     depInfoList: [],
+    watchFiles: watchFiles || [],
   }
   for (const id of Object.keys(optimized)) {
     addOptimizedDepInfo(metadata, 'optimized', {
@@ -1068,14 +1103,22 @@ function stringifyDepsOptimizerMetadata(
   metadata: DepOptimizationMetadata,
   depsCacheDir: string,
 ) {
-  const { hash, configHash, lockfileHash, browserHash, optimized, chunks } =
-    metadata
+  const {
+    hash,
+    configHash,
+    lockfileHash,
+    browserHash,
+    optimized,
+    chunks,
+    watchFiles,
+  } = metadata
   return JSON.stringify(
     {
       hash,
       configHash,
       lockfileHash,
       browserHash,
+      watchFiles,
       optimized: Object.fromEntries(
         Object.values(optimized).map(
           ({ id, src, file, fileHash, needsInterop, isDynamicEntry }) => [

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -271,6 +271,11 @@ export class DevEnvironment extends BaseEnvironment {
   async listen(server: ViteDevServer): Promise<void> {
     this.hot.listen()
     await Promise.all([this.bundledDev?.listen(), this.depsOptimizer?.init()])
+
+    if (this.depsOptimizer?.metadata.watchFiles) {
+      server.watcher.add(this.depsOptimizer.metadata.watchFiles)
+    }
+
     warmupFiles(server, this)
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -903,8 +903,34 @@ export async function _createServer(
     }
   }
 
+  const checkOptimizedDepSource = async (file: string) => {
+    let isOptimizedDepSource = false
+    for (const environment of Object.values(server.environments)) {
+      if (
+        environment.depsOptimizer?.metadata.watchFiles?.some(
+          (id) => file === id || file.startsWith(id + '/'),
+        )
+      ) {
+        isOptimizedDepSource = true
+        break
+      }
+    }
+    if (isOptimizedDepSource) {
+      server.config.logger.info(
+        colors.green(
+          `optimized dependency source changed, restarting server...`,
+        ),
+        { clear: true, timestamp: true },
+      )
+      await server.restart(true)
+      return true
+    }
+    return false
+  }
+
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
+    if (await checkOptimizedDepSource(file)) return
     reloadOnTsconfigChange(server, file)
 
     await Promise.all(
@@ -943,6 +969,7 @@ export async function _createServer(
 
   const onFileChange = async (file: string) => {
     file = normalizePath(file)
+    if (await checkOptimizedDepSource(file)) return
     reloadOnTsconfigChange(server, file)
 
     await Promise.all(


### PR DESCRIPTION


<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->

fixes: #14099 

### What?
This PR fixes a long-standing issue where changing asset files (such as `.css`, `.html`, or `.json`) inside a linked optimized dependency (e.g., using `npm link` or `pnpm workspace`) does not trigger a server reload or HMR.

**What was changed:**
Previously, `optimizer/index.ts` only pushed individual javascript `chunk.moduleIds` to `metadata.watchFiles`. This caused asset files adjacent to those modules to be ignored by the `chokidar` watcher.
In this PR, we gather the resolved parent directories of optimized dependencies (up to their `package.json`) and push these directories into `metadata.watchFiles`. We also updated `checkOptimizedDepSource` in `server/index.ts` to use `.startsWith()` instead of strict equality so it can catch any file modifications within those linked directories. `watchFiles` is also now safely serialized in `_metadata.json` for cache integrity.

**Why tests are not included:**
An automated test for this was attempted in `playground/optimize-deps`. However, editing a linked package's file (e.g., `dep-linked-include/test.css`) directly in the source tree violates the `playground-temp` test isolation, causing race conditions and flaky failures when running the full test suite in parallel. Thus, this fix is intended to be tested manually or handled via Vite's core E2E suite without explicit git-workspace file mutations.

## Motivation and Context
Improves DX significantly for monorepo and library developers relying on local symlinks, ensuring that style and asset changes propagate instantly without requiring a manual server restart.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change for internal architecture/code styling)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)