### PR TITLE
docs: fix 'allows to' grammar in applyToEnvironment docs

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -211,7 +211,7 @@ const UnoCssPlugin = () => {
 }
 ```
 
-If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `applyToEnvironment` hook allows to easily make it per-environment.
+If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `applyToEnvironment` hook allows you to easily make it per-environment.
 
 ```js
 import { nonShareablePlugin } from 'non-shareable-plugin'


### PR DESCRIPTION
## Summary
Fix grammar in the environment plugins guide: "allows to easily make" → "allows you to easily make".

## Test plan
- [x] Confirmed the sentence reads correctly after the change
- [x] Docs-only wording fix; no code or test changes

I reviewed this change manually and confirmed it is only a grammar correction in documentation.