### PR TITLE
fix(css): run pre resolveId plugins for @import (fix #23052)

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -273,7 +273,7 @@ Importing `.css` files will inject its content to the page via a `<style>` tag w
 
 ### `@import` Inlining and Rebasing
 
-Vite is pre-configured to support CSS `@import` inlining via `postcss-import`. Vite aliases are also respected for CSS `@import`. In addition, all CSS `url()` references, even if the imported files are in different directories, are always automatically rebased to ensure correctness.
+Vite is pre-configured to support CSS `@import` inlining via `postcss-import`. Vite aliases and `resolveId` hooks from `enforce: 'pre'` plugins are also respected for CSS `@import`. In addition, all CSS `url()` references, even if the imported files are in different directories, are always automatically rebased to ensure correctness.
 
 `@import` aliases and URL rebasing are also supported for Sass and Less files (see [CSS Pre-processors](#css-pre-processors)).
 

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -3,6 +3,7 @@ import type { PartialResolvedId } from 'rolldown'
 import type { PartialEnvironment } from './baseEnvironment'
 import type { ResolvedConfig } from './config'
 import type { Environment } from './environment'
+import type { Plugin } from './plugin'
 import { oxcResolvePlugin } from './plugins/resolve'
 import type { InternalResolveOptions } from './plugins/resolve'
 import type { EnvironmentPluginContainer } from './server/pluginContainer'
@@ -35,6 +36,24 @@ export function createBackCompatIdResolver(
   }
 }
 
+// `@import` inlining needs a file, so a result a plugin marks as external is
+// dropped and resolution falls through to the next plugin.
+function withoutExternalResults(plugin: Plugin): Plugin {
+  const hook = plugin.resolveId!
+  const handler = typeof hook === 'object' ? hook.handler : hook
+  const wrapped = async function (this: any, ...args: any[]) {
+    const result = await (handler as any).apply(this, args)
+    return result && typeof result === 'object' && result.external
+      ? null
+      : result
+  }
+  return {
+    ...plugin,
+    resolveId:
+      typeof hook === 'object' ? { ...hook, handler: wrapped } : wrapped,
+  } as Plugin
+}
+
 /**
  * Create an internal resolver to be used in special scenarios, e.g.
  * optimizer and handling css @imports
@@ -44,6 +63,7 @@ export function createIdResolver(
   options?: Partial<InternalResolveOptions>,
 ): ResolveIdFn {
   const scan = options?.scan
+  const userPrePlugins = options?.userPrePlugins
 
   const pluginContainerMap = new Map<
     PartialEnvironment,
@@ -56,11 +76,26 @@ export function createIdResolver(
   ): Promise<PartialResolvedId | null> {
     let pluginContainer = pluginContainerMap.get(environment)
     if (!pluginContainer) {
+      // Same set of plugins the main pipeline runs before its own resolver
+      // (see `resolvePlugins`), so a `resolveId` hook that works for JS
+      // imports also works here.
+      const prePlugins = userPrePlugins
+        ? environment.config.plugins
+            .filter(
+              (plugin) =>
+                plugin.resolveId &&
+                (plugin.enforce === 'pre' ||
+                  (typeof plugin.resolveId === 'object' &&
+                    plugin.resolveId.order === 'pre')),
+            )
+            .map(withoutExternalResults)
+        : []
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
           // @ts-expect-error  the aliasPlugin uses rollup types
           aliasPlugin({ entries: environment.config.resolve.alias }),
+          ...prePlugins,
           ...oxcResolvePlugin(
             {
               root: config.root,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1376,6 +1376,7 @@ export function createCSSResolvers(
   return {
     get css() {
       return (cssResolve ??= createBackCompatIdResolver(config, {
+        userPrePlugins: true,
         extensions: ['.css'],
         mainFields: ['style'],
         conditions: ['style', DEV_PROD_CONDITION],
@@ -1387,6 +1388,7 @@ export function createCSSResolvers(
     get sass() {
       if (!sassResolve) {
         const resolver = createBackCompatIdResolver(config, {
+          userPrePlugins: true,
           extensions: ['.scss', '.sass', '.css'],
           mainFields: ['sass', 'style'],
           conditions: ['sass', 'style', DEV_PROD_CONDITION],
@@ -1415,6 +1417,7 @@ export function createCSSResolvers(
 
     get less() {
       return (lessResolve ??= createBackCompatIdResolver(config, {
+        userPrePlugins: true,
         extensions: ['.less', '.css'],
         mainFields: ['less', 'style'],
         conditions: ['less', 'style', DEV_PROD_CONDITION],

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -134,6 +134,13 @@ interface ResolvePluginOptions {
   // True when resolving during the scan phase to discover dependencies
   scan?: boolean
   /**
+   * Also run user plugins with `enforce: 'pre'` (or a `resolveId` hook with
+   * `order: 'pre'`). Set by the CSS resolvers so `@import` can follow the
+   * migration path the `customResolver` deprecation warning suggests.
+   * @internal
+   */
+  userPrePlugins?: boolean
+  /**
    * @internal
    */
   skipMainField?: boolean

--- a/playground/css/__tests__/tests.ts
+++ b/playground/css/__tests__/tests.ts
@@ -86,6 +86,18 @@ test('postcss config', async () => {
   await expect.poll(() => getColor(imported)).toBe('red')
 })
 
+test('@import resolved by a user resolveId plugin', async () => {
+  expect(await getColor('.user-resolver-layer')).toBe('blue')
+  expect(await getColor('.user-resolver-nested')).toBe('green')
+  expect(await getColor('.user-resolver-scss')).toBe('blue')
+  expect(await getColor('.user-resolver-scss-nested')).toBe('green')
+  expect(await getColor('.user-resolver-hook')).toBe('blue')
+  expect(await getColor('.user-resolver-hook-nested')).toBe('green')
+  // a pre plugin returning `external: true` is ignored here
+  expect(await getColor('.user-resolver-external-layer')).toBe('blue')
+  expect(await getColor('.user-resolver-external')).toBe('green')
+})
+
 test('postcss plugin that injects url()', async () => {
   const imported = await page.$('.inject-url')
   // alias should be resolved

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -245,6 +245,32 @@
   <pre class="aliased-content"></pre>
   <p class="aliased-module">import '#alias-module': this should be blue</p>
 
+  <h2>@import through a user resolveId plugin</h2>
+  <p class="user-resolver-layer">
+    import '~layers/layer.css': this should be blue
+  </p>
+  <p class="user-resolver-nested">
+    nested @import '~layers/nested.css': this should be green
+  </p>
+  <p class="user-resolver-scss">
+    import '~layers/layer.scss': this should be blue
+  </p>
+  <p class="user-resolver-scss-nested">
+    nested scss @import: this should be green
+  </p>
+  <p class="user-resolver-hook">
+    import '~layers-hook/hook-layer.css' (object hook): this should be blue
+  </p>
+  <p class="user-resolver-hook-nested">
+    nested @import via object hook: this should be green
+  </p>
+  <p class="user-resolver-external-layer">
+    import './user-resolver/external-layer.css': this should be blue
+  </p>
+  <p class="user-resolver-external">
+    @import marked external by a pre plugin still inlines: this should be green
+  </p>
+
   <p>Imports field</p>
   <p class="imports-field">import '#imports': this should be red</p>
 </div>

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -138,3 +138,8 @@ import('./same-name/sub1/sub')
 import('./same-name/sub2/sub')
 
 import './imports-imports-field.css'
+
+import '~layers/layer.css'
+import '~layers/layer.scss'
+import '~layers-hook/hook-layer.css'
+import './user-resolver/external-layer.css'

--- a/playground/css/user-resolver/external-layer.css
+++ b/playground/css/user-resolver/external-layer.css
@@ -1,0 +1,5 @@
+@import './external.css';
+
+.user-resolver-external-layer {
+  color: blue;
+}

--- a/playground/css/user-resolver/external.css
+++ b/playground/css/user-resolver/external.css
@@ -1,0 +1,3 @@
+.user-resolver-external {
+  color: green;
+}

--- a/playground/css/user-resolver/hook-layer.css
+++ b/playground/css/user-resolver/hook-layer.css
@@ -1,0 +1,5 @@
+@import '~layers-hook/hook-nested.css';
+
+.user-resolver-hook {
+  color: blue;
+}

--- a/playground/css/user-resolver/hook-nested.css
+++ b/playground/css/user-resolver/hook-nested.css
@@ -1,0 +1,3 @@
+.user-resolver-hook-nested {
+  color: green;
+}

--- a/playground/css/user-resolver/layer.css
+++ b/playground/css/user-resolver/layer.css
@@ -1,0 +1,5 @@
+@import '~layers/nested.css';
+
+.user-resolver-layer {
+  color: blue;
+}

--- a/playground/css/user-resolver/layer.scss
+++ b/playground/css/user-resolver/layer.scss
@@ -1,0 +1,5 @@
+@import '~layers/nested.scss';
+
+.user-resolver-scss {
+  color: blue;
+}

--- a/playground/css/user-resolver/nested.css
+++ b/playground/css/user-resolver/nested.css
@@ -1,0 +1,3 @@
+.user-resolver-nested {
+  color: green;
+}

--- a/playground/css/user-resolver/nested.scss
+++ b/playground/css/user-resolver/nested.scss
@@ -1,0 +1,3 @@
+.user-resolver-scss-nested {
+  color: green;
+}

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -20,6 +20,49 @@ export default defineConfig({
   },
   plugins: [
     {
+      // the replacement the customResolver deprecation warning points users to
+      name: 'test-layers-resolver',
+      enforce: 'pre',
+      resolveId(id) {
+        if (id.startsWith('~layers/')) {
+          return path.resolve(
+            dirname,
+            'user-resolver',
+            id.slice('~layers/'.length),
+          )
+        }
+      },
+    },
+    {
+      // a pre plugin that marks things external must not break @import
+      name: 'test-layers-external',
+      enforce: 'pre',
+      resolveId(id, importer) {
+        if (
+          id === './external.css' &&
+          importer?.endsWith('external-layer.css')
+        ) {
+          return { id, external: true }
+        }
+      },
+    },
+    {
+      // same thing with the object hook form
+      name: 'test-layers-resolver-hook',
+      resolveId: {
+        order: 'pre',
+        handler(id) {
+          if (id.startsWith('~layers-hook/')) {
+            return path.resolve(
+              dirname,
+              'user-resolver',
+              id.slice('~layers-hook/'.length),
+            )
+          }
+        },
+      },
+    },
+    {
       // Emulate a UI framework component where a framework module would import
       // scoped CSS files that should treeshake if the default export is not used.
       name: 'treeshake-scoped-css',


### PR DESCRIPTION
In Vite 8, using `resolve.alias[].customResolver` logs a warning that says it will be removed in Vite 9 and that a `resolveId` hook with `enforce: 'pre'` should be used instead. If you follow that, imports in JS files keep working, but `@import` inside CSS files fails with ENOENT.

The reason is that there are two resolvers. The main one that handles JS imports runs user plugins. The CSS resolver for `@import` (`createIdResolver` in `idResolver.ts`) only has the alias plugin and the internal resolver, so it does not know about user plugins. So the way the warning suggests does not work for CSS.

fixes #23052

## Fix

When the CSS resolver builds its plugin list, I pick the registered plugins whose `enforce` is `pre` (or whose `resolveId` is an object hook with `order: 'pre'`), and put them after the alias plugin and before the internal resolver. This is the same order the main pipeline uses, where pre plugins run before the internal resolver.

`createIdResolver` is also used in other places (dep optimizer, worker and asset `import.meta.url`, dynamic imports, and so on), so I gated the user plugin injection behind an internal option that only the CSS resolvers turn on. The other callers keep their current behavior.

## Alternatives

I also checked falling back to the environment's real plugin container, but `compileCSS` is also called outside of a plugin context, so that would only work in dev. Leaving `customResolver` out of the deprecation for the CSS case was another option, but that seemed like just delaying the problem, so I tried to fix it instead.

## Testing

I added a case to `playground/css` where an `enforce: 'pre'` plugin resolves `~layers/*`, and checked that a JS import and a nested `@import` both work:

```js
// vite.config.js: enforce: 'pre' resolveId plugin that maps '~layers/*'
import '~layers/layer.css'          // JS import: works
@import '~layers/nested.css';       // inside layer.css: ENOENT before this PR
```

I used `playground/css` so the postcss and lightningcss transformers share the same test, and I also added a sass `@import` case and an object `order: 'pre'` hook case. Without this PR the build fails with `[postcss] ENOENT '~layers/nested.css'`. With it, serve, build and bundled-dev all pass. I also ran the unit tests and the optimize-deps, worker, assets, dynamic-import, resolve and alias playgrounds, and there were no failures.

## Notes for reviewers

Pre plugins now also get CSS `@import` specifiers. Most of them return undefined when nothing matches, so I think this is fine. If a plugin marks the result as `external`, I ignore it and fall through, because an external result would break `@import` inlining. Please double check this part.

This CSS resolver does not run `buildStart` and `this.environment` is a PartialEnvironment, so a plugin whose `resolveId` depends on post-`buildStart` state or on the module graph would not see it here. This is how the resolver already worked.

I added one sentence to the `@import` section in `docs/guide/features.md` about pre plugin `resolveId` hooks working for CSS `@import`. I also checked and there is no other open PR for this.

## AI usage

I used Claude Code to help write the code. I had it write a failing repro test first and compared the results before and after the patch myself. I also questioned the decisions while reviewing, like why the injection is limited to the CSS resolvers and why an `external` result is ignored.
