### PR TITLE
fix(bundledDev): serve sourcemap for lazy chunks in bundledDev mode

### DIFF
--- a/packages/vite/src/node/server/bundledDev.ts
+++ b/packages/vite/src/node/server/bundledDev.ts
@@ -346,6 +346,13 @@ export class BundledDev {
     )
     const result = await this.devEngine.compileEntry(moduleId, clientId)
     this.pendingPayloadFilenames.add(result.filename)
+    if (result.sourcemapFilename && result.sourcemap) {
+      // The chunk is served from `/@vite/lazy?...`, so its relative
+      // `sourceMappingURL` resolves to `/@vite/<sourcemapFilename>`.
+      this.memoryFiles.set(`@vite/${result.sourcemapFilename}`, {
+        source: result.sourcemap,
+      })
+    }
     return {
       filename: result.filename,
       code: result.code + payloadDeliveredAck(result.filename),

--- a/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
+++ b/playground/hmr-full-bundle-mode/__tests__/hmr-full-bundle-mode.spec.ts
@@ -298,8 +298,26 @@ if (isBuild) {
   })
 
   test('lazy bundling', async () => {
+    const lazyResponsePromise = page.waitForResponse((res: Response) =>
+      res.url().includes('/@vite/lazy'),
+    )
     await page.click('#load-dynamic')
     await expect.poll(() => page.textContent('.dynamic')).toBe('loaded')
+
+    // the lazy chunk's relative sourceMappingURL must resolve to a served map
+    const lazyResponse = await lazyResponsePromise
+    const code = await lazyResponse.text()
+    const mapRef = /\/\/# sourceMappingURL=(.+)$/m.exec(code)?.[1]
+    if (!mapRef) {
+      throw new Error('lazy chunk has no sourceMappingURL')
+    }
+    const mapUrl = new URL(mapRef, lazyResponse.url()).href
+    const mapResponse = await page.request.get(mapUrl)
+    expect(mapResponse.ok()).toBe(true)
+    const map = await mapResponse.json()
+    expect(
+      (map.sources as string[]).some((source) => source.endsWith('dynamic.js')),
+    ).toBe(true)
   })
 
   // placed before `invalidate` on purpose: that test's cleanup restores


### PR DESCRIPTION
<!--
- What is this PR solving? Write a clear and concise description.
- Reference the issues it solves (e.g. `fixes #123`).
- What other alternatives have you explored?
- Are there any parts you think require more attention from reviewers?

Also, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it. If you've solved it in a different way, clarify what is different and link the other PRs in the PR description.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it. If the tests are not included, explain why.

If you have used AI:

- Read the AI Policy at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#ai-policy.
- Keep the PR description and discussion concise. Use your own words, do not let AI write for you.
- Disclose and describe how you have reviewed its code, e.g. the thought process and decisions that lead to the final code.

Thank you for contributing to Vite!
-->
In bundledDev mode, modules loaded via `import.meta.glob` or dynamic import will cause sourcemaps to become invalid.

https://github.com/btea/rolldown-panic/tree/fix/import-bundledDev
This is the repository for reproducing the issue. Simply install the dependencies, then run `pnpm dev`. You should then see the information shown in the image below when you open your browser's developer tools.

<img width="420" height="33" alt="image" src="https://github.com/user-attachments/assets/8dd88cac-0548-4389-b044-b20e47af38fa" />
