### PR TITLE
docs: build.rolldownOptions.preserveEntrySignatures shows incorrect default

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -2,6 +2,8 @@
 
 Unless noted, the options in this section are only applied to build.
 
+Vite may override some Rolldown defaults for build-specific behavior. For `build.rolldownOptions.preserveEntrySignatures`, the effective default is `false` for regular client builds, `'strict'` in library mode, and `'allow-extension'` for SSR builds.
+
 ## build.target
 
 - **Type:** `string | string[]`


### PR DESCRIPTION
## Summary

Addresses #23451: build.rolldownOptions.preserveEntrySignatures shows incorrect default

## Changed files

- `docs/config/build-options.md`

## Validation

- `git diff --check`: passed

Fixes #23451
