### PR TITLE
fix(server): clear failed resolution cache

### DIFF
--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -35,6 +35,26 @@ describe('moduleGraph', () => {
       expect(mod2.meta).to.equal(meta)
     })
 
+    it('retries resolving a url after a failed resolution', async () => {
+      let shouldFail = true
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => {
+        if (shouldFail) {
+          throw new Error('temporary failure')
+        }
+        return { id: url }
+      })
+
+      await expect(moduleGraph.ensureEntryFromUrl('/foo.js')).rejects.toThrow(
+        'temporary failure',
+      )
+
+      shouldFail = false
+
+      await expect(
+        moduleGraph.ensureEntryFromUrl('/foo.js'),
+      ).resolves.toBeDefined()
+    })
+
     it('ensure backward compatibility', async () => {
       const clientModuleGraph = new EnvironmentModuleGraph(
         'client',

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -385,7 +385,14 @@ export class EnvironmentModuleGraph {
     // Also register the clean url to the module, so that we can short-circuit
     // resolving the same url twice
     this._setUnresolvedUrlToModule(rawUrl, modPromise)
-    return modPromise
+    try {
+      return await modPromise
+    } catch (error) {
+      if (this._getUnresolvedUrlToModule(rawUrl) === modPromise) {
+        this._unresolvedUrlToModuleMap.delete(rawUrl)
+      }
+      throw error
+    }
   }
 
   // some deps, like a css file referenced via @import, don't have its own


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
`EnvironmentModuleGraph._ensureEntryFromUrl()` caches the in-flight resolution Promise in `_unresolvedUrlToModuleMap`.

When `_resolveUrl()` or a plugin resolver rejects, the rejected Promise remains cached. Subsequent requests for the same URL reuse the rejected Promise and never retry resolution, even after the temporary failure is gone.

This PR removes the cached Promise when it rejects, but only if the map still points to that exact Promise.


