### PR TITLE
fix(html): keep module scripts with src and inline content in build

### DIFF
--- a/packages/vite/src/node/__tests__/html.spec.ts
+++ b/packages/vite/src/node/__tests__/html.spec.ts
@@ -1,6 +1,8 @@
 import type { OutputBundle, OutputChunk } from 'rolldown'
 import { describe, expect, test } from 'vitest'
-import { getCssFilesForChunk } from '../plugins/html'
+import { PartialEnvironment } from '../baseEnvironment'
+import { resolveConfig } from '../config'
+import { buildHtmlPlugin, getCssFilesForChunk } from '../plugins/html'
 
 function createChunk(
   fileName: string,
@@ -238,5 +240,34 @@ describe('getCssFilesForChunk', () => {
       'b.css',
       'a.css',
     ])
+  })
+})
+
+describe('buildHtmlPlugin module scripts with src and inline content', () => {
+  // https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model
+  // a script with both a `src` attribute and inline content must only run the
+  // external script and ignore the content. The buggy behavior was to treat
+  // the content as an inline module (visible as a `html-proxy` import in the
+  // returned entry js) and drop the script tag.
+  const transformHtml = async (html: string) => {
+    const config = await resolveConfig({ configFile: false }, 'build')
+    const plugin = buildHtmlPlugin(config)
+    const environment = new PartialEnvironment('client', config)
+    const handler = plugin.transform!.handler
+    const result = await handler.call(
+      { environment },
+      html,
+      '/index.html',
+    )
+    return result!.code
+  }
+
+  test('does not treat content of module scripts with an external (CDN) src as an inline module', async () => {
+    const code = await transformHtml(`<html><body>
+<script type="module" src="https://cdn.example.com/cdn-module.js">
+  // this inline content must be ignored
+</script>
+</body></html>`)
+    expect(code).not.toContain('html-proxy')
   })
 })

--- a/packages/vite/src/node/__tests__/html.spec.ts
+++ b/packages/vite/src/node/__tests__/html.spec.ts
@@ -254,11 +254,7 @@ describe('buildHtmlPlugin module scripts with src and inline content', () => {
     const plugin = buildHtmlPlugin(config)
     const environment = new PartialEnvironment('client', config)
     const handler = plugin.transform!.handler
-    const result = await handler.call(
-      { environment },
-      html,
-      '/index.html',
-    )
+    const result = await handler.call({ environment }, html, '/index.html')
     return result!.code
   }
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -583,7 +583,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   // add it as an import
                   js += `\nimport ${JSON.stringify(url)}`
                   shouldRemove = true
-                } else if (node.childNodes.length) {
+                } else if (!url && node.childNodes.length) {
                   const scriptNode =
                     node.childNodes.pop() as DefaultTreeAdapterMap['textNode']
                   const contents = scriptNode.value


### PR DESCRIPTION
Per the HTML spec, a script with both a `src` attribute and inline content must only execute the external script and ignore the content.

In buildHtmlPlugin, when a module script had a src that was excluded from bundling (external URL, data URL) or referenced a public file, and the tag also contained text (e.g. a newline), the code fell into the inline-module branch: the whitespace was treated as an inline module and the whole script tag was removed, silently dropping the external script. The dev server already handles this correctly by checking `src` first.

Only treat the content as an inline module when the script has no src at all.

<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
