### PR TITLE
docs(api-javascript): remove example file name

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -205,7 +205,7 @@ async function build(
 
 **Example Usage:**
 
-```ts twoslash [vite.config.js]
+```ts twoslash
 import path from 'node:path'
 import { build } from 'vite'
 


### PR DESCRIPTION
Found on [discord](https://discord.com/channels/804011606160703521/804011606160703524/1544277894015229985) that this example shouldn't be `vite.config.js`