### PR TITLE
feat(html): warn when build cannot preserve authored stylesheet link order

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -186,6 +186,21 @@ function getLinkShouldInline(
   return isNoInlineLink ? false : undefined
 }
 
+// Only `<link rel="stylesheet">` directly under `<head>` take part in the
+// cascade we can reason about: `traverseHtml` also descends into `<template>`,
+// and parse5 runs with `scriptingEnabled: false` so `<noscript>` contents are
+// parsed as real elements too.
+function isHeadStylesheetLink(
+  node: DefaultTreeAdapterMap['element'],
+  attributes: Record<string, string>,
+): boolean {
+  return (
+    node.nodeName === 'link' &&
+    node.parentNode?.nodeName === 'head' &&
+    parseRelAttr(attributes.rel ?? '').includes('stylesheet')
+  )
+}
+
 export const isAsyncScriptMap: WeakMap<
   ResolvedConfig,
   Map<string, boolean>
@@ -515,6 +530,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         const s = new MagicString(html)
         const scriptUrls: ScriptAssetsUrl[] = []
         const styleUrls: ScriptAssetsUrl[] = []
+        // every `<link rel="stylesheet">` directly under `<head>`, in document
+        // order, and whether it gets bundled away or is left where it is. Used
+        // to warn when building cannot keep the authored cascade order (#8739).
+        const headStylesheetLinks: { url: string; bundled: boolean }[] = []
         let inlineModuleIndex = -1
 
         let everyScriptIsAsync = true
@@ -670,6 +689,24 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               )
             } else if (attr.type === 'src') {
               const url = decodeURIIfPossible(attr.value)
+              if (
+                url !== undefined &&
+                isHeadStylesheetLink(node, attr.attributes)
+              ) {
+                headStylesheetLinks.push({
+                  url,
+                  // mirrors the "convert to import" condition below; links that
+                  // turn out to be unresolvable are downgraded further down
+                  bundled:
+                    !checkPublicFile(url, config) &&
+                    !isExcludedUrl(url) &&
+                    isCSSRequest(url) &&
+                    !(
+                      'media' in attr.attributes ||
+                      'disabled' in attr.attributes
+                    ),
+                })
+              }
               if (url === undefined) {
                 // ignore it
               } else if (checkPublicFile(url, config)) {
@@ -803,9 +840,36 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             )
             const importExpression = `\nimport ${JSON.stringify(url)}`
             js = js.replace(importExpression, '')
+            // it stays in the html, so it keeps its authored position
+            for (const link of headStylesheetLinks) {
+              if (link.url === url) {
+                link.bundled = false
+              }
+            }
           } else {
             s.remove(start, end)
           }
+        }
+
+        // Bundled stylesheet links are removed here and their CSS is appended at
+        // the end of `<head>` in `generateBundle`, while the others keep their
+        // authored position. Any stylesheet link authored after a bundled one
+        // therefore ends up before it, silently flipping the cascade (#8739).
+        const firstBundled = headStylesheetLinks.findIndex((l) => l.bundled)
+        const displaced =
+          firstBundled === -1
+            ? undefined
+            : headStylesheetLinks
+                .slice(firstBundled + 1)
+                .find((l) => !l.bundled)
+        if (displaced) {
+          config.logger.warnOnce(
+            `\n<link rel="stylesheet" href="${displaced.url}"> in "${publicPath}" is authored after ` +
+              `<link rel="stylesheet" href="${headStylesheetLinks[firstBundled].url}">, but Vite bundles the ` +
+              `latter and appends it at the end of <head>, so the built page applies the two in the opposite ` +
+              `order. Move it before the bundled stylesheet links, or import it from JavaScript instead. ` +
+              `See https://github.com/vitejs/vite/issues/8739`,
+          )
         }
 
         processedHtml(this).set(id, s.toString())

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -274,6 +274,21 @@ describe('link with props', () => {
   })
 })
 
+// building moves a bundled stylesheet link to the end of `<head>`, so a
+// stylesheet Vite leaves in place after it wins the cascade instead of losing
+// it. That can't be fixed by placement alone, so warn about it (#8739).
+describe.runIf(isBuild)('link order', () => {
+  test('warns when a stylesheet link is authored after a bundled one', () => {
+    expect(serverLogs.join('\n')).toContain(
+      '<link rel="stylesheet" href="/link-order-public.css"> in "/link-order/index.html" is authored after',
+    )
+  })
+
+  test('does not warn when the authored order already survives', () => {
+    expect(serverLogs.join('\n')).not.toContain('/link-order/ordered.html')
+  })
+})
+
 describe.runIf(isServe)('SPA fallback', () => {
   test('should serve index.html via page navigation even when path matches file basename', async () => {
     const response = await page.goto(viteTestUrl + '/test')

--- a/playground/html/link-order/bundled.css
+++ b/playground/html/link-order/bundled.css
@@ -1,0 +1,3 @@
+#link-order {
+  color: red;
+}

--- a/playground/html/link-order/index.html
+++ b/playground/html/link-order/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Link order</title>
+    <!-- bundled away and re-added at the end of <head>, so the publicDir sheet
+         below loses the cascade it was authored to win -->
+    <link rel="stylesheet" href="./bundled.css" />
+    <link rel="stylesheet" href="/link-order-public.css" />
+  </head>
+  <body>
+    <h1 id="link-order">link order</h1>
+  </body>
+</html>

--- a/playground/html/link-order/ordered.html
+++ b/playground/html/link-order/ordered.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Link order (already preserved)</title>
+    <!-- the publicDir sheet is authored first, so appending the bundled one at
+         the end of <head> still matches the authored order -->
+    <link rel="stylesheet" href="/link-order-public.css" />
+    <link rel="stylesheet" href="./bundled.css" />
+  </head>
+  <body>
+    <h1 id="link-order">link order</h1>
+  </body>
+</html>

--- a/playground/html/public/link-order-public.css
+++ b/playground/html/public/link-order-public.css
@@ -1,0 +1,3 @@
+#link-order {
+  color: blue;
+}

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -23,6 +23,8 @@ const input = {
     'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
   ),
   linkProps: resolve(dirname, 'link-props/index.html'),
+  linkOrder: resolve(dirname, 'link-order/index.html'),
+  linkOrderOrdered: resolve(dirname, 'link-order/ordered.html'),
   valid: resolve(dirname, 'valid.html'),
   importmapOrder: resolve(dirname, 'importmapOrder.html'),
   env: resolve(dirname, 'env.html'),


### PR DESCRIPTION
### Description

`vite build` can silently invert the cascade order of stylesheet links authored in HTML.

`vite:build-html` converts a resolvable `<link rel="stylesheet">` into a JS import and removes the node; the resulting stylesheet is appended at the end of `<head>` in `generateBundle`. Links Vite leaves in place — `publicDir` files, external URLs, `media`/`disabled`, unresolvable ones — keep their authored position. So any stylesheet link authored *after* a bundled one ends up *before* it, and the page is styled differently than in dev. Nothing fails; only the rendered result differs.

This is #8739 (open since 2022, `p3-minor-bug` + `inconsistency`, six reporters).

**This PR does not fix the ordering — it makes the failure visible.** I built the obvious fix (put the generated `<link>` back where the authored one was) and measured that it trades one inversion for another: in build, the CSS from HTML-authored links and the CSS imported from the entry's JS are the *same output file*, so the single generated `<link>` has one slot, while dev establishes two orderings (`authored < retained < fromjs`, the last because the dev client appends a `<style>` to `<head>` at runtime). Computed colours measured in Chromium:

| | dev | build (`main`) | build (move the link back) |
| --- | --- | --- | --- |
| `<link>` + `publicDir` link | `pub` wins | **bundle wins** ❌ | `pub` wins ✅ |
| the above + CSS imported from JS | `fromjs` wins | `fromjs` wins ✅ | **`pub` wins** ❌ |

Details and the proposed real fix (emitting the CSS reachable from HTML-authored links as its own chunk) are in https://github.com/vitejs/vite/issues/8739#issuecomment-5553130971 — that one needs a maintainer decision, so this PR is deliberately limited to the warning, which is useful either way.

### Implementation

Records every `<link rel="stylesheet">` that is a **direct child of `<head>`** in document order, tagged with whether Vite bundles it away, and warns when a retained one is authored after a bundled one.

- The head-child restriction is load-bearing, not defensive. `traverseHtml` descends into `<template>`, and parse5 runs with `scriptingEnabled: false`, so a stylesheet link inside `<noscript>` is a real element in the tree. Those don't participate in the cascade the built page applies, and counting them produced false positives.
- Only `rel="stylesheet"` is considered — `preload`/`icon`/`manifest` links don't take part in the cascade.
- The `bundled` flag mirrors the existing "CSS references, convert to import" condition rather than restating it; links that later fail to resolve are downgraded to retained in the loop that already handles that case, because they keep their authored position.
- `warnOnce`, so a repeated build of the same page doesn't repeat it.

### Notes for review

- **The warning names the two conflicting hrefs and the file.** I went back and forth on whether to point at the first bundled link or the last; the first is what determines the boundary, so that's what it reports.
- **Interleaved links are reported once, not per pair.** A document alternating bundled and retained stylesheet links has several inverted pairs; the warning reports the first. Reporting all of them seemed noisier than useful, but I'll change it if you'd rather.
- **I deliberately did not touch the `media`/`disabled` path.** Those links are also left in place and so can be displaced, and they're counted here, but #9402 tracks the fact that they aren't processed at all — I didn't want to widen this.
- **No behaviour change.** Output is byte-identical; this only adds a log line. I verified that by building `playground/html` on this branch and on `main` and diffing every emitted file.
- One adjacent bug I found while investigating and did **not** fix here: a `<link rel="stylesheet">` inside `<noscript>` in `<head>` is converted to an import and its CSS is emitted unconditionally, so a no-JS-only stylesheet applies to everyone. That's current `main` behaviour and independent of this change; happy to open a separate issue.

### Test

`playground/html/link-order/` adds two complete documents: one with a `publicDir` sheet authored after a bundled one (must warn) and one with the same two sheets in the order that survives building (must not warn). Both assert against `serverLogs` in build mode.

They are complete documents rather than fragments on purpose: `playground/html`'s own `pre-transform` plugin wraps any fixture without a `<!doctype html>` in a synthesized `<html><head>…</head><body>`, which pushes authored links into `<body>` — a fragment fixture cannot exercise this path at all. My first attempt at a fixture did exactly that and passed without the implementation.

Verified discriminating: reverting `html.ts` and rerunning fails the positive test and leaves the negative one passing.
