### PR TITLE
docs: fix 'allows to' grammar in handleHotUpdate guide

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -14,7 +14,7 @@ Affected scope: `Vite Plugin Authors`
 
 ## Motivation
 
-The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
+The [`handleHotUpdate` hook](/guide/api-plugin.md#handlehotupdate) allows you to perform custom HMR update handling. A list of modules to be updated is passed in the `HmrContext`.
 
 ```ts
 interface HmrContext {


### PR DESCRIPTION
## Summary
Fix grammar in the `handleHotUpdate` docs: "allows to perform" → "allows you to perform".

## Test plan
- [x] Confirmed the sentence reads correctly after the change
- [x] Docs-only wording fix; no code or test changes

I reviewed this change manually and confirmed it is only a grammar correction in documentation.