### PR TITLE
fix(css): parse image-set() with nested parentheses

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -10,6 +10,7 @@ import {
   createCSSResolvers,
   cssPlugin,
   cssUrlRE,
+  findClosingParenIndex,
   getEmptyChunkReplacer,
   hoistAtRules,
   injectInlinedCSS,
@@ -19,6 +20,36 @@ import {
 import { normalizePath } from '../../utils'
 
 const dirname = import.meta.dirname
+
+describe('image-set() paren matching', () => {
+  test('handles nested functions with inner parentheses', () => {
+    const css =
+      'image-set(url("a.png") 1x, linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1)) 2x)'
+    const open = css.indexOf('(')
+    const close = findClosingParenIndex(css, open)
+    expect(close).toBe(css.length - 1)
+    expect(css.slice(open + 1, close)).toBe(
+      'url("a.png") 1x, linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1)) 2x',
+    )
+  })
+
+  test('handles nested cross-fade with urls', () => {
+    const css = 'image-set(cross-fade(url(a.png), url(b.png)) 1x)'
+    const open = css.indexOf('(')
+    const close = findClosingParenIndex(css, open)
+    expect(close).toBe(css.length - 1)
+    expect(css.slice(open + 1, close)).toBe(
+      'cross-fade(url(a.png), url(b.png)) 1x',
+    )
+  })
+
+  test('ignores parentheses inside quotes', () => {
+    const css = `image-set(url("awkward).png") 1x)`
+    const open = css.indexOf('(')
+    const close = findClosingParenIndex(css, open)
+    expect(close).toBe(css.length - 1)
+  })
+})
 
 describe('search css url function', () => {
   test('some spaces before it', () => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1600,7 +1600,7 @@ async function compilePostCSS(
   // although at serve time it can work without processing, we do need to
   // crawl them in order to register watch dependencies.
   const needInlineImport = code.includes('@import')
-  const hasUrl = cssUrlRE.test(code) || cssImageSetRE.test(code)
+  const hasUrl = cssUrlRE.test(code) || code.includes('image-set(')
   const postcssConfig = await resolvePostcssConfig(
     environment.getTopLevelConfig(),
   )
@@ -2089,9 +2089,41 @@ export const cssDataUriRE: RegExp =
   /(?<=^|[^\w\-\u0080-\uffff])data-uri\((\s*('[^']+'|"[^"]+")\s*|[^'")]+)\)/
 export const importCssRE: RegExp =
   /@import\s+(?:url\()?('[^']+\.css'|"[^"]+\.css"|[^'"\s)]+\.css)/
-// Assuming a function name won't be longer than 256 chars
-// eslint-disable-next-line regexp/no-unused-capturing-group -- doesn't detect asyncReplace usage
-const cssImageSetRE = /(?<=image-set\()((?:[\w-]{1,256}\([^)]*\)|[^)])*)(?=\))/
+
+/**
+ * Find the index of the `)` that closes the `(` at `openIndex`, respecting
+ * nested parentheses and quoted strings.
+ */
+export function findClosingParenIndex(str: string, openIndex: number): number {
+  let depth = 1
+  let inQuote: '"' | "'" | null = null
+  for (let i = openIndex + 1; i < str.length; i++) {
+    const c = str[i]
+    if (inQuote) {
+      if (c === '\\') {
+        i++
+        continue
+      }
+      if (c === inQuote) {
+        inQuote = null
+      }
+      continue
+    }
+    if (c === '"' || c === "'") {
+      inQuote = c
+      continue
+    }
+    if (c === '(') {
+      depth++
+    } else if (c === ')') {
+      depth--
+      if (depth === 0) {
+        return i
+      }
+    }
+  }
+  return -1
+}
 
 const UrlRewritePostcssPlugin: PostCSS.PluginCreator<{
   resolver: CssUrlResolver
@@ -2117,7 +2149,7 @@ const UrlRewritePostcssPlugin: PostCSS.PluginCreator<{
           )
         }
         const isCssUrl = cssUrlRE.test(declaration.value)
-        const isCssImageSet = cssImageSetRE.test(declaration.value)
+        const isCssImageSet = declaration.value.includes('image-set(')
         if (isCssUrl || isCssImageSet) {
           const replacerForDeclaration = async (rawUrl: string) => {
             const [newUrl, resolvedId] = await opts.resolver(rawUrl, importer)
@@ -2195,9 +2227,26 @@ async function rewriteCssImageSet(
   css: string,
   replacer: CssUrlReplacer,
 ): Promise<string> {
-  return await asyncReplace(css, cssImageSetRE, async (match) => {
-    const [, rawUrl] = match
-    const url = await processSrcSet(rawUrl, async ({ url }) => {
+  // Do not use a single regex for the image-set() contents: nested functions
+  // like linear-gradient(... rgba(...)) contain `)` and truncate [^)]* matches.
+  let result = ''
+  let i = 0
+  while (i < css.length) {
+    const start = css.indexOf('image-set(', i)
+    if (start === -1) {
+      result += css.slice(i)
+      break
+    }
+    result += css.slice(i, start)
+    const openParen = start + 'image-set'.length
+    // handle optional vendor prefix already included via indexOf('image-set(')
+    const closeParen = findClosingParenIndex(css, openParen)
+    if (closeParen === -1) {
+      result += css.slice(start)
+      break
+    }
+    const rawUrl = css.slice(openParen + 1, closeParen)
+    const rewritten = await processSrcSet(rawUrl, async ({ url }) => {
       // the url maybe url(...)
       if (cssUrlRE.test(url)) {
         return await rewriteCssUrls(url, replacer)
@@ -2207,8 +2256,10 @@ async function rewriteCssImageSet(
       }
       return url
     })
-    return url
-  })
+    result += `image-set(${rewritten})`
+    i = closeParen + 1
+  }
+  return result
 }
 function skipUrlReplacer(unquotedUrl: string) {
   return (


### PR DESCRIPTION
## Description

`cssImageSetRE` extracted `image-set(...)` contents with a shallow `[^)]*` / single-level `func(...)` pattern. Nested closers inside `linear-gradient(... rgba(...))` or `cross-fade(url(...), url(...))` ended the capture early, so URL rewrite / `processSrcSet` saw truncated candidates.

Replace the regex extraction with a small parenthesis walker (`findClosingParenIndex`) that respects quotes, and detect `image-set(` via `includes` for the has-url fast path.

Fixes #23472

## Additional context

Verified with `pnpm run test-unit css.spec`.


Made with [Cursor](https://cursor.com)