### PR TITLE
feat: check output for valid input paths

### DIFF
--- a/packages/vite/src/node/__tests__/checkOutputReferences.spec.ts
+++ b/packages/vite/src/node/__tests__/checkOutputReferences.spec.ts
@@ -1,0 +1,151 @@
+import type { Plugin } from 'rolldown'
+import { describe, expect, test } from 'vitest'
+import { build } from '..'
+
+/**
+ * main-a.js and main-b.js both statically import shared.js, so a normal
+ * production build splits it into its own chunk referenced from both
+ * entries - the minimal shape needed to exercise cross-chunk references
+ * (including, with `chunkImportMap: true`, references that only resolve
+ * through the generated import map) without any worker involved.
+ */
+function fixturePlugin(): Plugin {
+  return {
+    name: 'test',
+    resolveId(id) {
+      if (id === 'main-a.js' || id === 'main-b.js' || id === 'shared.js') {
+        return '\0' + id
+      }
+    },
+    load(id) {
+      if (id === '\0main-a.js') {
+        return `import { marker } from 'shared.js'
+console.log('entry-a', marker)`
+      }
+      if (id === '\0main-b.js') {
+        return `import { marker } from 'shared.js'
+console.log('entry-b', marker)`
+      }
+      if (id === '\0shared.js') {
+        return `export const marker = 'shared-marker'`
+      }
+    },
+  }
+}
+
+/**
+ * Corrupts the emitted chunk whose code contains `marker` into a broken
+ * relative reference, in `renderChunk` (which always completes, across
+ * every plugin, before any `generateBundle` hook runs - including
+ * `vite:check-output-references`).
+ */
+function corruptReferencePlugin(marker: string): Plugin {
+  return {
+    name: 'corrupt-chunk-reference',
+    renderChunk(code) {
+      if (!code.includes(marker)) return null
+      // the referenced file name may still be an unresolved internal hash
+      // placeholder at this point (not yet the plain string seen in the
+      // final output), so match broadly rather than assuming a
+      // `[\w.-]+`-safe file name is already there.
+      const corrupted = code.replace(
+        /from\s*(["'])(\.\/[^"']+)\1/,
+        (_, quote) => `from ${quote}./this-file-does-not-exist.js${quote}`,
+      )
+      return corrupted === code ? null : { code: corrupted, map: null }
+    },
+  }
+}
+
+function outputsOf(result: Awaited<ReturnType<typeof build>>) {
+  return Array.isArray(result) ? result.flatMap((r) => r.output) : result.output
+}
+
+describe('vite:check-output-references', () => {
+  test('does not false-positive on an ordinary multi-chunk build', async () => {
+    const result = await build({
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        rollupOptions: { input: ['main-a.js', 'main-b.js'] },
+      },
+      plugins: [fixturePlugin()],
+    })
+
+    const shared = outputsOf(result).find(
+      (o) => o.type === 'chunk' && o.code.includes('shared-marker'),
+    )
+    expect(
+      shared,
+      'shared.js should be extracted into its own chunk',
+    ).toBeDefined()
+  })
+
+  test('fails the build if a chunk ends up with a broken relative reference', async () => {
+    const buildPromise = build({
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        rollupOptions: { input: ['main-a.js', 'main-b.js'] },
+      },
+      plugins: [fixturePlugin(), corruptReferencePlugin('entry-a')],
+    })
+
+    await expect(buildPromise).rejects.toThrow(
+      /this-file-does-not-exist\.js.*doesn't match any file this build actually emitted/s,
+    )
+  })
+
+  // Regression test for the concern raised in review: `build.chunkImportMap`
+  // may legitimately leave a chunk's static import specifiers as
+  // "preliminary" names only resolvable through the generated import map -
+  // valid for any ordinary chunk, unlike the worker realm this safety net
+  // used to be scoped to. Without the import-map fallback, this would
+  // false-positive on every chunkImportMap-enabled build.
+  test('does not false-positive when a reference only resolves through the chunk import map', async () => {
+    const result = await build({
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        chunkImportMap: true,
+        rollupOptions: { input: ['main-a.js', 'main-b.js'] },
+      },
+      plugins: [fixturePlugin()],
+    })
+
+    const outputs = outputsOf(result)
+    expect(
+      outputs.some(
+        (o) => o.type === 'asset' && o.fileName === 'importmap.json',
+      ),
+      'build.chunkImportMap should still produce an import map',
+    ).toBe(true)
+    const shared = outputs.find(
+      (o) => o.type === 'chunk' && o.code.includes('shared-marker'),
+    )
+    expect(
+      shared,
+      'shared.js should be extracted into its own chunk',
+    ).toBeDefined()
+  })
+
+  test('still fails on a genuinely broken reference when the chunk import map is enabled', async () => {
+    const buildPromise = build({
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      build: {
+        write: false,
+        chunkImportMap: true,
+        rollupOptions: { input: ['main-a.js', 'main-b.js'] },
+      },
+      plugins: [fixturePlugin(), corruptReferencePlugin('entry-a')],
+    })
+
+    await expect(buildPromise).rejects.toThrow(
+      /this-file-does-not-exist\.js.*doesn't match any file this build actually emitted/s,
+    )
+  })
+})

--- a/packages/vite/src/node/plugins/checkOutputReferences.ts
+++ b/packages/vite/src/node/plugins/checkOutputReferences.ts
@@ -1,0 +1,99 @@
+import path from 'node:path'
+import { type ImportSpecifier, initSync, parse } from 'es-module-lexer'
+import type { Plugin } from '../plugin'
+import { getImportMap } from './html'
+
+/**
+ * Sanity-check the finished bundle: none of a chunk's (relative) static or
+ * dynamic import specifiers should point at a file this build didn't
+ * actually emit. This has no known way to trigger from user code - it's a
+ * last-resort net for an internal Vite/Rolldown bug that leaves a chunk's
+ * emitted code pointing at a reference the rest of the build's bookkeeping
+ * lost track of. A chunk silently pointing at a nonexistent file would only
+ * surface as a runtime 404 for users - fail the build instead.
+ *
+ * Runs last (see `order: 'post'` below) so every other plugin's mutations to
+ * the bundle (asset renaming, import rewriting, preload injection, etc.)
+ * are already applied by the time this checks it.
+ */
+export function checkOutputReferencesPlugin(): Plugin {
+  return {
+    name: 'vite:check-output-references',
+    generateBundle: {
+      order: 'post',
+      handler(opts, bundle) {
+        // es-module-lexer only has anything to find in ES module output -
+        // cjs/umd/iife (library mode, worker.format: 'iife', a legacy
+        // build's SystemJS pass) have no `import`/`export` syntax to parse,
+        // the same gate `vite:build-import-analysis` already uses.
+        if (opts.format !== 'es') return
+
+        // generateBundle can't be async here without forcing every plugin
+        // whose hooks run around it to tolerate that. initSync compiles the
+        // (tiny, embedded) WASM synchronously - a no-op if some other
+        // plugin already `await init`-ed it earlier in this same build,
+        // which is normally the case by the time generateBundle runs.
+        initSync()
+
+        const config = this.environment.config
+        // With `build.chunkImportMap` enabled, Rolldown may legitimately
+        // leave a chunk's static import specifiers as "preliminary" names
+        // that only resolve to their real file through the import map it
+        // generates for the main HTML document - by design, and correct at
+        // runtime for any ordinary chunk loaded by a document that sees
+        // that import map. Treat a specifier resolvable through the import
+        // map as valid too, so this doesn't false-positive on every build
+        // that enables the option.
+        const mapping = config.build.chunkImportMap
+          ? getImportMap(bundle, config)?.mapping
+          : undefined
+
+        const violations: {
+          fileName: string
+          specifier: string
+          resolved: string
+        }[] = []
+        for (const fileName in bundle) {
+          const output = bundle[fileName]
+          if (output.type !== 'chunk') continue
+
+          let imports: readonly ImportSpecifier[]
+          try {
+            imports = parse(output.code)[0]
+          } catch {
+            continue
+          }
+          for (const { n: specifier } of imports) {
+            if (!specifier || !specifier.startsWith('.')) continue
+            const resolved = path.posix.normalize(
+              path.posix.join(path.posix.dirname(fileName), specifier),
+            )
+            if (bundle[resolved]) continue
+            const real = mapping?.[resolved]
+            if (real && bundle[real]) continue
+            violations.push({ fileName, specifier, resolved })
+          }
+        }
+
+        if (violations.length > 0) {
+          throw new Error(
+            `Internal error: this build produced ${violations.length} ` +
+              `broken chunk reference(s):\n` +
+              violations
+                .map(
+                  (v) =>
+                    `  - "${v.fileName}" imports "${v.specifier}", which ` +
+                    `doesn't match any file this build actually emitted ` +
+                    `(resolved to "${v.resolved}")`,
+                )
+                .join('\n') +
+              `\nThis points to a bug in how Vite or Rolldown computed ` +
+              `these chunks' references, not in your source code. Please ` +
+              `report this at https://github.com/vitejs/vite/issues with ` +
+              `your build config.`,
+          )
+        }
+      },
+    },
+  }
+}

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -16,6 +16,7 @@ import {
 } from '../plugin'
 import { assetPlugin } from './asset'
 import { assetImportMetaUrlPlugin } from './assetImportMetaUrl'
+import { checkOutputReferencesPlugin } from './checkOutputReferences'
 import { clientInjectionsPlugin } from './clientInjections'
 import { cssAnalysisPlugin, cssPlugin, cssPostPlugin } from './css'
 import { definePlugin } from './define'
@@ -148,6 +149,7 @@ export async function resolvePlugins(
 
     ...buildPlugins.post,
     devtoolsIntegrationPlugin,
+    checkOutputReferencesPlugin(),
 
     // internal server-only plugins are always applied after everything else
     clientInjectionsPlugin(config),


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->

*Disclaimer: I used Claude to start and iterate, but I made sure that I understand everything in this PR and handle all edge cases manually*

While working in #23418, I discovered that with `build.chunkImportMap: true`, Rolldown can leave a chunk's static import specifiers as "preliminary" names only resolvable through the import map embedded in the main HTML document fine for the document, but a worker runs in its own realm and never sees that import map, so its chunk would end up pointing at a reference that 404s at runtime. 

Claude then committed a safeguard that checked if workers import paths matched with actually emitted files, but I discarded it, since it didn't make any sense to check for that after the problem was fixed and just for workers. 

However, later on I thought it might be of interest to refactor it so it checks the entire bundle (not just workers) which might, potentially, make it easier to discover unknown bugs and troubleshoot more easily during Vite's development for all.

Non-ES output (cjs/umd/iife, legacy/SystemJS/CSS) is skipped since es-module-lexer is not capable of checking there reliably.

I'm opening this in case nobody thought about adding this safeguard, but I understand it's not essential, adds maintenance burden and build time, so feel free to close this PR if you deem it nnecessary.