### PR TITLE
fix(build): do not close watch bundle if skipWrite is true (#20412)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -899,12 +899,25 @@ async function buildEnvironment(
         },
       })
 
+      let prevResult: any | undefined
       watcher.on('event', (event) => {
         if (event.code === 'BUNDLE_START') {
+          if (prevResult) {
+            prevResult.close()
+            prevResult = undefined
+          }
           logger.info(colors.cyan(`\nbuild started...`))
           chunkMetadataMap.clearResetChunks()
         } else if (event.code === 'BUNDLE_END') {
-          event.result.close()
+          const skipWrite =
+            options.write === false ||
+            (options.watch && (options.watch as any).skipWrite) ||
+            (rolldownOptions.watch && (rolldownOptions.watch as any).skipWrite)
+          if (!skipWrite) {
+            event.result.close()
+          } else {
+            prevResult = event.result
+          }
           logger.info(colors.cyan(`built in ${event.duration}ms.`))
         } else if (event.code === 'ERROR') {
           const e = event.error


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
prevent `event.result.close()` from being forcefully called when `watch.skipWrite` or `build.write: false` is set. Implementing a `prevResult` reference that will close unclosed bundles in an orderly manner at the start of the next `BUNDLE_START` cycle is a way to address the memory leak issue raised by the author