### PR TITLE
fix: preserve Windows input paths with glob-special segment names 

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1319,6 +1319,64 @@ describe('resolveConfig', () => {
     }
   })
 
+  // https://github.com/vitejs/vite/issues/23383
+  test('preserves Windows input paths with glob-special segment names', async () => {
+    const cases: {
+      name: string
+      input: UserConfig['input']
+      expected: UserConfig['input']
+    }[] = [
+      ...(isWindows
+        ? [
+            {
+              name: 'segment starting with @',
+              input: 'D:\\desk\\test\\@src\\whatever.html',
+              expected: 'D:\\desk\\test\\@src\\whatever.html',
+            },
+            {
+              name: 'segment starting with !',
+              input: 'D:\\desk\\test\\!notes\\page.html',
+              expected: 'D:\\desk\\test\\!notes\\page.html',
+            },
+            {
+              name: 'segment starting with +',
+              input: 'D:\\desk\\test\\+draft\\page.html',
+              expected: 'D:\\desk\\test\\+draft\\page.html',
+            },
+            {
+              name: 'segment starting with (',
+              input: 'D:\\desk\\test\\(draft)\\page.html',
+              expected: 'D:\\desk\\test\\(draft)\\page.html',
+            },
+            {
+              name: 'segment starting with [',
+              input: 'D:\\desk\\test\\[id]\\page.html',
+              expected: 'D:\\desk\\test\\[id]\\page.html',
+            },
+            {
+              name: 'relative path',
+              input: 'test\\@src\\whatever.html',
+              expected: 'test\\@src\\whatever.html',
+            },
+            {
+              name: 'escaped glob on windows',
+              input: 'D:/desk/test/\\[id]\\page.html',
+              expected: 'D:/desk/test/[id]\\page.html',
+            },
+          ]
+        : []),
+    ]
+
+    for (const { name, input, expected } of cases) {
+      await expect(
+        resolveConfig({ input }, 'serve'),
+        name,
+      ).resolves.toMatchObject({
+        input: expected,
+      })
+    }
+  })
+
   test('allows non-glob special characters in input', async () => {
     const cases: {
       name: string

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -33,7 +33,7 @@ import {
   createImportMetaResolver,
   importMetaResolveWithCustomHookString,
 } from '../module-runner/importMetaResolver'
-import { withTrailingSlash } from '../shared/utils'
+import { withTrailingSlash, isWindows } from '../shared/utils'
 import type { AnymatchFn } from '../types/anymatch'
 import type { HtmlAssetSource } from './assetSource'
 import { PartialEnvironment } from './baseEnvironment'
@@ -945,10 +945,14 @@ function normalizeInput(
   return resolved
 }
 
-const escapedGlobCharactersRE = /\\([*?[\]{}()!+@|])/g
+const escapedGlobCharactersRE = /\\([*?[\]{}()|]|[@+!](?=\())/g
+function hasUnescapedGlob(value: string): boolean {
+  return isDynamicPattern(value.replace(escapedGlobCharactersRE, ''))
+}
 
 function unescapeGlobCharacters(value: string): string {
-  if (isDynamicPattern(value)) {
+  if (isWindows) return value
+  if (hasUnescapedGlob(value)) {
     // so that it could later be changed to accept globs without a breaking change
     throw new Error(
       `\`input\` cannot contain glob characters. They are reserved, ` +


### PR DESCRIPTION


<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
## Summary
fixes #23383 

On Windows, paths like `D:\desk\test\@src\whatever.html` or `D:\desk\test\[id]\page.html`
crash Vite with `[UNRESOLVED_ENTRY]`.
## Root Cause
`unescapeGlobCharacters()` calls `isDynamicPattern(value)` on the raw input **before**
any Windows check. On Windows, `\` is the path separator — not an escape character —
so `D:\test\[id]` is misinterpreted as a glob pattern and throws.
```ts
// Before
function unescapeGlobCharacters(value: string): string {
  if (isDynamicPattern(value)) { // ← crashes for D:\test\[id]
    throw new Error(...)
  }
  // isWindows check never reached for paths with [ or (
}
```

## Fix
Add if `(isWindows)` return value at the top of `unescapeGlobCharacters` to skip all glob processing on Windows (backslash is a path separator, not an escape character).
Refine `escapedGlobCharactersRE` to only match extglob modifiers (`@`, `+`, `!`) when followed by `(`, aligning with `tinyglobby`'s extglob support.
Add a `hasUnescapedGlob` helper that strips valid escapes before calling `isDynamicPattern`, so valid glob escapes on POSIX are handled correctly.


## Other PRs / Alternatives
There is an existing local branch [chris/fix/windows-input-glob-unescape](https://github.com/vitejs/vite/pull/23385) with a similar approach. However, it places `if (isWindows)` after `isDynamicPattern(value)`, so paths with `[` or `(` segments (e.g. `D:\test\[id]\page.html`) still crash. Our fix places the guard at the very top, making it work for all glob-special characters.

i also add a unit test to make sure this change is saved and doesn't break the existing codebase:
Added unit tests in `config.spec.ts`  (guarded by `isWindows` so they only run on Windows CI) covering all affected path patterns:

- `D:\desk\test\@src\whatever.html`
- `D:\desk\test\!notes\page.html`
- `D:\desk\test\+draft\page.html`
- `D:\desk\test\(draft)\page.html` ← would still fail with the other approach
- `D:\desk\test\[id]\page.html` ← would still fail with the other approach