### PR TITLE
fix(client): preserve 0 in ws timeout and port injection

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/clientInjections.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/clientInjections.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { createServer } from '../../server'
+
+describe('clientInjections: server.ws sentinels', () => {
+  const servers: Awaited<ReturnType<typeof createServer>>[] = []
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()))
+  })
+
+  async function injectClient(ws: Record<string, unknown>) {
+    const server = await createServer({
+      configFile: false,
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      optimizeDeps: { noDiscovery: true, include: [] },
+      server: { middlewareMode: true, ws },
+    })
+    servers.push(server)
+    const code =
+      (await server.environments.client.transformRequest('/@vite/client'))
+        ?.code ?? ''
+    return {
+      timeout: Number(code.match(/const hmrTimeout = (-?\d+)/)?.[1]),
+      port: code.match(/const hmrPort = ([^\n]+)/)?.[1]?.trim().replace(/;$/, ''),
+      direct: code
+        .match(/const directSocketHost = ([^\n]+)/)?.[1]
+        ?.trim()
+        .replace(/;$/, ''),
+      resolved: server.config.server.ws,
+    }
+  }
+
+  test('timeout: 0 is injected instead of the 30000 default', async () => {
+    const { timeout, resolved } = await injectClient({ timeout: 0 })
+    expect(resolved).toMatchObject({ timeout: 0 })
+    expect(timeout).toBe(0)
+  })
+
+  test('hmr.timeout: 0 is synced to ws and injected as 0', async () => {
+    const server = await createServer({
+      configFile: false,
+      root: import.meta.dirname,
+      logLevel: 'silent',
+      optimizeDeps: { noDiscovery: true, include: [] },
+      server: { middlewareMode: true, hmr: { timeout: 0 } },
+    })
+    servers.push(server)
+    const code =
+      (await server.environments.client.transformRequest('/@vite/client'))
+        ?.code ?? ''
+    expect(server.config.server.ws).toMatchObject({ timeout: 0 })
+    expect(Number(code.match(/const hmrTimeout = (-?\d+)/)?.[1])).toBe(0)
+  })
+
+  test('port: 0 is injected instead of the middleware 24678 default', async () => {
+    const { port, resolved } = await injectClient({ port: 0 })
+    expect(resolved).toMatchObject({ port: 0 })
+    expect(port).toBe('0')
+  })
+
+  test('clientPort: 0 is injected instead of falling through to 24678', async () => {
+    const { port, resolved } = await injectClient({ clientPort: 0 })
+    expect(resolved).toMatchObject({ clientPort: 0 })
+    expect(port).toBe('0')
+  })
+
+  test('direct target keeps port: 0 instead of the HTTP server port', async () => {
+    const { direct, resolved } = await injectClient({ port: 0 })
+    expect(resolved).toMatchObject({ port: 0 })
+    expect(direct).toMatch(/:0\//)
+  })
+
+  test('clientPort still overrides port: 0', async () => {
+    const { port } = await injectClient({ port: 0, clientPort: 5173 })
+    expect(port).toBe('5173')
+  })
+})

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -82,7 +82,7 @@ async function createClientConfigValueReplacer(
   const wsConfig = isObject(config.server.ws) ? config.server.ws : undefined
   const host = wsConfig?.host || null
   const protocol = wsConfig?.protocol || null
-  const timeout = wsConfig?.timeout || 30000
+  const timeout = wsConfig?.timeout ?? 30000
   const isWsServerSpecified = !!wsConfig?.server
   const hmrConfigName = path.basename(config.configFile || 'vite.config.js')
 
@@ -91,13 +91,13 @@ async function createClientConfigValueReplacer(
 
   // ws.clientPort -> ws.port
   // -> (24678 if middleware mode and WS server is not specified) -> new URL(import.meta.url).port
-  let port = wsConfig?.clientPort || wsConfig?.port || null
+  let port = wsConfig?.clientPort ?? wsConfig?.port ?? null
   if (config.server.middlewareMode && !isWsServerSpecified) {
-    port ||= 24678
+    port ??= 24678
   }
 
   let directTarget = wsConfig?.host || resolvedServerHostname
-  directTarget += `:${wsConfig?.port || resolvedServerPort}`
+  directTarget += `:${wsConfig?.port ?? resolvedServerPort}`
   directTarget += devBase
 
   let hmrBase = devBase

--- a/packages/vite/src/shared/__tests__/moduleRunnerTransport.spec.ts
+++ b/packages/vite/src/shared/__tests__/moduleRunnerTransport.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createWebSocketModuleRunnerTransport } from '../moduleRunnerTransport'
+
+describe('createWebSocketModuleRunnerTransport', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function openSocket() {
+    return {
+      readyState: 1,
+      OPEN: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      addEventListener: vi.fn(),
+    }
+  }
+
+  test('pingInterval: 0 does not schedule a ping timer', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const socket = openSocket()
+    const transport = createWebSocketModuleRunnerTransport({
+      createConnection: () => socket as unknown as WebSocket,
+      pingInterval: 0,
+    })
+    await transport.connect({
+      onMessage: () => {},
+      onDisconnection: () => {},
+    })
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    await transport.disconnect()
+  })
+
+  test('default pingInterval still schedules a ping timer', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const socket = openSocket()
+    const transport = createWebSocketModuleRunnerTransport({
+      createConnection: () => socket as unknown as WebSocket,
+    })
+    await transport.connect({
+      onMessage: () => {},
+      onDisconnection: () => {},
+    })
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30000)
+    await transport.disconnect()
+  })
+})

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -317,11 +317,14 @@ export const createWebSocketModuleRunnerTransport = (options: {
 
       // proxy(nginx, docker) hmr ws maybe caused timeout,
       // so send ping package let ws keep alive.
-      pingIntervalId = setInterval(() => {
-        if (socket.readyState === socket.OPEN) {
-          socket.send(JSON.stringify({ type: 'ping' }))
-        }
-      }, pingInterval)
+      // 0 is a legal timeout (disable ping), matching invoke's `if (timeout > 0)`.
+      if (pingInterval > 0) {
+        pingIntervalId = setInterval(() => {
+          if (socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify({ type: 'ping' }))
+          }
+        }, pingInterval)
+      }
     },
     disconnect() {
       clearInterval(pingIntervalId)


### PR DESCRIPTION
fix(client): preserve 0 in ws timeout and port injection

`server.ws.timeout: 0` is kept on the resolved config (`setupHmrWsOptionCompat` uses `??=`) but `@vite/client` was injected with `30000` because `clientInjections` used `timeout || 30000`. The same helper treated `port: 0` / `clientPort: 0` as missing (`|| 24678`, `port || resolvedServerPort`).

Sibling `createWebSocketModuleRunnerTransport` already uses `??` for invoke timeout and skips the timer when `timeout > 0`. Ping used `setInterval` unconditionally, so injecting `0` would have scheduled a 0ms ping. Guard ping the same way.

`server.hmr.timeout` / `server.hmr.port` go through the same injection after compat sync.

Not changed (on purpose):
- `ws.ts` listen (`wsPort || 24678` / `!wsPort`): `listen(0)` without writing back the bound port would desync the client
- `client.ts` `hmrPort || importMetaUrl.port` / `if (!hmrPort)`: connection fallback still treats 0 as "infer from the page"
- `host ||` / `protocol ||`: empty string vs null is a separate observed fallback

### Test plan
- [ ] `pnpm test-unit clientInjections moduleRunnerTransport`
- [ ] middlewareMode + `server.ws.timeout: 0` → `@vite/client` has `const hmrTimeout = 0`
- [ ] middlewareMode + `server.ws.port: 0` → `const hmrPort = 0` and direct target keeps `:0`
- [ ] `server.ws.port: 0` + `clientPort: 5173` still injects `5173`
