### PR TITLE
fix(server): do not re-arm watcher via addWatchFile after container is closed (fix #18224)

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -1,6 +1,10 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { stripVTControlCharacters } from 'node:util'
 import MagicString from 'magic-string'
 import { describe, expect, it, vi } from 'vitest'
+import type { FSWatcher } from '#dep-types/chokidar'
 import type { UserConfig } from '../../config'
 import { resolveConfig } from '../../config'
 import { createLogger } from '../../logger'
@@ -478,6 +482,69 @@ describe('plugin container', () => {
     })
   })
 
+  describe('addWatchFile', () => {
+    it('does not re-arm the watcher for a hook call still pending when the container is closed (#18224)', async () => {
+      // The watched file must exist on disk and be outside the environment
+      // root for `ensureWatchedFile` to call `watcher.add`.
+      const watchedFile = path.join(
+        fs.realpathSync(os.tmpdir()),
+        `vite-plugin-container-watch-test-${Date.now()}.txt`,
+      )
+      fs.writeFileSync(watchedFile, '')
+
+      try {
+        const watcher = { add: vi.fn() } as unknown as FSWatcher
+
+        let resolveTransformStarted: () => void
+        const transformStarted = new Promise<void>((resolve) => {
+          resolveTransformStarted = resolve
+        })
+        let resolveTransform: () => void
+        const canFinishTransform = new Promise<void>((resolve) => {
+          resolveTransform = resolve
+        })
+
+        const plugin: Plugin = {
+          name: 'p1',
+          async transform(_code, id) {
+            if (id === '/x.js') {
+              resolveTransformStarted()
+              await canFinishTransform
+              // Simulates a plugin (e.g. vite:css) calling `addWatchFile`
+              // after the server/container has already been closed.
+              this.addWatchFile(watchedFile)
+            }
+          },
+        }
+
+        const environment = await getDevEnvironment(
+          { plugins: [plugin] },
+          watcher,
+        )
+        await environment.moduleGraph.ensureEntryFromUrl('/x.js', false)
+
+        const transformPromise = environment.pluginContainer.transform(
+          '',
+          '/x.js',
+        )
+        await transformStarted
+
+        const closePromise = environment.pluginContainer.close()
+        resolveTransform!()
+
+        // Once closed, any plugin transform hook running after `p1` in the
+        // pipeline will reject with a "closed server" error, which is
+        // expected and unrelated to what this test checks.
+        await transformPromise.catch(() => {})
+        await closePromise
+
+        expect(watcher.add).not.toHaveBeenCalled()
+      } finally {
+        fs.rmSync(watchedFile)
+      }
+    })
+  })
+
   describe('closeBundle', () => {
     it('passes buildEnd errors to closeBundle', async () => {
       const buildEndError = new Error('buildEnd failed')
@@ -537,6 +604,7 @@ describe('plugin container', () => {
 
 async function getDevEnvironment(
   inlineConfig?: UserConfig,
+  watcher?: FSWatcher,
 ): Promise<DevEnvironment> {
   const config = await resolveConfig(
     { configFile: false, ...inlineConfig },
@@ -547,7 +615,7 @@ async function getDevEnvironment(
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
   const environment = new DevEnvironment('client', config, { hot: true })
-  await environment.init()
+  await environment.init({ watcher })
 
   return environment
 }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -187,6 +187,10 @@ class EnvironmentPluginContainer<Env extends Environment = Environment> {
   private _buildStartPromise: Promise<void> | undefined
   private _closed = false
 
+  get closed(): boolean {
+    return this._closed
+  }
+
   /**
    * @internal use `createEnvironmentPluginContainer` instead
    */
@@ -866,7 +870,11 @@ class PluginContext
 
   addWatchFile(id: string): void {
     this._container.watchFiles.add(id)
-    if (this._container.watcher)
+    // The container may be closed (e.g. the server was closed) while this
+    // hook's pending call is still in flight. Watching a file at that point
+    // would re-arm the underlying fs watcher and keep the process alive, so
+    // this needs to be a no-op instead. https://github.com/vitejs/vite/issues/18224
+    if (this._container.watcher && !this._container.closed)
       ensureWatchedFile(
         this._container.watcher,
         id,


### PR DESCRIPTION
## Description

Fixes #18224.

If a plugin's `resolveId`/`load`/`transform` hook is still pending when `server.close()` runs, and that hook calls `this.addWatchFile()` after the watcher has already been closed, the file gets re-added to the (already closed) chokidar watcher. This re-arms the underlying OS-level fs watch handles, which keeps the Node.js process alive indefinitely — the process never exits even though `server.close()` has resolved.

This is exactly the scenario described in the issue: `vite:css` can call `addWatchFile()` from inside a Sass/Less compile that is still running when the dev server is closed (e.g. because a test runner's global teardown closes the Vite server while a request is still being processed).

## Root cause

`EnvironmentPluginContainer.close()` already flips a private `_closed` flag to `true` *before* it awaits any hook calls still in flight (`_processesing`). However, `PluginContext.addWatchFile()` had no way to observe that flag, and unconditionally called `ensureWatchedFile()` -> `watcher.add()` whenever a watcher instance was present, regardless of whether the container had already begun closing.

## Fix

- Exposed the container's closed state via a new public `closed` getter on `EnvironmentPluginContainer`.
- `PluginContext.addWatchFile()` now skips calling `ensureWatchedFile()` (and therefore `watcher.add()`) once the container is closed, making it a no-op for any hook call that is still resolving after `server.close()` has started tearing things down. The file id is still recorded in `watchFiles` for consistency with the existing `_closed` behavior elsewhere in this class.

This targets the minimal fix suggested in the issue itself ("Make `PluginContext.addWatchFile()` a noop after the watcher is closed").

## Test plan

Added a regression test in `packages/vite/src/node/server/__tests__/pluginContainer.spec.ts` that:
1. Starts a `transform()` call whose plugin hook pauses mid-flight.
2. Closes the plugin container while that hook is still pending.
3. Lets the pending hook resume and call `this.addWatchFile()`.
4. Asserts the (mocked) watcher's `add()` was never called.

I verified this test fails without the fix (reproducing the exact bug — `watcher.add` gets called once) and passes with the fix applied.

Also ran:
- `pnpm run test-unit` (all green except one pre-existing, unrelated failure — `resolves a symlinked root to its real path` — which also fails on `main` without my changes, due to a local Windows/git symlink environment quirk mentioned in CONTRIBUTING.md, not related to this change)
- `pnpm run typecheck` — passes
- `eslint` on changed files — passes