### PR TITLE
fix: close chokidar dir watchers orphaned by a close during their add

### DIFF
--- a/patches/chokidar@3.6.0.patch
+++ b/patches/chokidar@3.6.0.patch
@@ -34,3 +34,30 @@ index fe29393c179d3d6673f996ca6f95bbc83f9a0699..0a341f3d6a2f1497486a23ea99b3c6da
      if (
        opts.depth !== undefined &&
        calcDepth(fullPath, realPath) > opts.depth
+diff --git a/lib/nodefs-handler.js b/lib/nodefs-handler.js
+--- a/lib/nodefs-handler.js
++++ b/lib/nodefs-handler.js
+@@ -615,7 +615,10 @@
+       const targetPath = follow ? await fsrealpath(path) : path;
+       if (this.fsw.closed) return;
+       closer = await this._handleDir(wh.watchPath, stats, initialAdd, depth, target, wh, targetPath);
+-      if (this.fsw.closed) return;
++      if (this.fsw.closed) {
++        if (closer) closer();
++        return;
++      }
+       // preserve this symlink's target path
+       if (absPath !== targetPath && targetPath !== undefined) {
+         this.fsw._symlinkPaths.set(absPath, targetPath);
+@@ -627,7 +630,10 @@
+       this.fsw._getWatchedDir(parent).add(wh.watchPath);
+       this.fsw._emit(EV_ADD, wh.watchPath, stats);
+       closer = await this._handleDir(parent, stats, initialAdd, depth, path, wh, targetPath);
+-      if (this.fsw.closed) return;
++      if (this.fsw.closed) {
++        if (closer) closer();
++        return;
++      }
+ 
+       // preserve this symlink's target path
+       if (targetPath !== undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ overrides:
 packageExtensionsChecksum: sha256-TN34VxQ4aEf/0bmMCAf/tyq2fur66+GWTFoIOcaYREE=
 
 patchedDependencies:
-  chokidar@3.6.0: e17269188c54412478078f7ac7877c1d5a475a2f2438328e3a7e725513ccbf1f
+  chokidar@3.6.0: 0a32f7239023b94e96263c95f333baef227b15abaac1b55d50938fd8b8b9f7d6
   dotenv-expand@13.0.0: 49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889
   sirv@3.0.2: c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95
 
@@ -395,7 +395,7 @@ importers:
         version: 7.0.0
       chokidar:
         specifier: ^3.6.0
-        version: 3.6.0(patch_hash=e17269188c54412478078f7ac7877c1d5a475a2f2438328e3a7e725513ccbf1f)
+        version: 3.6.0(patch_hash=0a32f7239023b94e96263c95f333baef227b15abaac1b55d50938fd8b8b9f7d6)
       connect:
         specifier: ^3.7.0
         version: 3.7.0(ms@2.1.3)
@@ -11350,7 +11350,7 @@ snapshots:
     dependencies:
       is-regex: 1.2.1
 
-  chokidar@3.6.0(patch_hash=e17269188c54412478078f7ac7877c1d5a475a2f2438328e3a7e725513ccbf1f):
+  chokidar@3.6.0(patch_hash=0a32f7239023b94e96263c95f333baef227b15abaac1b55d50938fd8b8b9f7d6):
     dependencies:
       anymatch: 3.1.3
       braces: 3.0.3
@@ -13910,7 +13910,7 @@ snapshots:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.6.0(patch_hash=e17269188c54412478078f7ac7877c1d5a475a2f2438328e3a7e725513ccbf1f)
+      chokidar: 3.6.0(patch_hash=0a32f7239023b94e96263c95f333baef227b15abaac1b55d50938fd8b8b9f7d6)
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.3.3


### PR DESCRIPTION
## Description

This extends `patches/chokidar@3.6.0.patch` with a disposal for a watcher that chokidar would otherwise orphan.

`_addToNodeFs()` registers the closer returned by `_handleDir()` with `_addPathCloser()` only **after** re-checking `this.fsw.closed`. When `server.close()` lands inside that await gap, it sweeps a still-empty `_closers` list, the resumed `_addToNodeFs` discards the closer, and the `fs.watch` handle created moments earlier stays open forever — `server.close()` resolves, but the Node process cannot exit.

Seen in the wild on apache/maka CI: a dev server restarted by a manifest edit (config-file dependency) kept scanning in the background; `server.close()` raced it; the orphaned `fs.watch` on a temporary repository root kept a `node --test` child process alive for 13.5 minutes after every test had passed, until the CI workspace hit its timeout. Full fs-level attribution and a ~6% natural-occurrence repro under load: apache/maka#4940.

Upstream root fix (v5, same two drop points, with a regression test): paulmillr/chokidar#1483 (issue: paulmillr/chokidar#1482). chokidar 3.6.0 is EOL, so this patch is the only channel for bundled-3.6.0 users.

## Verification

- The extended patch applies cleanly to pristine `chokidar@3.6.0` (`patch -p1`), the patched module passes `node --check` and loads.
- On the maka repro harness (Linux, node 24, 3-way load), the same disposal makes the previously hanging test child exit; the chokidar-side regression test fails without the fix and passes with it (paulmillr/chokidar#1483).