### PR TITLE
docs: clarify preserveEntrySignatures defaults

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -166,6 +166,14 @@ Note that this option requires [`import.meta.resolve` support](https://caniuse.c
 
 Directly customize the underlying Rolldown bundle. This is the same as options that can be exported from a Rolldown config file and will be merged with Vite's internal Rolldown options. See [Rolldown options docs](https://rolldown.rs/reference/) for more details.
 
+When `build.rolldownOptions.preserveEntrySignatures` is not specified, Vite uses different defaults from Rolldown depending on the build type:
+
+- regular client builds: `false`
+- library builds: `'strict'`
+- SSR builds: `'allow-extension'`
+
+Set `build.rolldownOptions.preserveEntrySignatures` explicitly to override these defaults.
+
 Instead of `build.rolldownOptions.input`, it is recommended to set the top-level [`input`](/config/shared-options#input) option, because it will be used in dev as well. If `build.rolldownOptions.input` is set, it overrides the top-level `input` option for build only.
 
 ## build.rollupOptions


### PR DESCRIPTION
## What is this PR solving?

Fixes #23451

The `build.rolldownOptions` documentation currently points readers to Rolldown's defaults, but Vite overrides `preserveEntrySignatures` when the option is not provided. This can make a regular client build, library build, and SSR build behave differently from what the linked Rolldown reference suggests.

This adds Vite's effective defaults for each build type and explains how to override them explicitly.

## Alternatives considered

The implementation already defines these values in `resolveRolldownOptions`, so this PR documents the current behavior rather than changing the defaults or adding a new option.

## Tests

- Verified the documented values against `packages/vite/src/node/build.ts`.
- Confirmed that user-provided `build.rolldownOptions` are spread after Vite's defaults.
- Ran a Markdown structure sanity check and `git diff --check`.

No runtime test was added because this is a documentation-only change.

## AI disclosure

I used AI assistance to inspect the repository and organize the documentation update. I verified the source-level behavior, checked the relevant open PRs for overlap, and reviewed the final diff myself.
