### PR TITLE
fix: resolve relative imports for optimized source files (fix #23430)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -450,6 +450,18 @@ function optimizerResolvePlugin(
 
             const normalizedFsPath = normalizePath(fsPath)
 
+            if (asSrc && !options.scan && !SPECIAL_QUERY_RE.test(id)) {
+              const resolvedFsPath = tryFsResolve(fsPath, options)
+              const optimizedDep = depsOptimizer.metadata.depInfoList.find(
+                (depInfo) =>
+                  depInfo.src ===
+                  normalizePath(resolvedFsPath || normalizedFsPath),
+              )
+              if (optimizedDep) {
+                return depsOptimizer.getOptimizedDepId(optimizedDep)
+              }
+            }
+
             if (depsOptimizer.isOptimizedDepFile(normalizedFsPath)) {
               // Optimized files could not yet exist in disk, resolve to the full path
               // Inject the current browserHash version if the path doesn't have one

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -126,6 +126,24 @@ test('forced include', async () => {
     .toMatch(`[success]`)
 })
 
+test.runIf(isServe)(
+  'optimizes a project source file imported relatively',
+  async () => {
+    await expect
+      .poll(() => page.textContent('.source-include'))
+      .toBe('source include')
+
+    const metadata = readDepOptimizationMetadata()
+    const optimizedFile = metadata.optimized['./source-include.js'].file
+    const response = await fetch(
+      new URL('/source-include-entry.js', viteTestUrl),
+    )
+    const source = await response.text()
+
+    expect(source).toContain(`/node_modules/.vite/deps/${optimizedFile}`)
+  },
+)
+
 test('import * from optimized dep', async () => {
   await expect.poll(() => page.textContent('.import-star')).toMatch(`[success]`)
 })

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -58,6 +58,10 @@
 <h2>Optimizing force included dep even when it's linked</h2>
 <div class="force-include"></div>
 
+<h2>Optimizing a project source file through a relative import</h2>
+<div class="source-include"></div>
+<script type="module" src="./source-include-entry.js"></script>
+
 <h2>Dep with CSS</h2>
 <div class="dep-linked-include">This should be red</div>
 

--- a/playground/optimize-deps/source-include-entry.js
+++ b/playground/optimize-deps/source-include-entry.js
@@ -1,0 +1,3 @@
+import { message } from './source-include'
+
+document.querySelector('.source-include').textContent = message

--- a/playground/optimize-deps/source-include.js
+++ b/playground/optimize-deps/source-include.js
@@ -1,0 +1,1 @@
+export const message = 'source include'

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -30,6 +30,7 @@ export default defineConfig({
       // only referenced by the import that injectImportIntoOptimizedDep()
       // adds at serve time, so the scanner can never discover it
       '@vitejs/test-dep-cjs-for-injected-import',
+      './source-include.js',
     ],
     exclude: [
       '@vitejs/test-nested-exclude',


### PR DESCRIPTION
## Summary

- resolve relative imports to source files listed in `optimizeDeps.include` to their optimized dep entry
- match optimized metadata by the final resolved source path, including extensionless relative imports
- preserve special query handling for `?raw`, workers, and URLs
- add a regression test covering a project source file imported relatively

## Cause

`optimizeDeps.include` already resolved and pre-bundled the source file, but the dev optimizer resolver only checked optimized metadata for bare specifiers. Relative imports went through the normal filesystem path and continued to serve source modules, leaving the generated pre-bundle unused.

Fixes #23430

## Tests

- `pnpm --filter vite build-bundle`
- `pnpm test-serve playground/optimize-deps/__tests__/optimize-deps.spec.ts`
- `pnpm test-build playground/optimize-deps/__tests__/optimize-deps.spec.ts`
- `pnpm --filter vite typecheck`
- `pnpm exec eslint packages/vite/src/node/plugins/resolve.ts playground/optimize-deps/__tests__/optimize-deps.spec.ts`
