### PR TITLE
fix(server): queue restarts requested during restart (fix #23392)

### DIFF
--- a/packages/vite/src/node/server/__tests__/restart.spec.ts
+++ b/packages/vite/src/node/server/__tests__/restart.spec.ts
@@ -1,0 +1,53 @@
+import { expect, onTestFinished, test } from 'vitest'
+import { promiseWithResolvers } from '../../../shared/utils'
+import { createServer } from '../index'
+
+test('queues one follow-up restart while a restart is in flight', async () => {
+  const restartEntered = promiseWithResolvers<void>()
+  const restartGate = promiseWithResolvers<void>()
+  const forceOptimizeDeps: boolean[] = []
+  let configCalls = 0
+
+  const server = await createServer({
+    configFile: false,
+    root: import.meta.dirname,
+    logLevel: 'silent',
+    server: { middlewareMode: true, ws: false },
+    plugins: [
+      {
+        name: 'restart-during-restart',
+        async config(config) {
+          configCalls++
+          forceOptimizeDeps.push(
+            (config as { forceOptimizeDeps?: boolean }).forceOptimizeDeps ===
+              true,
+          )
+
+          if (configCalls === 2) {
+            restartEntered.resolve()
+            await restartGate.promise
+          }
+        },
+      },
+    ],
+  })
+
+  onTestFinished(async () => {
+    await server.close()
+  })
+
+  const firstRestart = server.restart()
+  await restartEntered.promise
+
+  const queuedRestarts = [
+    server.restart(),
+    server.restart(true),
+    server.restart(),
+  ]
+
+  restartGate.resolve()
+  await Promise.all([firstRestart, ...queuedRestarts])
+
+  expect(configCalls).toBe(3)
+  expect(forceOptimizeDeps).toEqual([false, false, true])
+})

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -472,6 +472,10 @@ export interface ViteDevServer {
   /**
    * @internal
    */
+  _pendingRestart: boolean
+  /**
+   * @internal
+   */
   _forceOptimizeOnRestart: boolean
   /**
    * @internal
@@ -516,6 +520,7 @@ export async function _createServer(
     previousEnvironments?: Record<string, DevEnvironment>
     previousShortcutsState?: ShortcutsState<ViteDevServer>
     previousRestartPromise?: Promise<void> | null
+    previousPendingRestart?: boolean
     previousForceOptimizeOnRestart?: boolean
   },
 ): Promise<ViteDevServer> {
@@ -840,10 +845,23 @@ export async function _createServer(
       bindCLIShortcuts(server, options)
     },
     async restart(forceOptimize?: boolean) {
-      if (!server._restartPromise) {
+      if (server._restartPromise) {
+        server._pendingRestart = true
+        server._forceOptimizeOnRestart ||= !!forceOptimize
+      } else {
+        server._pendingRestart = false
         server._forceOptimizeOnRestart = !!forceOptimize
-        server._restartPromise = restartServer(server).finally(() => {
+        server._restartPromise = (async () => {
+          while (true) {
+            await restartServer(server)
+            if (!server._pendingRestart) {
+              break
+            }
+            server._pendingRestart = false
+          }
+        })().finally(() => {
           server._restartPromise = null
+          server._pendingRestart = false
           server._forceOptimizeOnRestart = false
         })
       }
@@ -866,6 +884,7 @@ export async function _createServer(
       return closeServerPromise
     },
     _restartPromise: options.previousRestartPromise ?? null,
+    _pendingRestart: options.previousPendingRestart ?? false,
     _forceOptimizeOnRestart: options.previousForceOptimizeOnRestart ?? false,
     _shortcutsState: options.previousShortcutsState,
   }
@@ -1407,6 +1426,7 @@ async function restartServer(server: ViteDevServer) {
         previousEnvironments: server.environments,
         previousShortcutsState: server._shortcutsState,
         previousRestartPromise: server._restartPromise,
+        previousPendingRestart: server._pendingRestart,
         previousForceOptimizeOnRestart: server._forceOptimizeOnRestart,
       })
     } catch (err: any) {
@@ -1424,11 +1444,19 @@ async function restartServer(server: ViteDevServer) {
     // restart from a real close.
     await server._closeServer('restart')
 
+    const restartPromise = server._restartPromise
+    const pendingRestart = server._pendingRestart
+    const forceOptimizeOnRestart = server._forceOptimizeOnRestart
+
     // Assign new server props to existing server instance
     const middlewares = server.middlewares
     newServer._configServerPort = server._configServerPort
     newServer._currentServerPort = server._currentServerPort
     Object.assign(server, newServer)
+
+    server._restartPromise = restartPromise
+    server._pendingRestart = pendingRestart
+    server._forceOptimizeOnRestart = forceOptimizeOnRestart
 
     // Keep the same connect instance so app.use(vite.middlewares) works
     // after a restart in middlewareMode (.route is always '/')


### PR DESCRIPTION
fixes #23392

If vite.config changes while a restart is already running, the extra restart gets ignored. We keep serving the old config until the file is touched again.

We remember that a restart was requested, run one more after the current one finishes, and keep that when Vite swaps in the new server.

the restart.spec test holds the first restart, asks for more, and checks that exactly one follow-up runs.

Windows CI failed on a different HMR playground test. This restart test passed.

I used an agent for the first patch. I read the restart queue and the test before opening this.