### PR TITLE
fix: align hook filter globs with Rolldown (fix #21979)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/pluginFilter.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/pluginFilter.spec.ts
@@ -114,6 +114,47 @@ describe('createIdFilter', () => {
       inputFilter: '/virtual/foo',
       cases: [{ id: '/virtual/foo', expected: true }],
     },
+    // Align picomatch with Rolldown: bare `()` are literals, not regex groups.
+    {
+      inputFilter: { include: '**/*.(js)' },
+      cases: [
+        { id: 'foo.js', expected: false },
+        { id: 'src/foo.js', expected: false },
+        { id: 'foo.(js)', expected: true },
+        { id: 'src/foo.(js)', expected: true },
+      ],
+    },
+    {
+      inputFilter: { include: '**/*.(js|ts)' },
+      cases: [
+        { id: 'foo.js', expected: false },
+        { id: 'foo.ts', expected: false },
+        { id: 'foo.(js|ts)', expected: true },
+      ],
+    },
+    {
+      inputFilter: { include: '**/*.@(js|ts)' },
+      cases: [
+        { id: 'foo.js', expected: true },
+        { id: 'foo.ts', expected: true },
+        { id: 'foo.jsx', expected: false },
+      ],
+    },
+    {
+      inputFilter: { include: '**/*.+(js)' },
+      cases: [
+        { id: 'foo.js', expected: true },
+        { id: 'foo.ts', expected: false },
+      ],
+    },
+    {
+      inputFilter: { include: '**/*.{js,ts}' },
+      cases: [
+        { id: 'foo.js', expected: true },
+        { id: 'foo.ts', expected: true },
+        { id: 'foo.jsx', expected: false },
+      ],
+    },
   ]
 
   for (const filter of filters) {

--- a/packages/vite/src/node/plugins/pluginFilter.ts
+++ b/packages/vite/src/node/plugins/pluginFilter.ts
@@ -33,6 +33,61 @@ function getMatcherString(glob: string, cwd: string) {
   return slash(resolved)
 }
 
+const EXTGLOB_PREFIX_CHARS = '@+*?!'
+
+/**
+ * picomatch compiles unescaped `()` as regex capturing groups (and `|` as
+ * alternation), so `*.(js)` matches `foo.js`. Rolldown's `fast_glob` treats
+ * bare `()` as literals. Escape those groups so dev hook filters match
+ * build. Leave extglobs (`@()`, `!()`, `?()`, `+()`, `*()`) unchanged.
+ */
+function escapeBareParentheses(glob: string): string {
+  let result = ''
+  const groupIsExtglob: boolean[] = []
+  let lastWasEscaped = false
+
+  for (let i = 0; i < glob.length; i++) {
+    const char = glob[i]!
+
+    if (char === '\\' && i + 1 < glob.length) {
+      result += char + glob[++i]
+      lastWasEscaped = true
+      continue
+    }
+
+    if (char === '(') {
+      const prev = i > 0 ? glob[i - 1] : undefined
+      const isExtglob =
+        !lastWasEscaped &&
+        prev !== undefined &&
+        EXTGLOB_PREFIX_CHARS.includes(prev)
+      groupIsExtglob.push(isExtglob)
+      result += isExtglob ? '(' : '\\('
+      lastWasEscaped = false
+      continue
+    }
+
+    if (char === ')') {
+      const isExtglob = groupIsExtglob.pop() ?? false
+      result += isExtglob ? ')' : '\\)'
+      lastWasEscaped = false
+      continue
+    }
+
+    if (char === '|') {
+      const insideExtglob = groupIsExtglob.at(-1) === true
+      result += insideExtglob ? '|' : '\\|'
+      lastWasEscaped = false
+      continue
+    }
+
+    result += char
+    lastWasEscaped = false
+  }
+
+  return result
+}
+
 function patternToIdFilter(
   pattern: string | RegExp,
   cwd: string,
@@ -46,7 +101,7 @@ function patternToIdFilter(
     }
   }
 
-  const glob = getMatcherString(pattern, cwd)
+  const glob = escapeBareParentheses(getMatcherString(pattern, cwd))
   const matcher = picomatch(glob, { dot: true })
   return (id: string) => {
     const normalizedId = slash(id)


### PR DESCRIPTION
Fixes #21979

### Problem

Dev applies hook `id` filters with picomatch. Build applies them with Rolldown's `fast_glob`. picomatch compiles bare `()` as regex capturing groups (and `|` as alternation), so `**/*.(js)` matches `foo.js` in `vite dev`. `fast_glob` has no group syntax, so the same pattern matches only a literal `.(js)` suffix during `vite build`.

`noextglob` does not fix this; sapphi-red confirmed the picomatch behavior is a bug relative to glob/bash, and that we should align the two sides.

### Approach

Preprocess glob strings in `pluginFilter.ts` before picomatch: escape `(` / `)` that are not part of an extglob (`@()`, `!()`, `?()`, `+()`, `*()`), and escape `|` unless it sits inside an extglob. Extglobs and brace expansion are left alone.

This is the opposite of #22564, which ran Vite's picomatch filter during build. That would have made both sides match `.js` for `**/*.(js)`. The intended alignment is the Rolldown/literal one.

### Matching-behavior change (dev only)

- `**/*.(js)` no longer matches `foo.js`; it matches `foo.(js)`
- `**/*.(js|ts)` no longer matches `foo.js` / `foo.ts`; it matches `foo.(js|ts)`. `|` outside an extglob is now a literal, not regex alternation
- `**/*.@(js|ts)`, `**/*.+(js)`, `**/*.{js,ts}` are unchanged

Extglobs still do not match during build (`fast_glob` does not implement them). That difference already existed and is not addressed here.

### Tests

`packages/vite/src/node/__tests__/plugins/pluginFilter.spec.ts`: the `**/*.(js)` and `**/*.(js|ts)` cases fail on main and pass with this change.

### Alternatives

- `noextglob: true` — does not stop picomatch from emitting capturing groups
- Applying Vite's filter in the build wrapper (#22564) — aligns the wrong direction
- Escaping every `(` including extglobs — would also stop `@(js|ts)` from working in dev; out of scope for this bug

### AI

I used Cursor to search the issue, #22564, Rolldown `pattern_filter.rs`, and oxc `fast-glob` syntax, then to run the unit tests. I wrote the scanner myself after checking that paren-only escaping still left `|` as regex OR (`**/*.(js|ts)` matching `foo.(js` / `ts)` instead of `foo.(js|ts)`).