### PR TITLE
perf: avoid duplicate module resolution in dev transform requests

### DIFF
--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -31,6 +31,31 @@ describe('the dev server', () => {
     await server?.close()
   })
 
+  test('does not resolve a new transform request twice', async () => {
+    const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
+    const resolveId = vi.fn((id: string) => {
+      if (id === '/entry.js') return normalizePath(path.join(root, 'entry.js'))
+    })
+
+    server = await createServer({
+      configFile: false,
+      root,
+      logLevel: 'silent',
+      optimizeDeps: { noDiscovery: true },
+      server: { middlewareMode: true, watch: null, ws: false },
+      plugins: [{ name: 'count-entry-resolves', enforce: 'pre', resolveId }],
+    })
+
+    const callsBeforeTransform = resolveId.mock.calls.length
+    await server.environments.client.transformRequest('/entry.js')
+
+    expect(
+      resolveId.mock.calls
+        .slice(callsBeforeTransform)
+        .filter(([id]) => id.endsWith('/entry.js')),
+    ).toHaveLength(1)
+  })
+
   test('resolves each environment input as a safe module', async () => {
     const root = path.join(import.meta.dirname, 'fixtures', 'input-option')
     const clientEntry = normalizePath(path.join(root, 'client-entry.js'))

--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -35,6 +35,46 @@ describe('moduleGraph', () => {
       expect(mod2.meta).to.equal(meta)
     })
 
+    it('returns the resolved id so entry creation does not resolve twice', async () => {
+      let resolveCalls = 0
+      const moduleGraph = new EnvironmentModuleGraph('client', async () => {
+        resolveCalls++
+        return null
+      })
+
+      const lookup = await moduleGraph._getModuleByUrlAndResolved('/x.js')
+      expect(lookup.module).toBeUndefined()
+      expect(lookup.resolved).toBeNull()
+
+      await moduleGraph._ensureEntryFromUrl('/x.js', false, lookup.resolved)
+      expect(resolveCalls).toBe(1)
+    })
+
+    it('preserves the resolved id and meta when creating an entry', async () => {
+      let resolveCalls = 0
+      const resolved = {
+        id: '/resolved.js',
+        meta: { source: 'test' },
+      }
+      const moduleGraph = new EnvironmentModuleGraph('client', async () => {
+        resolveCalls++
+        return resolved
+      })
+
+      const lookup = await moduleGraph._getModuleByUrlAndResolved('/x.js')
+      expect(lookup.module).toBeUndefined()
+      expect(lookup.resolved).toEqual(resolved)
+
+      const module = await moduleGraph._ensureEntryFromUrl(
+        '/x.js',
+        false,
+        lookup.resolved,
+      )
+      expect(module.id).toBe('/resolved.js')
+      expect(module.meta).toEqual(resolved.meta)
+      expect(resolveCalls).toBe(1)
+    })
+
     it('ensure backward compatibility', async () => {
       const clientModuleGraph = new EnvironmentModuleGraph(
         'client',

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -134,6 +134,34 @@ export class EnvironmentModuleGraph {
     return this.urlToModuleMap.get(url)
   }
 
+  /**
+   * Resolve a URL and look up its module in one pass.
+   *
+   * This is used by the transform pipeline when it needs both the module and
+   * the resolved id. Keeping the resolved result lets the caller pass it to
+   * `_ensureEntryFromUrl` without invoking the resolver a second time.
+   *
+   * @internal
+   */
+  async _getModuleByUrlAndResolved(rawUrl: string): Promise<{
+    module: EnvironmentModuleNode | undefined
+    resolved: PartialResolvedId | null | undefined
+  }> {
+    // Quick path, if we already have a module for this rawUrl (even without extension)
+    rawUrl = removeImportQuery(removeTimestampQuery(rawUrl))
+    const mod = this._getUnresolvedUrlToModule(rawUrl)
+    if (mod) {
+      return { module: await mod, resolved: undefined }
+    }
+
+    const resolved = await this._resolveId(rawUrl)
+    const [url] = await this._resolveUrl(rawUrl, resolved)
+    return {
+      module: this.urlToModuleMap.get(url),
+      resolved,
+    }
+  }
+
   getModuleById(id: string): EnvironmentModuleNode | undefined {
     return this.idToModuleMap.get(removeTimestampQuery(id))
   }
@@ -344,7 +372,7 @@ export class EnvironmentModuleGraph {
     rawUrl: string,
     setIsSelfAccepting = true,
     // Optimization, avoid resolving the same url twice if the caller already did it
-    resolved?: PartialResolvedId,
+    resolved?: PartialResolvedId | null,
   ): Promise<EnvironmentModuleNode> {
     // Quick path, if we already have a module for this rawUrl (even without extension)
     rawUrl = removeImportQuery(removeTimestampQuery(rawUrl))
@@ -467,9 +495,12 @@ export class EnvironmentModuleGraph {
    */
   async _resolveUrl(
     url: string,
-    alreadyResolved?: PartialResolvedId,
+    alreadyResolved?: PartialResolvedId | null,
   ): Promise<ResolvedUrl> {
-    const resolved = alreadyResolved ?? (await this._resolveId(url))
+    const resolved =
+      alreadyResolved === undefined
+        ? await this._resolveId(url)
+        : alreadyResolved
     const resolvedId = resolved?.id || url
     if (
       url !== resolvedId &&

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -153,9 +153,9 @@ async function doTransform(
   options: TransformOptionsInternal,
   timestamp: number,
 ) {
-  const { pluginContainer } = environment
-
-  let module = await environment.moduleGraph.getModuleByUrl(url)
+  const moduleLookup =
+    await environment.moduleGraph._getModuleByUrlAndResolved(url)
+  let module = moduleLookup.module
   if (module) {
     // try use cache from url
     const cached = await getCachedTransformResult(
@@ -167,9 +167,7 @@ async function doTransform(
     if (cached) return cached
   }
 
-  const resolved = module
-    ? undefined
-    : ((await pluginContainer.resolveId(url, undefined)) ?? undefined)
+  const resolved = module ? undefined : moduleLookup.resolved
 
   // resolve
   const id = module?.id ?? resolved?.id ?? url
@@ -241,7 +239,7 @@ async function loadAndTransform(
   options: TransformOptionsInternal,
   timestamp: number,
   mod?: EnvironmentModuleNode,
-  resolved?: PartialResolvedId,
+  resolved?: PartialResolvedId | null,
 ) {
   const { config, pluginContainer, logger } = environment
   const prettyUrl =


### PR DESCRIPTION
## Summary

Avoid resolving the same URL twice in the development server's cache-miss transform path.

`transformRequest` now receives both the module lookup result and the resolved result from a single module graph operation, so it can reuse the resolver result instead of invoking `resolveId` again.

## Background

Before this change, the uncached transform request flow was:

1. `moduleGraph.getModuleByUrl(url)` resolves the URL and looks up the module graph.
2. If no module is found, `transformRequest` calls `pluginContainer.resolveId()` for the same URL again.
3. The second resolver result is used to create the module entry.

The first resolved result is already available during the module lookup, but it is discarded instead of being returned to the caller. This duplicate work can accumulate across a large module graph, especially when resolver hooks are expensive or many resolver plugins are configured.

## Changes

- Add `EnvironmentModuleGraph._getModuleByUrlAndResolved()`.
  - Return the resolved result together with the module lookup result.
  - Preserve the existing unresolved URL fast path.
- Reuse the lookup result in `transformRequest`.
- Allow `_ensureEntryFromUrl()` and `_resolveUrl()` to reuse a resolved `null` result explicitly.
- Add tests covering resolved id and `meta` preservation and duplicate resolver avoidance.

## Related Prior Work

This change is related to [#13085](https://github.com/vitejs/vite/pull/13085), but addresses a different stage of the transform request flow.

- PR 13085 fixed a race condition where resolving the URL again while creating the module graph entry inside `loadAndTransform()` could produce a different resolver result. It passed the already computed `resolved` result to `_ensureEntryFromUrl()`.
- This change removes duplicate resolution earlier in the `transformRequest` module lookup path. The new `_getModuleByUrlAndResolved()` helper returns both the module lookup result and the resolved result, allowing the second `resolveId()` call for the same URL to be skipped.
- This complements, rather than replaces, the correctness fix from PR 13085.

## Verification

- `pnpm exec vitest run packages/vite/src/node/server/__tests__/moduleGraph.spec.ts packages/vite/src/node/__tests__/dev.spec.ts`
  - Test Files: 2 passed
  - Tests: 12 passed