### PR TITLE
fix(server): handle watcher errors

### DIFF
--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { type ViteDevServer, createServer } from '../index'
+import { createLogger } from '../../logger'
 
 const stubGetWatchedCode = /\(\)\s*\{\s*return this;\s*\}/
 
@@ -31,6 +32,21 @@ describe('watcher configuration', () => {
       },
     })
     expect(server.watcher.add.toString()).not.toMatch(stubGetWatchedCode)
+  })
+
+  it('logs watcher errors without throwing', async () => {
+    const logger = createLogger('silent')
+    logger.warn = vi.fn()
+    server = await createServer({
+      customLogger: logger,
+      server: { watch: {} },
+    })
+
+    const error = new Error('watch failed')
+    expect(() => server!.watcher.emit('error', error)).not.toThrow()
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('watcher error: watch failed'),
+    )
   })
 
   it('should watch the root directory, config file dependencies, dotenv files, and the public directory', async () => {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -968,6 +968,12 @@ export async function _createServer(
     onFileAddUnlink(file, true).catch((e) => server.config.logger.error(e))
   })
 
+  watcher.on('error', (error) => {
+    server.config.logger.warn(
+      colors.yellow(`file watcher error: ${error.message}`),
+    )
+  })
+
   if (!middlewareMode && httpServer) {
     httpServer.once('listening', () => {
       // update actual port since this may be different from initial value


### PR DESCRIPTION
Fixes #23470

A Chokidar `error` event had no listener, which makes Node treat a per-path watcher failure as an uncaught exception and terminates the dev server. This adds a warning handler so the affected path can degrade without taking down the server.

The regression test emits a watcher error and verifies that it does not throw while the configured logger receives the warning.

Validation:
- `pnpm test-unit packages/vite/src/node/server/__tests__/watcher.spec.ts` (4 passed)
- `pnpm exec tsc -p packages/vite/src/node --noEmit`
- `pnpm exec oxfmt --check packages/vite/src/node/server/index.ts packages/vite/src/node/server/__tests__/watcher.spec.ts`
- `git diff --check`