### PR TITLE
perf(build): avoid encoding intermediate preload maps

### DIFF
--- a/packages/vite/scripts/benchPreloadSourcemap.ts
+++ b/packages/vite/scripts/benchPreloadSourcemap.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict'
 import { performance } from 'node:perf_hooks'
+import remapping from '@jridgewell/remapping'
 import type { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
 import MagicString from 'magic-string'
-import { combineSourcemaps } from '../src/node/utils'
 
 const source = Array.from(
   { length: 10_000 },
@@ -16,13 +16,18 @@ const original = new MagicString(source).generateMap({
 const edited = new MagicString(source)
 edited.prepend('const preloadDependencies = ["lazy.js", "lazy.css"];\n')
 const options = { source: 'assets/entry.js', hires: 'boundary' as const }
+// Measure the composition used by combineSourcemaps without importing Vite's
+// source types into the scripts project, which also loads Vite's built types.
 const compose = (decoded: boolean) =>
-  combineSourcemaps('assets/entry.js', [
-    decoded
-      ? (edited.generateDecodedMap(options) as DecodedSourceMap)
-      : (edited.generateMap(options) as RawSourceMap),
-    original,
-  ])
+  remapping(
+    [
+      decoded
+        ? (edited.generateDecodedMap(options) as DecodedSourceMap)
+        : (edited.generateMap(options) as RawSourceMap),
+      original,
+    ],
+    () => null,
+  )
 
 assert.deepEqual(compose(false), compose(true))
 const samples: number[][] = [[], []]

--- a/packages/vite/scripts/benchPreloadSourcemap.ts
+++ b/packages/vite/scripts/benchPreloadSourcemap.ts
@@ -4,8 +4,11 @@ import remapping from '@jridgewell/remapping'
 import type { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
 import MagicString from 'magic-string'
 
+// BENCH_LINES=100000 node --import tsx packages/vite/scripts/benchPreloadSourcemap.ts
+const lineCount = Number(process.env.BENCH_LINES ?? 10_000)
+assert(Number.isSafeInteger(lineCount) && lineCount > 0)
 const source = Array.from(
-  { length: 10_000 },
+  { length: lineCount },
   (_, i) => `export const value${i} = ${i};`,
 ).join('\n')
 const original = new MagicString(source).generateMap({
@@ -30,6 +33,9 @@ const compose = (decoded: boolean) =>
   )
 
 assert.deepEqual(compose(false), compose(true))
+console.log(
+  `${lineCount} lines; ${Buffer.byteLength(source)} source bytes; ${Buffer.byteLength(JSON.stringify(original))} original map bytes`,
+)
 const samples: number[][] = [[], []]
 for (let round = 0; round < 25; round++) {
   for (const variant of round % 2 ? [1, 0] : [0, 1]) {

--- a/packages/vite/scripts/benchPreloadSourcemap.ts
+++ b/packages/vite/scripts/benchPreloadSourcemap.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+import type { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
+import MagicString from 'magic-string'
+import { combineSourcemaps } from '../src/node/utils'
+
+const source = Array.from(
+  { length: 10_000 },
+  (_, i) => `export const value${i} = ${i};`,
+).join('\n')
+const original = new MagicString(source).generateMap({
+  source: 'src/entry.js',
+  hires: true,
+  includeContent: true,
+}) as RawSourceMap
+const edited = new MagicString(source)
+edited.prepend('const preloadDependencies = ["lazy.js", "lazy.css"];\n')
+const options = { source: 'assets/entry.js', hires: 'boundary' as const }
+const compose = (decoded: boolean) =>
+  combineSourcemaps('assets/entry.js', [
+    decoded
+      ? (edited.generateDecodedMap(options) as DecodedSourceMap)
+      : (edited.generateMap(options) as RawSourceMap),
+    original,
+  ])
+
+assert.deepEqual(compose(false), compose(true))
+const samples: number[][] = [[], []]
+for (let round = 0; round < 25; round++) {
+  for (const variant of round % 2 ? [1, 0] : [0, 1]) {
+    const start = performance.now()
+    compose(Boolean(variant))
+    if (round >= 5) samples[variant].push(performance.now() - start)
+  }
+}
+for (const [i, values] of samples.entries()) {
+  values.sort((a, b) => a - b)
+  const median = (values[9] + values[10]) / 2
+  console.log(`${i ? 'decoded' : 'encoded'} median: ${median.toFixed(2)} ms`)
+}

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -2,6 +2,9 @@ import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os, { type NetworkInterfaceInfoIPv4 } from 'node:os'
 import path from 'node:path'
+import type { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
+import MagicString, { Bundle } from 'magic-string'
 import { fileURLToPath } from 'mlly'
 import { describe, expect, test, vi, onTestFinished } from 'vitest'
 import type { CommonServerOptions, ResolvedServerUrls } from '..'
@@ -901,6 +904,55 @@ describe('combineSourcemaps', () => {
   const resolveFile = (file: string) => {
     return normalizePath(path.resolve(_dirname, file))
   }
+
+  test.each(['assets/index.js', '/dist/index.js', 'C:/dist/index.js'])(
+    'composes decoded intermediate mappings identically for %s',
+    (filename) => {
+      const bundle = new Bundle({ separator: '\n' })
+      bundle.addSource({
+        filename: 'first.js',
+        content: new MagicString('const greeting = "hello 🌍";'),
+      })
+      bundle.addSource({
+        filename: 'second.js',
+        content: new MagicString(
+          'const load = () => import("./lazy.js"); console.log(greeting);',
+        ),
+      })
+      const originalMap = bundle.generateMap({
+        hires: true,
+        includeContent: true,
+      })
+      const s = new MagicString(bundle.toString())
+      const importStart = s.original.indexOf('import(')
+      s.appendLeft(importStart, '__vitePreload(() => ')
+      s.appendRight(s.original.indexOf(';', importStart), ', ["lazy.css"])')
+      s.prepend('const helper = true;\n')
+      const options = { source: filename, hires: 'boundary' as const }
+      const encoded = combineSourcemaps(filename, [
+        s.generateMap(options) as RawSourceMap,
+        originalMap as RawSourceMap,
+      ])
+      const decoded = combineSourcemaps(filename, [
+        s.generateDecodedMap(options) as DecodedSourceMap,
+        originalMap as RawSourceMap,
+      ])
+
+      expect(decoded).toStrictEqual(encoded)
+      expect(typeof decoded.mappings).toBe('string')
+      expect(decoded.sourcesContent).toStrictEqual(originalMap.sourcesContent)
+      expect(
+        originalPositionFor(new TraceMap(decoded), {
+          line: 3,
+          column: s.toString().split('\n')[2].indexOf('console'),
+        }),
+      ).toMatchObject({
+        source: 'second.js',
+        line: 1,
+        column: bundle.toString().split('\n')[1].indexOf('console'),
+      })
+    },
+  )
 
   test('should combine sourcemaps with single sources', () => {
     const sourcemaps = [

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { RawSourceMap } from '@jridgewell/remapping'
+import type { DecodedSourceMap, RawSourceMap } from '@jridgewell/remapping'
 import convertSourceMap from 'convert-source-map'
 import type { ImportSpecifier } from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
@@ -604,13 +604,14 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin[] {
           if (s.hasChanged()) {
             chunk.code = s.toString()
             if (buildSourcemap && chunk.map) {
-              const nextMap = s.generateMap({
+              // Avoid encoding mappings only for combineSourcemaps to decode them.
+              const nextMap = s.generateDecodedMap({
                 source: chunk.fileName,
                 hires: 'boundary',
               })
               const originalFile = chunk.map.file
               const map = combineSourcemaps(chunk.fileName, [
-                nextMap as RawSourceMap,
+                nextMap as DecodedSourceMap,
                 chunk.map as RawSourceMap,
               ]) as SourceMap
               map.toUrl = () => genSourceMapUrl(map)


### PR DESCRIPTION
Preload rewriting generates an encoded temporary source map that `combineSourcemaps` immediately decodes. Use `generateDecodedMap()` to skip that round trip. The composer already accepts decoded maps; mapping precision (`hires: 'boundary'`) and final encoded output stay the same.

```mermaid
flowchart LR
  E[Preload edits] --> B["Before: generateMap()<br/>Encode intermediate map"]
  B --> D[Decode intermediate map]
  E --> A["After: generateDecodedMap()<br/>Keep decoded mappings"]
  D --> C[Compose with original chunk map]
  A --> C
  C --> F[Encode final source map]
```

On a large production application with **25.5 MB of source maps**, 10 measured builds per variant gave:

| Median | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Import-analysis `generateBundle` hook | 584.12 ms | 511.57 ms | 12.4% |
| Vite invocation, including startup | 4.727 s | 4.707 s | 0.4% |

The hook improved in all 10 paired comparisons. Overall build timings overlap substantially, so this does **not** establish a reliable full-build speedup. All 3,463 output files, including maps, were byte-identical across 22 builds including warmups.

Review the three files in this order:

1. [Runtime change](https://github.com/vitejs/vite/blob/97e4cd6bbce97a5130fe18bb44b81ce96e305ac2/packages/vite/src/node/plugins/importAnalysisBuild.ts#L604): change map generation and its type assertion. No new dependency, option, or API.
2. [Equivalence tests](https://github.com/vitejs/vite/blob/97e4cd6bbce97a5130fe18bb44b81ce96e305ac2/packages/vite/src/node/__tests__/utils.spec.ts#L908): check final maps, source content, and original positions with multiple sources and relative/POSIX/Windows paths. These preserve existing behavior and pass on the baseline too.
3. [Reproducible benchmark](https://github.com/vitejs/vite/blob/97e4cd6bbce97a5130fe18bb44b81ce96e305ac2/packages/vite/scripts/benchPreloadSourcemap.ts): compare encoded/decoded composition with configurable input size.

All CI checks pass, including type checking and the Linux/macOS/Windows test matrix.

<details>
<summary>Application measurement method and local verification</summary>

Vite 8.2.0, macOS arm64, Node 22.22.2. Output: 30.8 MB JavaScript and 25.5 MB source maps across 1,389 map files (uncompressed).

One warmup build per variant, then 10 measured pairs, alternating which variant runs first. Each build uses a fresh Vite process and cleared output; dependency libraries are already built. The measured bundle task does not use Turbo caching. Both variants use the same hook instrumentation.

Hook ranges: 576.69–675.49 ms before, 490.18–533.57 ms after. Full-invocation ranges: 4.641–5.254 s before, 4.533–4.882 s after.

Verification performed locally:

- 138 focused utility/import-analysis tests pass.
- Eight additional temporary fixtures (not committed) produce identical code/maps: external, inline, hidden, disabled, relative base, runtime asset URLs, CSS-only preloads, and debug IDs. Fixtures also exercise Unicode, hashbangs, repeated dynamic imports, and shared dependencies.

</details>

<details>
<summary>Run the microbenchmark, including a larger source map</summary>

After installing repository dependencies:

```sh
node --import tsx packages/vite/scripts/benchPreloadSourcemap.ts
BENCH_LINES=100000 node --import tsx packages/vite/scripts/benchPreloadSourcemap.ts
```

The script checks output equality and measures map generation/composition through `@jridgewell/remapping`. It excludes Vite's path normalization and full build pipeline.

On upstream base `9913672`, macOS arm64, Node 26.8.1: five fresh processes per input size, each with five warmup pairs and 20 measured pairs in alternating order. Results below are medians of process medians; map sizes include source content.

| Source | Original map | Encoded | Decoded |
| --- | ---: | ---: | ---: |
| 10,000 lines / 0.308 MB | 1.82 MB | 19.65 ms | 18.23 ms |
| 100,000 lines / 3.28 MB | 19.37 MB | 251.14 ms | 198.56 ms |

The larger case improved in four of five processes; one regressed (206.40 → 230.05 ms). These synthetic results are not full-build speedups or a guarantee that gains scale with map size.

</details>

AI assistance: Codex prepared the patch, tests, benchmark, and description; inspected the composition path; and ran the local checks above. Human author review is pending.
