### PR TITLE
docs(config): document preserveEntrySignatures defaults (fix #23451)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -166,6 +166,8 @@ Note that this option requires [`import.meta.resolve` support](https://caniuse.c
 
 Directly customize the underlying Rolldown bundle. This is the same as options that can be exported from a Rolldown config file and will be merged with Vite's internal Rolldown options. See [Rolldown options docs](https://rolldown.rs/reference/) for more details.
 
+Vite overrides Rolldown's default for `preserveEntrySignatures`. When this option is not set, Vite uses `false` for regular client builds, `'strict'` for library builds, and `'allow-extension'` for SSR builds.
+
 Instead of `build.rolldownOptions.input`, it is recommended to set the top-level [`input`](/config/shared-options#input) option, because it will be used in dev as well. If `build.rolldownOptions.input` is set, it overrides the top-level `input` option for build only.
 
 ## build.rollupOptions


### PR DESCRIPTION
## Problem

Rolldown documents `preserveEntrySignatures` with a default of `'exports-only'`, but Vite supplies different defaults based on the build mode. This makes the effective behavior unclear when the option is omitted.

## Fix

Document Vite's effective defaults under `build.rolldownOptions`: `false` for regular client builds, `'strict'` for library builds, and `'allow-extension'` for SSR builds.

Fixes #23451.

## Test

- `pnpm exec oxfmt --check docs/config/build-options.md`
- `pnpm run build`
- `pnpm run docs-build`
- `git diff --check`

## Risk

Documentation-only. The values are taken directly from the current build option construction, and user-provided `rolldownOptions` continue to override them.
