### PR TITLE
fix(server): treat a missing configured publicDir as having no public files (fix #19864)

### DIFF
--- a/packages/vite/src/node/__tests__/publicDir.spec.ts
+++ b/packages/vite/src/node/__tests__/publicDir.spec.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ResolvedConfig } from '../config'
+import { initPublicFiles } from '../publicDir'
+
+describe('initPublicFiles', () => {
+  const dirsToClean: string[] = []
+
+  afterEach(() => {
+    while (dirsToClean.length) {
+      fs.rmSync(dirsToClean.pop()!, { recursive: true, force: true })
+    }
+  })
+
+  function makeTempDir() {
+    const dir = fs.mkdtempSync(
+      path.join(fs.realpathSync(os.tmpdir()), 'vite-public-dir-test-'),
+    )
+    dirsToClean.push(dir)
+    return dir
+  }
+
+  it('returns undefined when the configured public dir does not exist (#19864)', async () => {
+    const publicDir = path.join(makeTempDir(), 'does-not-exist')
+
+    const result = await initPublicFiles({ publicDir } as ResolvedConfig)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns the set of files when the public dir exists', async () => {
+    const publicDir = makeTempDir()
+    fs.writeFileSync(path.join(publicDir, 'foo.txt'), '')
+
+    const result = await initPublicFiles({ publicDir } as ResolvedConfig)
+
+    expect(result).toEqual(new Set(['/foo.txt']))
+  })
+
+  it('returns an empty set when the public dir exists but is empty', async () => {
+    const publicDir = makeTempDir()
+
+    const result = await initPublicFiles({ publicDir } as ResolvedConfig)
+
+    expect(result).toEqual(new Set())
+  })
+})

--- a/packages/vite/src/node/publicDir.ts
+++ b/packages/vite/src/node/publicDir.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import { cleanUrl, withTrailingSlash } from '../shared/utils'
 import type { ResolvedConfig } from './config'
@@ -13,6 +14,14 @@ const publicFilesMap = new WeakMap<ResolvedConfig, Set<string>>()
 export async function initPublicFiles(
   config: ResolvedConfig,
 ): Promise<Set<string> | undefined> {
+  // If the configured public dir doesn't exist, don't return an (empty)
+  // in-memory cache for it: callers rely on `undefined` here to know the
+  // directory isn't there, e.g. so it isn't added to the dev server's file
+  // watcher, which would otherwise silently break the watcher entirely.
+  // https://github.com/vitejs/vite/issues/19864
+  if (!fs.existsSync(config.publicDir)) {
+    return
+  }
   let fileNames: string[]
   try {
     fileNames = await recursiveReaddir(config.publicDir)


### PR DESCRIPTION
## Description

Fixes #19864.

If `publicDir` is configured in `vite.config.js` but the directory doesn't actually exist on disk, the dev server starts without any error/warning, but the chokidar file watcher silently stops detecting **any** file changes at all — not just changes under `publicDir` — breaking HMR for the whole project.

## Root cause

`initPublicFiles()` calls `recursiveReaddir(config.publicDir)`, which returns `[]` (not an error) when the directory doesn't exist:

https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L683-L686

So `initPublicFiles()` still resolves to an **empty `Set`** (a truthy value) instead of `undefined`, even though `publicDir` is missing.

The dev server then uses that truthiness to decide whether to add `publicDir` to the list of paths chokidar should watch:

https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/index.ts#L591-L593

```js
...(publicDir && publicFiles ? [publicDir] : []),
```

Because `publicFiles` is an empty `Set` (truthy) rather than `undefined`, a **non-existent path** gets added to chokidar's watch list. Asking chokidar to watch a path that doesn't exist breaks its ability to report changes reliably, which is what silently kills HMR for the rest of the project.

## Fix

`initPublicFiles()` now returns `undefined` when `config.publicDir` doesn't exist on disk, before attempting to read it. This:
- Keeps a non-existent `publicDir` out of the chokidar watch paths (fixing the watcher breakage), matching the `publicDir && publicFiles` guard's original intent.
- Is consistent with how the other two consumers of the in-memory `publicFiles` cache already treat `undefined` — both `checkPublicFile()` and `servePublicMiddleware()` already fall back gracefully when `publicFiles` is `undefined` (e.g. `checkPublicFile` falls back to `tryStatSync`, and `servePublicMiddleware`'s `publicFiles` parameter is already optional).
- Leaves the existing-but-empty-`publicDir` case unaffected: an empty (but existing) directory still resolves to an empty `Set`, so it's still watched and files added to it later are still picked up.

## Test plan

Added `packages/vite/src/node/__tests__/publicDir.spec.ts` covering `initPublicFiles()`:
1. Returns `undefined` when the configured directory does not exist (the regression case — fails without the fix, since it previously returned an empty `Set`).
2. Returns the correct `Set` of files when the directory exists and has files.
3. Returns an empty `Set` (not `undefined`) when the directory exists but is empty.

I verified test 1 fails on `main` without this fix and passes with it applied.

Also ran:
- `pnpm run test-unit` — all green aside from two pre-existing failures unrelated to this change (a Windows-only symlink resolution test failure due to a local git/symlink environment quirk mentioned in CONTRIBUTING.md, and one flaky worker-runner test that passes in isolation and on `main` — both reproduce identically without my changes)
- `pnpm run typecheck` — passes
- `eslint` on changed files — passes