### PR TITLE
docs(config): correct the server.sourcemapIgnoreList default

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -467,21 +467,21 @@ export default defineConfig({
 ## server.sourcemapIgnoreList
 
 - **Type:** `false | (sourcePath: string, sourcemapPath: string) => boolean`
-- **Default:** `(sourcePath) => sourcePath.includes('node_modules')`
+- **Default:** `(sourcePath) => /(?:^|[\\/])node_modules(?:[\\/]|$)/.test(sourcePath)`
 
 Whether or not to ignore source files in the server sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/articles/x-google-ignore-list/).
 
 `server.sourcemapIgnoreList` is the equivalent of [`build.rolldownOptions.output.sourcemapIgnoreList`](https://rolldown.rs/reference/OutputOptions.sourcemapIgnoreList) for the dev server. A difference between the two config options is that the Rolldown function is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source in the same folder, so the relative path for `sourcePath` is the file name itself. In these cases, absolute paths make it convenient to be used instead.
 
-By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
+By default, it excludes all paths that contain `node_modules` as a whole path segment. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
 
 ```js
 export default defineConfig({
   server: {
-    // This is the default value, and will add all files with node_modules
-    // in their paths to the ignore list.
+    // This is the default value, and will add all files that have
+    // node_modules as a path segment to the ignore list.
     sourcemapIgnoreList(sourcePath, sourcemapPath) {
-      return sourcePath.includes('node_modules')
+      return /(?:^|[\\/])node_modules(?:[\\/]|$)/.test(sourcePath)
     },
   },
 })


### PR DESCRIPTION
Follow-up to #23437, which changed `isInNodeModules` from a substring test to a whole-path-segment test. `server.sourcemapIgnoreList` defaults to that function, so its documented default no longer matches the code.

Three spots in that section still describe the old implementation: the **Default:** line, the sentence "excludes all paths containing `node_modules`", and the example.

The example is the one that actually bites. It is labelled "This is the default value", so copying it into a config restores the substring match — and a project living in, say, `~/work/node_modules_bug/` puts its own sources back on the `x_google_ignoreList`, which is the DevTools symptom #17467 was about.

The regex now shown in the docs is copied verbatim from `inNodeModulesRE` in `packages/vite/src/node/utils.ts`, so the two can be diffed by eye.

Docs only, no behaviour change. `pnpm run test-docs` and `pnpm format && git diff --exit-code` both pass locally.


https://claude.ai/code/session_01CBv9CTLkwDs3MuPiW3TQ6T
